### PR TITLE
Fix MATLAB ice_getConnectionAsync to pass the communicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ might need to be aware of.
 - Fixed the unmarshaling of unknown optional values with tags greater than or equal to 30. These no
   longer desynchronize the input stream causing spurious `MarshalException`.
 
+- Fixed the `ice_getConnectionAsync` proxy method. Retrieving the result of the returned future failed on every
+  successful call because the `Ice.Connection` was constructed without its communicator.
+
 ### Python Changes
 
 - Fixed Ice for Python to reliably abort request marshaling when an invalid value is supplied for a sequence

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -1061,7 +1061,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
                 con = libpointer('voidPtr', 0); % Output param
                 f.iceCall('fetch', con);
                 assert(~isNull(con));
-                varargout{1} = Ice.Connection(con);
+                varargout{1} = Ice.Connection(con, obj.communicator);
             end
             r = Ice.Future(future, 'ice_getConnection', 1, 'Ice_GetConnectionFuture', @fetch);
         end

--- a/matlab/test/Ice/ami/AllTests.m
+++ b/matlab/test/Ice/ami/AllTests.m
@@ -154,6 +154,13 @@ classdef AllTests
             fprintf('ok\n');
 
             if ~isempty(p.ice_getConnection())
+                fprintf('testing ice_getConnectionAsync... ');
+                con = p.ice_getConnectionAsync().fetchOutputs();
+                assert(isa(con, 'Ice.Connection'));
+                proxy = con.createProxy(p.ice_getIdentity());
+                assert(strcmp(proxy.ice_getIdentity().name, p.ice_getIdentity().name));
+                fprintf('ok\n');
+
                 fprintf('testing connection close... ');
 
                 %


### PR DESCRIPTION
Fixes #5548.

### Problem
The `fetch` closure in `ObjectPrx.ice_getConnectionAsync` built its result with `Ice.Connection(con)` (one argument), but `Ice.Connection`'s constructor is `Connection(impl, communicator)` and reads `communicator` unconditionally. Every successful `fetchOutputs()` therefore failed with *"Not enough input arguments"*, making the asynchronous variant of `ice_getConnection` unusable. (Even with a `nargin` guard the result would be a communicator-less `Connection`, which breaks `Connection.createProxy`.)

### Fix
Pass `obj.communicator`, matching the synchronous siblings `ice_getConnection` and `ice_getCachedConnection`.

### Testing
Added a regression test to the `Ice/ami` suite that calls `ice_getConnectionAsync().fetchOutputs()` and then `con.createProxy(...)` (which needs the communicator). Verified locally with MATLAB R2025b against a Python server:
- before the fix: the `ami` suite fails at this test
- after the fix: the full `ami` suite passes

Fix also reviewed with codex locally.
