### PR TITLE
Fix C# ObjectAdapter.findAllFacets for unknown identity (#5501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@ might need to be aware of.
   declaring it in declaration order. As a result, an operation whose out-parameters were declared in an order
   different from their marshal order could return values in the wrong tuple slots or fail to compile.
 
-- Fixed `ObjectAdapter.findAllFacets` in C# throwing `KeyNotFoundException` for an unknown identity instead of
-  returning an empty dictionary as documented.
-
 ### JavaScript Changes
 
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ might need to be aware of.
   declaring it in declaration order. As a result, an operation whose out-parameters were declared in an order
   different from their marshal order could return values in the wrong tuple slots or fail to compile.
 
+- Fixed `ObjectAdapter.findAllFacets` in C# throwing `KeyNotFoundException` for an unknown identity instead of
+  returning an empty dictionary as documented.
+
 ### JavaScript Changes
 
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a

--- a/csharp/src/Ice/Internal/ServantManager.cs
+++ b/csharp/src/Ice/Internal/ServantManager.cs
@@ -211,8 +211,7 @@ internal sealed class ServantManager : Object
     {
         lock (_mutex)
         {
-            Dictionary<string, Object>? m = _servantMapMap[ident];
-            if (m is not null)
+            if (_servantMapMap.TryGetValue(ident, out Dictionary<string, Object>? m))
             {
                 return new Dictionary<string, Object>(m);
             }

--- a/csharp/test/Ice/facets/AllTests.cs
+++ b/csharp/test/Ice/facets/AllTests.cs
@@ -96,7 +96,7 @@ public class AllTests : global::Test.AllTests
             // findAllFacets returns all registered facets for a known identity.
             Dictionary<string, Ice.Object> all = adapter.findAllFacets(Ice.Util.stringToIdentity("d"));
             test(all.ContainsKey(""));
-            // For an unknown identity it must return an empty dictionary, not throw (see #5501).
+            // For an unknown identity it must return an empty dictionary, not throw.
             test(adapter.findAllFacets(Ice.Util.stringToIdentity("nonexistent")).Count == 0);
         }
         output.WriteLine("ok");

--- a/csharp/test/Ice/facets/AllTests.cs
+++ b/csharp/test/Ice/facets/AllTests.cs
@@ -91,6 +91,16 @@ public class AllTests : global::Test.AllTests
         test(fm[""] == obj3);
         output.WriteLine("ok");
 
+        output.Write("testing findAllFacets... ");
+        {
+            // findAllFacets returns all registered facets for a known identity.
+            Dictionary<string, Ice.Object> all = adapter.findAllFacets(Ice.Util.stringToIdentity("d"));
+            test(all.ContainsKey(""));
+            // For an unknown identity it must return an empty dictionary, not throw (see #5501).
+            test(adapter.findAllFacets(Ice.Util.stringToIdentity("nonexistent")).Count == 0);
+        }
+        output.WriteLine("ok");
+
         adapter.deactivate();
 
         output.Write("testing stringToProxy... ");


### PR DESCRIPTION
Fixes #5501

`ServantManager.findAllFacets` looked up `_servantMapMap[ident]` with the `Dictionary` indexer, which throws `KeyNotFoundException` for an unknown identity — so the `is not null` guard and empty-dictionary fallback below it were dead code, while `ObjectAdapter.findAllFacets` documents its return as "Can be empty". Switched to `TryGetValue`, matching the file's existing idiom.

Adds a `findAllFacets` regression test in the facets suite (known identity → facets; unknown identity → empty, not an exception). Verified RED→GREEN; independently confirmed by codex.