### PR TITLE
Fix IceGrid node deadlock between server and adapter operations

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -2,6 +2,7 @@
     "version": "0.2",
     "language": "en",
     "words": [
+        "activatable",
         "apos",
         "Authenticode",
         "autoreleasepool",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ might need to be aware of.
   - [MATLAB Changes](#matlab-changes)
   - [Python Changes](#python-changes)
   - [Ruby Changes](#ruby-changes)
+  - [Ice Service Changes](#ice-service-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -72,6 +73,14 @@ might need to be aware of.
 - Fixed `Ice::Endpoint` comparison in Ice for Ruby. `<=>` compared an endpoint with itself, making `==`/`<=>`
   asymmetric, and the class defined `eql?` without a matching `hash`; equal endpoints now compare consistently and
   can be used as `Hash`/`Set` keys.
+
+### Ice Service Changes
+
+#### IceGrid
+
+- Fixed a deadlock in the IceGrid node that could occur when a server was restarted while one of its object adapters
+  was concurrently activated, deactivated, or queried. The node could hang, blocking all subsequent operations on
+  that node.
 
 These are the changes since the [Ice 3.8.2] release.
 

--- a/cpp/src/IceGrid/ServerAdapterI.cpp
+++ b/cpp/src/IceGrid/ServerAdapterI.cpp
@@ -68,8 +68,7 @@ ServerAdapterI::activateAsync(
         {
             return;
         }
-        _activateAfterDeactivating =
-            serverState >= ServerState::Deactivating && serverState < ServerState::Destroying;
+        _activateAfterDeactivating = serverState >= ServerState::Deactivating && serverState < ServerState::Destroying;
     }
 
     //

--- a/cpp/src/IceGrid/ServerAdapterI.cpp
+++ b/cpp/src/IceGrid/ServerAdapterI.cpp
@@ -33,6 +33,9 @@ ServerAdapterI::activateAsync(
     function<void(exception_ptr)>,
     const Ice::Current&)
 {
+    ServerState serverState = _server->getState();
+    bool activatable = _server->isAdapterActivatable(_id);
+
     {
         lock_guard lock(_mutex);
         if (_enabled && _proxy)
@@ -49,7 +52,7 @@ ServerAdapterI::activateAsync(
             // Nothing else waits for this adapter so we must make sure that this
             // adapter if still activatable.
             //
-            if (!_enabled || !_server->isAdapterActivatable(_id))
+            if (!_enabled || !activatable)
             {
                 response(nullopt);
                 return;
@@ -68,7 +71,7 @@ ServerAdapterI::activateAsync(
             return;
         }
         _activateAfterDeactivating =
-            _server->getState() >= ServerState::Deactivating && _server->getState() < ServerState::Destroying;
+            serverState >= ServerState::Deactivating && serverState < ServerState::Destroying;
     }
 
     //
@@ -104,6 +107,8 @@ ServerAdapterI::activateAsync(
 optional<Ice::ObjectPrx>
 ServerAdapterI::getDirectProxy(const Ice::Current&) const
 {
+    bool activatable = _server->isAdapterActivatable(_id);
+
     lock_guard lock(_mutex);
 
     //
@@ -116,71 +121,72 @@ ServerAdapterI::getDirectProxy(const Ice::Current&) const
     }
     else
     {
-        throw AdapterNotActiveException(_enabled && _server->isAdapterActivatable(_id));
+        throw AdapterNotActiveException(_enabled && activatable);
     }
 }
 
 void
 ServerAdapterI::setDirectProxy(optional<Ice::ObjectPrx> proxy)
 {
-    lock_guard lock(_mutex);
+    ServerState serverState = _server->getState();
 
-    //
-    // We don't allow to override an existing proxy by another non
-    // null proxy if the server is not inactive.
-    //
-    if (!_node->allowEndpointsOverride())
+    // The proxy is not null when the object adapter is activated; it's null when it's deactivated.
+    bool activated = (proxy != nullopt);
+
     {
-        if (proxy && _proxy)
+        lock_guard lock(_mutex);
+
+        //
+        // We don't allow to override an existing proxy by another non
+        // null proxy if the server is not inactive.
+        //
+        if (!_node->allowEndpointsOverride() && proxy && _proxy && serverState == ServerState::Active)
         {
-            if (_server->getState() == ServerState::Active)
+            throw AdapterActiveException();
+        }
+
+        bool updated = _proxy != proxy;
+        _proxy = std::move(proxy);
+
+        //
+        // If the server is being deactivated and the activation callback
+        // was added during the deactivation, we don't send the response
+        // now. The server is going to be activated again and the adapter
+        // activated.
+        //
+        if (serverState < ServerState::Deactivating || serverState >= ServerState::Destroying ||
+            !_activateAfterDeactivating)
+        {
+            for (const auto& response : _activateCB)
             {
-                throw AdapterActiveException();
+                response(_proxy);
+            }
+            _activateCB.clear();
+        }
+
+        if (updated)
+        {
+            _node->observerUpdateAdapter({_id, _proxy});
+        }
+
+        if (_node->getTraceLevels()->adapter > 1)
+        {
+            Ice::Trace out(_node->getTraceLevels()->logger, _node->getTraceLevels()->adapterCat);
+            out << "server '" + _serverId + "' adapter '" << _id << "' " << (_proxy ? "activated" : "deactivated");
+            if (_proxy)
+            {
+                out << ": " << _proxy;
             }
         }
     }
 
-    bool updated = _proxy != proxy;
-    _proxy = std::move(proxy);
-
-    //
-    // If the server is being deactivated and the activation callback
-    // was added during the deactivation, we don't send the response
-    // now. The server is going to be activated again and the adapter
-    // activated.
-    //
-    if (_server->getState() < ServerState::Deactivating || _server->getState() >= ServerState::Destroying ||
-        !_activateAfterDeactivating)
-    {
-        for (const auto& response : _activateCB)
-        {
-            response(_proxy);
-        }
-        _activateCB.clear();
-    }
-
-    if (updated)
-    {
-        _node->observerUpdateAdapter({_id, _proxy});
-    }
-
-    if (_proxy)
+    if (activated)
     {
         _server->adapterActivated(_id);
     }
     else
     {
         _server->adapterDeactivated(_id);
-    }
-
-    if (_node->getTraceLevels()->adapter > 1)
-    {
-        Ice::Trace out(_node->getTraceLevels()->logger, _node->getTraceLevels()->adapterCat);
-        out << "server '" + _serverId + "' adapter '" << _id << "' " << (_proxy ? "activated" : "deactivated");
-        if (_proxy)
-        {
-            out << ": " << _proxy;
-        }
     }
 }
 
@@ -207,8 +213,10 @@ ServerAdapterI::destroy()
 void
 ServerAdapterI::updateEnabled()
 {
+    // Query the server outside _mutex to preserve the lock order (see _mutex in the header).
+    bool enabled = _server->isEnabled();
     lock_guard lock(_mutex);
-    _enabled = _server->isEnabled();
+    _enabled = enabled;
 }
 
 void

--- a/cpp/src/IceGrid/ServerAdapterI.h
+++ b/cpp/src/IceGrid/ServerAdapterI.h
@@ -46,6 +46,7 @@ namespace IceGrid
         std::vector<std::function<void(const std::optional<Ice::ObjectPrx>&)>> _activateCB;
         bool _activateAfterDeactivating;
 
+        // Lock order: ServerI::_mutex is always acquired before ServerAdapterI::_mutex, never after.
         mutable std::mutex _mutex;
     };
 }

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -2611,6 +2611,16 @@ ServerI::setStateNoSync(InternalServerState st, const string& reason)
     _state = st;
 
     //
+    // Wake any thread waiting for the server to leave the Activating state (adapterDeactivated() and terminated()).
+    // The successful activation path notifies explicitly in activate(), but the activation-failure path
+    // (Activating -> Deactivating -> Inactive) would otherwise never notify, leaving those waiters parked forever.
+    //
+    if (previous == InternalServerState::Activating && _state != InternalServerState::Activating)
+    {
+        _condVar.notify_all();
+    }
+
+    //
     // Check if some commands are done.
     //
     bool loadFailure = false;

--- a/cpp/src/IceGrid/ServerI.h
+++ b/cpp/src/IceGrid/ServerI.h
@@ -171,6 +171,7 @@ namespace IceGrid
 
         int _pid{0};
 
+        // Lock order: ServerI::_mutex is always acquired before ServerAdapterI::_mutex, never after.
         mutable std::mutex _mutex;
         std::condition_variable _condVar;
     };


### PR DESCRIPTION
## Problem

### Lock-order inversion (deadlock)

`ServerI` owns its object adapters and the one unavoidable cross-lock nesting runs that way: `ServerI::update()` holds the `ServerI` `_mutex` and, via `updateImpl()`, calls `ServerAdapterI::destroy()`, which takes the adapter `_mutex`. So the intended order is **`ServerI::_mutex` before `ServerAdapterI::_mutex`**.

Several `ServerAdapterI` methods violated it by calling back into `ServerI` (which acquires the `ServerI` mutex) **while holding the adapter mutex**:

| Method | Call under the adapter `_mutex` |
|---|---|
| `setDirectProxy` | `getState()`, `adapterActivated()` / `adapterDeactivated()` |
| `activateAsync` | `isAdapterActivatable()`, `getState()` |
| `getDirectProxy` | `isAdapterActivatable()` |
| `updateEnabled` | `isEnabled()` |

Each is the inverse order (adapter mutex, then `ServerI` mutex) and forms an AB-BA cycle with `update() -> updateImpl() -> destroy()`, deadlocking the node and hanging all further operations on it.

The originally reported instance is `setDirectProxy` vs `activate`: `setDirectProxy` held the adapter mutex across `adapterDeactivated()`, which blocks until the server leaves the `Activating` state — and the only code that advances that state, `activate()`, needs the adapter mutex (via `clear()`):

```cpp
_condVar.wait(lock, [this] { return _state != InternalServerState::Activating; }); // adapterDeactivated, holds nothing of the adapter
for (const auto& adpt : adpts) { adpt.second->clear(); }                           // activate(), needs the adapter _mutex
```

### Companion lost wakeup

`ServerI::setStateNoSync` only notified `_condVar` on the `Destroyed` transition. The successful activation path notifies explicitly in `activate()`, but the activation-**failure** path (`Activating -> Deactivating -> Inactive`) never notified, so a thread parked in `adapterDeactivated()`/`terminated()` waiting for `_state != Activating` was never woken when activation failed.

## Fix

Establish a single lock order — **`ServerI::_mutex` before `ServerAdapterI::_mutex`, never the reverse** — so no `ServerAdapterI` method calls into `ServerI` while holding the adapter mutex:

- **`setDirectProxy`** — snapshot `getState()` before taking the adapter mutex; call `adapterActivated()`/`adapterDeactivated()` after releasing it.
- **`activateAsync` / `getDirectProxy` / `updateEnabled`** — query the needed `ServerI` state (`getState()` / `isAdapterActivatable()` / `isEnabled()`) before taking the adapter mutex, then use the snapshot under the lock.
- **`ServerI::setStateNoSync`** — notify `_condVar` whenever the server leaves the `Activating` state (not only on `Destroyed`), so the activation-failure path wakes parked waiters.
- Documented the lock order above the `_mutex` field in `ServerI.h` and `ServerAdapterI.h`.

## Notes

Snapshotting the server state before the lock means it is read slightly earlier than before; these reads were already best-effort (the original `setDirectProxy` called `getState()` three times non-atomically). If the server is `Destroyed`, `getState()` throws `ObjectNotExistException` — at least as safe as the prior behavior.
