### PR TITLE
Fix C# IceLocatorDiscovery request hang on same-proxy retry (#5497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@ might need to be aware of.
   declaring it in declaration order. As a result, an operation whose out-parameters were declared in an order
   different from their marshal order could return values in the wrong tuple slots or fail to compile.
 
-- Fixed C# IceLocatorDiscovery hanging a request when locator rediscovery resolved to the same proxy that had
-  just failed: the retry threw into a discarded task, leaving the request's `TaskCompletionSource` uncompleted.
-
 ### JavaScript Changes
 
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ might need to be aware of.
   declaring it in declaration order. As a result, an operation whose out-parameters were declared in an order
   different from their marshal order could return values in the wrong tuple slots or fail to compile.
 
+- Fixed C# IceLocatorDiscovery hanging a request when locator rediscovery resolved to the same proxy that had
+  just failed: the retry threw into a discarded task, leaving the request's `TaskCompletionSource` uncompleted.
+
 ### JavaScript Changes
 
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a

--- a/changelog.d/csharp/5497.md
+++ b/changelog.d/csharp/5497.md
@@ -1,0 +1,2 @@
+- Fixed a hang in C# IceLocatorDiscovery where a request could fail to complete when a failed locator
+  invocation was retried and locator rediscovery returned the same locator proxy.

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -48,8 +48,8 @@ internal class Request : TaskCompletionSource<Ice.Object_Ice_invokeResult>
         }
         else
         {
-            Debug.Assert(_exception != null);
-            throw _exception;
+            Debug.Assert(_exception != null); // Don't retry if the proxy didn't change
+            SetException(_exception); // Complete the request directly, matching the C++ mapping
         }
 
         async Task performInvokeAsync(Ice.LocatorPrx locator)
@@ -60,35 +60,31 @@ internal class Request : TaskCompletionSource<Ice.Object_Ice_invokeResult>
                     await locator.ice_invokeAsync(_operation, _mode, _inParams, _context).ConfigureAwait(false);
                 SetResult(result);
             }
-            catch (Ice.RequestFailedException exc)
-            {
-                SetException(exc);
-            }
-            catch (Ice.UnknownException exc)
-            {
-                SetException(exc);
-            }
-            catch (Ice.NoEndpointException)
-            {
-                SetException(new Ice.ObjectNotExistException());
-            }
-            catch (Ice.ObjectAdapterDeactivatedException)
-            {
-                SetException(new Ice.ObjectNotExistException());
-            }
-            catch (Ice.ObjectAdapterDestroyedException)
-            {
-                SetException(new Ice.ObjectNotExistException());
-            }
-            catch (Ice.CommunicatorDestroyedException)
-            {
-                SetException(new Ice.ObjectNotExistException());
-            }
             catch (Exception exc)
             {
+                exception(exc);
+            }
+        }
+    }
+
+    private void exception(Exception exc)
+    {
+        switch (exc)
+        {
+            case Ice.RequestFailedException:
+            case Ice.UnknownException:
+                SetException(exc);
+                break;
+            case Ice.NoEndpointException:
+            case Ice.ObjectAdapterDeactivatedException:
+            case Ice.ObjectAdapterDestroyedException:
+            case Ice.CommunicatorDestroyedException:
+                SetException(new Ice.ObjectNotExistException());
+                break;
+            default:
                 _exception = exc;
                 _locator.invoke(_locatorPrx, this); // Retry with new locator proxy
-            }
+                break;
         }
     }
 

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -60,14 +60,14 @@ internal class Request : TaskCompletionSource<Ice.Object_Ice_invokeResult>
                     await locator.ice_invokeAsync(_operation, _mode, _inParams, _context).ConfigureAwait(false);
                 SetResult(result);
             }
-            catch (Exception exc)
+            catch (System.Exception exc)
             {
-                exception(exc);
+                handleException(exc);
             }
         }
     }
 
-    private void exception(Exception exc)
+    private void handleException(System.Exception exc)
     {
         switch (exc)
         {


### PR DESCRIPTION
Fixes #5497

When an invocation on a discovered locator failed with an unmapped exception, the generic `catch` re-entered `LocatorI.invoke` to retry. If rediscovery resolved to a proxy **equal** to the one that just failed, `Request.invoke` took the `else` branch and did `throw _exception;` — but that throw happened inside the `catch` of a discarded fire-and-forget task, so the request's `TaskCompletionSource` never completed and the caller hung.

This extracts the exception-mapping cascade into a private `exception()` helper (used by the async-failure path) and, in the same-proxy branch, completes the request **directly** with `SetException(_exception)`.

That mirrors the **C++** sibling (`_exceptionCallback(_exception)`), not Java's `exception(_exception)`. The Java form re-enters discovery, which can livelock when a discoverable-but-unreachable locator keeps being rediscovered (`_nextRetry` only advances on lookup timeout, not on a successful rediscovery) — a latent issue worth reporting against the Java mapping separately. `_exception` only ever holds a default-category exception, so completing with it directly loses no mapping.

No automated test: there is no C# IceLocatorDiscovery test harness and a deterministic repro of the multicast-rediscovery race is flaky. Verified by inspection against the C++ mapping and cross-checked by codex and copilot (both confirmed the request always completes, no livelock).