### PR TITLE
Fix IceStorm topic-operation guards and a shutdown hang

### DIFF
--- a/changelog.d/service-icestorm/icestorm-topic-guards-shutdown.md
+++ b/changelog.d/service-icestorm/icestorm-topic-guards-shutdown.md
@@ -1,0 +1,4 @@
+- Fixed a hang that could prevent IceStorm from shutting down cleanly when a subscriber still had requests outstanding
+  to an unreachable endpoint.
+- Fixed a race in IceStorm where destroying a topic concurrently with a subscribe or link to the same topic could leave
+  an orphaned record in the database, causing the destroyed topic to reappear the next time IceStorm was restarted.

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -717,6 +717,11 @@ Subscriber::error(bool dec, exception_ptr e)
     auto now = std::chrono::steady_clock::now();
     if (!hardError && _state == SubscriberStateOffline && now < _next)
     {
+        // _outstanding was decremented above, so wake a waiting shutdown() like the other exit paths do.
+        if (_shutdown)
+        {
+            _condVar.notify_one();
+        }
         return;
     }
 

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -199,6 +199,7 @@ namespace
 
         void link(optional<TopicPrx> topic, int cost, const Ice::Current& current) override
         {
+            checkNotNull(topic, __FILE__, __LINE__, current);
             while (true)
             {
                 int64_t generation = -1;
@@ -231,6 +232,7 @@ namespace
 
         void unlink(optional<TopicPrx> topic, const Ice::Current& current) override
         {
+            checkNotNull(topic, __FILE__, __LINE__, current);
             while (true)
             {
                 int64_t generation = -1;
@@ -496,6 +498,12 @@ TopicImpl::subscribeAndGetPublisher(QoS qos, Ice::ObjectPrx obj)
     auto id = obj->ice_getIdentity();
     auto traceLevels = _instance->traceLevels();
     lock_guard lock(_subscribersMutex);
+
+    if (_destroyed)
+    {
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
+    }
+
     if (traceLevels->topic > 0)
     {
         Ice::Trace out(traceLevels->logger, traceLevels->topicCat);
@@ -612,6 +620,11 @@ TopicImpl::link(const TopicPrx& topic, int cost)
     }
 
     lock_guard lock(_subscribersMutex);
+
+    if (_destroyed)
+    {
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
+    }
 
     Ice::Identity id = topic->ice_getIdentity();
 

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -251,8 +251,10 @@ TransientTopicImpl::link(optional<TopicPrx> topic, int cost, const Ice::Current&
 }
 
 void
-TransientTopicImpl::unlink(optional<TopicPrx> topic, const Ice::Current&)
+TransientTopicImpl::unlink(optional<TopicPrx> topic, const Ice::Current& current)
 {
+    checkNotNull(topic, __FILE__, __LINE__, current);
+
     lock_guard lock(_mutex);
 
     if (_destroyed)


### PR DESCRIPTION
Three independent IceStorm fixes.

### 1. Shutdown hang via a lost condition-variable wakeup (`Subscriber.cpp`)

`Subscriber::error()` has an early-return path — taken when an additional error reply arrives while the subscriber is already offline and inside its discard interval — that decrements `_outstanding` but, unlike every other exit path of `error()`/`completed()`, did **not** notify `_condVar` when `_shutdown` is set. If the decrement that brings `_outstanding` to zero takes this path, `Subscriber::shutdown()` waits forever — and it runs while holding `TopicImpl::_subscribersMutex` and `TopicManagerImpl::_mutex`, so `ServiceI::stop()` hangs the whole IceStorm process. The path now notifies the waiter, matching the others.

### 2. `subscribeAndGetPublisher` / `link` miss the `_destroyed` check (`TopicI.cpp`)

`TopicImpl::subscribeAndGetPublisher` and `TopicImpl::link` committed subscriber/link records to LMDB without first checking `_destroyed`, unlike `unlink()` and `destroy()`. A subscribe/link dispatch that serializes after `destroy()` on `_subscribersMutex` commits a subscriber record keyed by the destroyed topic with no placeholder record. On restart `TopicManagerImpl` asserts the first record per topic is a placeholder — so debug builds abort and release builds resurrect the destroyed topic with an orphan subscriber. Both operations now throw `ObjectNotExistException` when the topic is destroyed.

### 3. `TransientTopicImpl::unlink` dereferences a null optional (`TransientTopicI.cpp`)

`unlink` dereferenced its `optional<TopicPrx>` parameter without the `checkNotNull` that `subscribeAndGetPublisher`, `unsubscribe`, and `link` all perform, so a null `Topic*` proxy on the wire was undefined behavior. It now calls `checkNotNull` first.

A changelog fragment is included under `changelog.d/service-icestorm/` (per #5653).

🤖 Generated with [Claude Code](https://claude.com/claude-code)