### PR TITLE
Fix IceGrid registry crashes in allocatable object cleanup

### DIFF
--- a/changelog.d/service-icegrid/icegrid-alloc-nullderef.md
+++ b/changelog.d/service-icegrid/icegrid-alloc-nullderef.md
@@ -1,0 +1,2 @@
+- Fixed a crash in the IceGrid registry that could occur when an allocatable object was removed by an
+  application update while an allocation request for that object was still pending.

--- a/changelog.d/service-icegrid/icegrid-alloc-nullderef.md
+++ b/changelog.d/service-icegrid/icegrid-alloc-nullderef.md
@@ -1,2 +1,3 @@
-- Fixed a crash in the IceGrid registry that could occur when an allocatable object was removed by an
-  application update while an allocation request for that object was still pending.
+- Fixed a crash in the IceGrid registry that could occur when an application declared the same
+  allocatable object identity more than once (which IceGrid tolerates with a logged error) and that
+  application was later updated or removed.

--- a/cpp/src/IceGrid/Allocatable.cpp
+++ b/cpp/src/IceGrid/Allocatable.cpp
@@ -305,7 +305,10 @@ Allocatable::release(const shared_ptr<SessionI>& session, bool fromRelease)
                 }
                 catch (const Ice::UserException&)
                 {
-                    request->cancel(current_exception());
+                    if (request)
+                    {
+                        request->cancel(current_exception());
+                    }
                 }
             }
         }

--- a/cpp/src/IceGrid/Allocatable.cpp
+++ b/cpp/src/IceGrid/Allocatable.cpp
@@ -305,10 +305,10 @@ Allocatable::release(const shared_ptr<SessionI>& session, bool fromRelease)
                 }
                 catch (const Ice::UserException&)
                 {
-                    if (request)
-                    {
-                        request->cancel(current_exception());
-                    }
+                    // Reachable only via the allocate(request, true) branch above; canTryAllocate()
+                    // never throws a UserException, so request is non-null here.
+                    assert(request);
+                    request->cancel(current_exception());
                 }
             }
         }

--- a/cpp/src/IceGrid/AllocatableObjectCache.cpp
+++ b/cpp/src/IceGrid/AllocatableObjectCache.cpp
@@ -168,6 +168,7 @@ AllocatableObjectCache::remove(const Ice::Identity& id)
         {
             Ice::Error out(_communicator->getLogger());
             out << "can't remove unknown object '" << _communicator->identityToString(id) << "'";
+            return;
         }
         removeImpl(id);
 


### PR DESCRIPTION
Two registry null-dereference crash fixes in the allocatable path:
- Only call `request->cancel()` when the request is non-null (`tryAllocate` attempts are queued with a null request).
- Return after logging an unknown-object error in `AllocatableObjectCache::remove()`, mirroring `ObjectCache::remove()`.

Fixes #5459
Fixes #5458