### PR TITLE
Track last ids for DataStorm filter subscriptions

### DIFF
--- a/changelog.d/datastorm/5471-datastorm-filter-lastid.md
+++ b/changelog.d/datastorm/5471-datastorm-filter-lastid.md
@@ -1,0 +1,3 @@
+- Fixed a bug in DataStorm where a filtered or any-key reader could receive duplicate samples after a session
+  reconnect: the writer re-sent its entire retained history instead of resuming after the samples the reader had
+  already received.

--- a/changelog.d/datastorm/5471-datastorm-filter-lastid.md
+++ b/changelog.d/datastorm/5471-datastorm-filter-lastid.md
@@ -1,3 +1,3 @@
-- Fixed a bug in DataStorm where a filtered or any-key reader could receive duplicate samples after a session
-  reconnect: the writer re-sent its entire retained history instead of resuming after the samples the reader had
-  already received.
+- Fixed a bug in DataStorm where a reader connected to an any-key (filtered) writer could receive duplicate
+  samples after a session reconnect: the writer re-sent its entire retained history instead of resuming after
+  the samples the reader had already received.

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1120,13 +1120,13 @@ SessionI::getLastIds(int64_t topicId, int64_t keyOrFilterId, const std::shared_p
             // after a reconnect, delivering duplicate samples. We iterate all filter subscriptions rather than the
             // single keyOrFilterId entry because multiple any-key writers share a filter id but have distinct
             // element ids.
-            for (auto& [eid, elementSubscribers] : subscriber.getAll())
+            for (auto& [elementId, elementSubscribers] : subscriber.getAll())
             {
-                if (eid < 0)
+                if (elementId < 0)
                 {
                     if (auto* s = elementSubscribers.getSubscriber(element))
                     {
-                        lastIds.emplace(-eid, s->lastId);
+                        lastIds.emplace(-elementId, s->lastId);
                     }
                 }
             }

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1113,13 +1113,11 @@ SessionI::getLastIds(int64_t topicId, int64_t keyOrFilterId, const std::shared_p
         TopicSubscriber& subscriber = p->second.getSubscriber(element->getTopic());
         if (keyOrFilterId < 0)
         {
-            // Filter (negative-id) subscriptions are not recorded in subscriber.keys (only key subscriptions are),
-            // so report the lastId for each of this element's filter subscriptions directly from the element
-            // subscribers, keyed by the remote writer's positive element id (the id the consumer matches against in
-            // DataElementI::attach). Without this the dict stays empty and the peer re-sends its whole retained queue
-            // after a reconnect, delivering duplicate samples. We iterate all filter subscriptions rather than the
-            // single keyOrFilterId entry because multiple any-key writers share a filter id but have distinct
-            // element ids.
+            // Filter subscription: report this element's lastId for each remote filter element it's subscribed to,
+            // keyed by the element's positive id (`-elementId`, the id the writer matches in DataElementI::attach).
+            // Unlike keys, filter subscriptions aren't indexed by id, so scan all subscriptions and pick the filter
+            // ones (negative element id). The value of `keyOrFilterId` isn't used to select them: a single filter
+            // can match multiple remote writer elements with distinct element ids, so report them all.
             for (auto& [elementId, elementSubscribers] : subscriber.getAll())
             {
                 if (elementId < 0)
@@ -1133,6 +1131,8 @@ SessionI::getLastIds(int64_t topicId, int64_t keyOrFilterId, const std::shared_p
         }
         else
         {
+            // Key subscription: report this element's lastId for each remote element it's subscribed to under this
+            // key. Key subscriptions are indexed by remote key id, so look the key up directly.
             for (const auto& [elementId, _] : subscriber.keys[keyOrFilterId].second)
             {
                 lastIds.emplace(elementId, subscriber.get(elementId)->getSubscriber(element)->lastId);

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1111,9 +1111,31 @@ SessionI::getLastIds(int64_t topicId, int64_t keyId, const std::shared_ptr<DataE
     if (p != _topics.end())
     {
         TopicSubscriber& subscriber = p->second.getSubscriber(element->getTopic());
-        for (const auto& [elementId, _] : subscriber.keys[keyId].second)
+        if (keyId < 0)
         {
-            lastIds.emplace(elementId, subscriber.get(elementId)->getSubscriber(element)->lastId);
+            // Filter (negative-id) subscriptions are not recorded in subscriber.keys (only key subscriptions are),
+            // so report the lastId for each of this element's filter subscriptions directly from the element
+            // subscribers, keyed by the remote writer's positive element id (the id the consumer matches against in
+            // DataElementI::attach). Without this the dict stays empty and the peer re-sends its whole retained queue
+            // after a reconnect, delivering duplicate samples. We iterate all filter subscriptions rather than the
+            // single keyId entry because multiple any-key writers share a filter id but have distinct element ids.
+            for (auto& [eid, elementSubscribers] : subscriber.getAll())
+            {
+                if (eid < 0)
+                {
+                    if (auto* s = elementSubscribers.getSubscriber(element))
+                    {
+                        lastIds.emplace(-eid, s->lastId);
+                    }
+                }
+            }
+        }
+        else
+        {
+            for (const auto& [elementId, _] : subscriber.keys[keyId].second)
+            {
+                lastIds.emplace(elementId, subscriber.get(elementId)->getSubscriber(element)->lastId);
+            }
         }
     }
     return lastIds;

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1187,7 +1187,10 @@ SessionI::subscriberInitialized(
         auto keyFactory = element->getTopic()->getKeyFactory();
         for (const auto& sample : samples)
         {
-            assert((!key && !sample.keyValue.empty()) || key == subscriber.keys[sample.keyId].first);
+            // An any-key writer marshals the key inline (keyId 0, keyValue set), as the live data path in s()
+            // handles; accept an inline-key sample for a key subscription too, rather than requiring keyId to map
+            // to the subscription key.
+            assert(!sample.keyValue.empty() || key == subscriber.keys[sample.keyId].first);
 
             samplesI.push_back(sampleFactory->create(
                 _id,

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1104,21 +1104,22 @@ SessionI::disconnectFromFilter(int64_t topicId, int64_t filterId, const std::sha
 }
 
 LongLongDict
-SessionI::getLastIds(int64_t topicId, int64_t keyId, const std::shared_ptr<DataElementI>& element)
+SessionI::getLastIds(int64_t topicId, int64_t keyOrFilterId, const std::shared_ptr<DataElementI>& element)
 {
     LongLongDict lastIds;
     auto p = _topics.find(topicId);
     if (p != _topics.end())
     {
         TopicSubscriber& subscriber = p->second.getSubscriber(element->getTopic());
-        if (keyId < 0)
+        if (keyOrFilterId < 0)
         {
             // Filter (negative-id) subscriptions are not recorded in subscriber.keys (only key subscriptions are),
             // so report the lastId for each of this element's filter subscriptions directly from the element
             // subscribers, keyed by the remote writer's positive element id (the id the consumer matches against in
             // DataElementI::attach). Without this the dict stays empty and the peer re-sends its whole retained queue
             // after a reconnect, delivering duplicate samples. We iterate all filter subscriptions rather than the
-            // single keyId entry because multiple any-key writers share a filter id but have distinct element ids.
+            // single keyOrFilterId entry because multiple any-key writers share a filter id but have distinct
+            // element ids.
             for (auto& [eid, elementSubscribers] : subscriber.getAll())
             {
                 if (eid < 0)
@@ -1132,7 +1133,7 @@ SessionI::getLastIds(int64_t topicId, int64_t keyId, const std::shared_ptr<DataE
         }
         else
         {
-            for (const auto& [elementId, _] : subscriber.keys[keyId].second)
+            for (const auto& [elementId, _] : subscriber.keys[keyOrFilterId].second)
             {
                 lastIds.emplace(elementId, subscriber.get(elementId)->getSubscriber(element)->lastId);
             }

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -330,15 +330,16 @@ namespace DataStormI
         void unsubscribeFromFilter(std::int64_t, std::int64_t, const std::shared_ptr<DataElementI>&);
         void disconnectFromFilter(std::int64_t, std::int64_t, const std::shared_ptr<DataElementI>&);
 
-        /// Retrieves a map of the last sample IDs read by a data element for a specified topic and key.
+        /// Retrieves a map of the last sample IDs read by a data element for a specified topic and key or filter.
         ///
         /// @param topic The unique identifier of the topic.
-        /// @param key The unique identifier of the ke.
+        /// @param keyOrFilterId The id of the remote key or filter being attached: a key id when positive, or the
+        /// negated filter id when negative.
         /// @param element The data element for which the last sample IDs are retrieved.
         /// @return A map where the key represents the remote element ID, and the value represents the last sample ID
         /// read by the specified data element.
         [[nodiscard]] DataStormContract::LongLongDict
-        getLastIds(std::int64_t topic, std::int64_t key, const std::shared_ptr<DataElementI>& element);
+        getLastIds(std::int64_t topic, std::int64_t keyOrFilterId, const std::shared_ptr<DataElementI>& element);
 
         [[nodiscard]] std::vector<std::shared_ptr<Sample>> subscriberInitialized(
             std::int64_t,

--- a/cpp/test/DataStorm/reliability/Reader.cpp
+++ b/cpp/test/DataStorm/reliability/Reader.cpp
@@ -123,6 +123,49 @@ void ::Reader::run(int argc, char* argv[])
         writerB.update(0);
         writerB.waitForNoReaders();
     }
+
+    {
+        Topic<string, int> topic(node, "anyKeyReconnect");
+        Topic<string, int> barrier(node, "anyKeyReconnectBarrier");
+        auto reader = makeAnyKeyReader(topic, "", config);
+        auto writerB = makeSingleKeyWriter(barrier, "reader_barrier");
+
+        string session;
+        for (int i = 0; i < 100; ++i)
+        {
+            auto sample = reader.getNextUnread();
+            if (sample.getValue() != i)
+            {
+                cerr << "unexpected sample: " << sample.getValue() << " expected:" << i << endl;
+                test(false);
+            }
+            session = sample.getSession();
+        }
+
+        // Force a session reconnect while the writer retains its history.
+        auto connection = node.getSessionConnection(session);
+        test(connection);
+        connection->close().get();
+
+        // Tell the writer the connection closed (processed after reconnect); it then sends the second batch.
+        writerB.waitForReaders();
+        writerB.update(0);
+
+        // After the reconnect the any-key reader must continue from 100. With #5471 it re-receives the retained
+        // 0..99 first, because the filter subscription reported no lastIds and the writer re-sent its whole queue.
+        for (int i = 0; i < 100; ++i)
+        {
+            auto sample = reader.getNextUnread();
+            if (sample.getValue() != i + 100)
+            {
+                cerr << "duplicate or rewound sample: " << sample.getValue() << " expected:" << (i + 100) << endl;
+                test(false);
+            }
+        }
+
+        writerB.waitForReaders();
+        writerB.update(0);
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/reliability/Reader.cpp
+++ b/cpp/test/DataStorm/reliability/Reader.cpp
@@ -127,7 +127,9 @@ void ::Reader::run(int argc, char* argv[])
     {
         Topic<string, int> topic(node, "anyKeyReconnect");
         Topic<string, int> barrier(node, "anyKeyReconnectBarrier");
-        auto reader = makeAnyKeyReader(topic, "", config);
+        // A plain single-key reader: the bug is triggered by the *writer* being any-key (filtered), so any
+        // reader connected to it is affected, regardless of its own kind.
+        auto reader = makeSingleKeyReader(topic, "k", "", config);
         auto writerB = makeSingleKeyWriter(barrier, "reader_barrier");
 
         string session;
@@ -151,8 +153,9 @@ void ::Reader::run(int argc, char* argv[])
         writerB.waitForReaders();
         writerB.update(0);
 
-        // After the reconnect the any-key reader must continue from 100. With #5471 it re-receives the retained
-        // 0..99 first, because the filter subscription reported no lastIds and the writer re-sent its whole queue.
+        // After the reconnect the reader must continue from 100. Without the fix it re-receives the retained
+        // 0..99 first, because the subscription to the any-key writer reported no lastIds and the writer re-sent
+        // its whole retained queue.
         for (int i = 0; i < 100; ++i)
         {
             auto sample = reader.getNextUnread();

--- a/cpp/test/DataStorm/reliability/Reader.cpp
+++ b/cpp/test/DataStorm/reliability/Reader.cpp
@@ -127,8 +127,8 @@ void ::Reader::run(int argc, char* argv[])
     {
         Topic<string, int> topic(node, "anyKeyReconnect");
         Topic<string, int> barrier(node, "anyKeyReconnectBarrier");
-        // A plain single-key reader: the bug is triggered by the *writer* being any-key (filtered), so any
-        // reader connected to it is affected, regardless of its own kind.
+        // A plain single-key reader against the any-key (filtered) writer: reconnect resumption is driven by the
+        // writer being filtered, so a reader of any kind connected to it must resume rather than re-read history.
         auto reader = makeSingleKeyReader(topic, "k", "", config);
         auto writerB = makeSingleKeyWriter(barrier, "reader_barrier");
 
@@ -153,9 +153,8 @@ void ::Reader::run(int argc, char* argv[])
         writerB.waitForReaders();
         writerB.update(0);
 
-        // After the reconnect the reader must continue from 100. Without the fix it re-receives the retained
-        // 0..99 first, because the subscription to the any-key writer reported no lastIds and the writer re-sent
-        // its whole retained queue.
+        // After the reconnect the reader must continue from 100: the writer resumes from the reader's last received
+        // sample rather than re-sending its whole retained queue (which would re-deliver 0..99).
         for (int i = 0; i < 100; ++i)
         {
             auto sample = reader.getNextUnread();

--- a/cpp/test/DataStorm/reliability/Writer.cpp
+++ b/cpp/test/DataStorm/reliability/Writer.cpp
@@ -90,7 +90,7 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
-    cout << "testing any-key reader reconnect without duplicate samples... " << flush;
+    cout << "testing reconnect with an any-key writer without duplicate samples... " << flush;
     {
         Topic<string, int> topic(node, "anyKeyReconnect");
         Topic<string, int> barrier(node, "anyKeyReconnectBarrier");

--- a/cpp/test/DataStorm/reliability/Writer.cpp
+++ b/cpp/test/DataStorm/reliability/Writer.cpp
@@ -89,6 +89,31 @@ void ::Writer::run(int argc, char* argv[])
         sample = readerB.getNextUnread();
     }
     cout << "ok" << endl;
+
+    cout << "testing any-key reader reconnect without duplicate samples... " << flush;
+    {
+        Topic<string, int> topic(node, "anyKeyReconnect");
+        Topic<string, int> barrier(node, "anyKeyReconnectBarrier");
+        auto writer = makeAnyKeyWriter(topic, "", config);
+        writer.waitForReaders();
+        for (int i = 0; i < 100; ++i)
+        {
+            writer.update("k", i);
+        }
+
+        // Wait for the reader to signal it read the batch and closed the connection.
+        auto readerB = makeSingleKeyReader(barrier, "reader_barrier");
+        auto sample = readerB.getNextUnread();
+
+        // The session has been reestablished; send a second batch. The reader must continue from 100, not
+        // re-receive the retained 0..99.
+        for (int i = 0; i < 100; ++i)
+        {
+            writer.update("k", i + 100);
+        }
+        sample = readerB.getNextUnread();
+    }
+    cout << "ok" << endl;
 }
 
 DEFINE_TEST(::Writer)


### PR DESCRIPTION
`getLastIds` returned an empty dict for a subscription to a filter (any-key/filtered) writer, because only
subscriptions to key writers are recorded in `subscriber.keys`. As a result, after a session reconnect the writer
was asked for samples from `lastId` 0 and re-sent its entire retained queue, delivering duplicate samples to the
connected reader (and tripping a debug assert).

The trigger is the writer being any-key/filtered: any reader connected to such a writer is affected, regardless of
whether the reader itself is a key or filtered reader (the reader's subscription to a filter writer element is not
indexed in `subscriber.keys`).

The fix reports the `lastId` for each subscription to a filter writer element directly from the element
subscribers, keyed by the writer's element id (the id the writer matches in `DataElementI::attach`). It iterates
all such subscriptions rather than looking one up because filters have no per-id index (unlike keys), and a single
filter can match multiple writer elements with distinct element ids.

Adds a reconnect regression test to the DataStorm/reliability test.

Fixes #5471
