### PR TITLE
Fix MATLAB Ice.Future.wait('sent') hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ might need to be aware of.
 - Fixed the `ice_getConnectionAsync` proxy method. Retrieving the result of the returned future failed on every
   successful call because the `Ice.Connection` was constructed without its communicator.
 
+- Fixed `Ice.Future.wait('sent')`, which could block indefinitely or report a spurious timeout. The wait now
+  completes once the invocation reaches or passes the requested state, and the transition to the sent state
+  notifies waiters.
+
 ### Python Changes
 
 - Fixed Ice for Python to reliably abort request marshaling when an invalid value is supplied for a sequence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,8 @@ might need to be aware of.
 - Fixed the `ice_getConnectionAsync` proxy method. Retrieving the result of the returned future failed on every
   successful call because the `Ice.Connection` was constructed without its communicator.
 
-- Fixed `Ice.Future.wait('sent')`, which could block indefinitely or report a spurious timeout. The wait now
-  completes once the invocation reaches or passes the requested state, and the transition to the sent state
-  notifies waiters.
+- Fixed `Ice.Future.wait('sent')`, which could block indefinitely or time out even after the request had been
+  sent. The wait now completes as soon as the invocation reaches or passes the requested state.
 
 ### Python Changes
 

--- a/matlab/src/Future.cpp
+++ b/matlab/src/Future.cpp
@@ -23,14 +23,14 @@ IceMatlab::Future::waitForState(State state, double timeout)
     unique_lock<mutex> lock(_mutex);
     if (timeout < 0)
     {
-        _cond.wait(lock, [this, state] { return state == this->stateImpl(); });
+        _cond.wait(lock, [this, state] { return this->stateImpl() >= state; });
         return !_exception;
     }
     else
     {
         auto now = chrono::system_clock::now();
         auto stop = now + chrono::milliseconds(static_cast<long long>(timeout * 1000));
-        bool b = _cond.wait_until(lock, stop, [this, state] { return state == this->stateImpl(); });
+        bool b = _cond.wait_until(lock, stop, [this, state] { return this->stateImpl() >= state; });
         return b && !_exception;
     }
 }

--- a/matlab/src/ObjectPrx.cpp
+++ b/matlab/src/ObjectPrx.cpp
@@ -48,6 +48,7 @@ namespace
         if (_state == State::Running)
         {
             _state = _twoway ? State::Sent : State::Finished;
+            _cond.notify_all();
         }
     }
 

--- a/matlab/test/Ice/ami/AllTests.m
+++ b/matlab/test/Ice/ami/AllTests.m
@@ -67,6 +67,15 @@ classdef AllTests
 
             fprintf('ok\n');
 
+            fprintf('testing wait(''sent'')... ');
+            % wait('sent') must return once the request has reached or passed the 'sent' state.
+            f = p.opAsync();
+            assert(f.wait('sent', 10));
+            assert(f.wait('finished', 10)); % advance to 'finished' without consuming the result
+            assert(f.wait('sent', 10));     % still returns even though the future is already 'finished'
+            f.fetchOutputs();
+            fprintf('ok\n');
+
             fprintf('testing local exceptions... ');
 
             indirect = p.ice_adapterId('dummy');


### PR DESCRIPTION
Fixes #5551.

### Problem
Two compounding defects in the `Ice.Future` wait machinery:
1. `waitForState` required exact state equality (`state == stateImpl()`). An invocation advances monotonically `Running → Sent → Finished`. If `wait('sent')` was called after the future had already reached `Finished`, the predicate `Sent == Finished` could never become true and the wait (default infinite timeout) blocked forever.
2. `InvocationFuture::sent()` changed the state but did not call `_cond.notify_all()` (the completion and exception paths do), so a thread already blocked in `wait('sent')` was not woken when the request was actually sent.

### Fix
- Wait on a reached-or-later state: `stateImpl() >= state` (the `State` enum is ordered `Running < Sent < Finished`), in both the timed and untimed waits.
- Add `_cond.notify_all()` to the `sent()` transition.

### Testing
Added a regression test to the `Ice/ami` suite that waits for `sent`, advances the future to `finished` without consuming the result (so the native future is still live), then asserts `wait('sent')` still returns. Verified with MATLAB R2025b: the `ami` suite fails against a mex built from the old code (the `wait('sent')` assertion times out) and passes after the fix. Reviewed with codex.
