### PR TITLE
Fix MATLAB ice_getCachedConnection to return a typed empty connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ might need to be aware of.
   - [C++ Changes](#c-changes)
   - [C# Changes](#c-changes-1)
   - [JavaScript Changes](#javascript-changes)
+  - [MATLAB Changes](#matlab-changes)
   - [Python Changes](#python-changes)
   - [Ruby Changes](#ruby-changes)
 
@@ -47,6 +48,11 @@ might need to be aware of.
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a
   `RangeError` instead of being silently ignored, matching the buffer-position behavior of the other language
   mappings.
+
+### MATLAB Changes
+
+- Fixed `ice_getCachedConnection` to return an empty `Ice.Connection` array, rather than an empty
+  `double` array, when the proxy has no cached connection.
 
 ### Python Changes
 

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -1081,7 +1081,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             v = libpointer('voidPtr');
             obj.iceCall('ice_getCachedConnection', v);
             if isNull(v)
-                r = [];
+                r = Ice.Connection.empty;
             else
                 r = Ice.Connection(v, obj.communicator);
             end

--- a/matlab/test/Ice/proxy/AllTests.m
+++ b/matlab/test/Ice/proxy/AllTests.m
@@ -21,6 +21,12 @@ classdef AllTests
             base = communicator.stringToProxy(ref);
             assert(~isempty(base));
 
+            % Issue #5554: a proxy with no cached connection returns a typed empty
+            % (Ice.Connection.empty), not a 0x0 double.
+            cachedConnection = base.ice_getCachedConnection();
+            assert(isa(cachedConnection, 'Ice.Connection'));
+            assert(isempty(cachedConnection));
+
             b1 = communicator.stringToProxy('test');
             assert(strcmp(b1.ice_getIdentity().name, 'test') && isempty(b1.ice_getIdentity().category) && ...
                    isempty(b1.ice_getAdapterId()) && isempty(b1.ice_getFacet()));

--- a/matlab/test/Ice/proxy/AllTests.m
+++ b/matlab/test/Ice/proxy/AllTests.m
@@ -21,8 +21,7 @@ classdef AllTests
             base = communicator.stringToProxy(ref);
             assert(~isempty(base));
 
-            % Issue #5554: a proxy with no cached connection returns a typed empty
-            % (Ice.Connection.empty), not a 0x0 double.
+            % Ensure a proxy with no cached connection returns an empty array of 'Ice.Connection', not doubles.
             cachedConnection = base.ice_getCachedConnection();
             assert(isa(cachedConnection, 'Ice.Connection'));
             assert(isempty(cachedConnection));


### PR DESCRIPTION
Fixes #5554.

### Problem
`ObjectPrx.ice_getCachedConnection` returned a bare `[]` (a `0x0 double`) when the proxy had no cached connection. This contradicts its documented contract (an empty array of `Ice.Connection`) and diverges from the synchronous sibling `ice_getConnection`, which returns `Ice.Connection.empty`. Callers relying on `isa` dispatch, `arguments`-block validation, or concatenation against `Ice.Connection` behave differently for a `double` empty.

### Fix
Return `Ice.Connection.empty`, matching `ice_getConnection`.

### Testing
Added an assertion to the `Ice/proxy` suite. Verified locally with MATLAB R2025b: the check fails before the fix (`isa` returns `double`) and passes after; the full `Ice/proxy` suite passes. Reviewed with codex.
