### PR TITLE
Fix IcePHP setBufferSize validation and UDP ConnectionInfo properties

### DIFF
--- a/php/src/Connection.cpp
+++ b/php/src/Connection.cpp
@@ -224,15 +224,23 @@ ZEND_METHOD(Ice_Connection, setBufferSize)
     Ice::ConnectionPtr _this = Wrapper<Ice::ConnectionPtr>::value(getThis());
     assert(_this);
 
-    zval* r;
-    zval* s;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("zz"), &r, &s) != SUCCESS)
+    zend_long r;
+    zend_long s;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("ll"), &r, &s) != SUCCESS)
     {
         RETURN_NULL();
     }
 
-    int rcvSize = static_cast<int>(Z_LVAL_P(r));
-    int sndSize = static_cast<int>(Z_LVAL_P(s));
+    // Connection::setBufferSize takes int arguments in C++; reject values outside that range instead of silently
+    // truncating them.
+    if (r < INT_MIN || r > INT_MAX || s < INT_MIN || s > INT_MAX)
+    {
+        invalidArgument("buffer size must be in the range of a 32-bit signed integer");
+        RETURN_NULL();
+    }
+
+    int rcvSize = static_cast<int>(r);
+    int sndSize = static_cast<int>(s);
 
     try
     {
@@ -432,6 +440,8 @@ IcePHP::connectionInit(void)
         "",
         ZEND_ACC_PUBLIC);
     zend_declare_property_long(udpConnectionInfoClassEntry, "mcastPort", sizeof("mcastPort") - 1, 0, ZEND_ACC_PUBLIC);
+    zend_declare_property_long(udpConnectionInfoClassEntry, "rcvSize", sizeof("rcvSize") - 1, 0, ZEND_ACC_PUBLIC);
+    zend_declare_property_long(udpConnectionInfoClassEntry, "sndSize", sizeof("sndSize") - 1, 0, ZEND_ACC_PUBLIC);
 
     // Register the WSConnectionInfo class.
     INIT_NS_CLASS_ENTRY(ce, "Ice", "WSConnectionInfo", nullptr);

--- a/php/src/Connection.cpp
+++ b/php/src/Connection.cpp
@@ -235,7 +235,7 @@ ZEND_METHOD(Ice_Connection, setBufferSize)
     // truncating them.
     if (r < INT_MIN || r > INT_MAX || s < INT_MIN || s > INT_MAX)
     {
-        invalidArgument("buffer size must be in the range of a 32-bit signed integer");
+        invalidArgument("buffer size must be in the range of a C++ int");
         RETURN_NULL();
     }
 

--- a/php/test/Ice/info/Client.php
+++ b/php/test/Ice/info/Client.php
@@ -104,6 +104,20 @@ function allTests($helper)
         $connection = $testIntf->ice_getConnection();
         $connection->setBufferSize(1024, 2048);
 
+        // setBufferSize must reject non-integer arguments instead of applying a garbage size (see #5534).
+        try {
+            $connection->setBufferSize("not an int", 2048);
+            test(false);
+        } catch (TypeError $ex) {
+        }
+
+        // It must also reject values outside the C++ int range instead of silently truncating them (see #5534).
+        try {
+            $connection->setBufferSize(2 ** 40, 2048);
+            test(false);
+        } catch (InvalidArgumentException $ex) {
+        }
+
         $info = $connection->getInfo();
         $tcpinfo = getTCPConnectionInfo($info);
         test($tcpinfo instanceof Ice\TCPConnectionInfo);
@@ -139,6 +153,16 @@ function allTests($helper)
             test($ctx["ws.Sec-WebSocket-Version"] == "13");
             test(isset($ctx["ws.Sec-WebSocket-Key"]));
         }
+
+        // rcvSize and sndSize must be declared properties on Ice\UDPConnectionInfo, not deprecated dynamic
+        // properties created only at runtime (see #5536).
+        $udpInfo = $testIntf->ice_datagram()->ice_getConnection()->getInfo();
+        test($udpInfo instanceof Ice\UDPConnectionInfo);
+        $udpInfoClass = new ReflectionClass(Ice\UDPConnectionInfo::class);
+        test($udpInfoClass->hasProperty("rcvSize"));
+        test($udpInfoClass->hasProperty("sndSize"));
+        test($udpInfo->rcvSize >= 0);
+        test($udpInfo->sndSize >= 0);
     }
     echo "ok\n";
 


### PR DESCRIPTION
Fixes #5534. Fixes #5536.

Two correctness fixes in the IcePHP `Connection` code:

- **#5534** — `Connection::setBufferSize` parsed its arguments with `"zz"` and then read `Z_LVAL_P` unconditionally, so a non-integer argument applied a garbage buffer size instead of raising an error. It now parses `"ll"` into `zend_long`, so the Zend engine rejects non-numeric input (raising `TypeError`) instead of reading a garbage value; numeric strings and floats are still coerced as an int-typed parameter would be, so legitimate callers are unaffected. This brings it in line with IcePy and the sibling `flushBatchRequests`, which also reject non-integer input.
- **#5536** — the UDP branch of `createConnectionInfo` sets `rcvSize`/`sndSize`, but those properties were declared only on `TCPConnectionInfo`, so on UDP they were created as dynamic properties (deprecated on PHP 8.2+). They are now declared on `UDPConnectionInfo`, mirroring the TCP entry.

### Testing

Adds `info`-test coverage for both: a negative `setBufferSize` call that must raise `TypeError`, and assertions that `rcvSize`/`sndSize` are declared properties on `Ice\UDPConnectionInfo`. Confirmed red→green locally (the red run showed the garbage size being applied). Independently re-checked with codex.

Addresses the AI-generated audit findings in #5534 and #5536, re-verified against the source.
