### PR TITLE
Fix slice2cs doubled cs:namespace prefix for nested modules (#5478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ might need to be aware of.
   internal dictionary (matching the `Shared` implementation). Code that mutated the returned dictionary to
   update the implicit context must now use `put` or `setContext`.
 
+- Fixed `slice2cs` emitting a doubled `cs:namespace` prefix for modules nested inside a module carrying
+  `cs:namespace` metadata, which produced C# that did not compile.
+
 ### JavaScript Changes
 
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ might need to be aware of.
   internal dictionary (matching the `Shared` implementation). Code that mutated the returned dictionary to
   update the implicit context must now use `put` or `setContext`.
 
-- Fixed `slice2cs` emitting a doubled `cs:namespace` prefix for modules nested inside a module carrying
-  `cs:namespace` metadata, which produced C# that did not compile.
+- Fixed a bug in `slice2cs` handling of `cs:namespace`: a nested module received the namespace prefix twice
+  (e.g. `Foo.A.Foo.B` instead of `Foo.A.B`), producing C# that did not compile.
 
 ### JavaScript Changes
 

--- a/cpp/src/slice2cs/CsVisitor.cpp
+++ b/cpp/src/slice2cs/CsVisitor.cpp
@@ -73,7 +73,7 @@ void
 Slice::CsVisitor::namespacePrefixStart(const ModulePtr& p)
 {
     string ns = getNamespacePrefix(p);
-    if (!ns.empty())
+    if (p->isTopLevel() && !ns.empty())
     {
         _out << sp;
         _out << nl << "namespace " << ns;
@@ -84,7 +84,7 @@ Slice::CsVisitor::namespacePrefixStart(const ModulePtr& p)
 void
 Slice::CsVisitor::namespacePrefixEnd(const ModulePtr& p)
 {
-    if (!getNamespacePrefix(p).empty())
+    if (p->isTopLevel() && !getNamespacePrefix(p).empty())
     {
         _out << eb;
     }

--- a/csharp/test/Ice/namespacemd/AllTests.cs
+++ b/csharp/test/Ice/namespacemd/AllTests.cs
@@ -64,6 +64,10 @@ public class AllTests : global::Test.AllTests
             output.Write("testing types with package... ");
             output.Flush();
             {
+                // A type in a module nested under a cs:namespace-tagged module must resolve at
+                // WithNamespace.Inner.S (single prefix), not a doubled prefix (regression test for #5478).
+                test(typeof(WithNamespace.Inner.S).Namespace == "Ice.namespacemd.WithNamespace.Inner");
+
                 WithNamespace.C1 c1 = initial.getWithNamespaceC2AsC1();
                 test(c1 != null);
                 test(c1 is WithNamespace.C2);

--- a/csharp/test/Ice/namespacemd/AllTests.cs
+++ b/csharp/test/Ice/namespacemd/AllTests.cs
@@ -67,6 +67,9 @@ public class AllTests : global::Test.AllTests
                 // A type in a module nested under a cs:namespace-tagged module must resolve at
                 // WithNamespace.Inner.S (single prefix), not a doubled prefix (regression test for #5478).
                 test(typeof(WithNamespace.Inner.S).Namespace == "Ice.namespacemd.WithNamespace.Inner");
+                test(typeof(global::ZeroC.Foo.Bar.S).Namespace == "ZeroC.Foo.Bar");
+                test(typeof(global::ZeroC.Other.Bar.S).Namespace == "ZeroC.Other.Bar");
+                test(typeof(global::ZeroC.Other.Baz.S).Namespace == "ZeroC.Other.Baz");
 
                 WithNamespace.C1 c1 = initial.getWithNamespaceC2AsC1();
                 test(c1 != null);

--- a/csharp/test/Ice/namespacemd/Namespace.ice
+++ b/csharp/test/Ice/namespacemd/Namespace.ice
@@ -38,7 +38,7 @@ module WithNamespace
     }
 }
 
-["cs:namespace:ZeroC.Foo"]
+["cs:namespace:ZeroC"]
 module Foo
 {
     module Bar
@@ -50,7 +50,7 @@ module Foo
     }
 }
 
-["cs:namespace:ZeroC.Other"]
+["cs:namespace:ZeroC"]
 module Other
 {
     module Bar

--- a/csharp/test/Ice/namespacemd/Namespace.ice
+++ b/csharp/test/Ice/namespacemd/Namespace.ice
@@ -26,4 +26,46 @@ module WithNamespace
     {
         long l;
     }
+
+    // A module nested under a cs:namespace-tagged module: its types must map to
+    // WithNamespace.Inner.*, not a doubled-prefix namespace (regression test for #5478).
+    module Inner
+    {
+        struct S
+        {
+            int i;
+        }
+    }
+}
+
+["cs:namespace:ZeroC.Foo"]
+module Foo
+{
+    module Bar
+    {
+        struct S
+        {
+            string str;
+        }
+    }
+}
+
+["cs:namespace:ZeroC.Other"]
+module Other
+{
+    module Bar
+    {
+        struct S
+        {
+            string str;
+        }
+    }
+
+    module Baz
+    {
+        struct S
+        {
+            string str;
+        }
+    }
 }


### PR DESCRIPTION
Fixes #5478

`slice2cs` opened the `cs:namespace` prefix block in `visitModuleStart` for every module, including nested ones. `getNamespacePrefix` walks to the top-level module's `cs:namespace` metadata, so a nested module received the prefix again, producing a doubled namespace (e.g. `Foo.A.Foo.B`) that did not match the references computed by `getNamespace()` (`Foo.A.B`) — the generated C# did not compile. Guarded the prefix block with `Module::isTopLevel()` so it is emitted only at the top-level module.

Adds a nested-module regression test to the `namespacemd` suite (`module Inner { struct S }` under the `cs:namespace`-tagged `WithNamespace`, referenced from `AllTests.cs`). Verified RED→GREEN: without the fix the generated `Namespace.cs` fails to compile (CS0234 — doubled prefix); with it the suite compiles and `WithNamespace.Inner.S` resolves at `Ice.namespacemd.WithNamespace.Inner`. Confirmed by codex.