### PR TITLE
Detect cyclic variables in IceGrid descriptors

### DIFF
--- a/changelog.d/service-icegrid/5464.md
+++ b/changelog.d/service-icegrid/5464.md
@@ -1,0 +1,2 @@
+- Fixed the IceGrid registry to reject a descriptor with a self-referential or cyclic variable definition by
+  raising a deployment error, instead of crashing from unbounded recursion.

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -822,6 +822,13 @@ Resolver::hasReplicaGroup(const string& id) const
 string
 Resolver::substitute(const string& v, bool useParams, bool useIgnored) const
 {
+    set<string> inProgress;
+    return substitute(v, useParams, useIgnored, inProgress);
+}
+
+string
+Resolver::substitute(const string& v, bool useParams, bool useIgnored, set<string>& inProgress) const
+{
     string value(v);
     string::size_type beg = 0;
     string::size_type end = 0;
@@ -885,7 +892,12 @@ Resolver::substitute(const string& v, bool useParams, bool useIgnored) const
         string val = getVariable(name, useParams, param);
         if (!param)
         {
-            val = substitute(val, false, useIgnored); // Recursive resolution
+            if (!inProgress.insert(name).second)
+            {
+                throw invalid_argument("detected circular dependency in variable '" + name + "'");
+            }
+            val = substitute(val, false, useIgnored, inProgress); // Recursive resolution
+            inProgress.erase(name);
         }
         value.replace(beg, end - beg + 1, val);
         beg += val.length();

--- a/cpp/src/IceGrid/DescriptorHelper.h
+++ b/cpp/src/IceGrid/DescriptorHelper.h
@@ -53,6 +53,7 @@ namespace IceGrid
 
     private:
         [[nodiscard]] std::string substitute(const std::string&, bool, bool) const;
+        [[nodiscard]] std::string substitute(const std::string&, bool, bool, std::set<std::string>&) const;
         std::string getVariable(const std::string&, bool, bool&) const;
         PropertyDescriptorSeq getProperties(const Ice::StringSeq&, std::set<std::string>&) const;
 

--- a/cpp/test/IceGrid/update/AllTests.cpp
+++ b/cpp/test/IceGrid/update/AllTests.cpp
@@ -607,6 +607,40 @@ allTests(Test::TestHelper* helper)
     }
 
     {
+        cout << "testing variable cycle detection... " << flush;
+
+        //
+        // A self-referential variable must be rejected with a DeploymentException, rather than recursing
+        // until the registry runs out of stack.
+        //
+        ApplicationDescriptor app;
+        app.name = "CycleApp";
+        app.variables["cycle"] = "${cycle}";
+
+        auto server = make_shared<ServerDescriptor>();
+        server->id = "CycleServer";
+        server->exe = "${cycle}";
+        server->pwd = ".";
+        server->activation = "on-demand";
+
+        NodeDescriptor node;
+        node.servers.push_back(server);
+        app.nodes["localnode"] = node;
+
+        try
+        {
+            admin->addApplication(app);
+            test(false);
+        }
+        catch (const DeploymentException& ex)
+        {
+            test(ex.reason.find("circular dependency") != string::npos);
+        }
+
+        cout << "ok" << endl;
+    }
+
+    {
         cout << "testing node add... " << flush;
 
         ApplicationDescriptor testApp;


### PR DESCRIPTION
Detects self-referential or cyclic descriptor variables and raises a `DeploymentException`, instead of recursing until the registry runs out of stack.

The check is path-based — a variable is marked in-progress before its value is resolved and unmarked afterward — so it flags only genuine cycles (`${a}` → `${a}`, or mutual A→B→A) and never the legitimate case of a variable referenced more than once (e.g. `${a}${a}`). It is similar in spirit to the existing circular-dependency check for property-set references, but more precise: that one only tracks visited references (without unmarking), so it can over-reject a property set referenced twice via independent parents.

Includes an `update` regression test.

Fixes #5464
