### PR TITLE
Fix WebSocket ping/pong control-frame masking in C++, C#, and Java (RFC 6455 §5.5.3)

### DIFF
--- a/changelog.d/cpp/ws-control-frame-masking.md
+++ b/changelog.d/cpp/ws-control-frame-masking.md
@@ -1,0 +1,3 @@
+- Fixed a WebSocket bug where Ice did not unmask the payload of a received ping before echoing it in the pong, and
+  did not mask the pong payload when sending as a client. A conforming WebSocket peer that sends payload-bearing pings
+  and validates the returned pong (a common liveness probe) now receives the correct payload (RFC 6455 §5.5.3).

--- a/changelog.d/cpp/ws-control-frame-masking.md
+++ b/changelog.d/cpp/ws-control-frame-masking.md
@@ -1,3 +1,4 @@
-- Fixed a WebSocket bug where Ice did not unmask the payload of a received ping before echoing it in the pong, and
-  did not mask the pong payload when sending as a client. A conforming WebSocket peer that sends payload-bearing pings
-  and validates the returned pong (a common liveness probe) now receives the correct payload (RFC 6455 §5.5.3).
+- Fixed a WebSocket bug where Ice, acting as a server, echoed a received ping's payload in the pong
+  without unmasking it (and, as a client, sent the pong payload unmasked). A non-Ice WebSocket peer
+  that sends payload-bearing pings and validates the echoed pong could therefore drop the connection
+  (RFC 6455 §5.5.3). The common cases — browser/JS clients and empty keepalive pings — were unaffected.

--- a/changelog.d/csharp/ws-control-frame-masking.md
+++ b/changelog.d/csharp/ws-control-frame-masking.md
@@ -1,0 +1,3 @@
+- Fixed a WebSocket bug where Ice did not unmask the payload of a received ping before echoing it in the pong, and
+  did not mask the pong payload when sending as a client. A conforming WebSocket peer that sends payload-bearing pings
+  and validates the returned pong (a common liveness probe) now receives the correct payload (RFC 6455 §5.5.3).

--- a/changelog.d/csharp/ws-control-frame-masking.md
+++ b/changelog.d/csharp/ws-control-frame-masking.md
@@ -1,3 +1,4 @@
-- Fixed a WebSocket bug where Ice did not unmask the payload of a received ping before echoing it in the pong, and
-  did not mask the pong payload when sending as a client. A conforming WebSocket peer that sends payload-bearing pings
-  and validates the returned pong (a common liveness probe) now receives the correct payload (RFC 6455 §5.5.3).
+- Fixed a WebSocket bug where Ice, acting as a server, echoed a received ping's payload in the pong
+  without unmasking it (and, as a client, sent the pong payload unmasked). A non-Ice WebSocket peer
+  that sends payload-bearing pings and validates the echoed pong could therefore drop the connection
+  (RFC 6455 §5.5.3). The common cases — browser/JS clients and empty keepalive pings — were unaffected.

--- a/changelog.d/java/ws-control-frame-masking.md
+++ b/changelog.d/java/ws-control-frame-masking.md
@@ -1,0 +1,3 @@
+- Fixed a WebSocket bug where Ice did not unmask the payload of a received ping before echoing it in the pong, and
+  did not mask the pong payload when sending as a client. A conforming WebSocket peer that sends payload-bearing pings
+  and validates the returned pong (a common liveness probe) now receives the correct payload (RFC 6455 §5.5.3).

--- a/changelog.d/java/ws-control-frame-masking.md
+++ b/changelog.d/java/ws-control-frame-masking.md
@@ -1,3 +1,4 @@
-- Fixed a WebSocket bug where Ice did not unmask the payload of a received ping before echoing it in the pong, and
-  did not mask the pong payload when sending as a client. A conforming WebSocket peer that sends payload-bearing pings
-  and validates the returned pong (a common liveness probe) now receives the correct payload (RFC 6455 §5.5.3).
+- Fixed a WebSocket bug where Ice, acting as a server, echoed a received ping's payload in the pong
+  without unmasking it (and, as a client, sent the pong payload unmasked). A non-Ice WebSocket peer
+  that sends payload-bearing pings and validates the echoed pong could therefore drop the connection
+  (RFC 6455 §5.5.3). The common cases — browser/JS clients and empty keepalive pings — were unaffected.

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -1444,6 +1444,16 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
                 _pingPayload.clear();
                 _pingPayload.resize(_readPayloadLength);
                 memcpy(&_pingPayload[0], _readI, _pingPayload.size());
+                if (_incoming)
+                {
+                    // A client masks its frames (RFC 6455 §5.3), so unmask the ping payload here, just like the
+                    // data path does in postRead. Otherwise the pong we echo back carries the still-masked bytes
+                    // instead of the original ping payload (RFC 6455 §5.5.3).
+                    for (size_t i = 0; i < _pingPayload.size(); ++i)
+                    {
+                        _pingPayload[i] ^= static_cast<uint8_t>(_readMask[i % 4]);
+                    }
+                }
             }
 
             _readI += _readPayloadLength;
@@ -1580,8 +1590,21 @@ IceInternal::WSTransceiver::preWrite(Buffer& buf)
                     _writeBuffer.b.resize(pos + _pingPayload.size());
                     _writeBuffer.i = _writeBuffer.b.begin() + pos;
                 }
-                memcpy(_writeBuffer.i, _pingPayload.data(), _pingPayload.size());
-                _writeBuffer.i += _pingPayload.size();
+                if (_incoming)
+                {
+                    // Server-to-client frames are not masked (RFC 6455 §5.1).
+                    memcpy(_writeBuffer.i, _pingPayload.data(), _pingPayload.size());
+                    _writeBuffer.i += _pingPayload.size();
+                }
+                else
+                {
+                    // Client-to-server frames are masked with _writeMask, like the OP_DATA and OP_CLOSE paths;
+                    // prepareWriteHeader set FLAG_MASKED, so the payload must be masked to match (RFC 6455 §5.5.3).
+                    for (size_t i = 0; i < _pingPayload.size(); ++i)
+                    {
+                        *_writeBuffer.i++ = static_cast<std::byte>(_pingPayload[i]) ^ _writeMask[i % 4];
+                    }
+                }
                 _pingPayload.clear();
             }
 

--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -1249,6 +1249,15 @@ internal sealed class WSTransceiver : Transceiver
                         _pingPayload,
                         0,
                         _readPayloadLength);
+                    if (_incoming)
+                    {
+                        // A client masks its frames (RFC 6455 section 5.3); unmask the ping payload so the echoed
+                        // pong matches the ping (RFC 6455 section 5.5.3), like the data path does in postRead.
+                        for (int i = 0; i < _pingPayload.Length; ++i)
+                        {
+                            _pingPayload[i] = (byte)(_pingPayload[i] ^ _readMask[i % 4]);
+                        }
+                    }
                 }
 
                 _readBufferPos += _readPayloadLength;
@@ -1382,7 +1391,20 @@ internal sealed class WSTransceiver : Transceiver
                     _writeBuffer.resize(pos + _pingPayload.Length, false);
                     _writeBuffer.b.position(pos);
                 }
-                _writeBuffer.b.put(_pingPayload);
+                if (_incoming)
+                {
+                    // Server-to-client frames are not masked (RFC 6455 section 5.1).
+                    _writeBuffer.b.put(_pingPayload);
+                }
+                else
+                {
+                    // Client-to-server frames are masked with _writeMask, like the data and close paths;
+                    // prepareWriteHeader set FLAG_MASKED, so the payload must be masked to match (RFC 6455 5.5.3).
+                    for (int i = 0; i < _pingPayload.Length; ++i)
+                    {
+                        _writeBuffer.b.put((byte)(_pingPayload[i] ^ _writeMask[i % 4]));
+                    }
+                }
                 _pingPayload = [];
 
                 _writeState = WriteStateControlFrame;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
@@ -841,6 +841,13 @@ final class WSTransceiver implements Transceiver {
                             _pingPayload[i] = _readBuffer.b.get(_readBufferPos + i);
                         }
                     }
+                    if (_incoming) {
+                        // A client masks its frames (RFC 6455 5.3); unmask the ping payload so the echoed pong
+                        // matches the ping (RFC 6455 5.5.3), like the data path does in postRead.
+                        for (int i = 0; i < _pingPayload.length; i++) {
+                            _pingPayload[i] = (byte) (_pingPayload[i] ^ _readMask[i % 4]);
+                        }
+                    }
                 }
 
                 _readBufferPos += _readPayloadLength;
@@ -953,7 +960,16 @@ final class WSTransceiver implements Transceiver {
                     _writeBuffer.resize(pos + _pingPayload.length, false);
                     _writeBuffer.position(pos);
                 }
-                _writeBuffer.b.put(_pingPayload);
+                if (_incoming) {
+                    // Server-to-client frames are not masked (RFC 6455 5.1).
+                    _writeBuffer.b.put(_pingPayload);
+                } else {
+                    // Client-to-server frames are masked with _writeMask, like the data and close paths;
+                    // prepareWriteHeader set FLAG_MASKED, so the payload must be masked to match (RFC 6455 5.5.3).
+                    for (int i = 0; i < _pingPayload.length; i++) {
+                        _writeBuffer.b.put((byte) (_pingPayload[i] ^ _writeMask[i % 4]));
+                    }
+                }
                 _pingPayload = new byte[0];
 
                 _writeState = WriteStateControlFrame;

--- a/scripts/tests/Ice/wsAllowedOrigins.py
+++ b/scripts/tests/Ice/wsAllowedOrigins.py
@@ -117,10 +117,11 @@ class WSAllowedOriginsPortTestCase(ClientServerTestCase):
 
 
 class WSPingTestCase(ClientServerTestCase):
-    # Exercises the WebSocket zero-length PING/PONG control-frame path. A zero-length ping (the common keep-alive
-    # case sent by browsers and load balancers) must elicit an empty pong. Before the fix the server formed
+    # Exercises the WebSocket PING/PONG control-frame path. A zero-length ping (the common keep-alive case sent by
+    # browsers and load balancers) must elicit an empty pong; before the corresponding fix the server formed
     # &_pingPayload[0] on an empty vector while building the pong -- undefined behavior that aborts under a hardened
-    # standard library.
+    # standard library. A payload-bearing ping must be echoed back verbatim (RFC 6455 5.5.3): the client masks its
+    # ping, so the server must unmask the payload before echoing it, otherwise the pong carries the masked bytes.
     def __init__(self):
         ClientServerTestCase.__init__(
             self,
@@ -129,11 +130,16 @@ class WSPingTestCase(ClientServerTestCase):
         )
 
     def runClientSide(self, current):
-        current.write("testing WebSocket zero-length ping/pong... ")
+        current.write("testing WebSocket ping/pong control frames... ")
         host = current.host
         port = current.driver.getTestPort(0)
         if ping_pong(host, port, b"") != b"":
             raise RuntimeError("zero-length ping: server did not return an empty pong")
+        # The probe masks its ping payload; the server must unmask it and echo it back unchanged in the pong.
+        payload = b"ice ping payload \x00\x01\x02\xfe\xff"
+        echoed = ping_pong(host, port, payload)
+        if echoed != payload:
+            raise RuntimeError("ping payload not echoed verbatim: sent {0!r}, got {1!r}".format(payload, echoed))
         current.writeln("ok")
 
 


### PR DESCRIPTION
The C++, C#, and Java WebSocket transceivers mishandled the payload of control frames in both directions:

- **On receipt**, a masked client **ping** payload was copied into `_pingPayload` raw — the unmask loop only ran for data frames — so the echoed **pong** carried the still-masked bytes instead of the ping payload.
- **On send**, the `OP_PONG` path copied `_pingPayload` without applying `_writeMask`, even though `prepareWriteHeader` had advertised `FLAG_MASKED` with a random key, so a conforming peer received a corrupted pong.

Each transceiver now unmasks the ping payload on receipt (when the connection is incoming/server, like the data path) and masks the pong payload on send (when outgoing/client, like the `OP_DATA`/`OP_CLOSE` paths). Ice↔Ice was unaffected because Ice never initiates pings and ignores pong payloads, but a conforming non-Ice peer that sends payload-bearing pings and validates the returned pong (a common liveness probe) saw a mismatch and could drop the connection.

The C# (`WSTransceiver.cs`) and Java (`WSTransceiver.java`) transceivers are line-for-line ports of the C++ one and carried the identical bug. JavaScript wraps the host's native `WebSocket` (no hand-rolled framing) and is not affected; Python/Ruby/PHP/Swift/MATLAB use the C++ core.

### Test

Extends the existing `wsAllowedOrigins` ping/pong control-frame test (the raw-WS probe from #5593) with a payload-bearing ping that asserts the pong echoes the payload verbatim. Because `scripts/tests/Ice/wsAllowedOrigins.py` is mapping-agnostic and C++, C#, and Java all have that test server, the one test covers all three mappings. It fails without the receive-side fix (the server echoes the masked bytes) and passes with it — verified green for all three.

Closes #5447