### PR TITLE
Fix Java PerThreadImplicitContext.remove returning null instead of empty string

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ImplicitContextI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ImplicitContextI.java
@@ -205,7 +205,7 @@ abstract class ImplicitContextI implements ImplicitContext {
             Map<String, String> threadContext = _map.get(Thread.currentThread());
 
             if (threadContext == null) {
-                return null;
+                return "";
             }
 
             String val = threadContext.remove(key);


### PR DESCRIPTION
## Description

`PerThreadImplicitContext.remove` returned `null` when the calling thread had never set any implicit context, while `SharedImplicitContext.remove` — and every other `PerThread`/`Shared` accessor — normalizes the same missing-value situation to `""`. The two implementations of the `ImplicitContext` interface disagreed, so `communicator.getImplicitContext().remove("key")` on a thread that never touched the context returned `null` under `Ice.ImplicitContext=PerThread` but `""` under `Shared`, which can surface as an NPE in caller code that trusts the documented "previous value" return.

This returns `""` in that case, matching `Shared.remove`, `PerThread.get`, and the C# per-thread port.

Fixes #5512