### PR TITLE
Fixed Escaping of `returnValue` Out Parameters in 'slice2swift'

### DIFF
--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1121,19 +1121,6 @@ Slice::Swift::writeMarshalUnmarshalCode(
 }
 
 string
-Slice::Swift::paramLabel(const string& param, const ParameterList& params)
-{
-    for (const auto& q : params)
-    {
-        if (q->mappedName() == param)
-        {
-            return "_" + removeEscaping(param);
-        }
-    }
-    return param;
-}
-
-string
 Slice::Swift::operationReturnType(const OperationPtr& op)
 {
     ostringstream os;
@@ -1149,7 +1136,7 @@ Slice::Swift::operationReturnType(const OperationPtr& op)
     {
         if (returnIsTuple)
         {
-            os << paramLabel("returnValue", outParams) << ": ";
+            os << getEscapedParamName(outParams, "returnValue") << ": ";
         }
         os << typeToString(returnType, op, op->returnIsOptional());
     }
@@ -1192,7 +1179,7 @@ Slice::Swift::operationReturnDeclaration(const OperationPtr& op)
 
     if (returnType)
     {
-        os << ("iceP_" + paramLabel("returnValue", outParams));
+        os << ("iceP_" + getEscapedParamName(outParams, "returnValue"));
     }
 
     for (auto q = outParams.begin(); q != outParams.end(); ++q)

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1179,7 +1179,7 @@ Slice::Swift::operationReturnDeclaration(const OperationPtr& op)
 
     if (returnType)
     {
-        os << ("iceP_" + getEscapedParamName(outParams, "returnValue"));
+        os << "iceP_" << getEscapedParamName(outParams, "returnValue");
     }
 
     for (auto q = outParams.begin(); q != outParams.end(); ++q)
@@ -1189,7 +1189,7 @@ Slice::Swift::operationReturnDeclaration(const OperationPtr& op)
             os << ", ";
         }
 
-        os << ("iceP_" + removeEscaping((*q)->mappedName()));
+        os << "iceP_" << removeEscaping((*q)->mappedName());
     }
 
     if (returnIsTuple)

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -33,7 +33,6 @@ namespace Slice::Swift
 
     void writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p, bool dispatch);
 
-    std::string paramLabel(const std::string& param, const ParameterList& params);
     std::string operationReturnType(const OperationPtr& op);
     std::string operationReturnDeclaration(const OperationPtr& op);
 

--- a/swift/test/Slice/escape/Clash.ice
+++ b/swift/test/Slice/escape/Clash.ice
@@ -15,7 +15,7 @@ module Clash
         void istr();
 
         void op(string context, string current, string response, string ex, string sent, string cookie,
-            string sync, string result, string istr, string ostr, out string returnValue, optional(1) string proxy);
+            string sync, string result, string istr, string ostr, string returnValue, optional(1) string proxy);
         void opOut(out string context, out string current, out string response, out string ex,
             out string sent, out string cookie, out string sync, out string result, out string istr,
             out string ostr, out string returnValue, out optional(1) string proxy);

--- a/swift/test/Slice/escape/Clash.ice
+++ b/swift/test/Slice/escape/Clash.ice
@@ -15,10 +15,10 @@ module Clash
         void istr();
 
         void op(string context, string current, string response, string ex, string sent, string cookie,
-            string sync, string result, string istr, string ostr, optional(1) string proxy);
+            string sync, string result, string istr, string ostr, out string returnValue, optional(1) string proxy);
         void opOut(out string context, out string current, out string response, out string ex,
             out string sent, out string cookie, out string sync, out string result, out string istr,
-            out string ostr, out optional(1) string proxy);
+            out string ostr, out string returnValue, out optional(1) string proxy);
     }
 
     class Cls


### PR DESCRIPTION
This PR fixes #5481 and adds a test.

If an operation had an out parameter named `returnValue`, `slice2swift` would generate uncompilable code.
I don't think this is worth a changelog entry.

The problem is we had 2 escaping functions, which we did not use consistently:
- `paramLabel` which was in `slice2swift` which would return `_returnValue`
- `getEscapedParamName` from `libSlice` which would return `returnValue_`

I deleted `paramLabel` and updated the call sites to use `getEscapedParamName`. This removes some barely used code, and fixes the mismatch in generated parameter names.