### PR TITLE
Fix IcePHP marshaling of non-empty optional string sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ might need to be aware of.
   - [C# Changes](#c-changes-1)
   - [JavaScript Changes](#javascript-changes)
   - [MATLAB Changes](#matlab-changes)
+  - [PHP Changes](#php-changes)
   - [Python Changes](#python-changes)
   - [Ruby Changes](#ruby-changes)
   - [Ice Service Changes](#ice-service-changes)
@@ -75,6 +76,10 @@ might need to be aware of.
 
 - Fixed `Ice.Future.wait('sent')`, which could block indefinitely or time out even after the request had been
   sent. The wait now completes as soon as the invocation reaches or passes the requested state.
+
+### PHP Changes
+
+- Fixed Ice for PHP mis-marshaling a non-empty optional `sequence<string>`.
 
 ### Python Changes
 

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -1458,32 +1458,31 @@ IcePHP::SequenceInfo::marshal(zval* zv, Ice::OutputStream* os, ObjectMap* object
         sz = static_cast<int32_t>(zend_hash_num_elements(arr));
     }
 
+    // An optional sequence whose elements are variable-length is written as an FSize-framed field:
+    // startSize() reserves the 4-byte size and endSize() patches it. The two calls are driven by a
+    // single flag so they can never get out of sync, regardless of how the body below is structured.
+    const bool fSize = optional && elementType->variableLength();
+
     Ice::OutputStream::size_type sizePos = 0;
-    if (optional)
+    if (fSize)
     {
-        if (elementType->variableLength())
-        {
-            sizePos = os->startSize();
-        }
-        else if (elementType->wireSize() > 1)
-        {
-            os->writeSize(sz == 0 ? 1 : sz * elementType->wireSize() + (sz > 254 ? 5 : 1));
-        }
+        sizePos = os->startSize();
+    }
+    else if (optional && elementType->wireSize() > 1)
+    {
+        os->writeSize(sz == 0 ? 1 : sz * elementType->wireSize() + (sz > 254 ? 5 : 1));
     }
 
     if (sz == 0)
     {
         os->writeSize(0);
     }
+    else if (PrimitiveInfoPtr pi = dynamic_pointer_cast<PrimitiveInfo>(elementType))
+    {
+        marshalPrimitiveSequence(pi, zv, os);
+    }
     else
     {
-        PrimitiveInfoPtr pi = dynamic_pointer_cast<PrimitiveInfo>(elementType);
-        if (pi)
-        {
-            marshalPrimitiveSequence(pi, zv, os);
-            return;
-        }
-
         os->writeSize(sz);
 
         zval* val;
@@ -1491,9 +1490,9 @@ IcePHP::SequenceInfo::marshal(zval* zv, Ice::OutputStream* os, ObjectMap* object
         {
             if (!elementType->validate(val, false))
             {
-                ostringstream os;
-                os << "invalid value for sequence element '" << id << "'";
-                invalidArgument(os.str());
+                ostringstream ostr;
+                ostr << "invalid value for sequence element '" << id << "'";
+                invalidArgument(ostr.str());
                 throw AbortMarshaling();
             }
             elementType->marshal(val, os, objectMap, false);
@@ -1501,7 +1500,7 @@ IcePHP::SequenceInfo::marshal(zval* zv, Ice::OutputStream* os, ObjectMap* object
         ZEND_HASH_FOREACH_END();
     }
 
-    if (optional && elementType->variableLength())
+    if (fSize)
     {
         os->endSize(sizePos);
     }


### PR DESCRIPTION
Fixes #5532.

`IcePHP::SequenceInfo::marshal` took a primitive fast path that returned before the trailing `endSize()`, so a non-empty optional/tagged `seq<string>` left the 4-byte FSize placeholder written by `startSize()` as zero. A peer that must skip the field as an _unknown_ optional then uses that zero size and loses framing, corrupting the rest of the encapsulation. The primitive path now falls through to `endSize()`, mirroring the IcePy implementation. `seq<string>` is the only affected case, since `KindString` is the only variable-length primitive.

### Testing

Verified by structural parity with the IcePy reference (identical control flow apart from the removed early `return`) and an independent codex audit; the existing `optional` test (which round-trips an optional `StringSeq` between matched peers) still passes.

The zero FSize is only observable on the unknown-optional **skip** path: a peer that doesn't know the tag uses the FSize to skip the field, and the mis-skip only breaks framing when there is data after it. In the optional test that path is reachable solely through the class-parameter `opClassAndUnknownOptional`/`Initial2` hook (a non-empty optional `seq<string>` there does reproduce it), so a dedicated check would either overload that class-versioning operation or require a new cross-language operation. For a one-line, IcePHP-only wire fix that exactly mirrors the correct IcePy code, we rely on that parity plus the codex audit instead.

Addresses the AI-generated audit finding in #5532, re-verified against the source.
