### PR TITLE
Fix LoggerAdminLogger.detach leaving the logger attached (#5442, #5651)

### DIFF
--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -666,10 +666,10 @@ namespace
         {
             lock_guard lock(_mutex);
 
+            _detached.store(true);
             if (_sendLogThread.joinable())
             {
                 sendLogThread = std::move(_sendLogThread);
-                _detached.store(true);
                 _conditionVariable.notify_all();
             }
         }

--- a/csharp/src/Ice/Internal/LoggerAdminLoggerI.cs
+++ b/csharp/src/Ice/Internal/LoggerAdminLoggerI.cs
@@ -75,11 +75,11 @@ internal sealed class LoggerAdminLoggerI : LoggerAdminLogger
         Thread thread = null;
         lock (_mutex)
         {
+            _detached = true;
             if (_sendLogThread != null)
             {
                 thread = _sendLogThread;
                 _sendLogThread = null;
-                _detached = true;
                 Monitor.PulseAll(_mutex);
             }
         }


### PR DESCRIPTION
Fixes #5442 and #5651 (same bug, C++ and C#).

## The bug

`LoggerAdminLogger::detach()` destroys the logger admin **unconditionally**, but set the `_detached` flag **only** inside the `if (send-log thread is running)` branch. The send-log thread is created lazily — only once a remote logger is attached *and* a message is actually logged. So if a remote logger is attached but nothing is logged before the communicator is destroyed, `detach()` destroys the logger admin yet leaves `_detached == false`.

`print`/`trace`/`warning`/`error` gate their remote dispatch on `!_detached`, so a later log call then passes the gate and invokes `log()` on the destroyed logger admin. In C++ that lazily spawns a **new, never-joined** send-log thread bound to the already-destroyed sendLog communicator → `std::terminate`.

## The fix

Set `_detached` **unconditionally** under the lock (moved above the `if`), so no further remote logging is attempted after `detach()` regardless of whether a send-log thread was ever started. `notify_all`/`PulseAll` stays inside the `if` — the only possible waiter is the send-log thread itself.

This mirrors the **Java fix** in #5631 (for #5511); applied here to the C++ and C# implementations, which were ported from the same code.

- C++ — `cpp/src/Ice/LoggerAdminI.cpp`
- C# — `csharp/src/Ice/Internal/LoggerAdminLoggerI.cs`

JS has no `LoggerAdminLogger` implementation (only the generated Slice), so it's unaffected.

## Testing

C++ Ice and C# Ice both build clean. No CHANGELOG entry (narrow trigger: a remote logger attached, nothing logged, communicator destroyed, then a log call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)