### PR TITLE
Fix Glacier2 _pending leak on synchronous CommunicatorDestroyedException

### DIFF
--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -147,13 +147,20 @@ namespace Glacier2
             auto ctx = _current.ctx;
             ctx.insert(_context.begin(), _context.end());
             auto self = static_pointer_cast<UserPasswordCreateSession>(shared_from_this());
-            _sessionRouter->_verifier->checkPermissionsAsync(
-                _user,
-                _password,
-                [self](bool ok, const string& reason) { self->checkPermissionsResponse(ok, reason); },
-                [self](exception_ptr e) { self->checkPermissionsException(e); },
-                nullptr,
-                ctx);
+            try
+            {
+                _sessionRouter->_verifier->checkPermissionsAsync(
+                    _user,
+                    _password,
+                    [self](bool ok, const string& reason) { self->checkPermissionsResponse(ok, reason); },
+                    [self](exception_ptr e) { self->checkPermissionsException(e); },
+                    nullptr,
+                    ctx);
+            }
+            catch (const Ice::CommunicatorDestroyedException&)
+            {
+                checkPermissionsException(std::current_exception());
+            }
         }
 
         shared_ptr<FilterManager> createFilterManager() final { return FilterManager::create(_instance, _user, true); }
@@ -252,12 +259,19 @@ namespace Glacier2
             ctx.insert(_context.begin(), _context.end());
 
             auto self = static_pointer_cast<SSLCreateSession>(shared_from_this());
-            _sessionRouter->_sslVerifier->authorizeAsync(
-                _sslInfo,
-                [self](bool ok, const string& reason) { self->authorizeResponse(ok, reason); },
-                [self](exception_ptr e) { self->authorizeException(e); },
-                nullptr,
-                ctx);
+            try
+            {
+                _sessionRouter->_sslVerifier->authorizeAsync(
+                    _sslInfo,
+                    [self](bool ok, const string& reason) { self->authorizeResponse(ok, reason); },
+                    [self](exception_ptr e) { self->authorizeException(e); },
+                    nullptr,
+                    ctx);
+            }
+            catch (const Ice::CommunicatorDestroyedException&)
+            {
+                authorizeException(std::current_exception());
+            }
         }
 
         shared_ptr<FilterManager> createFilterManager() final { return FilterManager::create(_instance, _user, false); }


### PR DESCRIPTION
## Problem

`Glacier2::CreateSession::authorize()` makes an asynchronous verifier call (`checkPermissionsAsync` / `authorizeAsync`). Contrary to first impressions, that call **can throw `CommunicatorDestroyedException` synchronously** while the router's communicator is being destroyed: the async machinery delivers a failed invocation through `OutgoingAsyncBase::invokeExceptionAsync()` → `clientThreadPool()->execute(...)`, and that call itself throws `CommunicatorDestroyedException` once the communicator is gone (its own comment notes it is "the only exception that can propagate directly from this method"). This is exercised by `test/Ice/ami/AllTests.cpp`.

`Instance::destroy()` tears down the outgoing connection factory and the thread pools before joining the threads still running dispatches/callbacks, so a `CreateSession` that reaches `authorize()` during that shutdown window can hit this.

When it does, the exception propagates up to `CreateSession::create()`, which calls `finished()` and leaves the connection in `_pending` without replaying the queued `_pendingCallbacks`. `~SessionRouterI` asserts `_pending.empty()`, so a **debug** build can abort on this shutdown race. (Release builds are unaffected, and functionally it's moot since the router is being destroyed.)

## Fix

Catch `CommunicatorDestroyedException` in `authorize()` and route it through the **same** handler the asynchronous failure path uses (`checkPermissionsException` / `authorizeException` → `exception()`), which erases the `_pending` entry and replays the queued callbacks. A synchronous and an asynchronous verifier failure now clean up identically; `create()` is unchanged and remains unaware of `_pending`.

No CHANGELOG entry: this only manifests as a debug-build assertion during a shutdown race.