### PR TITLE
Make Buffer.position setter throw on out-of-range values (JS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ might need to be aware of.
 - [Changes in Ice 3.9.0](#changes-in-ice-390)
   - [General Changes](#general-changes)
   - [C# Changes](#c-changes)
+  - [JavaScript Changes](#javascript-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -25,6 +26,12 @@ might need to be aware of.
 - Fixed a bug in `slice2cs --icerpc` where the generated proxy built the response tuple in marshal order while
   declaring it in declaration order. As a result, an operation whose out-parameters were declared in an order
   different from their marshal order could return values in the wrong tuple slots or fail to compile.
+
+### JavaScript Changes
+
+- Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a
+  `RangeError` instead of being silently ignored, matching the buffer-position behavior of the other language
+  mappings.
 
 These are the changes since the [Ice 3.8.2] release.
 

--- a/js/packages/ice/src/Ice/Buffer.js
+++ b/js/packages/ice/src/Ice/Buffer.js
@@ -244,7 +244,9 @@ export class Buffer {
     }
 
     set position(value) {
-        if (value < 0 || value > this._limit) {
+        // A position must be an integer in [0, limit]. Using Number.isInteger also rejects non-finite values such as
+        // NaN/undefined, which would otherwise slip past the < 0 / > limit comparisons and corrupt the buffer.
+        if (!Number.isInteger(value) || value < 0 || value > this._limit) {
             throw new RangeError(indexOutOfBoundsExceptionMsg);
         }
         this._position = value;

--- a/js/packages/ice/src/Ice/Buffer.js
+++ b/js/packages/ice/src/Ice/Buffer.js
@@ -244,9 +244,10 @@ export class Buffer {
     }
 
     set position(value) {
-        if (value >= 0 && value <= this._limit) {
-            this._position = value;
+        if (value < 0 || value > this._limit) {
+            throw new RangeError(indexOutOfBoundsExceptionMsg);
         }
+        this._position = value;
     }
 
     get limit() {

--- a/js/packages/test/Ice/stream/Client.ts
+++ b/js/packages/test/Ice/stream/Client.ts
@@ -575,6 +575,26 @@ export class Client extends TestHelper {
             }
         }
         out.writeLine("ok");
+
+        out.write("testing buffer position bounds... ");
+        {
+            // Setting the stream position out of range must throw, not silently no-op.
+            const inS = new Ice.InputStream(communicator, new Uint8Array(4));
+            for (const badPos of [5, -1]) {
+                try {
+                    inS.pos = badPos;
+                    test(false);
+                } catch (ex) {
+                    test(ex instanceof RangeError);
+                }
+            }
+            // Positions within [0, limit] are accepted (the limit itself is a valid position).
+            inS.pos = 4;
+            test(inS.pos === 4);
+            inS.pos = 0;
+            test(inS.pos === 0);
+        }
+        out.writeLine("ok");
     }
 
     async run(args: string[]) {

--- a/js/packages/test/Ice/stream/Client.ts
+++ b/js/packages/test/Ice/stream/Client.ts
@@ -578,9 +578,9 @@ export class Client extends TestHelper {
 
         out.write("testing buffer position bounds... ");
         {
-            // Setting the stream position out of range must throw, not silently no-op.
+            // Setting the stream position to an out-of-range or non-integer value must throw, not silently no-op.
             const inS = new Ice.InputStream(communicator, new Uint8Array(4));
-            for (const badPos of [5, -1]) {
+            for (const badPos of [5, -1, 1.5, NaN]) {
                 try {
                     inS.pos = badPos;
                     test(false);


### PR DESCRIPTION
Fixes #5576.

The JS `Buffer.position` setter silently ignored out-of-range assignments (it neither advanced nor threw), whereas the equivalent buffer position mutators in the other mappings all reject them: C# `ByteBuffer.position(int)` throws `ArgumentOutOfRangeException`, Java `Buffer.position(int)` throws `IllegalArgumentException` (via `java.nio.Buffer`), and Swift `changePos` throws.

This makes the setter throw `RangeError` — the same exception (`indexOutOfBoundsExceptionMsg`) the other `Buffer` methods already throw for out-of-range indices — when the value is negative or greater than the limit. The limit itself remains a valid position.

All current call sites already pre-check their bounds before assigning, so this is a defensive hardening rather than a behavior change on valid paths; the JS test suite exercises the message read/write, batch, and trace paths that assign `pos`, so CI validates that none relied on the previous silent-clamp behavior.

Adds a `stream` unit test covering both the throwing (out-of-range) and accepted (in-range, including `== limit`) cases.
