### PR TITLE
Fix JS string escape and diagnostic-text defects

### DIFF
--- a/js/packages/ice/src/Ice/Operation.js
+++ b/js/packages/ice/src/Ice/Operation.js
@@ -236,7 +236,7 @@ function marshalParams(os, params, retvalInfo, paramInfo, optParamInfo, usesClas
 function checkNonIdempotent(current) {
     if (current.mode !== OperationMode.Normal) {
         throw new MarshalException(
-            `Operation mode mismatch for operation '${current.operation}': received ${current.node} for non-idempotent operation`,
+            `Operation mode mismatch for operation '${current.operation}': received ${current.mode} for non-idempotent operation`,
         );
     }
 }

--- a/js/packages/ice/src/Ice/StringToIdentity.js
+++ b/js/packages/ice/src/Ice/StringToIdentity.js
@@ -30,7 +30,7 @@ export function stringToIdentity(s) {
                 //
                 // Extra unescaped slash found.
                 //
-                throw new ParseException(`unescaped backslash in identity '${s}'`);
+                throw new ParseException(`unescaped '/' in identity '${s}'`);
             }
         }
         pos++;

--- a/js/packages/ice/src/Ice/StringUtil.js
+++ b/js/packages/ice/src/Ice/StringUtil.js
@@ -405,7 +405,7 @@ function decodeChar(s, start, end, special, result) {
             }
             case "a": {
                 ++start;
-                result.append("\u0007");
+                result.push("\u0007");
                 break;
             }
             case "b": {

--- a/js/packages/test/Ice/proxy/Client.ts
+++ b/js/packages/test/Ice/proxy/Client.ts
@@ -371,7 +371,7 @@ export class Client extends TestHelper {
 
         try {
             // Extra unescaped slash
-            id = Ice.stringToIdentity("a/b/c");
+            Ice.stringToIdentity("a/b/c");
             test(false);
         } catch (ex) {
             test(ex instanceof Ice.ParseException, ex as Error);

--- a/js/packages/test/Ice/proxy/Client.ts
+++ b/js/packages/test/Ice/proxy/Client.ts
@@ -359,6 +359,25 @@ export class Client extends TestHelper {
         id2 = Ice.stringToIdentity(idStr);
         test(id.equals(id2));
 
+        // U+0007 (bell) is escaped as \a in the default mode and must round-trip.
+        id = new Ice.Identity("test\u0007bell", "cat\u0007");
+        idStr = Ice.identityToString(id);
+        test(idStr === "cat\\a/test\\abell");
+        id2 = Ice.stringToIdentity(idStr);
+        test(id.equals(id2));
+
+        id = Ice.stringToIdentity("\\a");
+        test(id.name === "\u0007" && id.category.length === 0);
+
+        try {
+            // Extra unescaped slash
+            id = Ice.stringToIdentity("a/b/c");
+            test(false);
+        } catch (ex) {
+            test(ex instanceof Ice.ParseException, ex as Error);
+            test((ex as Error).message.includes("unescaped '/'"), ex as Error);
+        }
+
         // Input string with various pitfalls
         // id = Ice.stringToIdentity("\\342\\x82\\254\\60\\x9\\60\\");
         // test(id.name === "€0\t0\\" && id.category.isEmpty());


### PR DESCRIPTION
Three small fixes in the JS runtime:

- `StringUtil.decodeChar`: the `\a` escape branch called `result.append(...)` — JS arrays have no `.append()`, so unescaping any string containing `\a` threw a raw `TypeError`. Since `escapeString` emits `\a` for U+0007 in the default mode, the escape round-trip was broken. Now uses `result.push(...)` like every sibling branch.

- `stringToIdentity`: the extra-unescaped-slash branch reported `unescaped backslash in identity '...'` for input like `a/b/c`. Reworded to `unescaped '/' in identity '...'`, matching the C++ message.

- `checkNonIdempotent`: the `MarshalException` message interpolated `current.node`, a property `Current` does not define, producing `received undefined for non-idempotent operation`. Now interpolates `current.mode`.

Regression tests in the `Ice/proxy` suite: a U+0007 identity escape round-trip (pre-fix: `TypeError: result.append is not a function`), a direct `stringToIdentity("\\a")` check, and an `a/b/c` ParseException message check. No test for the `checkNonIdempotent` message (requires a hand-crafted mode-mismatch request).

Fixes #5515
Fixes #5519