### PR TITLE
Fix unbounded _replicaGroups growth in IceDiscovery LocatorRegistryI

### DIFF
--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LocatorRegistryI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LocatorRegistryI.java
@@ -55,7 +55,7 @@ class LocatorRegistryI implements LocatorRegistry {
             if (s != null) {
                 s.remove(adapterId);
                 if (s.isEmpty()) {
-                    _replicaGroups.remove(adapterId);
+                    _replicaGroups.remove(replicaGroupId);
                 }
             }
         }


### PR DESCRIPTION
Fixes #5507.

### Problem
In `LocatorRegistryI.setReplicatedAdapterDirectProxy`, when the last adapter was removed from a replica group, the now-empty `Set` was removed from `_replicaGroups` by `adapterId` — but the map is keyed by `replicaGroupId` (the insert branch and the `get` two lines above both use `replicaGroupId`). Since the two ids differ in any real deployment, the `remove` was a no-op and the empty entry stayed forever, growing `_replicaGroups` unbounded (and `findObject` then iterates the dead empty keys).

### Fix
`_replicaGroups.remove(replicaGroupId)`, matching the C++ and C# implementations.

### Testing
A one-token key fix on private discovery state; a dedicated test is disproportionate. Verified by inspection and codex review (cross-checked against the correct C++/C# ports). `./gradlew assemble check rewriteDryRun` passes.
