### PR TITLE
Detach listeners when a topic is destroyed while elements are attached

### DIFF
--- a/changelog.d/datastorm/5469-datastorm-topic-destroy-detach.md
+++ b/changelog.d/datastorm/5469-datastorm-topic-destroy-detach.md
@@ -1,2 +1,3 @@
-- Fixed a bug in DataStorm where destroying a topic while a peer was still attached to one of its elements did not
-  detach the listeners, leaking them and (in debug builds) tripping an assertion.
+- Fixed a bug in DataStorm where destroying a topic before the readers and writers created from it, while a peer was
+  still attached to one of them, leaked the listeners and (in debug builds) tripped an assertion. This is uncommon,
+  since readers and writers are normally destroyed before their topic.

--- a/changelog.d/datastorm/5469-datastorm-topic-destroy-detach.md
+++ b/changelog.d/datastorm/5469-datastorm-topic-destroy-detach.md
@@ -1,0 +1,2 @@
+- Fixed a bug in DataStorm where destroying a topic while a peer was still attached to one of its elements did not
+  detach the listeners, leaking them and (in debug builds) tripping an assertion.

--- a/cpp/msbuild/ice.test.slnx
+++ b/cpp/msbuild/ice.test.slnx
@@ -60,6 +60,14 @@
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
     </Project>
   </Folder>
+  <Folder Name="/DataStorm/topicDestroy/">
+    <Project Path="../test/DataStorm/topicDestroy/msbuild/reader/reader.vcxproj">
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
+    </Project>
+    <Project Path="../test/DataStorm/topicDestroy/msbuild/writer/writer.vcxproj">
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
+    </Project>
+  </Folder>
   <Folder Name="/DataStorm/types/">
     <Project Path="../test/DataStorm/types/msbuild/reader/reader.vcxproj">
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -941,7 +941,10 @@ SessionI::disconnect(int64_t topicId, TopicI* topic)
         return; // Peer topic detached first.
     }
 
-    runWithTopic(topicId, topic, [&](TopicSubscriber&) { unsubscribe(topicId, topic); });
+    // disconnect() is called from TopicI::destroy() after the topic is marked destroyed, so pass ignoreDestroyed to
+    // detach the listeners anyway. Otherwise unsubscribe (and the element detachKey/detachFilter it drives) is
+    // skipped by the isDestroyed gate and TopicI::_listenerCount is left stale, tripping a debug assert.
+    runWithTopic(topicId, topic, [&](TopicSubscriber&) { unsubscribe(topicId, topic); }, true);
 
     auto& subscriber = _topics.at(topicId);
     subscriber.removeSubscriber(topic);
@@ -1223,7 +1226,11 @@ SessionI::runWithTopics(int64_t topicId, const function<void(TopicI*, TopicSubsc
 }
 
 void
-SessionI::runWithTopic(int64_t topicId, TopicI* topic, const function<void(TopicSubscriber&)>& callback)
+SessionI::runWithTopic(
+    int64_t topicId,
+    TopicI* topic,
+    const function<void(TopicSubscriber&)>& callback,
+    bool ignoreDestroyed)
 {
     auto t = _topics.find(topicId);
     if (t != _topics.end())
@@ -1232,7 +1239,7 @@ SessionI::runWithTopic(int64_t topicId, TopicI* topic, const function<void(Topic
         if (p != t->second.getSubscribers().end())
         {
             unique_lock<mutex> lock(topic->getMutex());
-            if (topic->isDestroyed())
+            if (!ignoreDestroyed && topic->isDestroyed())
             {
                 return;
             }

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -944,7 +944,7 @@ SessionI::disconnect(int64_t topicId, TopicI* topic)
     // disconnect() is called from TopicI::destroy() after the topic is marked destroyed, so pass ignoreDestroyed to
     // detach the listeners anyway. Otherwise unsubscribe (and the element detachKey/detachFilter it drives) is
     // skipped by the isDestroyed gate and TopicI::_listenerCount is left stale, tripping a debug assert.
-    runWithTopic(topicId, topic, [&](TopicSubscriber&) { unsubscribe(topicId, topic); }, true);
+    runWithTopic(topicId, topic, [&](TopicSubscriber&) { unsubscribe(topicId, topic); }, /*ignoreDestroyed=*/true);
 
     auto& subscriber = _topics.at(topicId);
     subscriber.removeSubscriber(topic);

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -936,17 +936,24 @@ SessionI::disconnect(int64_t topicId, TopicI* topic)
         return;
     }
 
-    if (_topics.find(topicId) == _topics.end())
+    auto t = _topics.find(topicId);
+    if (t == _topics.end())
     {
         return; // Peer topic detached first.
     }
+    auto& subscriber = t->second;
 
-    // disconnect() is called from TopicI::destroy() after the topic is marked destroyed, so pass ignoreDestroyed to
-    // detach the listeners anyway. Otherwise unsubscribe (and the element detachKey/detachFilter it drives) is
-    // skipped by the isDestroyed gate and TopicI::_listenerCount is left stale, tripping a debug assert.
-    runWithTopic(topicId, topic, [&](TopicSubscriber&) { unsubscribe(topicId, topic); }, /*ignoreDestroyed=*/true);
+    // disconnect() is called from TopicI::destroy() after the topic is marked destroyed, so detach the listeners
+    // directly here instead of through runWithTopic, which skips destroyed topics. Skipping the unsubscribe (and the
+    // element detachKey/detachFilter it drives) would leave TopicI::_listenerCount stale and trip a debug assert.
+    if (subscriber.getSubscribers().find(topic) != subscriber.getSubscribers().end())
+    {
+        unique_lock<mutex> topicLock(topic->getMutex());
+        _topicLock = &topicLock;
+        unsubscribe(topicId, topic);
+        _topicLock = nullptr;
+    }
 
-    auto& subscriber = _topics.at(topicId);
     subscriber.removeSubscriber(topic);
     if (subscriber.getSubscribers().empty())
     {
@@ -1226,11 +1233,7 @@ SessionI::runWithTopics(int64_t topicId, const function<void(TopicI*, TopicSubsc
 }
 
 void
-SessionI::runWithTopic(
-    int64_t topicId,
-    TopicI* topic,
-    const function<void(TopicSubscriber&)>& callback,
-    bool ignoreDestroyed)
+SessionI::runWithTopic(int64_t topicId, TopicI* topic, const function<void(TopicSubscriber&)>& callback)
 {
     auto t = _topics.find(topicId);
     if (t != _topics.end())
@@ -1239,7 +1242,7 @@ SessionI::runWithTopic(
         if (p != t->second.getSubscribers().end())
         {
             unique_lock<mutex> lock(topic->getMutex());
-            if (!ignoreDestroyed && topic->isDestroyed())
+            if (topic->isDestroyed())
             {
                 return;
             }

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -379,13 +379,7 @@ namespace DataStormI
         /// @param topicId The ID of the topic to process.
         /// @param topic The topic to process.
         /// @param callback The callback function to execute for the subscriber.
-        /// @param ignoreDestroyed If true, run the callback even when the topic is being destroyed. Used by the
-        /// topic-destroy path, which must still detach listeners.
-        void runWithTopic(
-            std::int64_t topicId,
-            TopicI* topic,
-            const std::function<void(TopicSubscriber&)>& callback,
-            bool ignoreDestroyed = false);
+        void runWithTopic(std::int64_t topicId, TopicI* topic, const std::function<void(TopicSubscriber&)>& callback);
 
         /// Returns the topics that match the specified name.
         ///

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -379,7 +379,13 @@ namespace DataStormI
         /// @param topicId The ID of the topic to process.
         /// @param topic The topic to process.
         /// @param callback The callback function to execute for the subscriber.
-        void runWithTopic(std::int64_t topicId, TopicI* topic, const std::function<void(TopicSubscriber&)>& callback);
+        /// @param ignoreDestroyed If true, run the callback even when the topic is being destroyed. Used by the
+        /// topic-destroy path, which must still detach listeners.
+        void runWithTopic(
+            std::int64_t topicId,
+            TopicI* topic,
+            const std::function<void(TopicSubscriber&)>& callback,
+            bool ignoreDestroyed = false);
 
         /// Returns the topics that match the specified name.
         ///

--- a/cpp/test/DataStorm/topicDestroy/Makefile.mk
+++ b/cpp/test/DataStorm/topicDestroy/Makefile.mk
@@ -1,0 +1,9 @@
+# Copyright (c) ZeroC, Inc.
+
+$(project)_programs        = reader writer
+$(project)_dependencies    = DataStorm Ice TestCommon
+
+$(project)_reader_sources  = Reader.cpp
+$(project)_writer_sources  = Writer.cpp
+
+tests += $(project)

--- a/cpp/test/DataStorm/topicDestroy/Reader.cpp
+++ b/cpp/test/DataStorm/topicDestroy/Reader.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+
+using namespace DataStorm;
+using namespace std;
+
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Reader::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    Topic<string, string> controlTopic(node, "control");
+    auto control = makeSingleKeyReader(controlTopic, "control");
+
+    {
+        Topic<string, string> topic(node, "topic");
+        auto reader = makeSingleKeyReader(topic, "key");
+        reader.waitForWriters(); // attach to the writer so the writer topic's _listenerCount is > 0
+
+        // Stay attached (keep 'reader' alive) until the writer reports it destroyed its topic while
+        // we were still attached. This guarantees the writer hits the destroy-while-attached path.
+        auto sample = control.getNextUnread();
+        test(sample.getValue() == "done");
+    } // 'reader' then 'topic' are destroyed here in the usual order
+}
+
+DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/topicDestroy/Reader.cpp
+++ b/cpp/test/DataStorm/topicDestroy/Reader.cpp
@@ -21,23 +21,19 @@ void ::Reader::run(int argc, char* argv[])
     Topic<string, string> controlTopic(node, "control");
     auto control = makeSingleKeyReader(controlTopic, "control");
 
-    // Used to tell the writer we have fully attached to its topic, so it only destroys the topic once the attach
-    // is observed on both sides. Otherwise the writer can destroy (and detach us) before our waitForWriters() below
-    // observes the writer, leaving this reader waiting for a writer that never comes back.
+    // Tells the writer this reader has fully attached, so it only destroys its topic once the attach is observed
+    // on both sides (otherwise the writer could detach us before our waitForWriters() below returns).
     Topic<string, string> syncTopic(node, "sync");
     auto sync = makeSingleKeyWriter(syncTopic, "sync");
 
-    {
-        Topic<string, string> topic(node, "topic");
-        auto reader = makeSingleKeyReader(topic, "key");
-        reader.waitForWriters(); // attach to the writer so the writer topic's _listenerCount is > 0
-        sync.add("ready");       // tell the writer our attach is complete
+    Topic<string, string> topic(node, "topic");
+    auto reader = makeSingleKeyReader(topic, "key");
+    reader.waitForWriters(); // attach to the writer
+    sync.add("ready");       // tell the writer our attach is complete
 
-        // Stay attached (keep 'reader' alive) until the writer reports it destroyed its topic while
-        // we were still attached. This guarantees the writer hits the destroy-while-attached path.
-        auto sample = control.getNextUnread();
-        test(sample.getValue() == "done");
-    } // 'reader' then 'topic' are destroyed here in the usual order
+    // Stay attached until the writer reports it destroyed its topic while we were still attached.
+    auto sample = control.getNextUnread();
+    test(sample.getValue() == "done");
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/topicDestroy/Reader.cpp
+++ b/cpp/test/DataStorm/topicDestroy/Reader.cpp
@@ -21,10 +21,17 @@ void ::Reader::run(int argc, char* argv[])
     Topic<string, string> controlTopic(node, "control");
     auto control = makeSingleKeyReader(controlTopic, "control");
 
+    // Used to tell the writer we have fully attached to its topic, so it only destroys the topic once the attach
+    // is observed on both sides. Otherwise the writer can destroy (and detach us) before our waitForWriters() below
+    // observes the writer, leaving this reader waiting for a writer that never comes back.
+    Topic<string, string> syncTopic(node, "sync");
+    auto sync = makeSingleKeyWriter(syncTopic, "sync");
+
     {
         Topic<string, string> topic(node, "topic");
         auto reader = makeSingleKeyReader(topic, "key");
         reader.waitForWriters(); // attach to the writer so the writer topic's _listenerCount is > 0
+        sync.add("ready");       // tell the writer our attach is complete
 
         // Stay attached (keep 'reader' alive) until the writer reports it destroyed its topic while
         // we were still attached. This guarantees the writer hits the destroy-while-attached path.

--- a/cpp/test/DataStorm/topicDestroy/Writer.cpp
+++ b/cpp/test/DataStorm/topicDestroy/Writer.cpp
@@ -20,8 +20,8 @@ void ::Writer::run(int argc, char* argv[])
 {
     Node node(argc, argv);
 
-    // A long-lived control topic (reversed roles) used to rendezvous with the reader. It has an
-    // idiomatic lifetime, so it is unaffected by the topic destroyed mid-test below.
+    // A long-lived control topic (reversed roles) used to rendezvous with the reader; it outlives the test and
+    // is unaffected by the topic destroyed mid-test below.
     Topic<string, string> controlTopic(node, "control");
     auto control = makeSingleKeyWriter(controlTopic, "control");
 
@@ -31,21 +31,17 @@ void ::Writer::run(int argc, char* argv[])
 
     cout << "testing topic destroyed while a writer is still attached to a peer... " << flush;
     {
-        // Invert the usual destruction order: the writer element outlives its Topic handle. The
-        // Topic is destroyed (inner scope) while 'writer' remains alive and still attached to the
-        // reader. Before this fix (issue #5469) TopicI::destroy()'s disconnect went through
-        // SessionI::runWithTopic, whose isDestroyed gate is always true on that path, so the
-        // listener was never detached and TopicI::_listenerCount was left stale, tripping
-        // assert(_listenerCount == 0) in TopicI::disconnect on debug builds.
+        // Destroy the topic while its writer element is still alive and attached to the reader: 'writer'
+        // outlives its Topic handle, so the Topic is destroyed (inner scope) before 'writer', inverting the
+        // usual destruction order.
         optional<SingleKeyWriter<string, string>> writer;
         {
             Topic<string, string> topic(node, "topic");
             writer.emplace(makeSingleKeyWriter(topic, "key"));
-            writer->waitForReaders(); // the reader has attached: the topic's _listenerCount is > 0
+            writer->waitForReaders(); // the reader has attached
 
-            // Wait until the reader confirms its own attach completed, so the destroy below truly happens while
-            // the reader is still attached (i.e. the reader's waitForWriters() has already returned, and won't be
-            // left waiting for a writer we detached).
+            // Wait until the reader confirms its attach completed, so the destroy below happens while the
+            // reader is still attached.
             test(sync.getNextUnread().getValue() == "ready");
 
             control.waitForReaders(); // the control session is established

--- a/cpp/test/DataStorm/topicDestroy/Writer.cpp
+++ b/cpp/test/DataStorm/topicDestroy/Writer.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+
+#include <optional>
+
+using namespace DataStorm;
+using namespace std;
+
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Writer::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    // A long-lived control topic (reversed roles) used to rendezvous with the reader. It has an
+    // idiomatic lifetime, so it is unaffected by the topic destroyed mid-test below.
+    Topic<string, string> controlTopic(node, "control");
+    auto control = makeSingleKeyWriter(controlTopic, "control");
+
+    cout << "testing topic destroyed while a writer is still attached to a peer... " << flush;
+    {
+        // Invert the usual destruction order: the writer element outlives its Topic handle. The
+        // Topic is destroyed (inner scope) while 'writer' remains alive and still attached to the
+        // reader. Before this fix (issue #5469) TopicI::destroy()'s disconnect went through
+        // SessionI::runWithTopic, whose isDestroyed gate is always true on that path, so the
+        // listener was never detached and TopicI::_listenerCount was left stale, tripping
+        // assert(_listenerCount == 0) in TopicI::disconnect on debug builds.
+        optional<SingleKeyWriter<string, string>> writer;
+        {
+            Topic<string, string> topic(node, "topic");
+            writer.emplace(makeSingleKeyWriter(topic, "key"));
+            writer->waitForReaders(); // the reader has attached: the topic's _listenerCount is > 0
+            control.waitForReaders(); // the control session is established
+        } // 'topic' is destroyed here while 'writer' is still alive and attached to the reader
+    } // 'writer' is destroyed here, detaching from its already-destroyed topic
+    cout << "ok" << endl;
+
+    // Tell the reader the destroy completed, then keep the session up until the reader is done.
+    control.add("done");
+    control.waitForNoReaders();
+}
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/topicDestroy/Writer.cpp
+++ b/cpp/test/DataStorm/topicDestroy/Writer.cpp
@@ -25,6 +25,10 @@ void ::Writer::run(int argc, char* argv[])
     Topic<string, string> controlTopic(node, "control");
     auto control = makeSingleKeyWriter(controlTopic, "control");
 
+    // Reverse-direction topic the reader uses to confirm it has fully attached to our topic.
+    Topic<string, string> syncTopic(node, "sync");
+    auto sync = makeSingleKeyReader(syncTopic, "sync");
+
     cout << "testing topic destroyed while a writer is still attached to a peer... " << flush;
     {
         // Invert the usual destruction order: the writer element outlives its Topic handle. The
@@ -38,6 +42,12 @@ void ::Writer::run(int argc, char* argv[])
             Topic<string, string> topic(node, "topic");
             writer.emplace(makeSingleKeyWriter(topic, "key"));
             writer->waitForReaders(); // the reader has attached: the topic's _listenerCount is > 0
+
+            // Wait until the reader confirms its own attach completed, so the destroy below truly happens while
+            // the reader is still attached (i.e. the reader's waitForWriters() has already returned, and won't be
+            // left waiting for a writer we detached).
+            test(sync.getNextUnread().getValue() == "ready");
+
             control.waitForReaders(); // the control session is established
         } // 'topic' is destroyed here while 'writer' is still alive and attached to the reader
     } // 'writer' is destroyed here, detaching from its already-destroyed topic

--- a/cpp/test/DataStorm/topicDestroy/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/topicDestroy/msbuild/reader/reader.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{F5E083EF-0245-4635-AE81-76D6348B7399}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/topicDestroy/msbuild/reader/reader.vcxproj.filters
+++ b/cpp/test/DataStorm/topicDestroy/msbuild/reader/reader.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/topicDestroy/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/topicDestroy/msbuild/writer/writer.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{64CB58A0-7D98-4E88-B7A3-472308543A09}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/topicDestroy/msbuild/writer/writer.vcxproj.filters
+++ b/cpp/test/DataStorm/topicDestroy/msbuild/writer/writer.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/topicDestroy/test.py
+++ b/cpp/test/DataStorm/topicDestroy/test.py
@@ -1,0 +1,15 @@
+# Copyright (c) ZeroC, Inc.
+
+from DataStormUtil import Reader, Writer
+from Util import ClientServerTestCase, TestSuite
+
+traceProps = {
+    "DataStorm.Trace.Topic": 1,
+    "DataStorm.Trace.Session": 3,
+    "DataStorm.Trace.Data": 2,
+}
+
+TestSuite(
+    __file__,
+    [ClientServerTestCase(name="Writer/Reader", client=Writer(), server=Reader(), traceProps=traceProps)],
+)


### PR DESCRIPTION
SessionI::disconnect (called from TopicI::destroy) routed through runWithTopic,
whose isDestroyed gate is always true on this path, so the listener detachment
(unsubscribe -> detachKey/detachFilter) was skipped and TopicI::_listenerCount
was left stale, tripping a debug assert when a topic is destroyed while
readers/writers remain attached to a peer. Add an ignoreDestroyed flag to
runWithTopic, used only by the destroy path, so the listeners are detached.

Fixes #5469
