### PR TITLE
Fix NPE in MetricsMap.getMatching when reflective construction fails

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/MetricsMap.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/MetricsMap.java
@@ -391,6 +391,7 @@ public class MetricsMap<T extends Metrics> {
                     _objects.put(key, e);
                 } catch (Exception ex) {
                     assert false;
+                    return null;
                 }
             }
             e.attach(helper);


### PR DESCRIPTION
Fixes #5510.

### Problem
In `MetricsMap.getMatching`, the only handling for a reflective `newInstance()` failure was `assert false` — a no-op when assertions are disabled (the production default). If construction threw, `e` stayed null and the following `e.attach(helper)` raised a `NullPointerException` out of the observer path.

### Fix
Return `null` on the failure so callers skip attaching. The `IceMX.Observer` and `IceMX.ObserverFactory` callers already null-check the returned entry, and the intermediate `SubMap`/typed `getMatching` wrappers simply propagate it.

### Testing
Latent with the built-in metrics classes (all have accessible no-arg constructors), so a dedicated test would need an artificial reflection-hostile metrics class — disproportionate for a Low-severity fix. Verified by inspection (caller null-safety) and codex review. `./gradlew assemble check rewriteDryRun` passes.
