### PR TITLE
Fix four low-severity IceRuby audit findings

### DIFF
--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -267,7 +267,9 @@ IceRuby::OperationI::invoke(const Ice::ObjectPrx& proxy, VALUE args, VALUE hctx)
 
     if (!_deprecateMessage.empty())
     {
-        rb_warning("%s", _deprecateMessage.c_str());
+        // Route the warning through the rb_protect discipline: rb_warning dispatches to the overridable
+        // Warning.warn, and a raising override would otherwise longjmp past the live C++ locals above.
+        callRubyVoid([this] { rb_warning("%s", _deprecateMessage.c_str()); });
         _deprecateMessage.clear(); // Only show the warning once.
     }
 

--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -248,7 +248,7 @@ IceRuby_ObjectPrx_ice_endpoints(VALUE self, VALUE seq)
         if (!NIL_P(seq))
         {
             volatile VALUE arr = callRuby(rb_check_array_type, seq);
-            if (NIL_P(seq))
+            if (NIL_P(arr))
             {
                 throw RubyException(rb_eTypeError, "unable to convert value to an array of endpoints");
             }

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -786,7 +786,7 @@ IceRuby::EnumInfo::marshal(VALUE p, Ice::OutputStream* os, ValueMap*, bool)
     const int32_t ival = static_cast<int32_t>(getInteger(val));
     if (enumerators.find(ival) == enumerators.end())
     {
-        throw RubyException(rb_eRangeError, "invalid enumerator %ld for enum %s", ival, id.c_str());
+        throw RubyException(rb_eRangeError, "invalid enumerator %d for enum %s", ival, id.c_str());
     }
 
     os->writeEnum(ival, maxValue);

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -126,7 +126,7 @@ IceRuby::isString(VALUE val)
 bool
 IceRuby::isArray(VALUE val)
 {
-    return TYPE(val) == T_ARRAY || callRuby(rb_respond_to, val, rb_intern("to_arr")) != 0;
+    return TYPE(val) == T_ARRAY || callRuby(rb_respond_to, val, rb_intern("to_ary")) != 0;
 }
 
 bool
@@ -216,7 +216,7 @@ IceRuby::arrayToStringSeq(VALUE val, vector<string>& seq)
     for (long i = 0; i < RARRAY_LEN(arr); ++i)
     {
         string s = getString(RARRAY_AREF(arr, i));
-        seq.push_back(getString(RARRAY_AREF(arr, i)));
+        seq.push_back(std::move(s));
     }
     return true;
 }

--- a/ruby/test/Ice/properties/Client.rb
+++ b/ruby/test/Ice/properties/Client.rb
@@ -131,6 +131,18 @@ class Client < ::TestHelper
         end
         puts "ok"
 
+        print "testing that string-sequence elements are coerced once... "
+        # Regression test: each element of a string-sequence argument must be coerced to a string exactly once.
+        coercions = 0
+        probe = Object.new
+        probe.define_singleton_method(:to_str) do
+            coercions += 1
+            "--Probe.Value=1"
+        end
+        Ice.createProperties([probe])
+        test(coercions == 1)
+        puts "ok"
+
         print "testing Ice.initialize with args... "
         args = ["--Foo.Bar=1", "--Foo.Bar=2", "--Ice.Trace.Network=3"]
         Ice.initialize(args) do |communicator|

--- a/ruby/test/Ice/proxy/AllTests.rb
+++ b/ruby/test/Ice/proxy/AllTests.rb
@@ -536,6 +536,25 @@ def allTests(helper, communicator)
     test(e1.hash == e3.hash)                          # equal endpoints hash equally
     test({e1 => "v"}[e3] == "v")                      # usable as a value-based Hash key
 
+    #
+    # ice_endpoints accepts any object implementing Ruby's to_ary array-conversion protocol.
+    #
+    toAry = Object.new
+    toAry.define_singleton_method(:to_ary) { endpts1 }
+    test(compObj3.ice_endpoints(toAry).ice_getEndpoints() == endpts1)
+
+    #
+    # An argument that is not array-convertible must raise TypeError, not crash. (Regression: the array-type
+    # gate used the nonstandard to_arr and the null check tested the wrong value, crashing on conversion failure.)
+    #
+    notArray = Object.new
+    notArray.define_singleton_method(:to_arr) { [] }
+    begin
+        compObj3.ice_endpoints(notArray)
+        test(false)
+    rescue TypeError
+    end
+
     test(compObj1.ice_encodingVersion(Ice::Encoding_1_0) == compObj1.ice_encodingVersion(Ice::Encoding_1_0))
     test(compObj1.ice_encodingVersion(Ice::Encoding_1_0) != compObj1.ice_encodingVersion(Ice::Encoding_1_1))
     #test(compObj.ice_encodingVersion(Ice::Encoding_1_0) < compObj.ice_encodingVersion(Ice::Encoding_1_1))


### PR DESCRIPTION
Groups four trivial, low-severity correctness fixes in the Ice for Ruby extension from the audit.

- **#5542** — `isArray` checked the nonstandard `to_arr` instead of Ruby's standard `to_ary` array-conversion protocol (so array-coercible arguments were rejected), and `ice_endpoints` null-checked the already-non-nil input `seq` instead of `arr` (the `rb_check_array_type` result), crashing on a conversion failure. Both fixed; a non-convertible argument now raises `TypeError`.
- **#5545** — `arrayToStringSeq` coerced each element to a string **twice** (the first result was stored in a local and discarded). It now coerces once and moves the result.
- **#5544** — `EnumInfo::marshal`'s range-error message formatted an `int32_t` with `%ld` (a varargs type mismatch printing a garbage value). Now uses `%d`. Diagnostic text only.
- **#5543** — `OperationI::invoke` called `rb_warning` for a deprecated operation outside the `callRuby`/`rb_protect` discipline; a raising `Warning.warn` override could `longjmp` past live C++ destructors. Now routed through `callRubyVoid`.

### Tests

- **#5542**: `Ice/proxy` `AllTests.rb` — `ice_endpoints` accepts a `to_ary` object, and a non-convertible argument raises `TypeError` instead of crashing (fails/crashes before the fix).
- **#5545**: `Ice/properties` `Client.rb` — a string-sequence element with a counting `to_str` is coerced exactly once (asserts `2` before the fix).
- **#5543 / #5544**: no tests — the longjmp path is not deterministically observable and the enum change is diagnostic-only; both disproportionate to the fix. Verified by inspection; the operations/enums suites still pass.

Milestone: 3.8.3.