### PR TITLE
Fix Glacier2 session-creation strand on synchronous verifier failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ might need to be aware of.
   - [MATLAB Changes](#matlab-changes)
   - [Python Changes](#python-changes)
   - [Ruby Changes](#ruby-changes)
+  - [Ice Service Changes](#ice-service-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -72,6 +73,14 @@ might need to be aware of.
 - Fixed `Ice::Endpoint` comparison in Ice for Ruby. `<=>` compared an endpoint with itself, making `==`/`<=>`
   asymmetric, and the class defined `eql?` without a matching `hash`; equal endpoints now compare consistently and
   can be used as `Hash`/`Set` keys.
+
+### Ice Service Changes
+
+#### Glacier2
+
+- Fixed a Glacier2 router bug where a synchronous failure of the permissions verifier during session creation could
+  permanently strand the client connection: the client could no longer create a session, and any other
+  session-creation requests queued on the same connection hung forever.
 
 These are the changes since the [Ice 3.8.2] release.
 

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -344,16 +344,36 @@ CreateSession::CreateSession(shared_ptr<SessionRouterI> sessionRouter, string us
 void
 CreateSession::create()
 {
+    bool createSession = false;
     try
     {
-        if (_sessionRouter->startCreateSession(shared_from_this(), _current.con))
-        {
-            authorize();
-        }
+        createSession = _sessionRouter->startCreateSession(shared_from_this(), _current.con);
     }
     catch (const Ice::Exception&)
     {
+        //
+        // startCreateSession failed before this request was added to _pending, so there is nothing to clean up:
+        // just report the failure to the caller.
+        //
         finished(current_exception());
+        return;
+    }
+
+    if (createSession)
+    {
+        try
+        {
+            authorize();
+        }
+        catch (const Ice::Exception&)
+        {
+            //
+            // This request was added to _pending by startCreateSession. A synchronous failure of authorize() must
+            // go through exception() (like the asynchronous failure path) so the _pending entry is erased and any
+            // queued session-creation requests for this connection are re-driven; finished() alone would strand them.
+            //
+            exception(current_exception());
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

`Glacier2::CreateSession::create()` catches a synchronous `Ice::Exception` from `authorize()` and calls `finished(current_exception())`, which only invokes the caller's exception callback. It does **not** erase the connection from `_pending` or replay the queued `_pendingCallbacks` — that cleanup only happens in `CreateSession::exception()` (the asynchronous failure path).

Because `startCreateSession()` inserts the connection into `_pending` *before* `authorize()` runs, a synchronous throw from `authorize()` (e.g. a collocated/erroring permissions verifier, or a communicator shutting down) permanently strands:

- the connection's `_pending` entry — with no session created, no close callback is registered to remove it, so the connection can never create a session again; and
- any other session-creation requests queued on that connection as `_pendingCallbacks` — they are never re-driven, so those clients hang with no response.

## Fix

Split the `create()` try/catch so the two failure sources are handled distinctly:

- A failure of `startCreateSession()` (which happens *before* the request is added to `_pending`) still routes through `finished()` — there is nothing to clean up.
- A synchronous failure of `authorize()` (after the request was added to `_pending`) now routes through `exception()`, exactly like the asynchronous failure path. `exception()` erases the `_pending` entry via `finishCreateSession(_current.con, nullptr)` and replays the queued `_pendingCallbacks`.

Funnelling *all* exceptions through `exception()` unconditionally would be wrong, since a `startCreateSession()` failure never owned a `_pending` entry; the split keeps each path correct.

## Notes

No behavior change on the success path or the existing asynchronous failure path.