### PR TITLE
Removed incorrect 2nd arg to `substr` in `StringUtil.cpp`

### DIFF
--- a/cpp/src/Ice/StringUtil.cpp
+++ b/cpp/src/Ice/StringUtil.cpp
@@ -801,7 +801,7 @@ IceInternal::match(const string& s, const string& pat, bool emptyMatch)
     //
     // Make sure end of the strings match
     //
-    if (s.substr(endIndex, s.length()) != pat.substr(beginIndex + 1, pat.length()))
+    if (s.substr(endIndex) != pat.substr(beginIndex + 1))
     {
         return false;
     }


### PR DESCRIPTION
Fixes the C++ side of #5632.