### PR TITLE
Fix IceGrid node directory ordering to be locale-independent

### DIFF
--- a/changelog.d/service-icegrid/5465.md
+++ b/changelog.d/service-icegrid/5465.md
@@ -1,0 +1,3 @@
+- Fixed an IceGrid node consistency check that could remove files belonging to a deployed server when the node
+  ran under a non-C locale, because directory entries were sorted inconsistently. The node now sorts them using
+  a locale-independent ordering.

--- a/cpp/src/IceGrid/Util.cpp
+++ b/cpp/src/IceGrid/Util.cpp
@@ -429,7 +429,7 @@ IceGrid::readDirectory(const string& pa)
 #else
 
     struct dirent** namelist;
-    int n = scandir(path.c_str(), &namelist, nullptr, alphasort);
+    int n = scandir(path.c_str(), &namelist, nullptr, nullptr);
 
     if (n < 0)
     {
@@ -454,6 +454,13 @@ IceGrid::readDirectory(const string& pa)
     }
 
     free(namelist);
+
+    //
+    // Sort byte-wise so the result has the same ordering as the Windows branch above. Callers combine
+    // this list with byte-wise sorted ranges (e.g. std::set_difference), which requires a consistent
+    // ordering; scandir's alphasort uses the locale-dependent strcoll, which can disagree.
+    //
+    sort(result.begin(), result.end());
     return result;
 
 #endif


### PR DESCRIPTION
Sorts POSIX directory entries byte-wise (matching the Windows branch) instead of with the locale-dependent `alphasort`/`strcoll`, so the node's `set_difference`-based consistency checks stay correct under a non-C locale.

Fixes #5465