### PR TITLE
Reject keychain certificates without a label on iOS SecureTransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ might need to be aware of.
 ### C++ Changes
 
 - Fixed a crash in the iOS (SecureTransport) SSL transport: using `IceSSL.FindCert` to select a keychain
-  certificate that has no label attribute aborted the process during communicator initialization. Ice now reports
+  certificate that has no label attribute could abort the process during communicator initialization. Ice now reports
   a clear error instead.
 
 ### C# Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ might need to be aware of.
 
 - [Changes in Ice 3.9.0](#changes-in-ice-390)
   - [General Changes](#general-changes)
-  - [C# Changes](#c-changes)
+  - [C++ Changes](#c-changes)
+  - [C# Changes](#c-changes-1)
   - [JavaScript Changes](#javascript-changes)
   - [Python Changes](#python-changes)
   - [Ruby Changes](#ruby-changes)
@@ -18,6 +19,12 @@ might need to be aware of.
 
 - Fixed the server-side WebSocket opening handshake to reject messages that are not `GET` requests, as required by
   RFC 6455. A peer could previously trip an assertion by sending a response-shaped handshake.
+
+### C++ Changes
+
+- Fixed a crash in the iOS (SecureTransport) SSL transport: using `IceSSL.FindCert` to select a keychain
+  certificate that has no label attribute aborted the process during communicator initialization. Ice now reports
+  a clear error instead.
 
 ### C# Changes
 

--- a/cpp/src/Ice/SSL/SecureTransportUtil.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportUtil.cpp
@@ -903,11 +903,23 @@ Ice::SSL::SecureTransport::findCertificateChain(
         throw InitializationException(__FILE__, __LINE__, os.str());
     }
 
-    // Now lookup the identity with the label
+    // Now lookup the identity with the label. We match the identity by the certificate's label, so the
+    // certificate must have one; reject it with a clear error rather than passing a null value to
+    // CFDictionarySetValue (which aborts the process).
+    const void* label = CFDictionaryGetValue(attributes.get(), kSecAttrLabel);
+    if (label == nullptr)
+    {
+        throw InitializationException(
+            __FILE__,
+            __LINE__,
+            "SSL transport: couldn't create identity for certificate found in the keychain: the certificate has no "
+            "label attribute");
+    }
+
     query.reset(CFDictionaryCreateMutable(0, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CFDictionarySetValue(query.get(), kSecMatchLimit, kSecMatchLimitOne);
     CFDictionarySetValue(query.get(), kSecClass, kSecClassIdentity);
-    CFDictionarySetValue(query.get(), kSecAttrLabel, (CFDataRef)CFDictionaryGetValue(attributes.get(), kSecAttrLabel));
+    CFDictionarySetValue(query.get(), kSecAttrLabel, label);
     CFDictionarySetValue(query.get(), kSecReturnRef, kCFBooleanTrue);
     err = SecItemCopyMatching(query.get(), (CFTypeRef*)&identity.get());
     if (err == noErr)


### PR DESCRIPTION
Sibling of #5445, found during that review.

On iOS (SecureTransport), `findCertificateChain` (the `IceSSL.FindCert` path) looks up the SSL identity by the certificate's keychain label:

```cpp
CFDictionarySetValue(query.get(), kSecAttrLabel,
    (CFDataRef)CFDictionaryGetValue(attributes.get(), kSecAttrLabel));
```

`CFDictionaryGetValue(attributes, kSecAttrLabel)` returns null when the matched certificate has no label attribute, and passing that null as a value to `CFDictionarySetValue` on a `kCFTypeDictionaryValueCallBacks` dictionary aborts the process during communicator initialization (the same crash class as #5445 — a nil dictionary value).

This is iOS-only code (`#if defined(ICE_USE_SECURE_TRANSPORT_IOS)`), distinct from the macOS `loadPrivateKey` path fixed in #5445, which is why it's a separate PR.

The identity is matched *by* the certificate's label, so a certificate without one can't be located this way. This throws a clear `InitializationException` when the label is absent — consistent with the other error conditions in this function — instead of crashing. It also drops a misleading `(CFDataRef)` cast (`kSecAttrLabel` is a `CFString`).

### Notes
- iOS-only: compiled/exercised by the `ios` CI job (`iphonesimulator`), not the macOS jobs.
- The reachability of a label-less certificate item isn't proven, but the throw is strictly safer either way: if the label were null we'd otherwise abort.