### PR TITLE
Fix C# stringToThreadPriority for the "ThreadPriority." prefix form (#5500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ might need to be aware of.
   declaring it in declaration order. As a result, an operation whose out-parameters were declared in an order
   different from their marshal order could return values in the wrong tuple slots or fail to compile.
 
+- Fixed the C# parsing of a `ThreadPriority` property (such as `Ice.ThreadPriority`) throwing
+  `ArgumentOutOfRangeException` for any value written with the `ThreadPriority.` prefix.
+
 ### JavaScript Changes
 
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@ might need to be aware of.
   declaring it in declaration order. As a result, an operation whose out-parameters were declared in an order
   different from their marshal order could return values in the wrong tuple slots or fail to compile.
 
-- Fixed the C# parsing of a `ThreadPriority` property (such as `Ice.ThreadPriority`) throwing
-  `ArgumentOutOfRangeException` for any value written with the `ThreadPriority.` prefix.
-
 ### JavaScript Changes
 
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a

--- a/csharp/src/Ice/Internal/Util.cs
+++ b/csharp/src/Ice/Internal/Util.cs
@@ -14,7 +14,7 @@ public sealed class Util
         }
         if (s.StartsWith("ThreadPriority.", StringComparison.Ordinal))
         {
-            s = s.Substring("ThreadPriority.".Length, s.Length);
+            s = s.Substring("ThreadPriority.".Length);
         }
         if (s == "Lowest")
         {

--- a/csharp/test/Ice/threadPoolPriority/Client.cs
+++ b/csharp/test/Ice/threadPoolPriority/Client.cs
@@ -8,6 +8,16 @@ public class Client : global::Test.TestHelper
     {
         using Communicator communicator = initialize(ref args);
         TextWriter output = getWriter();
+
+        output.Write("testing stringToThreadPriority parsing... ");
+        // The "ThreadPriority." prefix form must parse (regression test for #5500).
+        test(Ice.Internal.Util.stringToThreadPriority("ThreadPriority.AboveNormal") ==
+            System.Threading.ThreadPriority.AboveNormal);
+        test(Ice.Internal.Util.stringToThreadPriority("AboveNormal") ==
+            System.Threading.ThreadPriority.AboveNormal);
+        test(Ice.Internal.Util.stringToThreadPriority("") == System.Threading.ThreadPriority.Normal);
+        output.WriteLine("ok");
+
         output.Write("testing server priority... ");
         output.Flush();
         ObjectPrx obj = communicator.stringToProxy("test:" + getTestEndpoint(0) + " -t 10000");

--- a/csharp/test/Ice/threadPoolPriority/Client.cs
+++ b/csharp/test/Ice/threadPoolPriority/Client.cs
@@ -10,7 +10,6 @@ public class Client : global::Test.TestHelper
         TextWriter output = getWriter();
 
         output.Write("testing stringToThreadPriority parsing... ");
-        // The "ThreadPriority." prefix form must parse (regression test for #5500).
         test(Ice.Internal.Util.stringToThreadPriority("ThreadPriority.AboveNormal") ==
             System.Threading.ThreadPriority.AboveNormal);
         test(Ice.Internal.Util.stringToThreadPriority("AboveNormal") ==


### PR DESCRIPTION
Fixes #5500

`Ice.Internal.Util.stringToThreadPriority` passed the original string length as the *length* argument of `Substring(int startIndex, int length)`, treating it as an end index. For any value beginning with `ThreadPriority.` (e.g. a `Ice.ThreadPriority=ThreadPriority.AboveNormal` property), `startIndex + length` exceeded the string length and `Substring` threw `ArgumentOutOfRangeException` unconditionally. Switched to the single-argument `Substring`.

Adds a parsing regression test in the `threadPoolPriority` suite. Verified RED→GREEN; confirmed by codex.