### PR TITLE
Fix out-of-bounds access in MATLAB MEX endpoint accessors

### DIFF
--- a/matlab/src/ObjectPrx.cpp
+++ b/matlab/src/ObjectPrx.cpp
@@ -417,7 +417,7 @@ extern "C"
         try
         {
             auto endpoints = restoreProxy(self)->ice_getEndpoints();
-            if (idx > endpoints.size())
+            if (idx >= endpoints.size())
             {
                 throw std::invalid_argument("index outside range");
             }
@@ -445,7 +445,7 @@ extern "C"
         try
         {
             vector<shared_ptr<Ice::Endpoint>>* v = reinterpret_cast<vector<shared_ptr<Ice::Endpoint>>*>(arr);
-            if (idx > v->size())
+            if (idx >= v->size())
             {
                 throw std::invalid_argument("index outside range");
             }


### PR DESCRIPTION
Fixes #5552.

### Problem
The MEX endpoint accessors `Ice_ObjectPrx_ice_getEndpoint` and `Ice_ObjectPrx_ice_setEndpoint` guarded their `std::vector` access with `idx > size` instead of `idx >= size`. The indices are 0-based (the MATLAB wrappers pass `i - 1`), so `idx == size` slipped past the check into an out-of-bounds element — an out-of-bounds `shared_ptr` read in the getter and an out-of-bounds `shared_ptr` write (heap corruption) in the setter.

### Fix
Use `idx >= size` in both accessors.

### Testing
The MEX extension builds cleanly. No runtime test was added: the stock MATLAB wrappers never pass `idx == size`, so the defect is latent (reachable only by a direct/custom MEX caller), and a meaningful test would be disproportionate to a two-character fix. Reviewed with codex.
