### PR TITLE
Fix icestormadmin replica command crash on a non-replicated IceStorm

### DIFF
--- a/changelog.d/service-icestorm/icestormadmin-replica-crash.md
+++ b/changelog.d/service-icestorm/icestormadmin-replica-crash.md
@@ -1,0 +1,2 @@
+- Fixed a crash in `icestormadmin`: running the `replica` command against a non-replicated IceStorm instance
+  dereferenced an empty node proxy. The command now reports that the instance is not replicated instead of crashing.

--- a/changelog.d/service-icestorm/icestormadmin-replica-crash.md
+++ b/changelog.d/service-icestorm/icestormadmin-replica-crash.md
@@ -1,2 +1,2 @@
-- Fixed a crash in `icestormadmin`: running the `replica` command against a non-replicated IceStorm instance
-  dereferenced an empty node proxy. The command now reports that the instance is not replicated instead of crashing.
+- Fixed a crash in `icestormadmin` when running the `replica` command against a non-replicated IceStorm instance.
+  The command now reports that the instance is not replicated instead of crashing.

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -247,6 +247,7 @@ Parser::replica(const list<string>& args)
         if (!node)
         {
             error("This topic is not replicated");
+            return;
         }
         auto nodes = node->nodes();
         consoleOut << "replica count: " << nodes.size() << endl;


### PR DESCRIPTION
Addresses the **IceStorm** finding in #5490 (item 1).

`Parser::replica` (the `icestormadmin` `replica` command) was missing a `return` after its "This topic is not replicated" error:

```cpp
auto node = manager->getReplicaNode();   // std::optional<NodePrx>
if (!node)
{
    error("This topic is not replicated");   // only prints + increments the error count; no return
}
auto nodes = node->nodes();                  // deref of a disengaged std::optional -> UB
```

`getReplicaNode()` returns `nullopt` for a non-replicated IceStorm — including the common non-replicated **persistent** deployment (the `id == -1` path constructs the instance with a default `nullopt` node proxy), not just the transient case — so this fired in normal use, crashing `icestormadmin`. The fix adds the missing `return`, matching the sibling error path a few lines above.

`icestormadmin` is C++-only, so no other language mapping needs the same change.

The DataStorm finding (item 2) in #5490 is still under review and will be handled separately, so this PR does not close the issue.