### PR TITLE
Fix connection leak in OutgoingConnectionFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ might need to be aware of.
 - [Changes in Ice 3.9.0](#changes-in-ice-390)
   - [General Changes](#general-changes)
   - [C# Changes](#c-changes)
+  - [Java Changes](#java-changes)
   - [JavaScript Changes](#javascript-changes)
   - [Python Changes](#python-changes)
   - [Ruby Changes](#ruby-changes)
@@ -28,6 +29,11 @@ might need to be aware of.
 - Fixed a bug in `slice2cs --icerpc` where the generated proxy built the response tuple in marshal order while
   declaring it in declaration order. As a result, an operation whose out-parameters were declared in an order
   different from their marshal order could return values in the wrong tuple slots or fail to compile.
+
+### Java Changes
+
+- Fixed a connection leak in Ice for Java. Closed outgoing connections were never removed from the connection
+  factory's internal maps, so they accumulated for the lifetime of the communicator.
 
 ### JavaScript Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ might need to be aware of.
 - [Changes in Ice 3.9.0](#changes-in-ice-390)
   - [General Changes](#general-changes)
   - [C# Changes](#c-changes)
-  - [Java Changes](#java-changes)
   - [JavaScript Changes](#javascript-changes)
   - [Python Changes](#python-changes)
   - [Ruby Changes](#ruby-changes)
@@ -29,11 +28,6 @@ might need to be aware of.
 - Fixed a bug in `slice2cs --icerpc` where the generated proxy built the response tuple in marshal order while
   declaring it in declaration order. As a result, an operation whose out-parameters were declared in an order
   different from their marshal order could return values in the wrong tuple slots or fail to compile.
-
-### Java Changes
-
-- Fixed a connection leak in Ice for Java. Closed outgoing connections were never removed from the connection
-  factory's internal maps, so they accumulated for the lifetime of the communicator.
 
 ### JavaScript Changes
 

--- a/changelog.d/java/5504.md
+++ b/changelog.d/java/5504.md
@@ -1,0 +1,2 @@
+- Fixed a memory leak in Ice for Java. Outgoing connections were not released after they closed, so the
+  memory used by a long-running program grew over the lifetime of the communicator.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
@@ -27,6 +27,16 @@ final class OutgoingConnectionFactory {
             list.add(value);
         }
 
+        public void removeOne(K key, V value) {
+            List<V> list = this.get(key);
+            if (list != null) {
+                list.remove(value);
+                if (list.isEmpty()) {
+                    this.remove(key);
+                }
+            }
+        }
+
         private static final long serialVersionUID = -8109942200313578944L;
     }
 
@@ -526,9 +536,9 @@ final class OutgoingConnectionFactory {
             return;
         }
 
-        _connections.remove(connection.connector(), connection);
-        _connectionsByEndpoint.remove(connection.endpoint(), connection);
-        _connectionsByEndpoint.remove(connection.endpoint().compress(true), connection);
+        _connections.removeOne(connection.connector(), connection);
+        _connectionsByEndpoint.removeOne(connection.endpoint(), connection);
+        _connectionsByEndpoint.removeOne(connection.endpoint().compress(true), connection);
     }
 
     private static class ConnectorInfo {


### PR DESCRIPTION
Fixes #5504.

### Problem
`MultiHashMap<K,V>` (a private nested class in `OutgoingConnectionFactory`) extends `HashMap<K, List<V>>` and defined only `putOne` — no `removeOne`. `removeConnection` therefore called the JDK default `Map.remove(Object key, Object value)`, which removes a mapping only if the currently-mapped value `.equals(value)`. The mapped value is a `List<ConnectionI>` and the argument is a single `ConnectionI`, so the comparison is always false and **nothing was ever removed**. `removeConnection` runs on every normal client connection close, so every closed connection (and its connector/endpoint keys) was retained for the communicator's lifetime — an unbounded leak.

### Fix
Add `MultiHashMap.removeOne(K, V)` (mirroring `putOne`) that removes the single value from the per-key list and drops the key when the list becomes empty, and call it from `removeConnection`.

### Testing
The leak lives in private factory state with no public observability, so a dedicated test would be disproportionate; verified by inspection and codex review. `./gradlew assemble check rewriteDryRun` passes.
