### PR TITLE
Fix C# iceboxnet rejecting valid per-service command-line options (#5498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ might need to be aware of.
 - Fixed thread-safety bugs in the C# metrics (IceMX) implementation that could produce incorrect metrics or
   throw under concurrent updates.
 
+- Fixed `iceboxnet` rejecting valid per-service command-line options (`--<service>.*`) with "unknown option" and
+  failing to start: the option validation iterated the original arguments instead of the filtered list.
+
 ### JavaScript Changes
 
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a

--- a/csharp/src/iceboxnet/Server.cs
+++ b/csharp/src/iceboxnet/Server.cs
@@ -26,7 +26,7 @@ internal static class Server
             argSeq.RemoveAll(v => v.StartsWith($"--{name}", StringComparison.Ordinal));
         }
 
-        foreach (string arg in args)
+        foreach (string arg in argSeq)
         {
             if (arg == "-h" || arg == "--help")
             {


### PR DESCRIPTION
Fixes #5498

`Server.run` built `argSeq` (the arguments with per-service `--<service>...` options removed) but then the option-validation loop iterated the original, unfiltered `args`, so its `else` branch rejected every per-service option with "unknown option" and exit code 1 — IceBox could not start. The loop now iterates `argSeq`, mirroring the Java sibling (`IceBox/Server.java`); `ServiceManagerI` still receives the full `args`.

No test: exercising this requires launching the iceboxnet process with a config plus a per-service option, which is disproportionate to the one-word fix.

Note (pre-existing, out of scope): the per-service stripping uses `StartsWith("--" + name)`, identical to Java's `startsWith("--" + name)`, so an unknown option sharing a service-name prefix is also stripped — consistent across the Java and C# mappings.