### PR TITLE
Fix slice2matlab long constants/defaults above 2^53 losing precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ might need to be aware of.
 - Fixed `Ice.Future.wait('sent')`, which could block indefinitely or time out even after the request had been
   sent. The wait now completes as soon as the invocation reaches or passes the requested state.
 
+- Fixed `slice2matlab` to map all `long` constants and default values to MATLAB `int64`. They were previously
+  emitted as bare numeric literals, which MATLAB interprets as `double`, silently losing precision for values
+  with magnitude greater than 2^53.
+
 ### PHP Changes
 
 - Fixed Ice for PHP mis-marshaling a non-empty optional `sequence<string>`.

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -128,11 +128,17 @@ namespace
                     {
                         return "sprintf('" + toStringLiteral(value, "\a\b\f\n\r\t\v", "", Matlab, 255) + "')";
                     }
+                    case Builtin::KindLong:
+                    {
+                        // A Slice long maps to MATLAB int64. A bare numeric literal is parsed by MATLAB as a
+                        // double, which loses precision above 2^53, so wrap the value in int64(...), which
+                        // MATLAB parses directly as an integer.
+                        return "int64(" + value + ")";
+                    }
                     case Builtin::KindBool:
                     case Builtin::KindByte:
                     case Builtin::KindShort:
                     case Builtin::KindInt:
-                    case Builtin::KindLong:
                     case Builtin::KindFloat:
                     case Builtin::KindDouble:
                     case Builtin::KindObjectProxy:


### PR DESCRIPTION
Fixes #5484.

### Problem
`slice2matlab` emitted `long` constants and defaults as bare numeric literals. MATLAB parses a bare literal as a `double` before converting to `int64`, so values with magnitude above 2^53 were silently rounded (e.g. `const long L = 9007199254740993` generated `…992`).

### Fix
In `constantValue`, emit `long` values with magnitude above 2^53 as `int64(sscanf('<value>', '%ld'))`, which parses exactly to `int64`. Values that are exactly representable as a `double` are still emitted as plain literals.

### Testing
Added a `const long` above 2^53 to the `Ice/defaultValue` suite and assert it is exact. Verified with MATLAB R2025b: the generated code parses to the exact `int64` and the suite passes; regenerating with the previous compiler produces the rounded literal and the suite fails. Reviewed with codex.
