### PR TITLE
Fix C# ImplicitContext contract violations (#5499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,9 @@ might need to be aware of.
 - Fixed `iceboxnet` rejecting valid per-service command-line options (`--<service>.*`) with "unknown option" and
   failing to start: the option validation iterated the original arguments instead of the filtered list.
 
-- Fixed several C# `ImplicitContext` contract violations: `get` and `remove` of an unknown key threw
-  `KeyNotFoundException` instead of returning the empty string; the per-thread `setContext` threw when replacing
-  an existing context; and the per-thread `getContext` returned the live dictionary instead of a snapshot.
+- The per-thread `ImplicitContext.getContext` in C# now returns a snapshot of the context instead of the live
+  internal dictionary (matching the `Shared` implementation). Code that mutated the returned dictionary to
+  update the implicit context must now use `put` or `setContext`.
 
 ### JavaScript Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ might need to be aware of.
 - Fixed `iceboxnet` rejecting valid per-service command-line options (`--<service>.*`) with "unknown option" and
   failing to start: the option validation iterated the original arguments instead of the filtered list.
 
+- Fixed several C# `ImplicitContext` contract violations: `get` and `remove` of an unknown key threw
+  `KeyNotFoundException` instead of returning the empty string; the per-thread `setContext` threw when replacing
+  an existing context; and the per-thread `getContext` returned the live dictionary instead of a snapshot.
+
 ### JavaScript Changes
 
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a

--- a/csharp/src/Ice/ImplicitContextI.cs
+++ b/csharp/src/Ice/ImplicitContextI.cs
@@ -83,8 +83,7 @@ internal class SharedImplicitContext : ImplicitContextI
         {
             key ??= "";
 
-            string val = _context[key] ?? "";
-            return val;
+            return _context.TryGetValue(key, out string val) ? val ?? "" : "";
         }
     }
 
@@ -109,18 +108,13 @@ internal class SharedImplicitContext : ImplicitContextI
         {
             key ??= "";
 
-            string val = _context[key];
-
-            if (val == null)
-            {
-                val = "";
-            }
-            else
+            if (_context.TryGetValue(key, out string val))
             {
                 _context.Remove(key);
+                return val ?? "";
             }
 
-            return val;
+            return "";
         }
     }
 
@@ -172,18 +166,16 @@ internal class PerThreadImplicitContext : ImplicitContextI
 {
     public override Dictionary<string, string> getContext()
     {
-        Dictionary<string, string> threadContext = null;
         Thread currentThread = Thread.CurrentThread;
         lock (_mutex)
         {
             if (_map.TryGetValue(currentThread, out Dictionary<string, string> value))
             {
-                threadContext = value;
+                return new Dictionary<string, string>(value);
             }
         }
 
-        threadContext ??= new Dictionary<string, string>();
-        return threadContext;
+        return new Dictionary<string, string>();
     }
 
     public override void setContext(Dictionary<string, string> context)
@@ -201,7 +193,7 @@ internal class PerThreadImplicitContext : ImplicitContextI
 
             lock (_mutex)
             {
-                _map.Add(Thread.CurrentThread, threadContext);
+                _map[Thread.CurrentThread] = threadContext;
             }
         }
     }
@@ -235,8 +227,7 @@ internal class PerThreadImplicitContext : ImplicitContextI
             }
         }
 
-        string val = threadContext[key] ?? "";
-        return val;
+        return threadContext.TryGetValue(key, out string val) ? val ?? "" : "";
     }
 
     public override string put(string key, string value)

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -1455,6 +1455,19 @@ internal class Twoways
                 test(Internal.DictionaryExtensions.DictionaryEqual(ic.getImplicitContext().getContext(), ctx));
                 test(Internal.DictionaryExtensions.DictionaryEqual(p3.opContext(), ctx));
 
+                test(ic.getImplicitContext().get("missing") == "");
+                test(ic.getImplicitContext().remove("missing") == "");
+
+                ic.getImplicitContext().setContext(new Dictionary<string, string> { ["only"] = "ONLY" });
+                test(ic.getImplicitContext().containsKey("only"));
+                test(ic.getImplicitContext().containsKey("one") == false); // replaced, old keys gone
+
+                Dictionary<string, string> snapshot = ic.getImplicitContext().getContext();
+                snapshot["only"] = "MUTATED";
+                test(ic.getImplicitContext().get("only") == "ONLY"); // getContext returned a snapshot
+
+                ic.getImplicitContext().setContext(ctx); // restore for the assertions below
+
                 test(ic.getImplicitContext().containsKey("zero") == false);
                 string r = ic.getImplicitContext().put("zero", "ZERO");
                 test(r.Length == 0);


### PR DESCRIPTION
Fixes #5499

Five `ImplicitContext` contract violations in `csharp/src/Ice/ImplicitContextI.cs`:

- `SharedImplicitContext.get` and `.remove` used the `Dictionary` indexer, throwing `KeyNotFoundException` for an unknown key instead of returning `""`.
- `PerThreadImplicitContext.get` had the same indexer bug.
- `PerThreadImplicitContext.setContext` used `_map.Add`, throwing when replacing an existing per-thread context; it now replaces via the indexer.
- `PerThreadImplicitContext.getContext` returned the live stored dictionary; it now returns a copy, matching `SharedImplicitContext`.

Adds regression coverage in the operations `ImplicitContext` test (both Shared and PerThread): get/remove of an unknown key, replace semantics, and getContext snapshot isolation. Verified RED→GREEN; confirmed by codex.