### PR TITLE
Fix C# metrics admin thread-safety (#5503, #5502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,8 @@ might need to be aware of.
   declaring it in declaration order. As a result, an operation whose out-parameters were declared in an order
   different from their marshal order could return values in the wrong tuple slots or fail to compile.
 
-- Fixed a data race in the C# metrics admin where `MetricsAdminI.getMaps` read a reused metrics view's map
-  dictionary without holding the metrics admin mutex, racing the dictionary writes performed by `updateViews`.
-
-- Fixed a thread-safety bug in the C# metrics implementation where `MetricsMap.Entry.execute` locked the
-  `MetricsMap` instance instead of its `_mutex`, so hot-path counter updates did not exclude `attach`, `detach`,
-  `failed`, or the admin metrics snapshot.
+- Fixed thread-safety bugs in the C# metrics (IceMX) implementation that could produce incorrect metrics or
+  throw under concurrent updates.
 
 ### JavaScript Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ might need to be aware of.
   declaring it in declaration order. As a result, an operation whose out-parameters were declared in an order
   different from their marshal order could return values in the wrong tuple slots or fail to compile.
 
+- Fixed a data race in the C# metrics admin where `MetricsAdminI.getMaps` read a reused metrics view's map
+  dictionary without holding the metrics admin mutex, racing the dictionary writes performed by `updateViews`.
+
+- Fixed a thread-safety bug in the C# metrics implementation where `MetricsMap.Entry.execute` locked the
+  `MetricsMap` instance instead of its `_mutex`, so hot-path counter updates did not exclude `attach`, `detach`,
+  `failed`, or the admin metrics snapshot.
+
 ### JavaScript Changes
 
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a

--- a/csharp/src/Ice/Internal/MetricsAdminI.cs
+++ b/csharp/src/Ice/Internal/MetricsAdminI.cs
@@ -900,7 +900,7 @@ public class MetricsAdminI : IceMX.MetricsAdminDisp_
             foreach (MetricsViewI v in _views.Values)
             {
                 MetricsMap<T> map = v.getMap<T>(mapName);
-                if (map != null)
+                if (map is not null)
                 {
                     maps.Add(map);
                 }

--- a/csharp/src/Ice/Internal/MetricsAdminI.cs
+++ b/csharp/src/Ice/Internal/MetricsAdminI.cs
@@ -154,7 +154,7 @@ public class MetricsMap<T> : IMetricsMap where T : IceMX.Metrics, new()
 
         public void execute(IceMX.Observer<T>.MetricsUpdate func)
         {
-            lock (_map)
+            lock (_map._mutex)
             {
                 func(_object);
             }
@@ -895,12 +895,15 @@ public class MetricsAdminI : IceMX.MetricsAdminDisp_
     public List<MetricsMap<T>> getMaps<T>(string mapName) where T : IceMX.Metrics, new()
     {
         var maps = new List<MetricsMap<T>>();
-        foreach (MetricsViewI v in _views.Values)
+        lock (_mutex)
         {
-            MetricsMap<T> map = v.getMap<T>(mapName);
-            if (map != null)
+            foreach (MetricsViewI v in _views.Values)
             {
-                maps.Add(map);
+                MetricsMap<T> map = v.getMap<T>(mapName);
+                if (map != null)
+                {
+                    maps.Add(map);
+                }
             }
         }
         return maps;


### PR DESCRIPTION
Fixes #5503
Fixes #5502

Two C# metrics thread-safety fixes, verified against `origin/main` and independently confirmed by codex.

- `MetricsAdminI.getMaps<T>` read a reused metrics view's `_maps` dictionary without holding `_mutex`, racing the writes performed by `updateViews()`. Now wrapped in `lock (_mutex)`, matching every sibling accessor in the file.
- `MetricsMap<T>.Entry.execute` locked the `MetricsMap` instance instead of `_map._mutex` (the shared monitor used by `failed`/`detach`/`attach` and the admin metrics snapshot), so hot-path counter updates did not exclude them. Now locks `_map._mutex`, matching the Java mapping.

No test: both are flaky concurrency races; the fixes mirror the established locking idiom (and Java parity).