### PR TITLE
Fix IPv4 loopback range and IPv6 scope-id address comparison (#5486)

### DIFF
--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -1914,7 +1914,8 @@ IceInternal::isLoopbackOrMulticastAddress(const string& name)
         if (inet_pton(AF_INET, name.c_str(), &addr) > 0)
         {
             // It's an IPv4 address. The whole 127.0.0.0/8 range is loopback, not just 127.0.0.1.
-            return (ntohl(addr.s_addr) & 0xFF000000u) == 0x7F000000u || IN_MULTICAST(ntohl(addr.s_addr));
+            const uint32_t host = ntohl(addr.s_addr);
+            return (host & 0xFF000000u) == 0x7F000000u || IN_MULTICAST(host);
         }
         else if (inet_pton(AF_INET6, name.c_str(), &addr6) > 0)
         {

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -720,6 +720,16 @@ IceInternal::compareAddress(const Address& addr1, const Address& addr2)
         {
             return 1;
         }
+
+        // Distinguish scoped link-local addresses such as fe80::1%eth0 and fe80::1%eth1.
+        if (addr1.saIn6.sin6_scope_id < addr2.saIn6.sin6_scope_id)
+        {
+            return -1;
+        }
+        else if (addr2.saIn6.sin6_scope_id < addr1.saIn6.sin6_scope_id)
+        {
+            return 1;
+        }
     }
 
     return 0;
@@ -1903,8 +1913,8 @@ IceInternal::isLoopbackOrMulticastAddress(const string& name)
         in6_addr addr6;
         if (inet_pton(AF_INET, name.c_str(), &addr) > 0)
         {
-            // It's an IPv4 address
-            return addr.s_addr == htonl(INADDR_LOOPBACK) || IN_MULTICAST(ntohl(addr.s_addr));
+            // It's an IPv4 address. The whole 127.0.0.0/8 range is loopback, not just 127.0.0.1.
+            return (ntohl(addr.s_addr) & 0xFF000000u) == 0x7F000000u || IN_MULTICAST(ntohl(addr.s_addr));
         }
         else if (inet_pton(AF_INET6, name.c_str(), &addr6) > 0)
         {

--- a/cpp/test/Ice/info/AllTests.cpp
+++ b/cpp/test/Ice/info/AllTests.cpp
@@ -70,10 +70,10 @@ allTests(Test::TestHelper* helper)
 
         // compareAddress must distinguish IPv6 addresses that differ only by their scope id, e.g.
         // fe80::1%eth0 vs fe80::1%eth1 (issue #5486 item 7).
-        IceInternal::Address a1;
-        a1.saIn6.sin6_family = AF_INET6;
-        a1.saIn6.sin6_port = htons(4061);
-        test(inet_pton(AF_INET6, "fe80::1", &a1.saIn6.sin6_addr) == 1);
+        // Build the address through Ice rather than calling Winsock (htons/inet_pton) directly, which the info
+        // test client doesn't link on Windows.
+        IceInternal::Address a1 =
+            IceInternal::getAddressForServer("fe80::1", 4061, IceInternal::EnableBoth, true, false);
         a1.saIn6.sin6_scope_id = 1;
 
         IceInternal::Address a2 = a1;

--- a/cpp/test/Ice/info/AllTests.cpp
+++ b/cpp/test/Ice/info/AllTests.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+#include "../../src/Ice/Network.h"
 #include "../../src/Ice/SSL/SSLUtil.h"
 #include "Ice/Ice.h"
 #include "TestHelper.h"
@@ -55,6 +56,35 @@ void
 allTests(Test::TestHelper* helper)
 {
     Ice::CommunicatorPtr communicator = helper->communicator();
+
+    cout << "testing internal network address classification... " << flush;
+    {
+        // The whole 127.0.0.0/8 range is IPv4 loopback, not just 127.0.0.1 (issue #5486 item 8).
+        test(IceInternal::isLoopbackOrMulticastAddress("127.0.0.1"));
+        test(IceInternal::isLoopbackOrMulticastAddress("127.0.0.2"));
+        test(IceInternal::isLoopbackOrMulticastAddress("127.255.255.254"));
+        test(IceInternal::isLoopbackOrMulticastAddress("239.1.2.3")); // multicast
+        test(!IceInternal::isLoopbackOrMulticastAddress("10.0.0.1"));
+        test(!IceInternal::isLoopbackOrMulticastAddress("126.0.0.1"));
+        test(!IceInternal::isLoopbackOrMulticastAddress("128.0.0.1"));
+
+        // compareAddress must distinguish IPv6 addresses that differ only by their scope id, e.g.
+        // fe80::1%eth0 vs fe80::1%eth1 (issue #5486 item 7).
+        IceInternal::Address a1;
+        a1.saIn6.sin6_family = AF_INET6;
+        a1.saIn6.sin6_port = htons(4061);
+        test(inet_pton(AF_INET6, "fe80::1", &a1.saIn6.sin6_addr) == 1);
+        a1.saIn6.sin6_scope_id = 1;
+
+        IceInternal::Address a2 = a1;
+        a2.saIn6.sin6_scope_id = 2;
+
+        test(IceInternal::compareAddress(a1, a1) == 0);
+        test(IceInternal::compareAddress(a1, a2) == -1);
+        test(IceInternal::compareAddress(a2, a1) == 1);
+    }
+    cout << "ok" << endl;
+
     cout << "testing proxy endpoint information... " << flush;
     {
         Ice::ObjectPrx p1(

--- a/cpp/test/Ice/info/AllTests.cpp
+++ b/cpp/test/Ice/info/AllTests.cpp
@@ -59,7 +59,7 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing internal network address classification... " << flush;
     {
-        // The whole 127.0.0.0/8 range is IPv4 loopback, not just 127.0.0.1 (issue #5486 item 8).
+        // The whole 127.0.0.0/8 range is IPv4 loopback, not just 127.0.0.1.
         test(IceInternal::isLoopbackOrMulticastAddress("127.0.0.1"));
         test(IceInternal::isLoopbackOrMulticastAddress("127.0.0.2"));
         test(IceInternal::isLoopbackOrMulticastAddress("127.255.255.254"));
@@ -69,7 +69,7 @@ allTests(Test::TestHelper* helper)
         test(!IceInternal::isLoopbackOrMulticastAddress("128.0.0.1"));
 
         // compareAddress must distinguish IPv6 addresses that differ only by their scope id, e.g.
-        // fe80::1%eth0 vs fe80::1%eth1 (issue #5486 item 7).
+        // fe80::1%eth0 vs fe80::1%eth1.
         // Build the address through Ice rather than calling Winsock (htons/inet_pton) directly, which the info
         // test client doesn't link on Windows.
         IceInternal::Address a1 =


### PR DESCRIPTION
Addresses #5486 (items 7, 8). One of a set of PRs splitting the grouped transport audit.

- `compareAddress` now compares `sin6_scope_id`, so two IPv6 addresses that differ only by their zone (e.g. `fe80::1%eth0` vs `fe80::1%eth1`) no longer compare equal — this previously allowed connection reuse to the wrong scoped interface.
- IPv4 loopback recognition now covers the whole `127.0.0.0/8` range instead of only `127.0.0.1`, fixing misclassification of hosts such as `127.0.0.2`.

Added deterministic unit assertions in `Ice/info`, verified red→green with each item isolated. Codex-audited.
