### PR TITLE
Fix low-severity correctness issues in IceGrid

### DIFF
--- a/changelog.d/service-icegrid/5489.md
+++ b/changelog.d/service-icegrid/5489.md
@@ -1,4 +1,2 @@
-- Fixed the expansion of a server environment variable whose value contains a `}` before a `${...}` reference.
-  Such a value was previously corrupted before being passed to the server process.
-- Fixed the IceGrid descriptor parser to reject a descriptor whose `<include>` elements include themselves
-  with a deployment error, instead of crashing from unbounded recursion.
+- Fixed a crash in IceGrid when parsing an application descriptor whose `<include>` elements reference
+  themselves directly or indirectly. The descriptor parser now reports a deployment error instead of crashing.

--- a/changelog.d/service-icegrid/5489.md
+++ b/changelog.d/service-icegrid/5489.md
@@ -1,0 +1,4 @@
+- Fixed the expansion of a server environment variable whose value contains a `}` before a `${...}` reference.
+  Such a value was previously corrupted before being passed to the server process.
+- Fixed the IceGrid descriptor parser to reject a descriptor whose `<include>` elements include themselves
+  with a deployment error, instead of crashing from unbounded recursion.

--- a/cpp/src/IceGrid/DescriptorParser.cpp
+++ b/cpp/src/IceGrid/DescriptorParser.cpp
@@ -49,6 +49,7 @@ namespace
         bool _isCurrentTargetDeployable{true};
         int _line{0};
         int _column{0};
+        int _includeLevel{0};
 
         unique_ptr<ApplicationDescriptorBuilder> _currentApplication;
         unique_ptr<NodeDescriptorBuilder> _currentNode;
@@ -124,6 +125,15 @@ namespace
             }
             else if (name == "include")
             {
+                //
+                // Guard against an <include> that (directly or indirectly) includes itself, which would
+                // otherwise recurse until the process runs out of stack.
+                //
+                if (++_includeLevel > 100)
+                {
+                    error("too many nested <include> elements");
+                }
+
                 string targets = attributes("targets", "");
                 string file = attributes("file");
                 if (file[0] != '/')
@@ -145,6 +155,7 @@ namespace
 
                 _filename = oldFileName;
                 _targets = oldTargets;
+                --_includeLevel;
             }
             else if (name == "application")
             {

--- a/cpp/src/IceGrid/ReapThread.h
+++ b/cpp/src/IceGrid/ReapThread.h
@@ -96,7 +96,7 @@ namespace IceGrid
         bool calcWakeInterval();
 
         Ice::CloseCallback _closeCallback;
-        std::chrono::milliseconds _wakeInterval;
+        std::chrono::milliseconds _wakeInterval{0};
         bool _terminated{false};
         struct ReapableItem
         {

--- a/cpp/src/IceGrid/ServerAdapterI.h
+++ b/cpp/src/IceGrid/ServerAdapterI.h
@@ -44,7 +44,7 @@ namespace IceGrid
         std::optional<Ice::ObjectPrx> _proxy;
         bool _enabled;
         std::vector<std::function<void(const std::optional<Ice::ObjectPrx>&)>> _activateCB;
-        bool _activateAfterDeactivating;
+        bool _activateAfterDeactivating{false};
 
         // Lock order: ServerI::_mutex is always acquired before ServerAdapterI::_mutex, never after.
         mutable std::mutex _mutex;

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -347,7 +347,7 @@ namespace IceGrid
             string variable;
             if (v[beg + 1] == '{')
             {
-                end = v.find('}');
+                end = v.find('}', beg);
                 if (end == string::npos)
                 {
                     break;


### PR DESCRIPTION
Low-severity IceGrid correctness cleanup (#5489):
- Initialize `ReapThread::_wakeInterval` and `ServerAdapterI::_activateAfterDeactivating`, which were read before being assigned.
- Expand a server environment variable whose value contains a `}` before a `${...}` reference correctly (search for the closing brace from the reference start), instead of corrupting the value.
- Reject a descriptor whose `<include>` elements include themselves with a `DeploymentException`, instead of recursing until the process runs out of stack.

Fixes #5489