### PR TITLE
Reject invalid negative sizes in InputStream (JS)

### DIFF
--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -1504,7 +1504,7 @@ export class InputStream {
     }
 
     skip(size) {
-        if (size > this._buf.remaining) {
+        if (size < 0 || size > this._buf.remaining) {
             throw new MarshalException(endOfBufferMessage);
         }
         this._buf.position += size;


### PR DESCRIPTION
JS counterpart of the Swift fix in #5560.

`InputStream.skip(size)` only checked the upper bound, so a negative `size` — for example an FSize-format optional field whose length is read as a raw signed `Int32` — passed the check and rewound the stream position (corrupting the parse) instead of being rejected.

This adds the `size < 0` guard, mirroring the equivalent check already present in the C# and Java `InputStream.skip` implementations, so a negative size now throws `MarshalException`. The fix is at the `skip()` choke point, so it covers every caller.