### PR TITLE
Fix std::terminate on clean shutdown of a Windows service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ might need to be aware of.
   - [MATLAB Changes](#matlab-changes)
   - [Python Changes](#python-changes)
   - [Ruby Changes](#ruby-changes)
+  - [Ice Service Changes](#ice-service-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -72,6 +73,15 @@ might need to be aware of.
 - Fixed `Ice::Endpoint` comparison in Ice for Ruby. `<=>` compared an endpoint with itself, making `==`/`<=>`
   asymmetric, and the class defined `eql?` without a matching `hash`; equal endpoints now compare consistently and
   can be used as `Hash`/`Set` keys.
+
+### Ice Service Changes
+
+#### Ice Service installed as a Windows Service
+
+- Fixed a crash on shutdown. When an Ice service running as a Windows service was stopped using an Ice admin tool —
+  for example, an IceGrid node shut down with `icegridadmin` or the IceGrid GUI — instead of through the Windows
+  Service Control Manager, the process terminated abnormally rather than stopping cleanly (and never reported
+  `SERVICE_STOPPED`). This affected the IceGrid registry and node, the Glacier2 router, and IceBox.
 
 These are the changes since the [Ice 3.8.2] release.
 

--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -1385,7 +1385,10 @@ ServiceStatusManager::stopUpdate()
         }
     }
 
-    thread.join();
+    if (thread.joinable())
+    {
+        thread.join();
+    }
 }
 
 void


### PR DESCRIPTION
## Problem

On Windows, `Ice::Service::ServiceStatusManager::stopUpdate()` unconditionally calls `join()` on a local `std::thread`:

```cpp
void ServiceStatusManager::stopUpdate()
{
    std::thread thread;
    {
        lock_guard lock(_mutex);
        if (_thread.joinable())
        {
            _stopped = true;
            _conditionVariable.notify_one();
            thread = std::move(_thread);
        }
    }
    thread.join();   // throws std::system_error if `thread` is not joinable
}
```

The local `thread` only becomes joinable when there was a running update thread to move out of `_thread`. The status-update thread is started for `SERVICE_START_PENDING`/`SERVICE_STOP_PENDING` and stopped right after `start()` succeeds. When the service then shuts **itself** down — the application calls `communicator->shutdown()` rather than the Service Control Manager sending a STOP control (which is what would call `startUpdate(SERVICE_STOP_PENDING)` and create a thread) — `terminateService()` calls `stopUpdate()` again with no update thread present.

In that case the local `thread` is default-constructed, `thread.join()` throws `std::system_error`, the exception escapes `serviceMain`, and the process aborts via `std::terminate`. The SCM never receives `SERVICE_STOPPED` and considers the service stuck. The same fault occurs on any second call to `stopUpdate()`.

## Fix

Guard the join:

```cpp
if (thread.joinable())
{
    thread.join();
}
```

so a `stopUpdate()` with no running update thread is a no-op instead of a crash.