### PR TITLE
Fix flushBatchRequests hang when a connection closes during flush

### DIFF
--- a/changelog.d/cpp/flush-batch-retryexception-hang.md
+++ b/changelog.d/cpp/flush-batch-retryexception-hang.md
@@ -1,0 +1,3 @@
+- Fixed a hang in `Communicator::flushBatchRequests` and `flushBatchRequestsAsync`. When a connection was closed while
+  the communicator was flushing its batch requests, the returned future or completion callback could remain pending
+  forever.

--- a/changelog.d/csharp/flush-batch-retryexception-hang.md
+++ b/changelog.d/csharp/flush-batch-retryexception-hang.md
@@ -1,0 +1,2 @@
+- Fixed a hang in `Communicator.flushBatchRequestsAsync`. When a connection was closed while the communicator was
+  flushing its batch requests, the returned task never completed.

--- a/changelog.d/js/flush-batch-retryexception-hang.md
+++ b/changelog.d/js/flush-batch-retryexception-hang.md
@@ -1,0 +1,2 @@
+- Fixed `Connection.flushBatchRequests` and `Communicator.flushBatchRequests` to report a proper Ice local exception
+  when a connection is closed while its batch requests are being flushed, instead of leaking an internal exception.

--- a/cpp/src/Ice/CommunicatorFlushBatchAsync.cpp
+++ b/cpp/src/Ice/CommunicatorFlushBatchAsync.cpp
@@ -6,6 +6,7 @@
 #include "ConnectionI.h"
 #include "Instance.h"
 #include "ObjectAdapterFactory.h"
+#include "RequestHandler.h" // For RetryException
 
 using namespace std;
 using namespace Ice;
@@ -96,6 +97,13 @@ CommunicatorFlushBatchAsync::flushConnection(const ConnectionIPtr& con, Ice::Com
             }
             con->sendAsyncRequest(flushBatch, compress, false, batchRequestNum);
         }
+    }
+    catch (const RetryException& ex)
+    {
+        // If the connection is closed and sendAsyncRequest throws a RetryException, we rethrow the underlying exception
+        // to the caller.
+        check(false);
+        rethrow_exception(ex.get());
     }
     catch (const LocalException&)
     {

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -1404,6 +1404,13 @@ public class CommunicatorFlushBatchAsync : OutgoingAsyncBase
                 con.sendAsyncRequest(flushBatch, comp, false, batchRequestNum);
             }
         }
+        catch (RetryException ex)
+        {
+            // If the connection is closed and sendAsyncRequest throws a RetryException, we rethrow the underlying
+            // exception to the caller.
+            check(false);
+            throw ex.get();
+        }
         catch (Ice.LocalException)
         {
             check(false);

--- a/js/packages/ice/src/Ice/OutgoingAsync.js
+++ b/js/packages/ice/src/Ice/OutgoingAsync.js
@@ -580,7 +580,13 @@ export class ConnectionFlushBatch extends OutgoingAsyncBase {
                 this._sentSynchronously = true;
             }
         } catch (ex) {
-            this.markFinishedEx(ex);
+            if (ex instanceof RetryException) {
+                // If the connection is closed and sendAsyncRequest throws a RetryException, we complete this
+                // invocation with the underlying exception.
+                this.markFinishedEx(ex.inner);
+            } else {
+                this.markFinishedEx(ex);
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`ConnectionI::sendAsyncRequest` throws the internal `RetryException` (not an `Ice::LocalException`) when the connection is already closed. `CommunicatorFlushBatchAsync::flushConnection` only caught `LocalException`, so a `RetryException`:

1. **leaked the in-flight `_useCount` increment** — the communicator-wide flush future/sent-callback never completed (a permanent hang), even for the healthy connections, and
2. **let an internal exception escape** the public `flushBatchRequests` / `flushBatchRequestsAsync` API.

This is a TOCTOU race: a connection passes the `isActiveOrHolding()` check when the connection list is snapshotted, then is closed (e.g. the peer gracefully closes it) before `flushConnection` runs the flush outside the factory lock.

## Fix

- **C++** and **C#**: catch `RetryException` in `flushConnection`, balance `_useCount` via `check(false)`, and rethrow the wrapped local exception — which `OutgoingConnectionFactory::flushAsyncBatchRequests` already catches and ignores. This mirrors the adjacent `LocalException` catch.
- **JavaScript**: there is no `_useCount` (the communicator flush is a `Promise.all` over per-connection flushes), but `ConnectionFlushBatch` passed the raw `RetryException` to `markFinishedEx`, leaking it out of **both** `Connection.flushBatchRequests` and `Communicator.flushBatchRequests`. It now completes the invocation with the underlying local exception.
- **Java** already handled this correctly (`CommunicatorFlushBatch` catches `RetryException`); no change.

## Notes

- This is the first PR to use the `changelog.d/` fragment layout proposed in #5653 (Option B). Three fragments added, one per affected language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)