### PR TITLE
Fix unsynchronized access to the metrics views in MetricsAdminI.getMaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,9 @@ might need to be aware of.
 
 ### Java Changes
 
-- Fixed an unsynchronized access to the metrics views in Ice for Java. `MetricsAdminI.getMaps` now snapshots the
-  metrics maps under the admin monitor, avoiding a data race with concurrent metrics configuration updates.
+- Fixed a data race in the Ice for Java metrics (IceMX) implementation. Reconfiguring the metrics views at
+  runtime while metrics were being collected could corrupt the internal metrics maps or throw a
+  `ConcurrentModificationException`.
 
 ### JavaScript Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ might need to be aware of.
   - [General Changes](#general-changes)
   - [C++ Changes](#c-changes)
   - [C# Changes](#c-changes-1)
+  - [Java Changes](#java-changes)
   - [JavaScript Changes](#javascript-changes)
   - [MATLAB Changes](#matlab-changes)
   - [PHP Changes](#php-changes)
@@ -56,6 +57,11 @@ might need to be aware of.
 
 - Fixed a bug in `slice2cs` handling of `cs:namespace`: a nested module received the namespace prefix twice
   (e.g. `Foo.A.Foo.B` instead of `Foo.A.B`), producing C# that did not compile.
+
+### Java Changes
+
+- Fixed an unsynchronized access to the metrics views in Ice for Java. `MetricsAdminI.getMaps` now snapshots the
+  metrics maps under the admin monitor, avoiding a data race with concurrent metrics configuration updates.
 
 ### JavaScript Changes
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/MetricsAdminI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/MetricsAdminI.java
@@ -208,7 +208,7 @@ public class MetricsAdminI
         }
     }
 
-    public synchronized <S extends Metrics> void registerSubMap(
+    public <S extends Metrics> void registerSubMap(
             String map, String subMap, Class<S> cl, java.lang.reflect.Field field) {
         boolean updated;
         MetricsMapFactory<?> factory;
@@ -243,10 +243,15 @@ public class MetricsAdminI
 
     public <T extends Metrics> List<MetricsMap<T>> getMaps(String mapName, Class<T> cl) {
         List<MetricsMap<T>> maps = new ArrayList<>();
-        for (MetricsViewI v : _views.values()) {
-            MetricsMap<T> map = v.getMap(mapName, cl);
-            if (map != null) {
-                maps.add(map);
+        // Snapshot the maps under the admin monitor: updateViews() reuses MetricsViewI
+        // instances and mutates their _maps under synchronized(this), while this method is
+        // called from ObserverFactory.update() after the admin lock is released.
+        synchronized (this) {
+            for (MetricsViewI v : _views.values()) {
+                MetricsMap<T> map = v.getMap(mapName, cl);
+                if (map != null) {
+                    maps.add(map);
+                }
             }
         }
         return maps;


### PR DESCRIPTION
Fixes #5506.

### Problem
`MetricsAdminI.getMaps` enumerated `_views` and read each reused `MetricsViewI`'s plain `HashMap` `_maps` (via `getMap`) without holding the admin monitor, while `updateViews`/`addOrUpdateMap`/`removeMap` mutate them under `synchronized(this)`. `getMaps` is called from `IceMX.ObserverFactory.update()` after the admin lock is released, so a metrics configuration update racing an observer update was an unsafe concurrent `HashMap` read/write.

### Fix
- Snapshot the maps under `synchronized(this)` in `getMaps` (same fix shape as the C# counterpart #5503).
- Drop the redundant method-level `synchronized` on `registerSubMap` — its critical section is already guarded by an inner `synchronized(this)` block — so its `factory.update()` runs **outside** the admin monitor, matching `registerMap` and `unregisterMap`. Without this, the new `getMaps` lock (acquired observer-factory → admin from `ObserverFactory.update()`) would invert with `registerSubMap`'s admin → observer-factory order and could deadlock.

### Testing
A deterministic test for a data race / lock inversion is disproportionate and would be flaky; verified by inspection and two codex review passes — the first caught the lock inversion, which this revision resolves. `./gradlew assemble check rewriteDryRun` passes.
