### PR TITLE
Reject certificates without a Subject Key Identifier on SecureTransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ might need to be aware of.
   certificate that has no label attribute could abort the process during communicator initialization. Ice now reports
   a clear error instead.
 
+- Fixed a crash in the macOS (SecureTransport) SSL transport: configuring `IceSSL.CertFile` together with
+  `IceSSL.KeyFile` using a certificate that has no Subject Key Identifier extension aborted the process during
+  communicator initialization. Such certificates are now rejected with a `CertificateReadException`.
+
 ### C# Changes
 
 - Fixed a bug in `slice2cs --icerpc` where the generated request decoder read in-parameters in declaration order

--- a/cpp/src/Ice/SSL/SecureTransportUtil.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportUtil.cpp
@@ -405,7 +405,8 @@ namespace
         // A certificate must expose a Subject Key Identifier to be imported into the keychain: the SKI is used
         // both to locate an already-imported certificate (the query below) and as the key label that pairs the
         // private key with the certificate (further down). Reject a certificate without one with a clear error
-        // instead of passing a null value to CFDictionarySetValue, which aborts the process.
+        // instead of passing a null value to CFDictionarySetValue, which aborts the process. Certificates without
+        // a Subject Key Identifier are uncommon in practice, so rejecting them is acceptable.
         if (!hash)
         {
             throw CertificateReadException(
@@ -504,8 +505,8 @@ namespace
         // kSecKeyLabel attribute should match the subject key identifier.
         //
         vector<SecKeychainAttribute> attributes;
-        if (hash)
         {
+            // hash is guaranteed non-null here: loadPrivateKey rejects certificates without a Subject Key Identifier.
             SecKeychainAttribute attr;
             attr.tag = kSecKeyLabel;
             attr.data = const_cast<UInt8*>(CFDataGetBytePtr(hash.get()));

--- a/cpp/src/Ice/SSL/SecureTransportUtil.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportUtil.cpp
@@ -402,6 +402,19 @@ namespace
             }
         }
 
+        // A certificate must expose a Subject Key Identifier to be imported into the keychain: the SKI is used
+        // both to locate an already-imported certificate (the query below) and as the key label that pairs the
+        // private key with the certificate (further down). Reject a certificate without one with a clear error
+        // instead of passing a null value to CFDictionarySetValue, which aborts the process.
+        if (!hash)
+        {
+            throw CertificateReadException(
+                __FILE__,
+                __LINE__,
+                "SSL transport: the certificate for key file '" + file +
+                    "' has no Subject Key Identifier extension and cannot be imported into the macOS keychain");
+        }
+
         const void* values[] = {keychain};
         UniqueRef<CFArrayRef> searchList(CFArrayCreate(kCFAllocatorDefault, values, 1, &kCFTypeArrayCallBacks));
 


### PR DESCRIPTION
Closes #5445.

On macOS (SecureTransport), `loadPrivateKey` passed a possibly-null Subject Key Identifier (`hash`) as the value to `CFDictionarySetValue` on a `kCFTypeDictionaryValueCallBacks` dictionary. When `IceSSL.CertFile` + `IceSSL.KeyFile` reference a certificate that has no SKI extension, `hash` is null and the call aborts the process during communicator initialization. (The actual mechanism on current macOS is an uncaught `NSInvalidArgumentException` via the toll-free `__NSDictionaryM` bridge — not the `CFRetain(NULL)` originally hypothesized in the issue — but the outcome is the same hard abort.)

The SKI is required to import the certificate into the keychain: it is both the keychain lookup key and the key label that pairs the private key with the certificate. A certificate without one therefore can't be imported on macOS, so we now reject it with a clear `CertificateReadException` instead of crashing.

### Notes
- The rejection set is exactly the set that aborts today, so no working macOS configuration is affected.
- This makes macOS stricter than the OpenSSL and Schannel transports, which accept no-SKI certificates. Acceptable since the macOS path crashes today; the error message explains why.
- A separate, same-class null-guard issue on the iOS `findCertificateChain` path (`kSecAttrLabel` from `CFDictionaryGetValue`, ~line 910) will be addressed in a separate PR.
- No regression test: the `IceSSL/configuration` cert fixtures are all generated with an SKI, and regenerating requires rebuilding the entire committed cert tree; a no-SKI fixture wasn't worth it for this one-line guard.