### PR TITLE
Fix ServerEntry data race on server allocation/load state

### DIFF
--- a/cpp/src/IceGrid/ServerCache.h
+++ b/cpp/src/IceGrid/ServerCache.h
@@ -110,8 +110,7 @@ namespace IceGrid
 
         std::shared_ptr<SessionI> _allocationSession;
 
-        mutable std::mutex _mutex;
-        std::condition_variable _condVar;
+        // ServerEntry deliberately does NOT declare its own _mutex/_condVar; it uses the Allocatable base members.
     };
     using ServerEntrySeq = std::vector<std::shared_ptr<ServerEntry>>;
 


### PR DESCRIPTION
## Problem

`IceGrid::ServerEntry` derives from `Allocatable` but declares its **own** `_mutex`/`_condVar`, which shadow the `protected` members of the `Allocatable` base:

```cpp
// ServerCache.h        — ServerEntry members (shadowing)
mutable std::mutex _mutex;
std::condition_variable _condVar;
```
```cpp
// Allocatable.h        — base members (shadowed)
mutable std::mutex _mutex;
std::condition_variable _condVar;
```

The base calls the `allocated()`/`released()` hooks **while holding `Allocatable::_mutex`** (`Allocatable.cpp` `allocate()`/`release()`). For a `ServerEntry`, those hooks mutate the load state — `_load`, `_loaded`, `_updated`, `_allocationSession`:

```cpp
// ServerCache.cpp — ServerEntry::allocated()
if (desc->activation == "session")
{
    _updated = true;
    if (!_load.get()) { _load.reset(_loaded.release()); }
    _allocationSession = session;
    _load->sessionId = session->getId();
}
```

But **every other** accessor of that same state — `update()`, `syncImpl()`, `loadCallback()`, `destroyCallback()`, `exception()`, `getInfo()`, `waitImpl()`, `allocatedNoSync()`/`releasedNoSync()` — synchronizes on the *shadowing* `ServerEntry::_mutex`, a different lock. So a client session allocating/releasing a `session`-activation server races a concurrent application update or node `loadCallback` on the same `unique_ptr`s (`loadCallback` does `_loaded.reset(_load.release())` while `allocated()` does `_load.reset(_loaded.release())`) — a data race / use-after-free, i.e. heap corruption in the registry. `update()` additionally wrote `_allocatable` (an `Allocatable` base field) under the shadowing lock.

## Fix

Remove the shadowing `ServerEntry::_mutex`/`_condVar` so all of `ServerEntry`'s load-state accessors bind to the `Allocatable` base members. The base's `allocated()`/`released()` hooks and the entry's own methods are then serialized by a single lock.

## Lock-ordering / recursion audit

Removing the shadow merges two locks into one, so I verified there is no recursive-lock or lock-order-inversion hazard:

- `allocated()`/`released()` are invoked **under** the base `_mutex` and do **not** take a lock themselves → no self-recursion; after the merge their field mutations are correctly serialized with all other accessors.
- `allocatedNoSync()`/`releasedNoSync()` are invoked **outside** the base lock (`Allocatable.cpp`), and only take the lock briefly before calling `sync()`/`waitForSyncNoThrow()` sequentially → no nesting.
- **No** `ServerEntry` method calls a base `Allocatable` locking method (`allocate`/`release`/`getSession`/`tryAllocate`) while holding the lock, so there is no `ServerEntry`→base ordering that could invert the base→`ServerEntry` ordering of the hooks.
- Base `checkAllocatable()` (called under the base lock) only reads `_allocatable`; `isEnabled()` takes no lock.
- All `_condVar` notifications in both `Allocatable.cpp` and `ServerCache.cpp` are `notify_all`, and `waitImpl()` loops on its predicate (`while (_synchronizing)`), so sharing one condition variable across the base's `!_releasing` predicate and the entry's `_synchronizing` predicate is safe.