### PR TITLE
Fix IceGrid node crash on property update of a process-less server

### DIFF
--- a/changelog.d/service-icegrid/5460.md
+++ b/changelog.d/service-icegrid/5460.md
@@ -1,0 +1,2 @@
+- Fixed a crash in the IceGrid node triggered by a no-restart application update that changed only the
+  properties of a running server whose Ice.Admin object adapter is disabled.

--- a/changelog.d/service-icegrid/5460.md
+++ b/changelog.d/service-icegrid/5460.md
@@ -1,2 +1,0 @@
-- Fixed a crash in the IceGrid node triggered by a no-restart application update that changed only the
-  properties of a running server whose Ice.Admin object adapter is disabled.

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -2497,6 +2497,7 @@ ServerI::updateRuntimePropertiesCallback(exception_ptr ex, const shared_ptr<Inte
 AdapterPrxDict
 ServerI::getAdapterProxies() const
 {
+    // assert(locked());
     AdapterPrxDict adapters;
     for (const auto& [id, servant] : _adapters)
     {
@@ -2508,6 +2509,7 @@ ServerI::getAdapterProxies() const
 void
 ServerI::finishLoad()
 {
+    // assert(locked());
     // Completes the pending load command, handing the current server and adapter proxies back to the caller.
     assert(_load);
     assert(_this);

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -2497,7 +2497,7 @@ ServerI::updateRuntimePropertiesCallback(exception_ptr ex, const shared_ptr<Inte
 AdapterPrxDict
 ServerI::getAdapterProxies() const
 {
-    // assert(locked());
+    // Must be called with _mutex held.
     AdapterPrxDict adapters;
     for (const auto& [id, servant] : _adapters)
     {
@@ -2509,7 +2509,7 @@ ServerI::getAdapterProxies() const
 void
 ServerI::finishLoad()
 {
-    // assert(locked());
+    // Must be called with _mutex held.
     // Completes the pending load command, handing the current server and adapter proxies back to the caller.
     assert(_load);
     assert(_this);
@@ -2519,7 +2519,7 @@ ServerI::finishLoad()
 bool
 ServerI::checkActivation()
 {
-    // assert(locked());
+    // Must be called with _mutex held.
     if (_state == InternalServerState::WaitForActivation || _state == InternalServerState::ActivationTimeout)
     {
         //

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -1205,8 +1205,24 @@ ServerI::load(
         {
             _load->addCallback(response, exception); // Must be called before startRuntimePropertiesUpdate!
             updateRevision(desc->uuid, desc->revision);
-            assert(_process);
-            _load->startRuntimePropertiesUpdate(*_process);
+            if (_process)
+            {
+                _load->startRuntimePropertiesUpdate(*_process);
+            }
+            else
+            {
+                //
+                // The server has no process to update its runtime properties on (e.g. its Ice.Admin object
+                // adapter is disabled), so there's nothing to update; complete the load now.
+                //
+                AdapterPrxDict adapters;
+                for (const auto& adapter : _adapters)
+                {
+                    adapters.insert({adapter.first, adapter.second->getProxy()});
+                }
+                assert(_this);
+                _load->finished(*_this, adapters, _activationTimeout, _deactivationTimeout);
+            }
         }
         else
         {
@@ -2760,8 +2776,24 @@ ServerI::setStateNoSync(InternalServerState st, const string& reason)
     {
         // If there's a pending load command, it's time to update the runtime properties of the server now that it's
         // active.
-        assert(_process);
-        _load->startRuntimePropertiesUpdate(*_process);
+        if (_process)
+        {
+            _load->startRuntimePropertiesUpdate(*_process);
+        }
+        else
+        {
+            //
+            // The server has no process to update its runtime properties on (e.g. its Ice.Admin object
+            // adapter is disabled), so there's nothing to update; complete the load now.
+            //
+            AdapterPrxDict adapters;
+            for (const auto& adapter : _adapters)
+            {
+                adapters.insert({adapter.first, adapter.second->getProxy()});
+            }
+            assert(_this);
+            _load->finished(*_this, adapters, _activationTimeout, _deactivationTimeout);
+        }
     }
 
     //

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -1138,13 +1138,8 @@ ServerI::load(
         }
         else if (response)
         {
-            AdapterPrxDict adapters;
-            for (const auto& [id, servant] : _adapters)
-            {
-                adapters.insert({id, servant->getProxy()});
-            }
             assert(_this);
-            response(*_this, adapters, secondsToInt(_activationTimeout), secondsToInt(_deactivationTimeout));
+            response(*_this, getAdapterProxies(), secondsToInt(_activationTimeout), secondsToInt(_deactivationTimeout));
         }
         return nullptr;
     }
@@ -1193,29 +1188,29 @@ ServerI::load(
             // the server proxy to register the server process proxy
             // with the node.
             //
-            AdapterPrxDict adapters;
-            for (const auto& adapter : _adapters)
-            {
-                adapters.insert({adapter.first, adapter.second->getProxy()});
-            }
             assert(_this);
-            response(*_this, adapters, secondsToInt(_activationTimeout), secondsToInt(_deactivationTimeout));
+            response(*_this, getAdapterProxies(), secondsToInt(_activationTimeout), secondsToInt(_deactivationTimeout));
         }
         else if (_state == InternalServerState::Active)
         {
-            _load->addCallback(response, exception); // Must be called before startRuntimePropertiesUpdate!
             updateRevision(desc->uuid, desc->revision);
             if (_process)
             {
+                _load->addCallback(response, exception); // Must be called before startRuntimePropertiesUpdate!
                 _load->startRuntimePropertiesUpdate(*_process);
             }
             else
             {
                 //
-                // The server has no process to update its runtime properties on (e.g. its Ice.Admin object
-                // adapter is disabled), so there's nothing to update; complete the load now.
+                // The server has no process to push runtime properties to (e.g. its Ice.Admin object adapter
+                // is disabled), so there's nothing to update; respond directly.
                 //
-                finishLoad();
+                assert(_this);
+                response(
+                    *_this,
+                    getAdapterProxies(),
+                    secondsToInt(_activationTimeout),
+                    secondsToInt(_deactivationTimeout));
             }
         }
         else
@@ -2499,18 +2494,24 @@ ServerI::updateRuntimePropertiesCallback(exception_ptr ex, const shared_ptr<Inte
     }
 }
 
+AdapterPrxDict
+ServerI::getAdapterProxies() const
+{
+    AdapterPrxDict adapters;
+    for (const auto& [id, servant] : _adapters)
+    {
+        adapters.insert({id, servant->getProxy()});
+    }
+    return adapters;
+}
+
 void
 ServerI::finishLoad()
 {
     // Completes the pending load command, handing the current server and adapter proxies back to the caller.
     assert(_load);
     assert(_this);
-    AdapterPrxDict adapters;
-    for (const auto& [id, servant] : _adapters)
-    {
-        adapters.insert({id, servant->getProxy()});
-    }
-    _load->finished(*_this, adapters, _activationTimeout, _deactivationTimeout);
+    _load->finished(*_this, getAdapterProxies(), _activationTimeout, _deactivationTimeout);
 }
 
 bool

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -1215,13 +1215,7 @@ ServerI::load(
                 // The server has no process to update its runtime properties on (e.g. its Ice.Admin object
                 // adapter is disabled), so there's nothing to update; complete the load now.
                 //
-                AdapterPrxDict adapters;
-                for (const auto& adapter : _adapters)
-                {
-                    adapters.insert({adapter.first, adapter.second->getProxy()});
-                }
-                assert(_this);
-                _load->finished(*_this, adapters, _activationTimeout, _deactivationTimeout);
+                finishLoad();
             }
         }
         else
@@ -1900,13 +1894,7 @@ ServerI::update()
                 _node->addServer(shared_from_this(), _desc->application);
             }
 
-            AdapterPrxDict adapters;
-            for (const auto& adpt : _adapters)
-            {
-                adapters.insert({adpt.first, adpt.second->getProxy()});
-            }
-            assert(_this);
-            _load->finished(*_this, adapters, _activationTimeout, _deactivationTimeout);
+            finishLoad();
         }
         catch (const DeploymentException& ex)
         {
@@ -2491,13 +2479,7 @@ ServerI::updateRuntimePropertiesCallback(const shared_ptr<InternalServerDescript
     assert(_process);
     if (_load->finishRuntimePropertiesUpdate(desc, *_process))
     {
-        AdapterPrxDict adapters;
-        for (const auto& [id, servant] : _adapters)
-        {
-            adapters.insert({id, servant->getProxy()});
-        }
-        assert(_this);
-        _load->finished(*_this, adapters, _activationTimeout, _deactivationTimeout);
+        finishLoad();
     }
 }
 
@@ -2515,6 +2497,20 @@ ServerI::updateRuntimePropertiesCallback(exception_ptr ex, const shared_ptr<Inte
     {
         _load->failed(ex);
     }
+}
+
+void
+ServerI::finishLoad()
+{
+    // Completes the pending load command, handing the current server and adapter proxies back to the caller.
+    assert(_load);
+    assert(_this);
+    AdapterPrxDict adapters;
+    for (const auto& [id, servant] : _adapters)
+    {
+        adapters.insert({id, servant->getProxy()});
+    }
+    _load->finished(*_this, adapters, _activationTimeout, _deactivationTimeout);
 }
 
 bool
@@ -2786,13 +2782,7 @@ ServerI::setStateNoSync(InternalServerState st, const string& reason)
             // The server has no process to update its runtime properties on (e.g. its Ice.Admin object
             // adapter is disabled), so there's nothing to update; complete the load now.
             //
-            AdapterPrxDict adapters;
-            for (const auto& adapter : _adapters)
-            {
-                adapters.insert({adapter.first, adapter.second->getProxy()});
-            }
-            assert(_this);
-            _load->finished(*_this, adapters, _activationTimeout, _deactivationTimeout);
+            finishLoad();
         }
     }
 

--- a/cpp/src/IceGrid/ServerI.h
+++ b/cpp/src/IceGrid/ServerI.h
@@ -129,6 +129,9 @@ namespace IceGrid
         std::shared_ptr<ServerCommand> nextCommand();
         void setStateNoSync(InternalServerState, const std::string& = std::string());
 
+        // Returns a dictionary with the proxies of all the server's adapters.
+        [[nodiscard]] AdapterPrxDict getAdapterProxies() const;
+
         // Completes the pending load command (_load), handing back the current server and adapter proxies.
         void finishLoad();
 

--- a/cpp/src/IceGrid/ServerI.h
+++ b/cpp/src/IceGrid/ServerI.h
@@ -129,6 +129,9 @@ namespace IceGrid
         std::shared_ptr<ServerCommand> nextCommand();
         void setStateNoSync(InternalServerState, const std::string& = std::string());
 
+        // Completes the pending load command (_load), handing back the current server and adapter proxies.
+        void finishLoad();
+
         [[nodiscard]] ServerState toServerState(InternalServerState) const;
         [[nodiscard]] ServerActivation toServerActivation(const std::string&) const;
         [[nodiscard]] ServerDynamicInfo getDynamicInfo() const;

--- a/cpp/test/IceGrid/noRestartUpdate/AllTests.cpp
+++ b/cpp/test/IceGrid/noRestartUpdate/AllTests.cpp
@@ -522,7 +522,7 @@ allTests(Test::TestHelper* helper)
             admin->stopServer("NoProcessServer");
 
             update = empty;
-            update.nodes[0].removeServers.push_back("NoProcessServer");
+            update.nodes[0].removeServers.emplace_back("NoProcessServer");
             admin->updateApplicationWithoutRestart(update);
         }
         cout << "ok" << endl;

--- a/cpp/test/IceGrid/noRestartUpdate/AllTests.cpp
+++ b/cpp/test/IceGrid/noRestartUpdate/AllTests.cpp
@@ -480,6 +480,53 @@ allTests(Test::TestHelper* helper)
         test(serverPid == admin->getServerPid("Server"));
         cout << "ok" << endl;
 
+        cout << "testing server update without a registered process... " << flush;
+        {
+            //
+            // A server with Ice.Admin.Enabled=0 reaches the Active state without a registered process. A
+            // property-only update of such a running server must complete without crashing the node.
+            //
+            auto noProcess = make_shared<ServerDescriptor>();
+            noProcess->id = "NoProcessServer";
+            noProcess->exe = properties->getProperty("ServerDir") + "/server";
+            noProcess->pwd = ".";
+            noProcess->allocatable = false;
+            noProcess->activation = "on-demand";
+            addProperty(noProcess, "Ice.Admin.Enabled", "0");
+            addProperty(noProcess, "Server.Endpoints", "default");
+            AdapterDescriptor noProcessAdapter;
+            noProcessAdapter.name = "Server";
+            noProcessAdapter.id = "NoProcessServerAdapter";
+            noProcessAdapter.serverLifetime = true;
+            ObjectDescriptor noProcessObject;
+            noProcessObject.id = Ice::stringToIdentity("${server}");
+            noProcessObject.type = "::Test::TestIntf";
+            noProcessAdapter.objects.push_back(noProcessObject);
+            noProcess->adapters.push_back(noProcessAdapter);
+
+            update = empty;
+            update.nodes[0].servers.push_back(noProcess);
+            admin->updateApplicationWithoutRestart(update);
+
+            admin->startServer("NoProcessServer");
+            test(admin->getServerState("NoProcessServer") == ServerState::Active);
+
+            ServerInfo noProcessInfo = admin->getServerInfo("NoProcessServer");
+            addProperty(noProcessInfo.descriptor, "test", "test");
+            updateServerRuntimeProperties(admin, "NoProcessServer", noProcessInfo.descriptor);
+
+            // The node survived the property update and the server is still active.
+            test(admin->getServerState("NoProcessServer") == ServerState::Active);
+            test(hasProperty(admin->getServerInfo("NoProcessServer").descriptor, "test", "test"));
+
+            admin->stopServer("NoProcessServer");
+
+            update = empty;
+            update.nodes[0].removeServers.push_back("NoProcessServer");
+            admin->updateApplicationWithoutRestart(update);
+        }
+        cout << "ok" << endl;
+
         cout << "testing icebox server add... " << flush;
 
         auto service = make_shared<ServiceDescriptor>();

--- a/cpp/test/IceGrid/noRestartUpdate/AllTests.cpp
+++ b/cpp/test/IceGrid/noRestartUpdate/AllTests.cpp
@@ -483,8 +483,9 @@ allTests(Test::TestHelper* helper)
         cout << "testing server update without a registered process... " << flush;
         {
             //
-            // A server with Ice.Admin.Enabled=0 reaches the Active state without a registered process. A
-            // property-only update of such a running server must complete without crashing the node.
+            // Misconfiguration guard: a server with Ice.Admin.Enabled=0 reaches the Active state without a
+            // registered process (a process is normally registered through the Ice.Admin Process facet). A
+            // property-only update of such a server must not crash the node.
             //
             auto noProcess = make_shared<ServerDescriptor>();
             noProcess->id = "NoProcessServer";


### PR DESCRIPTION
Guards the runtime-properties update on `_process` so a no-restart, property-only update of a running server with `Ice.Admin.Enabled=0` (which reaches the Active state without a registered process) no longer dereferences a disengaged optional and crashes the node. Includes a `noRestartUpdate` regression test.

Fixes #5460