### PR TITLE
Document that DataStorm Topic filters must be registered before use

### DIFF
--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -385,6 +385,8 @@ namespace DataStorm
 
         /// Sets a key filter factory. The given factory function must return a filter function that returns `true` if
         /// the key matches the filter criteria, `false` otherwise.
+        /// Register all key filters before creating any reader or writer for this topic: the set of filters is not
+        /// synchronized, so modifying it once the topic is in use races with the Ice threads that use the topic.
         /// @param name The name of the key filter.
         /// @param factory The filter factory function.
         template<typename Criteria>
@@ -394,6 +396,8 @@ namespace DataStorm
 
         /// Sets a sample filter factory. The given factory function must return a filter function that returns `true`
         /// if the sample matches the filter criteria, `false` otherwise.
+        /// Register all sample filters before creating any reader or writer for this topic: the set of filters is not
+        /// synchronized, so modifying it once the topic is in use races with the Ice threads that use the topic.
         /// @param name The name of the sample filter.
         /// @param factory The filter factory function.
         template<typename Criteria>


### PR DESCRIPTION
Documents the filter-registration contract for the DataStorm finding in #5490: the `Topic` filter set is not synchronized, and once a reader or writer is created the filter managers are shared with the Ice dispatch threads that use the topic. `setKeyFilter`/`setSampleFilter` now state that all filters must be registered before creating any reader or writer for the topic.

This is the docs-only, patch-safe mitigation. Enforcing the contract (throw) or making late registration thread-safe is tracked for 3.9.0 in #5676.

Does not close #5490 (its IceStorm item is in #5675; the `insert_or_assign` suggestion is intentionally not applied — see #5676 for why it would clobber the reserved `_regex`/`_event` filters).