### PR TITLE
Delete copy/move on IceRuby classes that register a GC root

### DIFF
--- a/ruby/src/IceRuby/RubySliceLoader.h
+++ b/ruby/src/IceRuby/RubySliceLoader.h
@@ -15,6 +15,12 @@ namespace IceRuby
         explicit RubySliceLoader(VALUE sliceLoader);
         ~RubySliceLoader() final;
 
+        // Registers a GC root tied to the address of _sliceLoader, so it's neither copyable nor movable.
+        RubySliceLoader(const RubySliceLoader&) = delete;
+        RubySliceLoader(RubySliceLoader&&) = delete;
+        RubySliceLoader& operator=(const RubySliceLoader&) = delete;
+        RubySliceLoader& operator=(RubySliceLoader&&) = delete;
+
         [[nodiscard]] Ice::ValuePtr newClassInstance(std::string_view typeId) const final;
 
         // TODO: we currently don't support loading of custom Slice exceptions from Ruby.

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -451,6 +451,12 @@ namespace IceRuby
         ValueWriter(VALUE, ValueMap*, const ClassInfoPtr&);
         ~ValueWriter();
 
+        // Registers a GC root tied to the address of _object, so it's neither copyable nor movable.
+        ValueWriter(const ValueWriter&) = delete;
+        ValueWriter(ValueWriter&&) = delete;
+        ValueWriter& operator=(const ValueWriter&) = delete;
+        ValueWriter& operator=(ValueWriter&&) = delete;
+
         void ice_preMarshal() final;
 
         void _iceWrite(Ice::OutputStream*) const final;
@@ -474,6 +480,12 @@ namespace IceRuby
         ValueReader(VALUE, const ClassInfoPtr&);
         ~ValueReader();
 
+        // Registers a GC root tied to the address of _object, so it's neither copyable nor movable.
+        ValueReader(const ValueReader&) = delete;
+        ValueReader(ValueReader&&) = delete;
+        ValueReader& operator=(const ValueReader&) = delete;
+        ValueReader& operator=(ValueReader&&) = delete;
+
         void ice_postUnmarshal() final;
 
         void _iceWrite(Ice::OutputStream*) const final;
@@ -496,7 +508,12 @@ namespace IceRuby
     {
     public:
         ExceptionReader(const ExceptionInfoPtr&);
+        // Copyable (ice_throw throws *this, and make_exception_ptr copies); the copy constructor re-registers a fresh
+        // GC root for _ex. Registering a root tied to the address of _ex makes it non-movable and non-assignable.
         ExceptionReader(const ExceptionReader&);
+        ExceptionReader(ExceptionReader&&) = delete;
+        ExceptionReader& operator=(const ExceptionReader&) = delete;
+        ExceptionReader& operator=(ExceptionReader&&) = delete;
         ~ExceptionReader();
 
         const char* ice_id() const noexcept final;

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -508,12 +508,7 @@ namespace IceRuby
     {
     public:
         ExceptionReader(const ExceptionInfoPtr&);
-        // Copyable (ice_throw throws *this, and make_exception_ptr copies); the copy constructor re-registers a fresh
-        // GC root for _ex. Registering a root tied to the address of _ex makes it non-movable and non-assignable.
         ExceptionReader(const ExceptionReader&);
-        ExceptionReader(ExceptionReader&&) = delete;
-        ExceptionReader& operator=(const ExceptionReader&) = delete;
-        ExceptionReader& operator=(ExceptionReader&&) = delete;
         ~ExceptionReader();
 
         const char* ice_id() const noexcept final;


### PR DESCRIPTION
`RubySliceLoader`, `ValueWriter` and `ValueReader` register a Ruby GC root tied to the **address** of a `VALUE` member (`rb_gc_register_address(&_member)`), so they are logically non-copyable and non-movable: a default copy/move would not re-register the new instance's address, and the moved-from/copied instance's destructor would `rb_gc_unregister_address` an address that was never registered. All four special members are now explicitly `= delete`d.

`ExceptionReader` must stay copyable — `ice_throw` does `throw *this` and `make_exception_ptr` copies it — and its copy constructor already re-registers a fresh root, so only its move constructor and assignment operators are deleted.

This is not an active bug today (these are only ever created with `make_shared` and handled through a `shared_ptr`), so it's hardening only with no behavior change — a good fit for 3.9.0.

Closes #5591