### PR TITLE
Fix Java idle-timeout heartbeat delay overflowing int above ~24.8 days

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IdleTimeoutTransceiverDecorator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IdleTimeoutTransceiverDecorator.java
@@ -170,6 +170,6 @@ final class IdleTimeoutTransceiverDecorator implements Transceiver {
     private void rescheduleWriteTimer() {
         cancelWriteTimer();
         _writeTimerFuture =
-            _scheduledExecutorService.schedule(_sendHeartbeat, _idleTimeout * 1000 / 2, TimeUnit.MILLISECONDS);
+            _scheduledExecutorService.schedule(_sendHeartbeat, (long) _idleTimeout * 1000 / 2, TimeUnit.MILLISECONDS);
     }
 }


### PR DESCRIPTION
## Description

`IdleTimeoutTransceiverDecorator.rescheduleWriteTimer()` computed the heartbeat delay as `_idleTimeout * 1000 / 2`, where `_idleTimeout` is an `int` (seconds). The multiplication used 32-bit arithmetic, so an idle timeout above ~2,147,483 seconds (~24.8 days) overflowed to a negative/garbage delay, making the write-side heartbeat fire immediately and repeatedly instead of at the intended interval. The read-side timer schedules in `TimeUnit.SECONDS` directly and was unaffected.

This casts `_idleTimeout` to `long` so the multiplication is 64-bit. Configuration-driven only (an extreme `Ice.Connection.IdleTimeout` misconfiguration).

Fixes #5513