### PR TITLE
Fix Ice::Endpoint comparison and add a matching hash in Ice for Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ might need to be aware of.
   registered the wrong address with the garbage collector, leaving a dangling root and allowing the loader to be
   collected while still in use.
 
+- Fixed `Ice::Endpoint` comparison in Ice for Ruby. `<=>` compared an endpoint with itself, making `==`/`<=>`
+  asymmetric, and the class defined `eql?` without a matching `hash`; equal endpoints now compare consistently and
+  can be used as `Hash`/`Set` keys.
+
 These are the changes since the [Ice 3.8.2] release.
 
 [Ice 3.8.2]: https://github.com/zeroc-ice/ice/blob/3.8/CHANGELOG-3.8.md

--- a/ruby/src/IceRuby/Endpoint.cpp
+++ b/ruby/src/IceRuby/Endpoint.cpp
@@ -90,7 +90,7 @@ IceRuby_Endpoint_cmp(VALUE self, VALUE other)
         {
             return INT2NUM(-1);
         }
-        else if (Ice::targetEqualTo(p1, p1))
+        else if (Ice::targetEqualTo(p1, p2))
         {
             return INT2NUM(0);
         }
@@ -107,6 +107,22 @@ extern "C" VALUE
 IceRuby_Endpoint_equals(VALUE self, VALUE other)
 {
     return IceRuby_Endpoint_cmp(self, other) == INT2NUM(0) ? Qtrue : Qfalse;
+}
+
+extern "C" VALUE
+IceRuby_Endpoint_hash(VALUE self)
+{
+    ICE_RUBY_TRY
+    {
+        Ice::EndpointPtr* p = reinterpret_cast<Ice::EndpointPtr*>(DATA_PTR(self));
+        assert(p);
+
+        // Hash the string representation, which encodes exactly the fields used by operator== (and hence eql?),
+        // so equal endpoints produce equal hashes.
+        return INT2FIX(std::hash<string>{}((*p)->toString()));
+    }
+    ICE_RUBY_CATCH
+    return Qnil;
 }
 
 // EndpointInfo
@@ -254,6 +270,7 @@ IceRuby::initEndpoint(VALUE iceModule)
     rb_define_method(_endpointClass, "<=>", CAST_METHOD(IceRuby_Endpoint_cmp), 1);
     rb_define_method(_endpointClass, "==", CAST_METHOD(IceRuby_Endpoint_equals), 1);
     rb_define_method(_endpointClass, "eql?", CAST_METHOD(IceRuby_Endpoint_equals), 1);
+    rb_define_method(_endpointClass, "hash", CAST_METHOD(IceRuby_Endpoint_hash), 0);
 
     //
     // EndpointInfo.

--- a/ruby/test/Ice/proxy/AllTests.rb
+++ b/ruby/test/Ice/proxy/AllTests.rb
@@ -520,6 +520,22 @@ def allTests(helper, communicator)
     endpts3 = compObj3.ice_getEndpoints()
     test(endpts1 == endpts3)
 
+    #
+    # Endpoint comparison regression test. The three-way comparator must be antisymmetric and able to
+    # return 1 (not just -1/0), and eql?/hash must be consistent so equal endpoints work as Hash keys.
+    #
+    e1 = endpts1[0]
+    e2 = endpts2[0]
+    e3 = endpts3[0]
+    test(e1 == e1)
+    test((e1 <=> e1) == 0)
+    test(e1 != e2)
+    test((e1 <=> e2) == -(e2 <=> e1))                 # antisymmetry
+    test([(e1 <=> e2), (e2 <=> e1)].sort == [-1, 1])  # the comparator can return 1, not just -1/0
+    test(e1.eql?(e3))
+    test(e1.hash == e3.hash)                          # equal endpoints hash equally
+    test({e1 => "v"}[e3] == "v")                      # usable as a value-based Hash key
+
     test(compObj1.ice_encodingVersion(Ice::Encoding_1_0) == compObj1.ice_encodingVersion(Ice::Encoding_1_0))
     test(compObj1.ice_encodingVersion(Ice::Encoding_1_0) != compObj1.ice_encodingVersion(Ice::Encoding_1_1))
     #test(compObj.ice_encodingVersion(Ice::Encoding_1_0) < compObj.ice_encodingVersion(Ice::Encoding_1_1))


### PR DESCRIPTION
Fixes #5541.

Two defects in `Ice::Endpoint`'s comparison surface, fixed together:

1. **`<=>` compared an endpoint with itself.** `IceRuby_Endpoint_cmp` called `Ice::targetEqualTo(p1, p1)` (always true), so it returned `0` whenever `p1` was not less than `p2` and could never return `1`. `==`/`eql?` are built on this comparator, so equality was **asymmetric** (`a == b` could differ from `b == a`). Fixed by comparing `p1` with `p2`.

2. **`eql?` without a matching `hash`.** The class defined `eql?` but kept identity-based `Object#hash`, and each `getInfo`/`ice_getEndpoints` creates a fresh wrapper — so two wrappers for equal endpoints hashed differently and misbehaved as `Hash`/`Set` keys. Added a `hash` method that hashes the endpoint's string representation, which is equality-consistent with `operator==`.

(The audit suggested mirroring `Proxy.cpp`'s `std::hash<Ice::ObjectPrx>`, but there is no public value-based hash for `Ice::Endpoint`, so hashing `toString()` is the correct approach.)

### Test

Extended `Ice/proxy` `AllTests.rb`: antisymmetry (`(e1<=>e2) == -(e2<=>e1)`), the comparator's sign set covers `{-1, 1}` (probing both orderings so it can't pass by sort luck), and equal endpoints hash equally / work as `Hash` keys. Fails before the fix, passes after.

Milestone: 3.8.3.