### PR TITLE
Fix IcePHP ClassInfo handling of optional members

### DIFF
--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -2482,6 +2482,15 @@ IcePHP::ClassInfo::destroy()
             p->type->destroy();
         }
     }
+    if (!optionalMembers.empty())
+    {
+        DataMemberList ml = optionalMembers;
+        const_cast<DataMemberList&>(optionalMembers).clear();
+        for (const auto& p : ml)
+        {
+            p->type->destroy();
+        }
+    }
 }
 
 void
@@ -2508,7 +2517,7 @@ IcePHP::ClassInfo::printMembers(zval* zv, IceInternal::Output& out, PrintObjectH
         }
     }
 
-    for (const auto& member : members)
+    for (const auto& member : optionalMembers)
     {
         out << nl << member->name << " = ";
         zval* val = zend_hash_str_find(Z_OBJPROP_P(zv), member->name.c_str(), member->name.size());

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -14,7 +14,7 @@ function allTests($helper)
     echo "testing class stringification... ";
     flush(); {
         // Stringifying a class must print each required member once and include the optional members. Before #5535
-        // ClassInfo::printMembers iterated the required members twice, so requiredA printed twice and ma never.
+        // ClassInfo::printMembers iterated the required members twice, so 'requiredA' printed twice and 'ma' never.
         $a = new Test\A();
         $a->requiredA = 11;
         $a->ma = 22;

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -11,6 +11,19 @@ function allTests($helper)
     $communicator = $helper->communicator();
     $initial = Test\InitialPrxHelper::createProxy($communicator, $ref);
 
+    echo "testing class stringification... ";
+    flush(); {
+        // Stringifying a class must print each required member once and include the optional members. Before #5535
+        // ClassInfo::printMembers iterated the required members twice, so requiredA printed twice and ma never.
+        $a = new Test\A();
+        $a->requiredA = 11;
+        $a->ma = 22;
+        $str = (string)$a;
+        test(substr_count($str, "requiredA = 11") == 1);
+        test(strpos($str, "ma = 22") !== false);
+    }
+    echo "ok\n";
+
     echo "testing optional data members... ";
     flush();
 


### PR DESCRIPTION
Fixes #5535.

Two `ClassInfo` defects in `Types.cpp`:

- `ClassInfo::printMembers` iterated the required member list twice (the second loop should iterate `optionalMembers`), so required members printed twice and optional members never appeared in a value's string representation. It now iterates `optionalMembers`, matching `ExceptionInfo::printMembers`.
- `ClassInfo::destroy()` cleared only `members`, leaving `optionalMembers` (and their recursive type references) alive at teardown. It now clears/destroys `optionalMembers` as well.

### Testing

Adds an `optional`-test assertion that stringifies a class with a required and an optional member (required appears once, optional appears). Confirmed red→green locally. Independently re-checked with codex.

Addresses the AI-generated audit finding in #5535, re-verified against the source.
