### PR TITLE
Fix dangling GC root for a custom Ruby SliceLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ might need to be aware of.
 - Fixed `Ice::createProperties` in Ice for Ruby to accept `nil` as the defaults argument (equivalent to omitting it).
   A `nil` defaults previously bypassed the type check and crashed the interpreter.
 
+- Fixed Ice for Ruby to keep a custom `SliceLoader` alive for the communicator's lifetime. The wrapper previously
+  registered the wrong address with the garbage collector, leaving a dangling root and allowing the loader to be
+  collected while still in use.
+
 These are the changes since the [Ice 3.8.2] release.
 
 [Ice 3.8.2]: https://github.com/zeroc-ice/ice/blob/3.8/CHANGELOG-3.8.md

--- a/ruby/src/IceRuby/RubySliceLoader.cpp
+++ b/ruby/src/IceRuby/RubySliceLoader.cpp
@@ -10,7 +10,7 @@ using namespace std;
 IceRuby::RubySliceLoader::RubySliceLoader(VALUE sliceLoader) : _sliceLoader{sliceLoader}
 {
     // Mark the object as in use for the lifetime of this wrapper.
-    rb_gc_register_address(&sliceLoader);
+    rb_gc_register_address(&_sliceLoader);
 }
 
 IceRuby::RubySliceLoader::~RubySliceLoader() { rb_gc_unregister_address(&_sliceLoader); }


### PR DESCRIPTION
Fixes #5539.

`RubySliceLoader`'s constructor called `rb_gc_register_address(&sliceLoader)` on its **by-value parameter** — a stack slot destroyed when the constructor returns — while the destructor unregisters `&_sliceLoader` (the member), which was never registered. Two consequences:

- the GC scans a **dangling stack address** as a root on every collection cycle, and
- the member holding the user's Ruby `SliceLoader` is **never protected**, so a custom loader set in `InitializationData` can be collected while the C++ wrapper still holds its `VALUE` (use-after-free in `newClassInstance`).

The fix registers the member address `&_sliceLoader`, matching the destructor and the `ValueWriter`/`ValueReader`/`ExceptionReader` sibling pattern.

### Test

No regression test: reliably triggering the use-after-free requires dropping every Ruby-side reference to the loader and forcing GC at the right moment, which is inherently non-deterministic across MRI versions/GC modes — disproportionate to a one-token fix. The existing `Ice/objects` suite (which exercises the custom-SliceLoader path) still passes.

Milestone: 3.8.3.