### PR TITLE
Fix MATLAB EncapsDecoder patch-map accounting on sparse slots

### DIFF
--- a/matlab/lib/+IceInternal/EncapsDecoder.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder.m
@@ -68,6 +68,13 @@ classdef (Hidden, Abstract) EncapsDecoder < handle
             r = obj.is.getCommunicator().getSliceLoader().newInstance(typeId);
         end
 
+        function r = hasPatchList(obj, index)
+            % True if patchMap holds an actual patch list at index. Cell arrays auto-extend with
+            % empty filler slots when a higher index is assigned, so an in-range index is not
+            % enough -- the slot must be non-empty.
+            r = index <= length(obj.patchMap) && ~isempty(obj.patchMap{index});
+        end
+
         function addPatchEntry(obj, index, cb)
             %assert(index > 0);
             %
@@ -87,12 +94,12 @@ classdef (Hidden, Abstract) EncapsDecoder < handle
             % the callback will be called when the instance is
             % unmarshaled.
             %
-            if index <= length(obj.patchMap)
+            if obj.hasPatchList(index)
                 pl = obj.patchMap{index};
             else
                 %
-                % We have no outstanding instances to be patched for this
-                % index, so make a new entry in the patch map.
+                % We have no outstanding instances to be patched for this index, so make a new
+                % entry in the patch map.
                 %
                 pl = {};
                 obj.patchMapLength = obj.patchMapLength + 1;
@@ -120,7 +127,7 @@ classdef (Hidden, Abstract) EncapsDecoder < handle
             %
             v.iceRead(obj.is);
 
-            if index <= length(obj.patchMap)
+            if obj.hasPatchList(index)
                 %
                 % Patch all instances now that the instance is unmarshaled.
                 %


### PR DESCRIPTION
Fixes #5550.

### Problem
`EncapsDecoder` tracks outstanding value-graph patches in `patchMap` (a cell array) with the counter `patchMapLength`. MATLAB cell arrays auto-extend with empty `[]` filler slots when a high index is assigned, and the two accounting sites treated those fillers inconsistently:
- `addPatchEntry` incremented the counter only when the index was beyond the array, so appending into a pre-existing filler slot added a patch without incrementing (undercount);
- `unmarshal` decremented for any in-range index, including filler slots that never held a patch (spurious decrement).

On value graphs with non-contiguous instance indices, `patchMapLength` could reach zero while patches were still outstanding — running `ice_postUnmarshal` before all members were patched and suppressing the missing-instance check.

### Fix
Count and decrement only on actual presence (`~isempty(patchMap{index})`), mirroring the entry-based `Map` accounting in the JavaScript mapping.

### Testing
The full `Ice/objects` suite (which exercises circular/forward value graphs in both compact and sliced formats) passes. A dedicated reproduction was not added: deterministically forcing the non-contiguous filler scenario requires precise control of internal wire-index assignment, which is disproportionate to a two-line fix. Reviewed with codex.
