### PR TITLE
Fix IcePHP out-argument leak in unmarshalResults

### DIFF
--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -529,6 +529,9 @@ IcePHP::TypedInvocation::unmarshalResults(int argc, zval* args, zval* ret, pair<
     {
         assert(Z_ISREF(args[i]));
         zval* arg = Z_REFVAL_P(&args[i]);
+        // Release any value the caller's by-reference out-argument already holds before overwriting it; otherwise a
+        // reused out-variable leaks its previous (refcounted) value.
+        zval_ptr_dtor(arg);
         ZVAL_COPY(arg, &(*q)->zv);
     }
 


### PR DESCRIPTION
Fixes #5537.

`TypedInvocation::unmarshalResults` copied each out-parameter into the caller's by-reference variable with `ZVAL_COPY` without releasing the value the variable already held, leaking the previous (refcounted) value when an out-argument variable is reused across invocations. It now calls `zval_ptr_dtor` on the slot before `ZVAL_COPY`. The return-value path is unaffected because `return_value` is always a fresh, non-refcounted zval.

### Testing

No dedicated test: the leak is reclaimed at request/process teardown and is not observable from a PHP assertion, so a probing test would be disproportionate. The `operations` and `optional` tests (heavy out-parameter users, including reused out-variables) still pass. Independently re-checked with codex.

Addresses the AI-generated audit finding in #5537, re-verified against the source.
