### PR TITLE
Fix malformed HTTP-proxy CONNECT for IPv6 targets (#5450)

### DIFF
--- a/cpp/src/Ice/NetworkProxy.cpp
+++ b/cpp/src/Ice/NetworkProxy.cpp
@@ -190,9 +190,22 @@ HTTPNetworkProxy::beginWrite(const Address& addr, Buffer& buf)
     //
     // HTTP connect request
     //
+
+    // An IPv6 address must be enclosed in square brackets in the authority (host:port) form.
+    ostringstream authority;
+    if (addr.saStorage.ss_family == AF_INET6)
+    {
+        authority << '[' << inetAddrToString(addr) << "]:" << getPort(addr);
+    }
+    else
+    {
+        authority << inetAddrToString(addr) << ':' << getPort(addr);
+    }
+    const string authorityStr = authority.str();
+
     ostringstream out;
-    out << "CONNECT " << addrToString(addr) << " HTTP/1.1\r\n"
-        << "Host: " << addrToString(addr) << "\r\n\r\n";
+    out << "CONNECT " << authorityStr << " HTTP/1.1\r\n"
+        << "Host: " << authorityStr << "\r\n\r\n";
     string str = out.str();
     buf.b.resize(str.size());
     memcpy(&buf.b[0], str.c_str(), str.size());

--- a/csharp/src/Ice/Internal/NetworkProxy.cs
+++ b/csharp/src/Ice/Internal/NetworkProxy.cs
@@ -169,7 +169,11 @@ public sealed class HTTPNetworkProxy : NetworkProxy
 
     public void beginWrite(EndPoint endpoint, Buffer buf)
     {
-        string addr = Network.addrToString(endpoint);
+        // An IPv6 address must be enclosed in square brackets in the authority (host:port) form.
+        var ipEndpoint = (IPEndPoint)endpoint;
+        string addr = ipEndpoint.AddressFamily == AddressFamily.InterNetworkV6 ?
+            $"[{ipEndpoint.Address}]:{ipEndpoint.Port}" :
+            $"{ipEndpoint.Address}:{ipEndpoint.Port}";
         var str = new StringBuilder();
         str.Append("CONNECT ");
         str.Append(addr);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HTTPNetworkProxy.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HTTPNetworkProxy.java
@@ -2,6 +2,8 @@
 
 package com.zeroc.Ice;
 
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 
@@ -19,7 +21,12 @@ final class HTTPNetworkProxy implements NetworkProxy {
 
     @Override
     public void beginWrite(InetSocketAddress endpoint, Buffer buf) {
-        String addr = Network.addrToString(endpoint);
+        // An IPv6 address must be enclosed in square brackets in the authority (host:port) form.
+        InetAddress address = endpoint.getAddress();
+        String addr =
+            address instanceof Inet6Address
+                ? "[" + address.getHostAddress() + "]:" + endpoint.getPort()
+                : address.getHostAddress() + ":" + endpoint.getPort();
         StringBuilder str = new StringBuilder();
         str.append("CONNECT ");
         str.append(addr);


### PR DESCRIPTION
Fixes #5450 (C++, C#, and Java — same bug ported across the mappings).

## The bug

The HTTP-proxy `CONNECT` request line and `Host:` header were built with an **unbracketed** `host:port` authority. For an IPv6 target that yields an invalid request line such as:

```
CONNECT 2001:db8::1:4061 HTTP/1.1
```

where the port is indistinguishable from the address — malformed per the authority-form rules, so a conforming proxy rejects it. IPv6 targets are reachable here because the HTTP proxy keeps IPv6 enabled during host resolution.

## The fix

Enclose IPv6 literals in square brackets in the authority, producing `CONNECT [2001:db8::1]:4061 HTTP/1.1`. IPv4 output is unchanged. The shared `addrToString` tracing/diagnostics helper is intentionally left alone — only the `CONNECT` assembly is fixed.

IPv6 is detected directly from the resolved address in each mapping:

- **C++** (`cpp/src/Ice/NetworkProxy.cpp`) — `addr.saStorage.ss_family == AF_INET6`
- **C#** (`csharp/src/Ice/Internal/NetworkProxy.cs`) — `ipEndpoint.AddressFamily == AddressFamily.InterNetworkV6`
- **Java** (`java/.../HTTPNetworkProxy.java`) — `endpoint.getAddress() instanceof Inet6Address`

JS has no HTTP-proxy implementation, so it's unaffected.

## Testing

C++ Ice, C# Ice, and Java `:ice:compileJava` all build clean. No CHANGELOG entry (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)