### PR TITLE
Fix JS ConnectRequestHandler completing queued requests through a nonexistent property

### DIFF
--- a/js/packages/ice/src/Ice/ConnectRequestHandler.js
+++ b/js/packages/ice/src/Ice/ConnectRequestHandler.js
@@ -122,7 +122,7 @@ export class ConnectRequestHandler {
                 } else {
                     console.assert(ex instanceof LocalException, ex);
                     exception = ex;
-                    request.out.completedEx(ex);
+                    request.completedEx(ex);
                 }
             }
         }


### PR DESCRIPTION
The failure path of `ConnectRequestHandler.flushRequests` called `request.out.completedEx(ex)`, but the queued entries are the outgoing-async objects themselves (`this._requests.push(out)`), so `request.out` is `undefined` and the call threw a raw `TypeError`. The original `LocalException` was lost (affected invocations settled with an opaque `TypeError` via the outer recovery in `Reference.getConnection`), the in-progress flush was aborted so later-queued requests were never sent on the handler, and already-flushed requests could be re-failed from the still-undrained queue.

The fix calls `request.completedEx(ex)`, mirroring the sibling `setException` path that completes the same queue entries.

No regression test: triggering this path deterministically requires a connection that fails with a `LocalException` in the middle of `flushRequests` during connection establishment — a race that can't be reliably staged from the public API. Verified with the connection-establishment-heavy `Ice/ami`, `Ice/exceptions`, and `Ice/binding` suites.

Fixes #5514