### PR TITLE
Fix permanent shutdown hang in ConnectionI::sendResponse (#5452)

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -401,7 +401,11 @@ Ice::ConnectionI::startAsync(
     }
     catch (const Ice::LocalException&)
     {
-        exception(current_exception());
+        {
+            std::lock_guard lock(_mutex);
+            setState(StateClosed, current_exception());
+        }
+
         if (connectionStartFailed)
         {
             connectionStartFailed(shared_from_this(), current_exception());
@@ -1850,13 +1854,6 @@ Ice::ConnectionI::setBufferSize(int32_t rcvSize, int32_t sndSize)
     _info = nullptr; // Invalidate the cached connection info
 }
 
-void
-Ice::ConnectionI::exception(std::exception_ptr ex)
-{
-    std::lock_guard lock(_mutex);
-    setState(StateClosed, ex);
-}
-
 Ice::ConnectionI::ConnectionI(
     CommunicatorPtr communicator,
     const InstancePtr& instance,
@@ -2418,74 +2415,71 @@ Ice::ConnectionI::sendResponse(OutgoingResponse response, uint8_t compress)
 {
     bool isTwoWay = !_endpoint->datagram() && response.current().requestId != 0;
 
-    bool finished = false;
+    // We hold _mutex for the duration of this function, including the catch handler below; hence the lock is not
+    // declared inside the try block.
+    std::unique_lock lock(_mutex);
+    assert(_state > StateNotValidated);
+
     try
     {
-        std::unique_lock lock(_mutex);
-        assert(_state > StateNotValidated);
+        bool finished = false;
 
-        try
+        if (--_upcallCount == 0)
         {
-            if (--_upcallCount == 0)
+            if (_state == StateFinished)
             {
-                if (_state == StateFinished)
+                finished = true;
+                if (_observer)
                 {
-                    finished = true;
-                    if (_observer)
-                    {
-                        _observer.detach();
-                    }
-                }
-                _conditionVariable.notify_all();
-            }
-
-            if (_state >= StateClosed)
-            {
-                exception_ptr exception = _exception;
-                assert(exception);
-
-                if (finished && _removeFromFactory)
-                {
-                    lock.unlock();
-                    _removeFromFactory(shared_from_this());
-                }
-
-                rethrow_exception(exception);
-            }
-            assert(!finished);
-
-            if (isTwoWay)
-            {
-                OutgoingMessage message(&response.outputStream(), compress > 0);
-                sendMessage(message);
-            }
-
-            if (_state == StateActive && _maxDispatches > 0 && _dispatchCount == _maxDispatches)
-            {
-                // Resume reading if the connection is active and the dispatch count is about to be less than
-                // _maxDispatches.
-                _threadPool->update(shared_from_this(), SocketOperationNone, SocketOperationRead);
-                if (_idleTimeoutTransceiver)
-                {
-                    _idleTimeoutTransceiver->enableIdleCheck();
+                    _observer.detach();
                 }
             }
+            _conditionVariable.notify_all();
+        }
 
-            --_dispatchCount;
+        if (_state >= StateClosed)
+        {
+            // The connection is already closed (or finished): we can't send the response. There is nothing else to
+            // do here since the connection's exception is already set.
+            assert(_exception);
 
-            if (_state == StateClosing && _upcallCount == 0)
+            if (finished && _removeFromFactory)
             {
-                initiateShutdown();
+                lock.unlock();
+                _removeFromFactory(shared_from_this());
+            }
+
+            return;
+        }
+        assert(!finished);
+
+        if (isTwoWay)
+        {
+            OutgoingMessage message(&response.outputStream(), compress > 0);
+            sendMessage(message);
+        }
+
+        if (_state == StateActive && _maxDispatches > 0 && _dispatchCount == _maxDispatches)
+        {
+            // Resume reading if the connection is active and the dispatch count is about to be less than
+            // _maxDispatches.
+            _threadPool->update(shared_from_this(), SocketOperationNone, SocketOperationRead);
+            if (_idleTimeoutTransceiver)
+            {
+                _idleTimeoutTransceiver->enableIdleCheck();
             }
         }
-        catch (const LocalException&)
+
+        --_dispatchCount;
+
+        if (_state == StateClosing && _upcallCount == 0)
         {
-            setState(StateClosed, current_exception());
+            initiateShutdown();
         }
     }
     catch (...)
     {
-        dispatchException(current_exception(), 1);
+        setState(StateClosed, current_exception());
     }
 }
 

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -208,8 +208,6 @@ namespace Ice
 
         void setBufferSize(std::int32_t rcvSize, std::int32_t sndSize) final; // From Connection
 
-        void exception(std::exception_ptr);
-
         // This method is called to execute user code (connection start completion callback, invocation sent callbacks,
         // or an upcall issued from an incoming message). The invocation sent callbacks and the message upcall might
         // both be set.


### PR DESCRIPTION
Fixes #5452.

## The bug

`ConnectionI::sendResponse` decremented `_upcallCount` once at the start of its inner `try`, then — when a **non-`LocalException`** propagated out of the inner `catch (const LocalException&)` — decremented it a **second** time in the outer `catch (...) { dispatchException(current_exception(), 1); }`. The counter went negative, the `_upcallCount == 0` notification never fired, and `waitUntilFinished()` (hence communicator destruction) hung **forever**.

A non-`LocalException` can reach that path via the rethrown connection `_exception` when it was set from a non-Ice dispatch exception, or `std::bad_alloc` from `sendMessage`.

## The fix

Rework `sendResponse` so `_upcallCount` is decremented **exactly once**:

- Hold `_mutex` for the whole function — `lock` now outlives the `try`, so the single `catch` runs with the mutex held (the previous nesting existed only to keep the lock for the inner `setState`).
- When the connection is already closed (`_state >= StateClosed`), **`return`** instead of rethrowing the stored exception — the response can't be sent and there's nothing else to do. This also removes the audit's secondary issue: the inner `setState(StateClosed, …)` could previously run after `lock.unlock()` on the connection-finished path.
- Handle a send failure with a single `catch (...) { setState(StateClosed, current_exception()); }`. `catch (...)` (rather than `LocalException`) keeps `sendResponse` non-throwing, matching the old behaviour and the neighbouring catch-all handlers.

`dispatchException` is no longer called from `sendResponse` (still used by the fatal-dispatch path).

The reworked method now lines up with the C#/Java/JS mappings, which each decrement once and never had this bug (verified — the double-decrement was C++-only; Swift and the script mappings route responses back through the C++ runtime and inherit the fix).

## Cleanup

Removed the confusingly named one-line `ConnectionI::exception()` helper (used in a single place) by inlining it into `startAsync`.

## Testing

Builds clean. `Ice/operations`, `Ice/ami`, `Ice/exceptions`, and `Ice/hold` pass (twoway/oneway/AMI/batch/collocated/AMD, plus exception and connection hold/close paths).

No CHANGELOG entry (exotic preconditions; internal robustness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)