### PR TITLE
Fix several IceGrid registry and node bugs

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -31,6 +31,7 @@
         "ostr",
         "PKCS",
         "Postamble",
+        "reapables",
         "reloadable",
         "RFCOMM",
         "slnx",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ might need to be aware of.
   - [MATLAB Changes](#matlab-changes)
   - [Python Changes](#python-changes)
   - [Ruby Changes](#ruby-changes)
+  - [Ice Service Changes](#ice-service-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -72,6 +73,16 @@ might need to be aware of.
 - Fixed `Ice::Endpoint` comparison in Ice for Ruby. `<=>` compared an endpoint with itself, making `==`/`<=>`
   asymmetric, and the class defined `eql?` without a matching `hash`; equal endpoints now compare consistently and
   can be used as `Hash`/`Set` keys.
+
+### Ice Service Changes
+
+#### IceGrid
+
+- Fixed a potential crash at startup in an IceGrid slave registry. A master registry registering with a slave while
+  the slave was still initializing could crash the slave.
+
+- Fixed a registry-wide stall in IceGrid. Previously, when a client that allocated a server with the `session`
+  allocation mode suddenly disconnected, the registry could temporarily stop accepting all new sessions.
 
 These are the changes since the [Ice 3.8.2] release.
 

--- a/cpp/src/IceGrid/AllocatableObjectCache.cpp
+++ b/cpp/src/IceGrid/AllocatableObjectCache.cpp
@@ -307,8 +307,7 @@ AllocatableObjectEntry::allocated(const shared_ptr<SessionI>& session)
     {
         try
         {
-            Ice::IdentitySeq seq(1);
-            seq.push_back(_info.proxy->ice_getIdentity());
+            Ice::IdentitySeq seq{_info.proxy->ice_getIdentity()};
             identities->add(seq);
         }
         catch (const Ice::LocalException& ex)
@@ -338,8 +337,7 @@ AllocatableObjectEntry::released(const shared_ptr<SessionI>& session)
     {
         try
         {
-            Ice::IdentitySeq seq(1);
-            seq.push_back(_info.proxy->ice_getIdentity());
+            Ice::IdentitySeq seq{_info.proxy->ice_getIdentity()};
             identities->remove(seq);
         }
         catch (const Ice::LocalException& ex)

--- a/cpp/src/IceGrid/Database.cpp
+++ b/cpp/src/IceGrid/Database.cpp
@@ -2633,6 +2633,16 @@ Database::finishApplicationUpdate(
     catch (const IceDB::LMDBException& ex)
     {
         logError(_communicator, ex);
+        finishUpdating(update.descriptor.name);
+        throw;
+    }
+    catch (...)
+    {
+        // Any other failure (e.g. a ServerNotExistException thrown by checkUpdate, which matches none of the handlers
+        // above) must still clear the in-progress update entry. Otherwise the entry is orphaned in _updating,
+        // waitForUpdate() blocks forever, and every future add/update/remove of this application wedges until the
+        // registry is restarted.
+        finishUpdating(update.descriptor.name);
         throw;
     }
 

--- a/cpp/src/IceGrid/ReapThread.cpp
+++ b/cpp/src/IceGrid/ReapThread.cpp
@@ -173,15 +173,22 @@ ReapThread::add(const shared_ptr<Reapable>& reapable, chrono::seconds timeout, c
 void
 ReapThread::connectionClosed(const Ice::ConnectionPtr& con)
 {
-    lock_guard lock(_mutex);
-    auto p = _connections.find(con);
-    if (p != _connections.end())
+    set<shared_ptr<Reapable>> reap;
     {
-        for (const auto& reapable : p->second)
+        lock_guard lock(_mutex);
+        auto p = _connections.find(con);
+        if (p == _connections.end())
         {
-            reapable->destroy(false);
+            return;
         }
+        reap.swap(p->second);
         _connections.erase(p);
+    }
+
+    // Destroy the reapables outside the lock, like run() and terminate().
+    for (const auto& reapable : reap)
+    {
+        reapable->destroy(false);
     }
 }
 

--- a/cpp/src/IceGrid/ReapThread.cpp
+++ b/cpp/src/IceGrid/ReapThread.cpp
@@ -173,7 +173,7 @@ ReapThread::add(const shared_ptr<Reapable>& reapable, chrono::seconds timeout, c
 void
 ReapThread::connectionClosed(const Ice::ConnectionPtr& con)
 {
-    set<shared_ptr<Reapable>> reap;
+    set<shared_ptr<Reapable>> reapables;
     {
         lock_guard lock(_mutex);
         auto p = _connections.find(con);
@@ -181,12 +181,12 @@ ReapThread::connectionClosed(const Ice::ConnectionPtr& con)
         {
             return;
         }
-        reap.swap(p->second);
+        reapables.swap(p->second);
         _connections.erase(p);
     }
 
     // Destroy the reapables outside the lock, like run() and terminate().
-    for (const auto& reapable : reap)
+    for (const auto& reapable : reapables)
     {
         reapable->destroy(false);
     }

--- a/cpp/src/IceGrid/ReplicaSessionManager.cpp
+++ b/cpp/src/IceGrid/ReplicaSessionManager.cpp
@@ -295,12 +295,11 @@ void
 ReplicaSessionManager::create(const InternalRegistryPrx& replica)
 {
     shared_ptr<Thread> thread;
-    shared_ptr<Database> database;
     {
         unique_lock lock(_mutex);
 
-        // Wait until the session manager is fully initialized (or destroyed). _thread and _database are set by the
-        // other create() overload once the slave registry is ready.
+        // Wait until the session manager is fully initialized (or destroyed). _thread is set by the other create()
+        // overload once the slave registry is ready.
         _condVar.wait(lock, [this] { return _thread || !_communicator; });
 
         if (!_thread)
@@ -309,21 +308,15 @@ ReplicaSessionManager::create(const InternalRegistryPrx& replica)
             return;
         }
 
-        // Capture under the lock: destroy() clears _thread/_database, so we keep them alive for the calls below.
+        // Capture under the lock: destroy() clears _thread, so we keep it alive for the calls below.
         thread = _thread;
-        database = _database;
     }
 
-    if (!_master)
-    {
-        // No master registry configured (the communicator has no default locator), so there is nothing to do.
-        database->getTraceLevels()->logger->error("cannot create a replica session: no master registry configured");
-        return;
-    }
+    assert(_master); // a slave always has a default locator (enforced by RegistryI::startImpl)
 
     if (replica->ice_getIdentity() != _master->ice_getIdentity())
     {
-        database->getTraceLevels()->logger->error("can only create sessions with the master replica");
+        _traceLevels->logger->error("can only create sessions with the master replica");
         return;
     }
 

--- a/cpp/src/IceGrid/ReplicaSessionManager.cpp
+++ b/cpp/src/IceGrid/ReplicaSessionManager.cpp
@@ -294,22 +294,42 @@ ReplicaSessionManager::create(
 void
 ReplicaSessionManager::create(const InternalRegistryPrx& replica)
 {
+    shared_ptr<Thread> thread;
+    shared_ptr<Database> database;
     {
         unique_lock lock(_mutex);
 
-        // Wait to be initialized.
-        _condVar.wait(lock, [this] { return _master; });
+        // Wait until the session manager is fully initialized (or destroyed). _thread and _database are set by the
+        // other create() overload once the slave registry is ready.
+        _condVar.wait(lock, [this] { return _thread || !_communicator; });
+
+        if (!_thread)
+        {
+            // Destroyed before initialization completed.
+            return;
+        }
+
+        // Capture under the lock: destroy() clears _thread/_database, so we keep them alive for the calls below.
+        thread = _thread;
+        database = _database;
+    }
+
+    if (!_master)
+    {
+        // No master registry configured (the communicator has no default locator), so there is nothing to do.
+        database->getTraceLevels()->logger->error("cannot create a replica session: no master registry configured");
+        return;
     }
 
     if (replica->ice_getIdentity() != _master->ice_getIdentity())
     {
-        _database->getTraceLevels()->logger->error("can only create sessions with the master replica");
+        database->getTraceLevels()->logger->error("can only create sessions with the master replica");
         return;
     }
 
-    _thread->setRegistry(replica);
-    _thread->tryCreateSession();
-    _thread->waitTryCreateSession();
+    thread->setRegistry(replica);
+    thread->tryCreateSession();
+    thread->waitTryCreateSession();
 }
 
 NodePrxSeq
@@ -347,6 +367,9 @@ ReplicaSessionManager::destroy()
         _thread = nullptr;
 
         _communicator = nullptr;
+
+        // Wake any create(replica) parked waiting for initialization so it can bail out instead of hanging.
+        _condVar.notify_all();
     }
 
     if (thread)


### PR DESCRIPTION
This PR bundles four independent, single-file IceGrid fixes.

### 1. Application updates wedge forever on a database error (`Database::finishApplicationUpdate`)

`finishApplicationUpdate()` removed the application from the in-progress `_updating` set only on the `DeploymentException` path. On an `IceDB::LMDBException` (e.g. `MDB_MAP_FULL` when the LMDB map is exhausted) it only logged and rethrew, and a `ServerNotExistException` from `checkUpdate()` matched no handler at all. The orphaned `_updating` entry made `waitForUpdate()` block forever, so every subsequent add/update/remove of that application hung until the registry was restarted. All failure paths now run `finishUpdating()` before rethrowing.

(No CHANGELOG entry: an `LMDBException` such as `MDB_MAP_FULL` is effectively fatal to the registry in practice, so clearing the orphaned entry is correctness hygiene rather than an observable behavior change.)

### 2. Null-deref crash of a starting slave registry (`ReplicaSessionManager::create`)

`create(replica)` waited on `_condVar` for `_master`, intending to block until the manager was initialized — but `_master` is set in the `SessionManager` **constructor**, so the wait returned immediately while `_thread`/`_database` were still null. Since the `InternalRegistryI` servant is live on the already-activated registry adapter before the replica session manager is initialized, a master calling `registerWithReplica` into the slave during its startup window dereferenced null `_thread`/`_database` and crashed the slave. The wait now blocks on `_thread`; the pointers are captured under the lock, and `destroy()` notifies so a parked waiter bails out instead of hanging or crashing during shutdown.

### 3. Registry-wide session-establishment stall (`ReapThread::connectionClosed`)

`connectionClosed()` destroyed sessions while holding the reaper `_mutex`, unlike `run()`/`terminate()` which deliberately destroy outside the lock. `SessionI::destroyImpl` releases the session's allocations; releasing a `session`-allocation-mode server runs `ServerEntry::releasedNoSync` (`sync()` + `waitForSyncNoThrow()`, which waits indefinitely for the node) plus synchronous Glacier2 filter calls. Holding `_mutex` across that blocked the reaper loop and every `ReapThread::add()` — the call every new client/admin/node/replica session registers through — so a client disconnecting while holding such an allocation could stall establishment of all new sessions registry-wide. The reapables are now swapped out under the lock and destroyed after releasing it.

### 4. Spurious empty identity in the Glacier2 session filter (`AllocatableObjectCache`)

`allocated()`/`released()` built the identity-filter update with `Ice::IdentitySeq seq(1)` followed by `push_back`, producing a 2-element sequence `["", realId]` — i.e. they added/removed an **empty** identity to/from the session's Glacier2 `IdentitySet` on every allocate/release. Constructed the sequence with exactly the real identity instead. (No CHANGELOG entry: the empty identity matches no real object and `IdentitySet` add/remove is idempotent, so there is no observable user impact.)
