### PR TITLE
Fix JS struct equality so different struct types never compare equal

### DIFF
--- a/js/packages/ice/src/Ice/ArrayUtil.js
+++ b/js/packages/ice/src/Ice/ArrayUtil.js
@@ -5,9 +5,9 @@ const eq = function (e1, e2) {
         return true; // If identity compare equals members are equal.
     } else if (e1 === null || e1 === undefined || e2 === null || e2 === undefined) {
         return false;
-    } else if (e1.prototype !== e2.prototype) {
-        return false;
     } else if (typeof e1.equals == "function") {
+        // The type's own equals decides; for example, struct equality requires the same type
+        // while proxy equality compares the references regardless of the proxy class.
         return e1.equals(e2);
     } else if (e1 instanceof Array || e1 instanceof Uint8Array) {
         return ArrayUtil.equals(e1, e2, eq);

--- a/js/packages/ice/src/Ice/Struct.js
+++ b/js/packages/ice/src/Ice/Struct.js
@@ -18,6 +18,11 @@ function equals(other) {
         return false;
     }
 
+    if (typeof other !== "object") {
+        // A struct can never equal a primitive (number/string/boolean/symbol/bigint) or a function.
+        return false;
+    }
+
     if (Object.getPrototypeOf(this) !== Object.getPrototypeOf(other)) {
         return false;
     }

--- a/js/packages/ice/src/Ice/Struct.js
+++ b/js/packages/ice/src/Ice/Struct.js
@@ -18,7 +18,7 @@ function equals(other) {
         return false;
     }
 
-    if (this.prototype !== other.prototype) {
+    if (Object.getPrototypeOf(this) !== Object.getPrototypeOf(other)) {
         return false;
     }
 

--- a/js/packages/test/Ice/operations/Test.ice
+++ b/js/packages/test/Ice/operations/Test.ice
@@ -20,6 +20,12 @@ module Test
         string s;
     }
 
+    // Same members as AnotherStruct: instances of the two types must not compare equal.
+    struct StillAnotherStruct
+    {
+        string s;
+    }
+
     struct Structure
     {
         MyClass* p;

--- a/js/packages/test/Ice/operations/Twoways.ts
+++ b/js/packages/test/Ice/operations/Twoways.ts
@@ -260,6 +260,16 @@ export async function twoways(
     }
 
     {
+        // Struct equality requires the same Slice type: structs of different types with
+        // identical members must not compare equal.
+        const as1 = new Test.AnotherStruct("abc");
+        test(as1.equals(new Test.AnotherStruct("abc")));
+        test(!as1.equals(new Test.AnotherStruct("def")));
+        test(!as1.equals(new Test.StillAnotherStruct("abc")));
+        test(!new Test.StillAnotherStruct("abc").equals(as1));
+    }
+
+    {
         const bsi1 = new Uint8Array([0x01, 0x11, 0x12, 0x22]);
         const bsi2 = new Uint8Array([0xf1, 0xf2, 0xf3, 0xf4]);
 

--- a/js/packages/test/Ice/operations/Twoways.ts
+++ b/js/packages/test/Ice/operations/Twoways.ts
@@ -267,6 +267,14 @@ export async function twoways(
         test(!as1.equals(new Test.AnotherStruct("def")));
         test(!as1.equals(new Test.StillAnotherStruct("abc")));
         test(!new Test.StillAnotherStruct("abc").equals(as1));
+
+        // Comparing a struct to a primitive must return false without throwing. The symbol and
+        // bigint cases in particular must not throw from Object.getPrototypeOf.
+        test(!as1.equals(5));
+        test(!as1.equals("abc"));
+        test(!as1.equals(true));
+        test(!as1.equals(Symbol()));
+        test(!as1.equals(10n));
     }
 
     {


### PR DESCRIPTION
`Struct.equals` guarded with `this.prototype !== other.prototype`, but instances don't carry a `.prototype` property, so the guard compared `undefined !== undefined` and never fired: two structs of different Slice types with coinciding members compared equal. The guard now uses `Object.getPrototypeOf`, which compares the instances' actual prototypes. This `equals` is installed on `Ice.Identity` and backs every Identity-keyed `HashMap` (ServantManager, LocatorTable, RouterInfo).

`ArrayUtil.eq` had the same dead `e1.prototype !== e2.prototype` branch. There it is **removed** rather than made live: `eq` delegates to the element's own `equals` when present, and making the prototype guard live would have wrongly rejected comparisons that are legitimately cross-class — most notably struct fields holding proxies, where a `MyInterfacePrx` written to a stream is read back as a base proxy class and equality is by reference (this actually broke the `Ice/stream` suite when tried). With the dead branch removed, `eq`'s behavior is unchanged, and the type check lives where it belongs, in `Struct.equals`.

Regression test: the `Ice/operations` suite gains `StillAnotherStruct`, member-identical to `AnotherStruct`, and asserts cross-type instances with equal fields do not compare equal (pre-fix they did), while same-type equality still holds. Verified with `Ice/operations`, `Ice/stream`, `Ice/optional`, and `Ice/location` (Identity-keyed locator table).

Fixes #5517