### PR TITLE
Fix slice2py writing typing-only whole-module imports as runtime imports

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2693,14 +2693,14 @@ namespace
             {
                 if (moduleImports.imported)
                 {
-                    out << nl << "import " << moduleName;
+                    outT << nl << "import " << moduleName;
                     if (moduleImports.moduleAlias.empty())
                     {
                         allImports.insert(moduleName);
                     }
                     else
                     {
-                        out << " as " << moduleImports.moduleAlias;
+                        outT << " as " << moduleImports.moduleAlias;
                         allImports.insert(moduleImports.moduleAlias);
                     }
                     hasTypingImports = true;

--- a/python/test/Slice/typingImports/Client.py
+++ b/python/test/Slice/typingImports/Client.py
@@ -16,7 +16,9 @@ import IcePy
 
 def importsModule(nodes: list[ast.stmt], module: str) -> bool:
     return any(
-        isinstance(node, ast.Import) and any(alias.name == module for alias in node.names) for node in nodes
+        (isinstance(node, ast.Import) and any(alias.name == module for alias in node.names))
+        or (isinstance(node, ast.ImportFrom) and node.module == module)
+        for node in nodes
     )
 
 

--- a/python/test/Slice/typingImports/Client.py
+++ b/python/test/Slice/typingImports/Client.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright (c) ZeroC, Inc.
+
+import ast
+import os
+import py_compile
+import sys
+import tempfile
+
+from TestHelper import TestHelper, test
+
+import Ice
+import IcePy
+
+
+def importsModule(nodes: list[ast.stmt], module: str) -> bool:
+    return any(
+        isinstance(node, ast.Import) and any(alias.name == module for alias in node.names) for node in nodes
+    )
+
+
+def typeCheckingSuite(tree: ast.Module) -> list[ast.stmt]:
+    for node in tree.body:
+        if isinstance(node, ast.If) and isinstance(node.test, ast.Name) and node.test.id == "TYPE_CHECKING":
+            return node.body
+    return []
+
+
+class Client(TestHelper):
+    def run(self, args: list[str]):
+        sys.stdout.write("testing placement of typing-only imports... ")
+        sys.stdout.flush()
+
+        sliceFile = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Test.ice")
+        with tempfile.TemporaryDirectory() as outputDir:
+            rc = IcePy.compileSlice(["slice2py", f"-I{Ice.getSliceDir()}", "--output-dir", outputDir, sliceFile])
+            test(rc == 0)
+
+            interfaceFiles = []
+            for root, _, files in os.walk(outputDir):
+                for name in files:
+                    if name.endswith(".py"):
+                        path = os.path.join(root, name)
+                        # Every generated file must compile (e.g. no empty TYPE_CHECKING suite).
+                        py_compile.compile(path, doraise=True)
+                        if name == "TypingImports.py":
+                            interfaceFiles.append(path)
+            test(len(interfaceFiles) == 1)
+
+            with open(interfaceFiles[0], encoding="utf-8") as f:
+                tree = ast.parse(f.read())
+
+            # numpy is only used in type hints, so it must be imported in the TYPE_CHECKING
+            # block, not at run time.
+            test(not importsModule(tree.body, "numpy"))
+            test(importsModule(typeCheckingSuite(tree), "numpy"))
+
+        print("ok")

--- a/python/test/Slice/typingImports/Test.ice
+++ b/python/test/Slice/typingImports/Test.ice
@@ -1,0 +1,16 @@
+// Copyright (c) ZeroC, Inc.
+
+#pragma once
+
+["python:identifier:generated.test.Slice.typingImports.Test"]
+module Test
+{
+    ["python:numpy.ndarray"] sequence<int> IntSeq;
+
+    // IntSeq is only used in operation signatures, so the generated code for this interface
+    // only needs numpy for type hints: the numpy import must be typing-only.
+    interface TypingImports
+    {
+        IntSeq op(IntSeq values);
+    }
+}


### PR DESCRIPTION
In `writeImports`, the loop that builds the `if TYPE_CHECKING:` block wrote whole-module imports to the runtime buffer `out` instead of the typing-only buffer `outT` (a copy-paste from the runtime-imports loop). A typing-only dependency such as `numpy` (via `["python:numpy.ndarray"]` sequence metadata used only in operation signatures) therefore became an unconditional runtime import of the generated module. This also made the latent empty-`TYPE_CHECKING`-suite `IndentationError` possible, since `hasTypingImports` was set without writing anything into `outT`; with the fix, the flag always reflects content actually emitted into the buffer.

For example, the generated `Custom.py` of the `Ice/custom` test (interface with numpy-mapped sequence parameters) previously contained a top-level `import numpy`; it is now emitted inside the `if TYPE_CHECKING:` block.

Regression test: new `Slice/typingImports` suite compiles a Slice file whose numpy-mapped sequence is used only in interface operations, then asserts (via `ast`) that `import numpy` appears in the `TYPE_CHECKING` block and not at module top level, and that all generated files byte-compile.

Fixes #5483