### PR TITLE
Fix crash in Ice for Ruby createProperties with a nil defaults argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ might need to be aware of.
   - [C# Changes](#c-changes)
   - [JavaScript Changes](#javascript-changes)
   - [Python Changes](#python-changes)
+  - [Ruby Changes](#ruby-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -39,6 +40,11 @@ might need to be aware of.
 - Fixed Ice for Python to reliably abort request marshaling when an invalid value is supplied for a sequence
   parameter (such as a non-sequence argument), instead of continuing with a pending Python exception and sending a
   corrupt or truncated request.
+
+### Ruby Changes
+
+- Fixed `Ice::createProperties` in Ice for Ruby to accept `nil` as the defaults argument (equivalent to omitting it).
+  A `nil` defaults previously bypassed the type check and crashed the interpreter.
 
 These are the changes since the [Ice 3.8.2] release.
 

--- a/ruby/src/IceRuby/Properties.cpp
+++ b/ruby/src/IceRuby/Properties.cpp
@@ -37,9 +37,9 @@ IceRuby_createProperties(int argc, VALUE* argv, VALUE /*self*/)
         }
 
         Ice::PropertiesPtr defaults;
-        if (argc == 2)
+        if (argc == 2 && !NIL_P(argv[1]))
         {
-            if (!NIL_P(argv[1]) && callRuby(rb_obj_is_instance_of, argv[1], _propertiesClass) == Qfalse)
+            if (callRuby(rb_obj_is_instance_of, argv[1], _propertiesClass) == Qfalse)
             {
                 throw RubyException(rb_eTypeError, "invalid properties argument to Ice::createProperties");
             }

--- a/ruby/test/Ice/properties/Client.rb
+++ b/ruby/test/Ice/properties/Client.rb
@@ -109,6 +109,28 @@ class Client < ::TestHelper
         end
         puts "ok"
 
+        print "testing createProperties with a defaults argument... "
+        # Passing nil for the optional defaults argument must behave like omitting it (no defaults),
+        # not crash. Regression test: a nil defaults argument previously bypassed the type check and
+        # dereferenced DATA_PTR(Qnil).
+        properties = Ice.createProperties([], nil)
+        properties.setProperty("Foo.Bar", "1")
+        test(properties.getProperty("Foo.Bar") == "1")
+
+        # A real Properties object passed as defaults is honored.
+        defaults = Ice.createProperties()
+        defaults.setProperty("Baz.Qux", "42")
+        properties = Ice.createProperties([], defaults)
+        test(properties.getProperty("Baz.Qux") == "42")
+
+        # A non-nil, non-Properties defaults argument still raises TypeError.
+        begin
+            Ice.createProperties([], "not a properties")
+            test(false)
+        rescue TypeError
+        end
+        puts "ok"
+
         print "testing Ice.initialize with args... "
         args = ["--Foo.Bar=1", "--Foo.Bar=2", "--Ice.Trace.Network=3"]
         Ice.initialize(args) do |communicator|


### PR DESCRIPTION
Fixes #5540.

In `IceRuby_createProperties`, the type check for the optional defaults argument short-circuited on nil:

```cpp
if (!NIL_P(argv[1]) && callRuby(rb_obj_is_instance_of, argv[1], _propertiesClass) == Qfalse) { throw ...; }
defaults = getProperties(argv[1]);   // argv[1] may be Qnil here
```

A `nil` argument passed validation, then `getProperties(argv[1])` applied `DATA_PTR` to `Qnil` and dereferenced a garbage pointer — crashing the interpreter on the natural `Ice.createProperties(args, nil)` call shape. The fix fetches the defaults only when `argv[1]` is non-nil (matching the IcePy/IcePHP siblings); the C++ core accepts a null defaults.

### Test

Extended the client-only `Ice/properties` suite: `createProperties([], nil)` (segfaults before the fix), plus a real two-arg defaults case (previously uncovered) and the negative `TypeError` case.

Milestone: 3.8.3.