### PR TITLE
Fix MATLAB InputStream.skipOptionals tag-30 sentinel detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ might need to be aware of.
 - Fixed `ice_getCachedConnection` to return an empty `Ice.Connection` array, rather than an empty
   `double` array, when the proxy has no cached connection.
 
+- Fixed the unmarshaling of optional values. An unread optional value with a tag greater than or equal to 30 no
+  longer desynchronizes the input stream and produces a spurious `MarshalException`.
+
 ### Python Changes
 
 - Fixed Ice for Python to reliably abort request marshaling when an invalid value is supplied for a sequence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@ might need to be aware of.
 - Fixed `ice_getCachedConnection` to return an empty `Ice.Connection` array, rather than an empty
   `double` array, when the proxy has no cached connection.
 
-- Fixed the unmarshaling of optional values. An unread optional value with a tag greater than or equal to 30 no
-  longer desynchronizes the input stream and produces a spurious `MarshalException`.
+- Fixed the unmarshaling of unknown optional values with tags greater than or equal to 30. These no
+  longer desynchronize the input stream causing spurious `MarshalException`.
 
 ### Python Changes
 

--- a/matlab/lib/+Ice/InputStream.m
+++ b/matlab/lib/+Ice/InputStream.m
@@ -613,7 +613,7 @@ classdef InputStream < handle
                 end
 
                 format = bitand(v, uint8(7)); % Read first 3 bits.
-                if bitshift(v, 3) == uint8(30)
+                if bitshift(v, -3) == uint8(30) % The remaining bits encode the tag; 30 is the sentinel.
                     obj.skipSize();
                 end
                 obj.skipOptional(format);

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -773,13 +773,9 @@ classdef AllTests
         end
 
         function skipUnreadOptionals(communicator)
-            % Regression test for issue #5549: InputStream.skipOptionals must recognize the
-            % tag-30 sentinel with a right shift. We marshal an encapsulation that holds one
-            % low-tag optional plus several optionals with tag >= 30 (each encoded as the
-            % tag-30 sentinel followed by a size), read back only the low-tag optional, and
-            % rely on endEncapsulation() -> skipOptionals() to skip the rest. With the former
-            % left-shift bug the sentinel was never detected, the size byte(s) were left in the
-            % stream, and endEncapsulation() failed with a buffer-size MarshalException.
+            % Marshal an encapsulation with one optional whose tag fits on a single byte,
+            % followed by several optionals with tags >= 30. Read back only the first optional, and let 
+            % `endEncapsulation() -> skipOptionals()` skip the rest to exercise detection of the tag-30 sentinel.
             encoding = Ice.EncodingVersion(1, 1);
 
             os = Ice.OutputStream(encoding);

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -7,6 +7,10 @@ classdef AllTests
 
             communicator = helper.communicator();
 
+            fprintf('testing skipping of unread optionals with tag >= 30... ');
+            AllTests.skipUnreadOptionals(communicator);
+            fprintf('ok\n');
+
             ref = ['initial:', helper.getTestEndpoint()];
             initial = InitialPrx(communicator, ref);
 
@@ -766,6 +770,37 @@ classdef AllTests
             fprintf('ok\n');
 
             r = initial;
+        end
+
+        function skipUnreadOptionals(communicator)
+            % Regression test for issue #5549: InputStream.skipOptionals must recognize the
+            % tag-30 sentinel with a right shift. We marshal an encapsulation that holds one
+            % low-tag optional plus several optionals with tag >= 30 (each encoded as the
+            % tag-30 sentinel followed by a size), read back only the low-tag optional, and
+            % rely on endEncapsulation() -> skipOptionals() to skip the rest. With the former
+            % left-shift bug the sentinel was never detected, the size byte(s) were left in the
+            % stream, and endEncapsulation() failed with a buffer-size MarshalException.
+            encoding = Ice.EncodingVersion(1, 1);
+
+            os = Ice.OutputStream(encoding);
+            os.startEncapsulation(Ice.FormatType.SlicedFormat);
+            os.writeOptional(1, Ice.OptionalFormat.F4);     % low tag, read back below
+            os.writeInt(11111);
+            os.writeOptional(30, Ice.OptionalFormat.F8);    % first sentinel tag
+            os.writeLong(int64(123456789));
+            os.writeOptional(50, Ice.OptionalFormat.VSize); % size-prefixed value
+            os.writeString('a high-tag optional string');
+            os.writeOptional(300, Ice.OptionalFormat.F4);   % tag needs a multi-byte size
+            os.writeInt(22222);
+            os.endEncapsulation();
+            data = os.finished();
+
+            is = Ice.InputStream(communicator, encoding, data);
+            is.startEncapsulation();
+            assert(is.readOptional(1, Ice.OptionalFormat.F4), 'tag 1 should be present');
+            assert(is.readInt() == 11111, 'tag 1 value mismatch');
+            % Tags 30, 50 and 300 are left unread; endEncapsulation must skip them cleanly.
+            is.endEncapsulation();
         end
     end
 end

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -7,7 +7,7 @@ classdef AllTests
 
             communicator = helper.communicator();
 
-            fprintf('testing skipping of unread optionals with tag >= 30... ');
+            fprintf('testing skipping of unknown optionals with tag >= 30... ');
             AllTests.skipUnreadOptionals(communicator);
             fprintf('ok\n');
 

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -8,7 +8,7 @@ classdef AllTests
             communicator = helper.communicator();
 
             fprintf('testing skipping of unknown optionals with tag >= 30... ');
-            AllTests.skipUnreadOptionals(communicator);
+            AllTests.skipUnknownOptionals(communicator);
             fprintf('ok\n');
 
             ref = ['initial:', helper.getTestEndpoint()];
@@ -772,7 +772,7 @@ classdef AllTests
             r = initial;
         end
 
-        function skipUnreadOptionals(communicator)
+        function skipUnknownOptionals(communicator)
             % Marshal an encapsulation with one optional whose tag fits on a single byte,
             % followed by several optionals with tags >= 30. Read back only the first optional, and let 
             % `endEncapsulation() -> skipOptionals()` skip the rest to exercise detection of the tag-30 sentinel.


### PR DESCRIPTION
Fixes #5549.

### Problem
`InputStream.skipOptionals` detected the tag-30 sentinel with a **left** shift (`bitshift(v, 3)`). For a `uint8`, a left shift can never equal 30, so the branch was dead and the size byte(s) following an unread optional with tag ≥ 30 were never skipped. `skipOptionals` runs at the end of an encapsulation (and at the end of a 1.1 slice) to skip optionals the receiver did not read, so any valid message carrying an unread optional with a tag ≥ 30 would desynchronize the stream and raise a spurious `MarshalException`.

### Fix
Use a **right** shift (`bitshift(v, -3)`) to recover the tag, matching the sibling `readOptionalImpl` in the same file (and `OutputStream.writeOptionalImpl` on the write side).

### Testing
Added a self-contained regression test (`skipUnreadOptionals`) to the `Ice/optional` suite. It marshals an encapsulation with a low-tag optional plus several optionals with tag ≥ 30 (tag 30, tag 50, and tag 300 which needs a multi-byte size), reads back only the low-tag optional, and relies on `endEncapsulation()` → `skipOptionals()` to skip the rest. Verified locally with MATLAB R2025b:
- before the fix: the test fails with a buffer-size `MarshalException`
- after the fix: the full `Ice/optional` suite passes (compact and sliced formats)

Fix also reviewed with codex locally.
