### PR TITLE
Fix Ice for Ruby marshaling of an empty sequence<byte> passed as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ might need to be aware of.
   asymmetric, and the class defined `eql?` without a matching `hash`; equal endpoints now compare consistently and
   can be used as `Hash`/`Set` keys.
 
+- Fixed Ice for Ruby to correctly marshal an empty `sequence<byte>` supplied as a string: it now writes a single size
+  byte instead of a raw 4-byte integer, which previously desynchronized the rest of the message.
+
 These are the changes since the [Ice 3.8.2] release.
 
 [Ice 3.8.2]: https://github.com/zeroc-ice/ice/blob/3.8/CHANGELOG-3.8.md

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -1352,7 +1352,7 @@ IceRuby::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, VALU
                 const long len = RSTRING_LEN(str);
                 if (s == 0 || len == 0)
                 {
-                    os->write(int32_t(0));
+                    os->writeSize(0);
                 }
                 else
                 {

--- a/ruby/test/Ice/operations/Twoways.rb
+++ b/ruby/test/Ice/operations/Twoways.rb
@@ -325,6 +325,13 @@ def twoways(helper, communicator, p)
     test(rso.unpack("C*") == arr)
 
     #
+    # opByteS with an empty sequence supplied as an empty string.
+    #
+    rso, bso = p.opByteS("", bsi2)
+    test(bso.length == 0)
+    test(rso.unpack("C*") == bsi2)
+
+    #
     # opBoolS
     #
     bsi1 = [true, true, false]


### PR DESCRIPTION
Fixes #5538.

In `SequenceInfo::marshalPrimitiveSequence`, an empty Ruby `String` supplied for a `sequence<byte>` was marshaled with `os->write(int32_t(0))` (a raw 4-byte little-endian integer) instead of `os->writeSize(0)` (a single size byte). The three extra bytes desynchronized the rest of the message, producing a `MarshalException` (or silent corruption) for any value that follows it.

The fix matches the non-empty path (the byte-range `write` overload writes the size first) and the Python/PHP siblings.

### Test

Added a regression test to `ruby/test/Ice/operations` (`Twoways.rb`): `opByteS("", bsi2)` — an empty `p1` supplied as a string followed by a non-empty `p2`. It fails before the fix (the stray bytes desync `p2`) and passes after.

Milestone: 3.8.3.