### PR TITLE
Always run peer verification on the OpenSSL and SecureTransport transports

### DIFF
--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -224,6 +224,12 @@ OpenSSL::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal::
         }
     }
 
+    if (!_peerCertificate)
+    {
+        _engine->verifyPeer(dynamic_pointer_cast<ConnectionInfo>(getInfo(_incoming, _adapterName, "")));
+    }
+    // else verifyPeer is called from the configured OpenSSL verify callback.
+
     if (_engine->securityTraceLevel() >= 1)
     {
         Trace out(_instance->logger(), _engine->securityTraceCategory());

--- a/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
@@ -245,6 +245,12 @@ Ice::SSL::SecureTransport::TransceiverI::initialize(IceInternal::Buffer& readBuf
 
     assert(_ssl);
 
+    if (!_peerCertificate)
+    {
+        _engine->verifyPeer(dynamic_pointer_cast<ConnectionInfo>(getInfo(_incoming, _adapterName, "")));
+    }
+    // else verifyPeer is called from the certificate validation callback.
+
     if (_instance->engine()->securityTraceLevel() >= 1)
     {
         Trace out(_instance->logger(), _engine->securityTraceCategory());

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -405,8 +405,18 @@ testCertificateVerification(
         server->ice_ping();
         test(false);
     }
-    catch (const LocalException&)
+    catch (const ProtocolException&)
     {
+        // Expected, if reported as an SSL alert by the server.
+    }
+    catch (const ConnectionLostException&)
+    {
+        // Expected.
+    }
+    catch (const LocalException& ex)
+    {
+        cerr << ex << endl;
+        test(false);
     }
     fact->destroyServer(server);
 

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -393,6 +393,23 @@ testCertificateVerification(
     }
     fact->destroyServer(server);
 
+    // Test IceSSL.VerifyPeer=1 with an IceSSL.TrustOnly rule. The connection is rejected because a client without
+    // a certificate cannot match the trust rule.
+    d = createServerProps(defaultProps, p12, "ca1/server", "");
+    d["IceSSL.VerifyPeer"] = "1";
+    d["IceSSL.TrustOnly"] = "C=US, ST=Florida, O=ZeroC,"
+                            "OU=Ice test infrastructure, emailAddress=info@zeroc.com, CN=ca1.client";
+    server = fact->createServer(d);
+    try
+    {
+        server->ice_ping();
+        test(false);
+    }
+    catch (const LocalException&)
+    {
+    }
+    fact->destroyServer(server);
+
     // Test IceSSL.VerifyPeer=2. This should fail because the client does not supply a certificate.
     d = createServerProps(defaultProps, p12, "ca1/server", "");
     d["IceSSL.VerifyPeer"] = "2";


### PR DESCRIPTION
verifyPeer is now also run when the peer presents no certificate, so the OpenSSL and SecureTransport transports behave consistently with the Schannel transport. Adds an IceSSL configuration test covering this case.