### PR TITLE
Fix out-of-bounds FD_SET in the IceGrid node termination listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ might need to be aware of.
   - [MATLAB Changes](#matlab-changes)
   - [Python Changes](#python-changes)
   - [Ruby Changes](#ruby-changes)
+  - [Ice Service Changes](#ice-service-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -72,6 +73,14 @@ might need to be aware of.
 - Fixed `Ice::Endpoint` comparison in Ice for Ruby. `<=>` compared an endpoint with itself, making `==`/`<=>`
   asymmetric, and the class defined `eql?` without a matching `hash`; equal endpoints now compare consistently and
   can be used as `Hash`/`Set` keys.
+
+### Ice Service Changes
+
+#### IceGrid
+
+- Fixed a memory-corruption bug in the IceGrid node on POSIX systems. A node managing enough servers for a server's
+  status pipe to reach file descriptor 1024 wrote out of bounds while monitoring server termination, which could
+  corrupt memory and leave that server's termination undetected.
 
 These are the changes since the [Ice 3.8.2] release.
 

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -11,6 +11,7 @@
 #include "Util.h"
 
 #include <chrono>
+#include <set>
 #include <stdexcept>
 #include <thread>
 
@@ -21,6 +22,7 @@
 
 #ifndef _WIN32
 #    include <csignal>
+#    include <poll.h>
 #    include <pwd.h> // for getpwuid
 #    include <sys/wait.h>
 #    include <unistd.h>
@@ -1259,44 +1261,56 @@ Activator::terminationListener()
 #else
     while (true)
     {
-        fd_set fdSet;
-        int maxFd = _fdIntrRead;
-        FD_ZERO(&fdSet);
-        FD_SET(_fdIntrRead, &fdSet);
-
+        //
+        // Build the poll set: the interrupt pipe plus every active server's status pipe. We use poll() rather than
+        // select() because these fds are unbounded (a node can run more servers than FD_SETSIZE), and calling FD_SET
+        // on an fd >= FD_SETSIZE is undefined behavior (out-of-bounds write).
+        //
+        vector<pollfd> pollFds;
         {
             lock_guard lock(_mutex);
 
+            pollFds.reserve(_processes.size() + 1);
+            pollFds.push_back({_fdIntrRead, POLLIN, 0});
             for (const auto& p : _processes)
             {
-                int fd = p.second.pipeFd;
-                FD_SET(fd, &fdSet);
-                if (maxFd < fd)
-                {
-                    maxFd = fd;
-                }
+                pollFds.push_back({p.second.pipeFd, POLLIN, 0});
             }
         }
 
-    repeatSelect:
-        int ret = ::select(maxFd + 1, &fdSet, nullptr, nullptr, nullptr);
-        assert(ret != 0);
+    repeatPoll:
+        int ret = ::poll(pollFds.data(), static_cast<nfds_t>(pollFds.size()), -1);
+        assert(ret != 0); // no timeout, so poll cannot return 0
 
         if (ret == -1)
         {
-#    ifdef EPROTO
-            if (errno == EINTR || errno == EPROTO)
-            {
-                goto repeatSelect;
-            }
-#    else
             if (errno == EINTR)
             {
-                goto repeatSelect;
+                goto repeatPoll;
             }
-#    endif
 
-            throw SyscallException{__FILE__, __LINE__, "select failed", errno};
+            throw SyscallException{__FILE__, __LINE__, "poll failed", errno};
+        }
+
+        //
+        // Collect the fds with activity. An fd is "ready" when there is data to read (POLLIN), the writer closed its
+        // end (POLLHUP, i.e. the server terminated), or an error was reported (POLLERR/POLLNVAL).
+        //
+        bool intr = false;
+        set<int> readyFds;
+        for (const auto& pollFd : pollFds)
+        {
+            if (pollFd.revents != 0)
+            {
+                if (pollFd.fd == _fdIntrRead)
+                {
+                    intr = true;
+                }
+                else
+                {
+                    readyFds.insert(pollFd.fd);
+                }
+            }
         }
 
         vector<Process> terminated;
@@ -1304,7 +1318,7 @@ Activator::terminationListener()
         {
             lock_guard lock(_mutex);
 
-            if (FD_ISSET(_fdIntrRead, &fdSet))
+            if (intr)
             {
                 clearInterrupt();
 
@@ -1318,7 +1332,7 @@ Activator::terminationListener()
             while (p != _processes.end())
             {
                 int fd = p->second.pipeFd;
-                if (!FD_ISSET(fd, &fdSet))
+                if (readyFds.find(fd) == readyFds.end())
                 {
                     ++p;
                     continue;


### PR DESCRIPTION
On POSIX, the IceGrid node's `Activator` termination listener built an `fd_set` with `FD_SET` over every active server's status-pipe file descriptor, with no `FD_SETSIZE` guard:

```cpp
fd_set fdSet;
FD_ZERO(&fdSet);
FD_SET(_fdIntrRead, &fdSet);
for (const auto& p : _processes)
{
    FD_SET(p.second.pipeFd, &fdSet); // no check against FD_SETSIZE
    ...
}
```

`fd_set` is a fixed-size bitmap of `FD_SETSIZE` (1024) bits. Once any monitored fd reaches 1024, `FD_SET` writes past the end of the structure — undefined behavior / stack corruption — and that server's termination is never detected (its bit can't be represented). A node running a few hundred servers crosses fd 1024 easily, since each server holds several descriptors.

This replaces `select()` with `poll()`, whose `pollfd` array has no `FD_SETSIZE` limit:

- Build a `vector<pollfd>` (interrupt pipe + each server's status pipe) under `_mutex`.
- Poll, retrying on `EINTR`.
- Treat any non-zero `revents` (`POLLIN`/`POLLHUP`/`POLLERR`/`POLLNVAL`) as activity; collect the ready fds into a `set<int>` and process terminations as before.

Behavior is otherwise unchanged; only the readiness mechanism differs.
