### PR TITLE
Fix StringUtil.match to match the C++ implementation

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/StringUtil.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/StringUtil.java
@@ -518,9 +518,6 @@ public final class StringUtil {
         // Make sure there is something present in the middle to match the wildcard.
         // If emptyMatch is true, allow a match of "".
         int endLength = pat.length() - beginIndex - 1;
-        if (endLength == 0) {
-            return true;
-        }
         if (endLength > s.length()) {
             return false;
         }
@@ -530,8 +527,7 @@ public final class StringUtil {
         }
 
         // Make sure end of the strings match
-        if (!s.substring(endIndex, s.length() - endIndex)
-            .equals(pat.substring(beginIndex + 1, pat.length() - beginIndex - 1))) {
+        if (!s.substring(endIndex).equals(pat.substring(beginIndex + 1))) {
             return false;
         }
 

--- a/java/test/src/main/java/test/IceUtil/inputUtil/Client.java
+++ b/java/test/src/main/java/test/IceUtil/inputUtil/Client.java
@@ -181,5 +181,44 @@ public class Client extends TestHelper {
             test(StringUtil.splitString("a\"b", ":") == null);
         }
         System.out.println("ok");
+
+        System.out.print("checking string matching... ");
+        System.out.flush();
+        {
+            // No wildcard: exact match.
+            test(StringUtil.match("foo", "foo", false));
+            test(!StringUtil.match("foo", "bar", false));
+
+            // Trailing wildcard.
+            test(StringUtil.match("foobar", "foo*", false));
+            test(!StringUtil.match("foobar", "baz*", false));
+
+            // A trailing wildcard must match at least one character unless emptyMatch is true.
+            test(!StringUtil.match("foo", "foo*", false));
+            test(StringUtil.match("foo", "foo*", true));
+
+            // Leading wildcard.
+            test(StringUtil.match("foobar", "*bar", false));
+            test(!StringUtil.match("foobar", "*baz", false));
+
+            // A leading wildcard must also match at least one character unless emptyMatch is true.
+            test(!StringUtil.match("bar", "*bar", false));
+            test(StringUtil.match("bar", "*bar", true));
+
+            // Wildcard with a non-empty tail (regression test for #5505).
+            test(StringUtil.match("fooXXXbar", "foo*bar", false));
+            test(!StringUtil.match("fooXXXbaz", "foo*bar", false));
+
+            // The wildcard must match at least one character unless emptyMatch is true.
+            test(!StringUtil.match("foobar", "foo*bar", false));
+            test(StringUtil.match("foobar", "foo*bar", true));
+
+            // A wildcard-only pattern matches any (non-empty) string: the wildcard consumes the whole
+            // string, so the emptyMatch flag makes no difference here (an empty input is disallowed by match).
+            test(StringUtil.match("a", "*", false));
+            test(StringUtil.match("a", "*", true));
+            test(StringUtil.match("foobar", "*", false));
+        }
+        System.out.println("ok");
     }
 }


### PR DESCRIPTION
Fixes #5505.

### Problem
`StringUtil.match` is a port of C++ `IceInternal::match` with two divergences from it:
1. The suffix comparison passed lengths to `String.substring`, which takes an end index (C++ `substr` takes a length). A wildcard pattern with a non-empty tail (e.g. `foo*bar`) threw `StringIndexOutOfBoundsException` or compared the wrong characters. (This is the reported bug.)
2. A Java-only `endLength == 0` fast path returned `true` for any trailing wildcard, so `match("foo", "foo*", false)` returned `true` whereas C++ returns `false` — a wildcard must consume at least one character when `emptyMatch` is false.

### Fix
- Use `s.substring(endIndex)` and `pat.substring(beginIndex + 1)`.
- Remove the `endLength == 0` fast path so the `emptyMatch` check applies to trailing wildcards too. `match()` now behaves exactly like the C++ implementation.

The only in-tree caller, `MetricsAdminI.validateProperties`, uses `emptyMatch=false` with trailing-`*` patterns; the second change only affects a degenerate property whose key is exactly the wildcard prefix (e.g. `…Accept.` with nothing after the dot), which is now correctly rejected.

### Testing
Added a `checking string matching...` section to the `IceUtil/inputUtil` test covering exact, leading, trailing, and mid-pattern wildcards plus `emptyMatch` semantics. Verified with JDK 21: the test fails against the previous code and passes after the fix. `./gradlew assemble check rewriteDryRun` passes.
