### PR TITLE
Fix low-severity core findings (#5487)

### DIFF
--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -1185,6 +1185,10 @@ IceInternal::Instance::initialize(const Ice::CommunicatorPtr& communicator)
 
         const_cast<bool&>(_acceptClassCycles) = _initData.properties->getIcePropertyAsInt("Ice.AcceptClassCycles") > 0;
 
+        // Read here (not in the noexcept destroy) so an invalid value is reported when the communicator is created.
+        const_cast<bool&>(_warnUnusedProperties) =
+            _initData.properties->getIcePropertyAsInt("Ice.Warn.UnusedProperties") > 0;
+
         string implicitContextKind = _initData.properties->getIceProperty("Ice.ImplicitContext");
         if (implicitContextKind == "Shared")
         {
@@ -1733,7 +1737,7 @@ IceInternal::Instance::destroy() noexcept
         _locatorManager->destroy();
     }
 
-    if (_initData.properties->getIcePropertyAsInt("Ice.Warn.UnusedProperties") > 0)
+    if (_warnUnusedProperties)
     {
         set<string> unusedProperties = _initData.properties.get()->getUnusedProperties();
         if (unusedProperties.size() != 0)

--- a/cpp/src/Ice/Instance.h
+++ b/cpp/src/Ice/Instance.h
@@ -158,6 +158,7 @@ namespace IceInternal
         const std::int32_t _classGraphDepthMax{0};                         // Immutable, not reset by destroy().
         const Ice::ToStringMode _toStringMode{Ice::ToStringMode::Unicode}; // Immutable, not reset by destroy().
         const bool _acceptClassCycles{false};                              // Immutable, not reset by destroy().
+        const bool _warnUnusedProperties{false};                           // Immutable, not reset by destroy().
         Ice::ConnectionOptions _clientConnectionOptions;
         Ice::ConnectionOptions _serverConnectionOptions;
         RouterManagerPtr _routerManager;

--- a/cpp/src/Ice/OpaqueEndpointI.cpp
+++ b/cpp/src/Ice/OpaqueEndpointI.cpp
@@ -298,7 +298,7 @@ IceInternal::OpaqueEndpointI::checkOption(const string& option, const string& ar
                     __LINE__,
                     "invalid type value '" + argument + "' in endpoint '" + endpoint + "'");
             }
-            else if (t < 0 || t > 65535)
+            else if (t < 0 || t > 32767)
             {
                 throw ParseException(
                     __FILE__,

--- a/cpp/src/Ice/Properties.cpp
+++ b/cpp/src/Ice/Properties.cpp
@@ -359,27 +359,28 @@ Ice::Properties::setProperty(string_view key, string_view value)
     }
 
     // Check if the property is in an Ice property prefix. If so, check that it's a valid property.
-    if (auto propertyArray = findIcePropertyArray(key))
+    if (auto propertyArray = findIcePropertyArray(currentKey))
     {
         if (propertyArray->isOptIn &&
             find(_optInPrefixes.begin(), _optInPrefixes.end(), propertyArray->name) == _optInPrefixes.end())
         {
             ostringstream os;
-            os << "unable to set '" << key << "': property prefix '" << propertyArray->name
+            os << "unable to set '" << currentKey << "': property prefix '" << propertyArray->name
                << "' is opt-in and must be explicitly enabled.";
             throw PropertyException{__FILE__, __LINE__, os.str()};
         }
         string propertyPrefix{propertyArray->name};
-        auto prop = IceInternal::findProperty(key.substr(propertyPrefix.length() + 1), propertyArray);
+        auto prop =
+            IceInternal::findProperty(string_view{currentKey}.substr(propertyPrefix.length() + 1), propertyArray);
         if (!prop)
         {
-            throw PropertyException{__FILE__, __LINE__, "unknown Ice property: " + string{key}};
+            throw PropertyException{__FILE__, __LINE__, "unknown Ice property: " + currentKey};
         }
 
         // If the property is deprecated, log a warning.
         if (prop->deprecated)
         {
-            getProcessLogger()->warning("setting deprecated property: " + string{key});
+            getProcessLogger()->warning("setting deprecated property: " + currentKey);
         }
     }
 

--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -425,6 +425,7 @@ Ice::Service::~Service()
 {
     _instance = nullptr;
     delete ctrlCHandler;
+    ctrlCHandler = nullptr;
 }
 
 bool

--- a/cpp/src/Ice/StringUtil.cpp
+++ b/cpp/src/Ice/StringUtil.cpp
@@ -337,6 +337,7 @@ namespace
     // end marks the one-past-the-end position of the substring to be scanned.
     // nextStart is set to the index of the first character following the decoded
     // character or escape sequence.
+    // Returns true if the decoded character is pure ASCII (<= 127), false otherwise.
     //
     bool decodeChar(
         const string& s,
@@ -617,7 +618,7 @@ IceInternal::unescapeString(
         result.reserve(end - start);
         while (start < end)
         {
-            if (decodeChar(*inputStringPtr, start, end, start, special, result))
+            if (!decodeChar(*inputStringPtr, start, end, start, special, result))
             {
                 resultIsPureASCII = false;
             }

--- a/cpp/test/Ice/properties/Client.cpp
+++ b/cpp/test/Ice/properties/Client.cpp
@@ -161,6 +161,15 @@ Client::run(int, char**)
         catch (const Ice::PropertyException&)
         {
         }
+        // The key is trimmed before being validated, so a leading/trailing space does not bypass validation.
+        try
+        {
+            properties->setProperty(" Ice.UnknownProperty ", "value");
+            test(false);
+        }
+        catch (const Ice::PropertyException&)
+        {
+        }
         cout << "ok" << endl;
     }
 

--- a/csharp/src/Ice/Internal/OpaqueEndpointI.cs
+++ b/csharp/src/Ice/Internal/OpaqueEndpointI.cs
@@ -258,7 +258,7 @@ internal sealed class OpaqueEndpointI : EndpointI
                     throw new ParseException($"invalid type value '{argument}' in endpoint '{endpoint}'", ex);
                 }
 
-                if (t < 0 || t > 65535)
+                if (t < 0 || t > 32767)
                 {
                     throw new ParseException($"type value '{argument}' out of range in endpoint '{endpoint}'");
                 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OpaqueEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OpaqueEndpointI.java
@@ -238,7 +238,7 @@ final class OpaqueEndpointI extends EndpointI {
                     throw new ParseException(msg, ex);
                 }
 
-                if (t < 0 || t > 65535) {
+                if (t < 0 || t > 32767) {
                     String msg = "type value '" + argument + "' out of range in endpoint '" + endpoint + "'";
                     throw new ParseException(msg);
                 }

--- a/js/packages/ice/src/Ice/OpaqueEndpoint.js
+++ b/js/packages/ice/src/Ice/OpaqueEndpoint.js
@@ -208,7 +208,7 @@ export class OpaqueEndpointI extends EndpointI {
                     throw new ParseException(`invalid type value '${argument}' in endpoint ${endpoint}`);
                 }
 
-                if (type < 0 || type > 65535) {
+                if (type < 0 || type > 32767) {
                     throw new ParseException(`type value '${argument}' out of range in endpoint ${endpoint}`);
                 }
 


### PR DESCRIPTION
Fixes five of the seven low-severity correctness findings in #5487. Each was verified against the source before fixing.

Fixes #5487.

| # | Fix | Mapping(s) |
|---|-----|-----------|
| 1 | `Properties::setProperty` validated the untrimmed `key`, so a key with leading/trailing whitespace (e.g. `" Ice.Bogus"`) skipped Ice-property validation and was stored silently. Now validates the trimmed key. | C++ |
| 2 | `Instance::destroy()` is `noexcept` but read `Ice.Warn.UnusedProperties`, which throws on a non-numeric value (e.g. `"yes"`) → `std::terminate`. Now read and cached during initialization, where an invalid value is reported when the communicator is created. | C++ |
| 3 | `OpaqueEndpointI` accepted `-t` values 32768–65535, which overflow the `int16_t`/`short` endpoint type and wrap to the `-1` "unset" sentinel (misleading errors, broken duplicate-`-t` detection). Bounded at 32767. | C++, C#, Java, JS |
| 5 | `unescapeString` inverted its pure-ASCII tracking (`decodeChar` returns `true` for ASCII, caller flipped to `false`), so an all-non-ASCII string skipped the UTF-8→native conversion when a custom narrow string converter was installed. | C++ |
| 6 | `~Service` deleted the namespace-scope `ctrlCHandler` without nulling it; a second sequential `Service` could double-free it. Null after delete. | C++ |

**On finding 3 across mappings:** C# and Java had the identical bug (`int` parsed, checked `> 65535`, then cast to a `short` field — `-t 65535` wraps to the `-1` sentinel). JavaScript stores the value in a plain number so it doesn't overflow, but it still accepted invalid 16-bit endpoint types (32768–65535) that round-trip to a negative type on the peer. All four are now bounded at 32767.

These are all low-impact (invalid-input handling or crashes with super-unlikely triggers), so **none gets a CHANGELOG entry**.

**Not addressed here** (tracked separately):
- **Finding 4** → #5668 — per-thread implicit context keyed by a recycled `Instance*`; the proper fix (keying by an instance-generation id) is too invasive for a 3.8.x patch.
- **Finding 7** → #5669 — property update callbacks invoked under the admin `_mutex`; left as-is because both the C# and Java mappings deliberately invoke these callbacks under the lock, so changing only C++ would create a cross-mapping inconsistency.

Added a regression case in `test/Ice/properties` for #1; the C++ `Ice/properties` test passes. C#/Java builds and the JS syntax check pass for the finding-3 changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)