### PR TITLE
Fix IceGrid node descriptor leaks on server activation failure

### DIFF
--- a/changelog.d/service-icegrid/icegrid-activator-leak.md
+++ b/changelog.d/service-icegrid/icegrid-activator-leak.md
@@ -1,0 +1,4 @@
+- Fixed a file descriptor leak in the IceGrid node. When server activation failed because the host was out of
+  file descriptors or processes, the node leaked the pipes it had already opened, worsening the shortage.
+- Fixed a shutdown hang in the IceGrid node on Windows that could occur when the node failed to register the
+  wait handler for a server it had just started.

--- a/changelog.d/service-icegrid/icegrid-activator-leak.md
+++ b/changelog.d/service-icegrid/icegrid-activator-leak.md
@@ -1,4 +1,1 @@
-- Fixed a file descriptor leak in the IceGrid node. When server activation failed because the host was out of
-  file descriptors or processes, the node leaked the pipes it had already opened, worsening the shortage.
-- Fixed a shutdown hang in the IceGrid node on Windows that could occur when the node failed to register the
-  wait handler for a server it had just started.
+- Fixed a shutdown hang in the IceGrid node on Windows that could occur after a server activation failed.

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -614,6 +614,13 @@ Activator::activate(
         Ice::Warning out(_traceLevels->logger);
         out << "server activation failed for '" << name << "':\ncouldn't register wait callback\n" << message;
 
+        //
+        // The wait callback was not registered, so this entry will never be reaped. Close the process
+        // handle and remove the entry so the table stays consistent and a later activate() re-inserts cleanly.
+        //
+        CloseHandle(pp->hnd);
+        _processes.erase(it);
+
         throw runtime_error(message);
     }
 
@@ -686,7 +693,10 @@ Activator::activate(
     int errorFds[2];
     if (pipe(errorFds) != 0)
     {
-        throw SyscallException{__FILE__, __LINE__, "pipe failed", errno};
+        int error = errno;
+        close(fds[0]);
+        close(fds[1]);
+        throw SyscallException{__FILE__, __LINE__, "pipe failed", error};
     }
 
     //
@@ -703,7 +713,12 @@ Activator::activate(
     pid_t pid = fork();
     if (pid == -1)
     {
-        throw SyscallException{__FILE__, __LINE__, "fork failed", errno};
+        int error = errno;
+        close(fds[0]);
+        close(fds[1]);
+        close(errorFds[0]);
+        close(errorFds[1]);
+        throw SyscallException{__FILE__, __LINE__, "fork failed", error};
     }
 
     if (pid == 0) // Child process.


### PR DESCRIPTION
Cleans up the Activator's activation-failure paths:
- POSIX: close the already-opened pipes before throwing on a second `pipe()`/`fork()` failure.
- Windows: close the process handle and erase the `_processes` entry when `RegisterWaitForSingleObject` fails, so the table stays consistent and node shutdown does not hang.

Fixes #5467
Fixes #5462