### PR TITLE
Fix slice2rb duplicate context parameter for a Context-named parameter

### DIFF
--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -15,16 +15,19 @@ using namespace IceInternal;
 
 namespace
 {
-    string getEscapedRubyParamName(const OperationPtr& p, const string& name)
+    // Returns the name of the synthesized trailing 'context' parameter for a generated proxy method. It is escaped
+    // to 'context_' when an in-parameter's lower-cased mapped name is already 'context' (e.g. a parameter named
+    // 'Context'), to avoid emitting a duplicate parameter name in the method signature.
+    string getEscapedContextParam(const OperationPtr& p)
     {
-        for (const auto& param : p->parameters())
+        for (const auto& param : p->inParameters())
         {
-            if (Slice::Ruby::getMappedName(param) == name)
+            if (Slice::Ruby::getMappedName(param, Slice::Ruby::IdentToLower) == "context")
             {
-                return name + "_";
+                return "context_";
             }
         }
-        return name;
+        return "context";
     }
 }
 
@@ -319,7 +322,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         {
             _out << inParams << ", ";
         }
-        const string contextParamName = getEscapedRubyParamName(op, "context");
+        const string contextParamName = getEscapedContextParam(op);
         _out << contextParamName << "=nil)";
         _out.inc();
         _out << nl << proxyName << "_mixin::OP_" << op->name() << ".invoke(self, [" << inParams;

--- a/ruby/test/Slice/escape/Clash.ice
+++ b/ruby/test/Slice/escape/Clash.ice
@@ -20,6 +20,10 @@ module Clash
         void opOut(out string context, out string current, out string response, out string ex,
             out string sent, out string cookie, out string sync, out string result, out string istr,
             out string ostr, out optional(1) string proxy);
+
+        // A parameter whose mapped name lower-cases to "context" must not clash with the synthesized
+        // trailing "context" parameter of the generated proxy method.
+        void opClashContext(string Context);
     }
 
     class Cls


### PR DESCRIPTION
Fixes #5482.

In `slice2rb`, `getEscapedRubyParamName` decides whether to escape the synthesized trailing `context` parameter of a generated proxy method. The check compared the *unmodified* identifier against `"context"` over *all* parameters, but in-parameters are emitted in the signature with their **lower-cased** mapped name. So a Slice parameter named `Context` was emitted as `context`, the clash with the synthesized `context` parameter went undetected, and the generator produced:

```ruby
def op(context, context=nil)   # Ruby SyntaxError: duplicated argument name
```

making the generated file unloadable.

The fix limits the check to **in-parameters** (the only ones in the signature) and compares against the same **lower-cased** name they are emitted with — i.e. it mirrors the emission loop exactly. This also removes a pre-existing spurious escape: an operation whose only `context`/`Context` parameter is an *out*-parameter no longer escapes the synthesized name unnecessarily.

Verified with Ruby reflection on the generated proxy:

| operation | generated params |
| --- | --- |
| `op(string context, …)` (in-param) | `[:context, …, :context_]` (unchanged) |
| `opOut(out string context, …)` (out-only) | `[:context]` (was spuriously `:context_`) |
| `opClashContext(string Context)` (in-param) | `[:context, :context_]` (**fixed**) |

### Test

Added `void opClashContext(string Context)` to `ruby/test/Slice/escape/Clash.ice`. The escape test compiles it in-process via `Ice::loadSlice`, so the duplicated-argument `SyntaxError` fails the test at load before the fix and passes after — no new assertion code needed.

Milestone: 3.8.3.