### PR TITLE
Fixed `@param` and `@throws` Being Labeled as 'Unknown' Tags

### DIFF
--- a/changelog.d/slice/5475-fix-doc-comments-tags-starting-on-following-lines.md
+++ b/changelog.d/slice/5475-fix-doc-comments-tags-starting-on-following-lines.md
@@ -1,0 +1,3 @@
+- Fixed a bug that caused `@param` and `@throws` doc-comment tags to be incorrectly reported as "unknown tags".
+  This only affected tags whose descriptions didn't start until the following line.
+  

--- a/changelog.d/slice/5475-fix-doc-comments-tags-starting-on-following-lines.md
+++ b/changelog.d/slice/5475-fix-doc-comments-tags-starting-on-following-lines.md
@@ -1,3 +1,2 @@
 - Fixed a bug that caused `@param` and `@throws` doc-comment tags to be incorrectly reported as "unknown tags".
   This only affected tags whose descriptions didn't start until the following line.
-  

--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -210,25 +210,19 @@ namespace
         {
             // Then we perform additional parsing to extract the name...
 
-            auto nameStart = line.find_first_not_of(ws, tag.size());
+            auto nameStart = doc.find_first_not_of(ws);
             if (nameStart == string::npos)
             {
-                return false; // Malformed line, ignore it.
+                return false; // Malformed line, missing the name part after the tag. Ignore this line.
             }
 
-            auto nameEnd = line.find_first_of(ws, nameStart);
-            if (nameEnd == string::npos)
-            {
-                return false; // Malformed line, ignore it.
-            }
-            name = line.substr(nameStart, nameEnd - nameStart);
+            // If there's no whitespace after the name, that means the name runs to the end of the line.
+            auto nameEnd = doc.find_first_of(ws, nameStart);
+            name = (nameEnd == string::npos) ? doc.substr(nameStart) : doc.substr(nameStart, nameEnd - nameStart);
 
-            // Store whatever remains of the doc comment in the `doc` string.
-            auto docSplitPos = line.find_first_not_of(ws, nameEnd);
-            if (docSplitPos != string::npos)
-            {
-                doc = line.substr(docSplitPos);
-            }
+            // If there's any non-whitespace characters after the name, store them in the `doc` string.
+            auto docStart = doc.find_first_not_of(ws, nameEnd);
+            doc = (docStart == string::npos) ? "" : doc.substr(docStart);
 
             return true;
         }

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -26,4 +26,4 @@ WarningInvalidComment.ice:59: warning: ignoring duplicate doc-comment tag: '@ret
 WarningInvalidComment.ice:59: warning: '@throws DerivedFromDummy': this exception is not listed in the exception specification of 'stringOp'
 WarningInvalidComment.ice:59: warning: '@throws SomeOtherException': this exception is not listed in the exception specification of 'stringOp'
 WarningInvalidComment.ice:59: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
-WarningInvalidComment.ice:64: warning: unterminated link tag: missing closing '}'
+WarningInvalidComment.ice:78: warning: unterminated link tag: missing closing '}'

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
@@ -57,6 +57,20 @@ module Test
         /// @throws SomeOtherException should give a not-thrown-by-this-operation warning.
         /// @throws CommentDummy should give a duplicate-tag warning.
         string stringOp(string name, int value, out byte myOut) throws CommentDummy;
+
+        /// This tests that doc-comment tags with named parameters can start on the line following the tag.
+        /// @param param
+        ///     It should be okay for the description of a parameter to start on the next line.
+        /// @throws CommentDummy
+        ///     It should be okay for the description of an exception to start on the next line.
+        bool fullMultilineCommentTest(int param) throws CommentDummy;
+
+        /// This tests that doc-comment tags with named parameters can span multiple lines.
+        /// @param param It should be okay for the description of a parameter to start on one line,
+        ///     and then continue onto the next line. Whitespace should be stripped correctly too.
+        /// @throws CommentDummy It should be okay for the description of an exception to start on one line,
+        ///     and then continue onto the next line. Whitespace should be stripped correctly too.
+        bool splitMultilineCommentTest(int param) throws CommentDummy;
     }
 
     /// Unterminated link tag: {@link CommentDummy


### PR DESCRIPTION
This PR fixes #5475.

There was a bug in how we parsed doc-comment tags with names before their description (ex: `@param <name> <desc>`)
that caused us to report the tag as "unknown" if the description didn't start until the following line.