### PR TITLE
Fix out-of-bounds reads in WebSocket pong and Schannel PEM handling

### DIFF
--- a/cpp/src/Ice/SSL/SchannelEngine.cpp
+++ b/cpp/src/Ice/SSL/SchannelEngine.cpp
@@ -601,7 +601,13 @@ namespace
             if (startpos != string::npos)
             {
                 endpos = strbuf.find("-----END CERTIFICATE-----", startpos);
-                size = endpos - startpos + sizeof("-----END CERTIFICATE-----");
+                if (endpos == string::npos)
+                {
+                    ostringstream os;
+                    os << "SSL transport: malformed PEM certificate (missing END marker): '" << file << "'";
+                    throw InitializationException(__FILE__, __LINE__, os.str());
+                }
+                size = endpos - startpos + strlen("-----END CERTIFICATE-----");
             }
             else if (first)
             {

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -1568,15 +1568,22 @@ IceInternal::WSTransceiver::preWrite(Buffer& buf)
         else if (_state == StatePongPending)
         {
             prepareWriteHeader(OP_PONG, _pingPayload.size());
-            if (_pingPayload.size() > static_cast<size_t>(_writeBuffer.b.end() - _writeBuffer.i))
+
+            // A zero-length ping (the common keep-alive case) leaves _pingPayload empty. Guard the copy so we
+            // never form &_pingPayload[0] on an empty vector, which is undefined behavior and aborts under
+            // hardened standard libraries (_GLIBCXX_ASSERTIONS, MSVC debug iterators, libc++ hardening).
+            if (!_pingPayload.empty())
             {
-                auto pos = static_cast<size_t>(_writeBuffer.i - _writeBuffer.b.begin());
-                _writeBuffer.b.resize(pos + _pingPayload.size());
-                _writeBuffer.i = _writeBuffer.b.begin() + pos;
+                if (_pingPayload.size() > static_cast<size_t>(_writeBuffer.b.end() - _writeBuffer.i))
+                {
+                    auto pos = static_cast<size_t>(_writeBuffer.i - _writeBuffer.b.begin());
+                    _writeBuffer.b.resize(pos + _pingPayload.size());
+                    _writeBuffer.i = _writeBuffer.b.begin() + pos;
+                }
+                memcpy(_writeBuffer.i, _pingPayload.data(), _pingPayload.size());
+                _writeBuffer.i += _pingPayload.size();
+                _pingPayload.clear();
             }
-            memcpy(_writeBuffer.i, &_pingPayload[0], _pingPayload.size());
-            _writeBuffer.i += _pingPayload.size();
-            _pingPayload.clear();
 
             _writeBuffer.b.resize(static_cast<size_t>(_writeBuffer.i - _writeBuffer.b.begin()));
             _writeState = WriteStateControlFrame;

--- a/scripts/tests/Ice/wsAllowedOrigins.py
+++ b/scripts/tests/Ice/wsAllowedOrigins.py
@@ -2,6 +2,7 @@
 
 from Util import ClientServerTestCase, Server, TestSuite
 from ws_origin_probe import probe
+from ws_ping_probe import ping_pong
 
 # An origin that the test server is configured to accept.
 ALLOWED_ORIGIN = "https://allowed.example.com"
@@ -115,7 +116,33 @@ class WSAllowedOriginsPortTestCase(ClientServerTestCase):
         current.writeln("ok")
 
 
+class WSPingTestCase(ClientServerTestCase):
+    # Exercises the WebSocket zero-length PING/PONG control-frame path. A zero-length ping (the common keep-alive
+    # case sent by browsers and load balancers) must elicit an empty pong. Before the fix the server formed
+    # &_pingPayload[0] on an empty vector while building the pong -- undefined behavior that aborts under a hardened
+    # standard library.
+    def __init__(self):
+        ClientServerTestCase.__init__(
+            self,
+            "ping/pong control frames",
+            server=Server(quiet=True, waitForShutdown=False),
+        )
+
+    def runClientSide(self, current):
+        current.write("testing WebSocket zero-length ping/pong... ")
+        host = current.host
+        port = current.driver.getTestPort(0)
+        if ping_pong(host, port, b"") != b"":
+            raise RuntimeError("zero-length ping: server did not return an empty pong")
+        current.writeln("ok")
+
+
 TestSuite(
     __name__,
-    [WSAllowedOriginsTestCase(), WSAllowedOriginsWildcardTestCase(), WSAllowedOriginsPortTestCase()],
+    [
+        WSAllowedOriginsTestCase(),
+        WSAllowedOriginsWildcardTestCase(),
+        WSAllowedOriginsPortTestCase(),
+        WSPingTestCase(),
+    ],
 )

--- a/scripts/ws_ping_probe.py
+++ b/scripts/ws_ping_probe.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) ZeroC, Inc.
+
+"""
+Probe an Ice WebSocket server's handling of PING control frames.
+
+Opens a TCP connection, performs the WebSocket upgrade, sends a masked PING
+frame, and waits for the server's PONG, returning the echoed payload. This
+exercises the WSTransceiver pong path, in particular the zero-length ping
+(the common keep-alive case sent by browsers and load balancers).
+
+It speaks just enough of RFC 6455 for this purpose; it does not interpret the
+Ice protocol and skips any data frames (such as the Ice connection-validation
+message) the server sends before the pong.
+"""
+
+import base64
+import os
+import socket
+
+# WebSocket opcodes (RFC 6455 section 5.2).
+_OP_CLOSE = 0x8
+_OP_PING = 0x9
+_OP_PONG = 0xA
+
+
+def _recvn(sock, n):
+    """Read exactly n bytes, raising if the connection closes first."""
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise RuntimeError("connection closed while reading {0} bytes".format(n))
+        buf += chunk
+    return buf
+
+
+def _upgrade(sock, host, port):
+    """Perform the WebSocket upgrade handshake; raise unless the server returns 101."""
+    key = base64.b64encode(os.urandom(16)).decode("ascii")
+    request = (
+        "\r\n".join(
+            [
+                "GET / HTTP/1.1",
+                "Host: {0}:{1}".format(host, port),
+                "Upgrade: websocket",
+                "Connection: Upgrade",
+                "Sec-WebSocket-Key: {0}".format(key),
+                "Sec-WebSocket-Version: 13",
+                "Sec-WebSocket-Protocol: ice.zeroc.com",
+            ]
+        )
+        + "\r\n\r\n"
+    ).encode("ascii")
+    sock.sendall(request)
+
+    buf = b""
+    while b"\r\n\r\n" not in buf and len(buf) < 8192:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        buf += chunk
+    status = buf.split(b"\r\n", 1)[0].decode("ascii", errors="replace") if buf else "<no response>"
+    if not status.startswith("HTTP/1.1 101"):
+        raise RuntimeError("WebSocket upgrade rejected: {0}".format(status))
+
+
+def _client_frame(opcode, payload):
+    """Build a masked client->server frame. Clients MUST mask (RFC 6455 5.3)."""
+    # Control frames carry at most 125 bytes, so a 7-bit length is always enough here.
+    assert len(payload) < 126
+    mask = os.urandom(4)
+    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    return bytes([0x80 | opcode, 0x80 | len(payload)]) + mask + masked
+
+
+def _read_frame(sock):
+    """Read one server->client frame and return (opcode, payload). Server frames are unmasked."""
+    b0, b1 = _recvn(sock, 2)
+    opcode = b0 & 0x0F
+    masked = b1 & 0x80
+    length = b1 & 0x7F
+    if length == 126:
+        length = int.from_bytes(_recvn(sock, 2), "big")
+    elif length == 127:
+        length = int.from_bytes(_recvn(sock, 8), "big")
+    mask = _recvn(sock, 4) if masked else b""
+    payload = _recvn(sock, length) if length else b""
+    if masked:
+        payload = bytes(p ^ mask[i % 4] for i, p in enumerate(payload))
+    return opcode, payload
+
+
+def ping_pong(host, port, payload=b"", timeout=10.0):
+    """
+    Upgrade, send a PING with the given payload, and return the PONG payload.
+
+    Non-PONG frames the server emits first (e.g. its Ice connection-validation
+    message) are skipped. Raises if the server sends CLOSE or never ponngs.
+    """
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        _upgrade(sock, host, port)
+        sock.sendall(_client_frame(_OP_PING, payload))
+        for _ in range(16):
+            opcode, data = _read_frame(sock)
+            if opcode == _OP_PONG:
+                return data
+            if opcode == _OP_CLOSE:
+                raise RuntimeError("server sent CLOSE instead of PONG")
+            # Otherwise a data frame (e.g. Ice connection validation); keep reading for the pong.
+        raise RuntimeError("no PONG received after PING")


### PR DESCRIPTION
Two low-severity, memory-safety-adjacent fixes in the transport code.

### WebSocket pong (zero-length ping)
When answering a zero-length WebSocket ping (the common keep-alive case sent by browsers and load balancers), `WSTransceiver::preWrite` formed `&_pingPayload[0]` on an empty vector while building the pong. That is undefined behavior regardless of the (zero) `memcpy` length, and aborts under hardened standard libraries (`_GLIBCXX_ASSERTIONS`, MSVC debug iterators, libc++ hardening). The copy is now guarded so an empty payload produces a header-only pong without indexing the empty vector.

Adds an `Ice/wsAllowedOrigins` test case that performs a raw WebSocket upgrade and sends a zero-length ping, verifying the server replies with an (empty) pong. The path aborts pre-fix under a hardened/sanitizer build and passes after.

### Schannel PEM parsing (1-byte over-read)
`addCertificatesToStore` computed the PEM chunk length with `sizeof("-----END CERTIFICATE-----")` (26, which counts the NUL terminator) instead of the marker length (25). `CryptStringToBinary` was then handed a length one byte too long and read one byte past the buffer when the file ended exactly at the END marker. The length now uses the marker length, and a `BEGIN` marker without a matching `END` is rejected instead of computing a wrapped length.