### PR TITLE
Fix memory leak in MATLAB MEX getMajorMinor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ might need to be aware of.
   emitted as bare numeric literals, which MATLAB interprets as `double`, silently losing precision for values
   with magnitude greater than 2^53.
 
+- Fixed a memory leak that occurred each time a proxy was marshaled, unmarshaled, or had its
+  encoding version set with `ice_encodingVersion`. Each of these operations leaked a small amount
+  of memory that accumulated over the lifetime of a MATLAB session.
+
 ### PHP Changes
 
 - Fixed Ice for PHP mis-marshaling a non-empty optional `sequence<string>`.

--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -27,20 +27,25 @@ namespace
 
     void getMajorMinor(mxArray* p, uint8_t& major, uint8_t& minor)
     {
+        // mxGetProperty returns a copy that the caller owns and must destroy.
         auto maj = mxGetProperty(p, 0, "major");
         assert(maj);
         if (!mxIsScalar(maj))
         {
+            mxDestroyArray(maj);
             throw std::invalid_argument("major is not a scalar");
         }
         major = static_cast<uint8_t>(mxGetScalar(maj));
+        mxDestroyArray(maj);
         auto min = mxGetProperty(p, 0, "minor");
         assert(min);
         if (!mxIsScalar(min))
         {
+            mxDestroyArray(min);
             throw std::invalid_argument("minor is not a scalar");
         }
         minor = static_cast<uint8_t>(mxGetScalar(min));
+        mxDestroyArray(min);
     }
 
     // This function converts the cell array input argument and returns a MATLAB string array.


### PR DESCRIPTION
Fixes #5553.

### Problem
`getMajorMinor` reads the `major` and `minor` properties with `mxGetProperty`, which returns a copy the caller owns, but never called `mxDestroyArray`. Both arrays leaked on every encoding/protocol-version conversion (`ice_encodingVersion`, opaque endpoint info, and every other path through `getMajorMinor`), accumulating over a long-lived MATLAB session.

### Fix
Destroy both copies on all paths, including the early-throw (non-scalar) paths.

### Testing
The MEX extension builds cleanly. No runtime test was added — a steady, small leak is not practical to assert in the test suite. Reviewed with codex.
