### PR TITLE
Fix JS ImplicitContext returning undefined where the contract says empty string

### DIFF
--- a/js/packages/ice/src/Ice/ImplicitContext.d.ts
+++ b/js/packages/ice/src/Ice/ImplicitContext.d.ts
@@ -35,7 +35,7 @@ declare module "@zeroc/ice" {
              * Gets the value associated with the specified key in the request context.
              *
              * @param key - The key.
-             * @returns The value associated with the key, or the empty string if no value is associated with the key.
+             * @returns The value associated with the key, or the empty string if the key is not set.
              */
             get(key: string): string;
 
@@ -44,7 +44,7 @@ declare module "@zeroc/ice" {
              *
              * @param key - The key.
              * @param value - The value.
-             * @returns The previous value associated with the key, if any.
+             * @returns The previous value associated with the key, or the empty string if the key was not set.
              */
             put(key: string, value: string): string;
 
@@ -52,7 +52,7 @@ declare module "@zeroc/ice" {
              * Removes the entry for the specified key in the request context.
              *
              * @param key - The key.
-             * @returns The value associated with the key, if any.
+             * @returns The value the key had, or the empty string if the key was not set.
              */
             remove(key: string): string;
         }

--- a/js/packages/ice/src/Ice/ImplicitContext.js
+++ b/js/packages/ice/src/Ice/ImplicitContext.js
@@ -39,7 +39,7 @@ export class ImplicitContext {
         }
 
         let val = this._context.get(key);
-        if (val === null) {
+        if (val === undefined) {
             val = "";
         }
 
@@ -55,7 +55,7 @@ export class ImplicitContext {
         }
 
         let oldVal = this._context.get(key);
-        if (oldVal === null) {
+        if (oldVal === undefined) {
             oldVal = "";
         }
 
@@ -72,7 +72,7 @@ export class ImplicitContext {
         let val = this._context.get(key);
         this._context.delete(key);
 
-        if (val === null) {
+        if (val === undefined) {
             val = "";
         }
         return val;

--- a/js/packages/ice/src/Ice/ImplicitContext.js
+++ b/js/packages/ice/src/Ice/ImplicitContext.js
@@ -34,7 +34,7 @@ export class ImplicitContext {
     }
 
     get(key) {
-        if (key === null) {
+        if (key === null || key === undefined) {
             key = "";
         }
 
@@ -47,10 +47,10 @@ export class ImplicitContext {
     }
 
     put(key, value) {
-        if (key === null) {
+        if (key === null || key === undefined) {
             key = "";
         }
-        if (value === null) {
+        if (value === null || value === undefined) {
             value = "";
         }
 
@@ -65,7 +65,7 @@ export class ImplicitContext {
     }
 
     remove(key) {
-        if (key === null) {
+        if (key === null || key === undefined) {
             key = "";
         }
 

--- a/js/packages/ice/src/Ice/ImplicitContext.js
+++ b/js/packages/ice/src/Ice/ImplicitContext.js
@@ -26,7 +26,7 @@ export class ImplicitContext {
     }
 
     containsKey(key) {
-        if (key === null) {
+        if (key === null || key === undefined) {
             key = "";
         }
 

--- a/js/packages/test/Ice/operations/Twoways.ts
+++ b/js/packages/test/Ice/operations/Twoways.ts
@@ -1331,6 +1331,17 @@ export async function twoways(
         test(implicitContext.remove("zero") === "");
         test(implicitContext.put("zero", "ZERO") === "");
 
+        // A null or undefined key is normalized to the empty-string key.
+        test(implicitContext.containsKey(null!) == false);
+        test(implicitContext.containsKey(undefined!) == false);
+        test(implicitContext.put(undefined!, "EMPTY") === "");
+        test(implicitContext.containsKey(null!) == true);
+        test(implicitContext.containsKey(undefined!) == true);
+        test(implicitContext.get(null!) === "EMPTY");
+        test(implicitContext.get(undefined!) === "EMPTY");
+        test(implicitContext.remove(undefined!) === "EMPTY");
+        test(implicitContext.containsKey("") == false);
+
         ctx = implicitContext.getContext();
         test(Ice.MapUtil.equals(await p3.opContext(), ctx));
 

--- a/js/packages/test/Ice/operations/Twoways.ts
+++ b/js/packages/test/Ice/operations/Twoways.ts
@@ -1316,21 +1316,22 @@ export async function twoways(
 
         let p3 = new Test.MyClassPrx(ic, "test:" + helper.getTestEndpoint());
 
-        ic.getImplicitContext().setContext(ctx);
-        test(Ice.MapUtil.equals(ic.getImplicitContext().getContext(), ctx));
+        const implicitContext = ic.getImplicitContext();
+        implicitContext.setContext(ctx);
+        test(Ice.MapUtil.equals(implicitContext.getContext(), ctx));
         test(Ice.MapUtil.equals(await p3.opContext(), ctx));
 
-        test(ic.getImplicitContext().containsKey("zero") == false);
-        test(ic.getImplicitContext().get("zero") === "");
-        const r = ic.getImplicitContext().put("zero", "ZERO");
+        test(implicitContext.containsKey("zero") == false);
+        test(implicitContext.get("zero") === "");
+        const r = implicitContext.put("zero", "ZERO");
         test(r === "");
-        test(ic.getImplicitContext().get("zero") == "ZERO");
-        test(ic.getImplicitContext().put("zero", "ZERO-2") === "ZERO");
-        test(ic.getImplicitContext().remove("zero") === "ZERO-2");
-        test(ic.getImplicitContext().remove("zero") === "");
-        test(ic.getImplicitContext().put("zero", "ZERO") === "");
+        test(implicitContext.get("zero") == "ZERO");
+        test(implicitContext.put("zero", "ZERO-2") === "ZERO");
+        test(implicitContext.remove("zero") === "ZERO-2");
+        test(implicitContext.remove("zero") === "");
+        test(implicitContext.put("zero", "ZERO") === "");
 
-        ctx = ic.getImplicitContext().getContext();
+        ctx = implicitContext.getContext();
         test(Ice.MapUtil.equals(await p3.opContext(), ctx));
 
         const prxContext = new Ice.Context();
@@ -1348,13 +1349,13 @@ export async function twoways(
 
         p3 = Test.MyClassPrx.uncheckedCast(p3.ice_context(prxContext));
 
-        ic.getImplicitContext().setContext(null!);
+        implicitContext.setContext(null!);
         test(Ice.MapUtil.equals(await p3.opContext(), prxContext));
 
-        ic.getImplicitContext().setContext(ctx);
+        implicitContext.setContext(ctx);
         test(Ice.MapUtil.equals(await p3.opContext(), combined));
 
-        test(ic.getImplicitContext().remove("one") == "ONE");
+        test(implicitContext.remove("one") == "ONE");
 
         await ic.destroy();
     }

--- a/js/packages/test/Ice/operations/Twoways.ts
+++ b/js/packages/test/Ice/operations/Twoways.ts
@@ -1321,9 +1321,14 @@ export async function twoways(
         test(Ice.MapUtil.equals(await p3.opContext(), ctx));
 
         test(ic.getImplicitContext().containsKey("zero") == false);
+        test(ic.getImplicitContext().get("zero") === "");
         const r = ic.getImplicitContext().put("zero", "ZERO");
-        test(r === undefined);
+        test(r === "");
         test(ic.getImplicitContext().get("zero") == "ZERO");
+        test(ic.getImplicitContext().put("zero", "ZERO-2") === "ZERO");
+        test(ic.getImplicitContext().remove("zero") === "ZERO-2");
+        test(ic.getImplicitContext().remove("zero") === "");
+        test(ic.getImplicitContext().put("zero", "ZERO") === "");
 
         ctx = ic.getImplicitContext().getContext();
         test(Ice.MapUtil.equals(await p3.opContext(), ctx));


### PR DESCRIPTION
`ImplicitContext.get`/`put`/`remove` normalized missing keys with `=== null`, but the backing `Ice.Context` is a native `Map`, whose `get` returns `undefined` for an absent key — never `null`. The dead normalizations meant `get`/`remove` returned `undefined` for a missing key and `put` returned `undefined` as the old value of a previously-unset key, where the declared return type (and the C++, C#, and Java implementations) say `""`. The checks now compare against `undefined`; the `null` normalizations of input arguments are unchanged.

The `Ice/operations` test explicitly asserted the buggy behavior (`test(r === undefined)` for a first `put`); it now asserts `""` and additionally covers `get` and `remove` of missing keys and the old-value returns of `put`.

This is the JavaScript member of the cross-language ImplicitContext family (C#: #5499, Java: #5512).

Fixes #5518