### PR TITLE
Removed Unnecessary `static_cast`s When Calling `zend_hash_str_find`

### DIFF
--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -2867,10 +2867,8 @@ IcePHP::ValueWriter::writeMembers(Ice::OutputStream* os, const DataMemberList& m
 {
     for (const auto& member : members)
     {
-        zval* val = zend_hash_str_find(
-            Z_OBJPROP_P(const_cast<zval*>(&_object)),
-            member->name.c_str(),
-            member->name.size());
+        zval* val =
+            zend_hash_str_find(Z_OBJPROP_P(const_cast<zval*>(&_object)), member->name.c_str(), member->name.size());
 
         if (!val)
         {

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -2870,7 +2870,7 @@ IcePHP::ValueWriter::writeMembers(Ice::OutputStream* os, const DataMemberList& m
         zval* val = zend_hash_str_find(
             Z_OBJPROP_P(const_cast<zval*>(&_object)),
             member->name.c_str(),
-            static_cast<int>(member->name.size()));
+            member->name.size());
 
         if (!val)
         {
@@ -3146,7 +3146,7 @@ IcePHP::ExceptionInfo::printMembers(zval* zv, IceInternal::Output& out, PrintObj
     for (const auto& member : members)
     {
         out << nl << member->name << " = ";
-        zval* val = zend_hash_str_find(Z_OBJPROP_P(zv), member->name.c_str(), static_cast<int>(member->name.size()));
+        zval* val = zend_hash_str_find(Z_OBJPROP_P(zv), member->name.c_str(), member->name.size());
         assert(Z_TYPE_P(val) == IS_INDIRECT);
         val = Z_INDIRECT_P(val);
 
@@ -3163,7 +3163,7 @@ IcePHP::ExceptionInfo::printMembers(zval* zv, IceInternal::Output& out, PrintObj
     for (const auto& member : optionalMembers)
     {
         out << nl << member->name << " = ";
-        zval* val = zend_hash_str_find(Z_OBJPROP_P(zv), member->name.c_str(), static_cast<int>(member->name.size()));
+        zval* val = zend_hash_str_find(Z_OBJPROP_P(zv), member->name.c_str(), member->name.size());
 
         assert(Z_TYPE_P(val) == IS_INDIRECT);
         val = Z_INDIRECT_P(val);


### PR DESCRIPTION
This PR fixes #5596.

The last parameter for `zend_hash_str_find` is of type `size_t`:
https://github.com/php/php-src/blob/a20aeb1eb8811897412a62f137f0c1eefe7671ec/Zend/zend_hash.h#L182

However, in a few places we were converting a perfectly good `size_type` to an `int` before passing it in.
There was no point to this cast. And there were already places where we passed `size()` directly without the cast anyways.