### PR TITLE
Fix IcePHP registered-communicator reaper destroying live communicators

### DIFF
--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -118,19 +118,36 @@ namespace
             ActiveCommunicatorPtr activeCommunicator;
             {
                 lock_guard lock(_registeredCommunicatorsMutex);
+
+                // The timer may have already dequeued this task before a concurrent registration cancelled (and
+                // possibly replaced) it. If this task is no longer the communicator's current reap task, it is
+                // stale and must not destroy the communicator.
+                if (_activeCommunicator->reapTask.get() != this)
+                {
+                    return;
+                }
+
                 auto now = std::chrono::steady_clock::now();
                 if (_activeCommunicator->lastAccess + _activeCommunicator->expires <= now)
                 {
-                    // Cancel the task to avoid schedule it again after the communicator has been destroyed.
+                    // Cancel the task to avoid scheduling it again after the communicator has been destroyed.
                     _timer->cancel(shared_from_this());
+
+                    // Break the ActiveCommunicator <-> ReapCommunicatorTimerTask ownership cycle so the
+                    // ActiveCommunicator is released once the timer drops its reference to this task.
+                    _activeCommunicator->reapTask = nullptr;
 
                     // Remove all the registrations for this communicator.
                     for (const auto& id : _activeCommunicator->ids)
                     {
                         _registeredCommunicators.erase(id);
                     }
+                    _activeCommunicator->ids.clear();
+
+                    // Destroy the communicator (outside the lock) below. This only runs when the communicator has
+                    // actually expired; otherwise the task would destroy it on every tick, i.e. at expires / 2.
+                    activeCommunicator = _activeCommunicator;
                 }
-                activeCommunicator = _activeCommunicator;
             }
 
             // Destroy the communicator outside the lock.
@@ -1006,8 +1023,10 @@ ZEND_FUNCTION(Ice_register)
 
     if (info->ac->reapTask)
     {
-        // Cancel existing reap task, we schedule a new reap task below according to the expiration time.
+        // Cancel the existing reap task; a new one is scheduled below when expires > 0. Clear the member as well so
+        // a re-registration with expires <= 0 doesn't retain the cancelled task (and its ownership cycle).
         _timer->cancel(info->ac->reapTask);
+        info->ac->reapTask = nullptr;
     }
 
     if (expires > 0)

--- a/php/test/Ice/registeredCommunicator/Client.php
+++ b/php/test/Ice/registeredCommunicator/Client.php
@@ -46,5 +46,18 @@ class Client extends TestHelper
         test(Ice\find('Hello6') != null);
         $communicator = Ice\initialize();
         test(Ice\register($communicator, "Hello6") == false);
+
+        // A registered communicator must not be reaped before its expiration time. The reap task runs every
+        // expires/2; intermediate ticks must not destroy a communicator that has not yet expired (see #5533).
+        $communicator = Ice\initialize();
+        Ice\register($communicator, "Reap", 0.1); // Expires after ~6s; the reap task ticks every ~3s.
+        sleep(4); // Past the first reap tick (~3s) but well before expiration (~6s).
+        $reapCommunicator = Ice\find("Reap");
+        test($reapCommunicator != null);
+        // The communicator has not expired, so it must still be usable. Before #5533 it was destroyed on the
+        // first reap tick and this call raised CommunicatorDestroyedException.
+        $reapCommunicator->stringToProxy("test");
+        $reapCommunicator->destroy();
+        test(Ice\find("Reap") == null);
     }
 }


### PR DESCRIPTION
Fixes #5533.

Three defects in the IcePHP registered-communicator reaper (`Communicator.cpp`):

1. **(the user-visible one)** `ReapCommunicatorTimerTask::runTimerTask` captured the local `ActiveCommunicator` _outside_ the expiry check, so `destroy()` ran on every tick. Since the task is scheduled via `scheduleRepeated` at `expires / 2`, a registered communicator was destroyed at roughly half its idle timeout even when recently accessed. The capture is now inside the expiry block.
2. `Ice_register` cancelled an existing reap task but never cleared `reapTask`, so re-registering with `expires <= 0` retained the cancelled task (and its ownership cycle). It now nulls `reapTask` after the cancel.
3. The natural-expiry branch never cleared `reapTask`, leaving a permanent `ActiveCommunicator <-> ReapCommunicatorTimerTask` cycle. It now clears it, mirroring `Communicator::destroy()`.

As part of this, `runTimerTask` now also ignores a task that is no longer the communicator's current reap task: `Timer::cancel()` does not stop a callback the timer already dequeued, so a task cancelled/replaced by a concurrent `Ice_register` could otherwise still run. The identity check under the lock makes such a stale task a no-op.

### Known limitation (follow-up)

A narrower, **pre-existing** race remains and is intentionally left out of scope here: the expired communicator is destroyed _outside_ the lock (as before), so a concurrent `Ice_register` landing between the in-lock expiry commit and the out-of-lock `destroy()` can re-register a communicator that is then destroyed. This PR strictly narrows the window (the original code destroyed on every tick; it now destroys only on genuine expiry), but fully closing it needs a terminal "reaping" state that `Ice_register` consults — a change to `Ice_register`'s contract that's better handled as a separate, maintainer-reviewed change. Tracked in #5590.

### Testing

Adds a `registeredCommunicator` test that registers with a coarse expiry and verifies the communicator survives past the first reap tick and is still usable. Confirmed red→green locally. Defects 2 and 3 are lifetime/leak fixes with no script-observable side effect, so they have no dedicated test. Independently re-checked with codex (including the Timer task-lifetime safety of clearing `reapTask` from within `runTimerTask`).

Addresses the AI-generated audit finding in #5533, re-verified against the source.
