### PR TITLE
Fix WSConnectionInfo.maxBufferedAmount always being undefined

### DIFF
--- a/js/packages/ice/src/Ice/Connection.js
+++ b/js/packages/ice/src/Ice/Connection.js
@@ -67,8 +67,8 @@ export class TCPConnectionInfo extends IPConnectionInfo {}
  *  Provides access to the connection details of a WebSocket connection
  */
 export class WSConnectionInfo extends ConnectionInfo {
-    constructor(adapterName, connectionId, localAddress, localPort, remoteAddress, remotePort, maxBufferedAmount) {
-        super(adapterName, connectionId, localAddress, localPort, remoteAddress, remotePort);
+    constructor(underlying, maxBufferedAmount) {
+        super(underlying);
         this._maxBufferedAmount = maxBufferedAmount;
     }
 

--- a/js/packages/ice/src/Ice/WSTransceiver.js
+++ b/js/packages/ice/src/Ice/WSTransceiver.js
@@ -245,21 +245,13 @@ class WSTransceiver {
     getInfo(adapterName, connectionId) {
         console.assert(this._fd !== null);
 
-        let info = new TCPConnectionInfo(
-            adapterName,
-            connectionId,
-            "",
-            -1,
-            this._addr.host,
-            this._addr.port,
-            this._maxBufferedAmount,
-        );
+        let info = new TCPConnectionInfo(adapterName, connectionId, "", -1, this._addr.host, this._addr.port);
 
         if (this._secure) {
             info = new SSLConnectionInfo(info);
         }
 
-        return new WSConnectionInfo(info);
+        return new WSConnectionInfo(info, this._maxBufferedAmount);
     }
 
     toString() {

--- a/js/packages/test/Ice/info/Client.ts
+++ b/js/packages/test/Ice/info/Client.ts
@@ -114,6 +114,9 @@ export class Client extends TestHelper {
         }
 
         if (conn.type() == "ws" || conn.type() == "wss") {
+            test(info instanceof Ice.WSConnectionInfo);
+            test(typeof (info as Ice.WSConnectionInfo).maxBufferedAmount === "number");
+
             test(getHeader(ctx, "ws.Upgrade")!.toLowerCase() == "websocket");
             test(
                 getHeader(ctx, "ws.Connection")!.includes("Upgrade") ||

--- a/js/packages/test/Ice/info/Client.ts
+++ b/js/packages/test/Ice/info/Client.ts
@@ -115,7 +115,8 @@ export class Client extends TestHelper {
 
         if (conn.type() == "ws" || conn.type() == "wss") {
             test(info instanceof Ice.WSConnectionInfo);
-            test(typeof (info as Ice.WSConnectionInfo).maxBufferedAmount === "number");
+            const maxBufferedAmount = (info as Ice.WSConnectionInfo).maxBufferedAmount;
+            test(Number.isFinite(maxBufferedAmount) && maxBufferedAmount >= 0);
 
             test(getHeader(ctx, "ws.Upgrade")!.toLowerCase() == "websocket");
             test(


### PR DESCRIPTION
`Connection.getInfo()` on a `ws`/`wss` connection always returned a `WSConnectionInfo` with `maxBufferedAmount === undefined`, for two stacked reasons:

- `WSTransceiver.getInfo` passed `this._maxBufferedAmount` as a 7th argument to `TCPConnectionInfo`, whose `IPConnectionInfo` base takes 6 parameters — silently dropped;
- `new WSConnectionInfo(info)` passed only the underlying info, while the constructor declared a misleading flat 7-parameter signature and read `maxBufferedAmount` from the absent 7th argument.

`WSConnectionInfo` is now an explicit wrapper — `constructor(underlying, maxBufferedAmount)` — matching the C++ model, and the transceiver passes `new WSConnectionInfo(info, this._maxBufferedAmount)` without the stray `TCPConnectionInfo` argument. The wrapping (`underlying`/`adapterName`/`connectionId`) behavior is unchanged, and `WSTransceiver` is the only construction site. The TypeScript declarations only expose getters, so no typings change is needed.

Regression test: the `Ice/info` suite now asserts on ws/wss connections that `getInfo()` returns an `Ice.WSConnectionInfo` whose `maxBufferedAmount` is a number (pre-fix: `undefined`). Verified over ws, wss, and tcp.

Fixes #5516