### PR TITLE
Fix LoggerAdminLoggerI.detach leaving _detached false

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminLoggerI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminLoggerI.java
@@ -63,10 +63,10 @@ final class LoggerAdminLoggerI implements LoggerAdminLogger, Runnable {
     public void detach() {
         Thread thread = null;
         synchronized (this) {
+            _detached = true;
             if (_sendLogThread != null) {
                 thread = _sendLogThread;
                 _sendLogThread = null;
-                _detached = true;
                 notifyAll();
             }
         }


### PR DESCRIPTION
Fixes #5511.

### Problem
`LoggerAdminLoggerI.detach()` set `_detached = true` only inside the `if (_sendLogThread != null)` branch, but called `_loggerAdmin.destroy()` unconditionally. If no send-log thread was ever started, `detach()` destroyed the logger admin yet left `_detached == false`, so later `print`/`trace`/`warning`/`error` calls still ran against the destroyed admin.

### Fix
Set `_detached = true` unconditionally at the top of the `synchronized(this)` block; the `notifyAll()` and thread-join handling stay inside the `if`.

### Testing
Internal lifecycle state with no clean public probe; a dedicated test is disproportionate for this Low-severity fix. Verified by inspection and codex review. `./gradlew assemble check rewriteDryRun` passes.
