### PR TITLE
Flush the DataStorm callback executor on session teardown

### DIFF
--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -810,6 +810,14 @@ SessionI::destroyImpl(const exception_ptr& ex)
         _topics.clear();
     }
 
+    // Deliver any disconnect notifications queued during teardown. The timer and AMI teardown paths can detach
+    // topics (queuing the user's onConnected* disconnect callbacks) and clear _session before destroyImpl, and
+    // unlike the dispatch and connection-close paths they have no later flush, so without this the notifications
+    // could sit in the queue indefinitely. Run it unconditionally (outside the _session check) so it is not skipped
+    // when _session was already cleared. flush() only signals the callback-executor thread; it does not run callbacks
+    // inline, so it is safe to call under _mutex.
+    _instance->getCallbackExecutor()->flush();
+
     try
     {
         _instance->getObjectAdapter()->remove(_proxy->ice_getIdentity());

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -810,12 +810,9 @@ SessionI::destroyImpl(const exception_ptr& ex)
         _topics.clear();
     }
 
-    // Deliver any disconnect notifications queued during teardown. The timer and AMI teardown paths can detach
-    // topics (queuing the user's onConnected* disconnect callbacks) and clear _session before destroyImpl, and
-    // unlike the dispatch and connection-close paths they have no later flush, so without this the notifications
-    // could sit in the queue indefinitely. Run it unconditionally (outside the _session check) so it is not skipped
-    // when _session was already cleared. flush() only signals the callback-executor thread; it does not run callbacks
-    // inline, so it is safe to call under _mutex.
+    // Deliver disconnect notifications queued while detaching topics above. The timer and AMI teardown paths have
+    // no later flush() like the dispatch and connection-close paths, so without this they could sit in the queue
+    // indefinitely. flush() only signals the executor thread (no inline callbacks), so it's safe under _mutex.
     _instance->getCallbackExecutor()->flush();
 
     try


### PR DESCRIPTION
CallbackExecutor::queue defaults to flush=false, and queued callbacks run only
when something later calls flush() (after a servant dispatch or in
ConnectionManager::remove). The retry-timer and AMI teardown paths reach
SessionI::destroyImpl, which queues the user disconnect callbacks during the
topic-detach loop on threads with no subsequent flush, so the notifications
could sit in the queue indefinitely. Flush the executor at the end of
destroyImpl so disconnect notifications are delivered promptly.

Fixes #5472
