### PR TITLE
Fix UDP ENOBUFS handling and multicast interface quoting (#5486)

### DIFF
--- a/cpp/src/Ice/UdpEndpointI.cpp
+++ b/cpp/src/Ice/UdpEndpointI.cpp
@@ -227,8 +227,9 @@ IceInternal::UdpEndpointI::options() const
     if (_mcastInterface.length() > 0)
     {
         s << " --interface ";
-        // Quote the interface if it contains a separator the endpoint parser would split on, such as a
-        // space (Windows adapter friendly names like "Ethernet 2") or a ':' (IPv6 address).
+        // Quote the interface if it contains a character that would be re-parsed as a separator: whitespace, on
+        // which the endpoint parser splits options (e.g. a Windows adapter name like "Ethernet 2"), or ':', on
+        // which the proxy-string parser splits endpoints (e.g. an IPv6 interface address).
         bool addQuote = _mcastInterface.find_first_of(" :\t\n\r") != string::npos;
         if (addQuote)
         {

--- a/cpp/src/Ice/UdpEndpointI.cpp
+++ b/cpp/src/Ice/UdpEndpointI.cpp
@@ -227,7 +227,9 @@ IceInternal::UdpEndpointI::options() const
     if (_mcastInterface.length() > 0)
     {
         s << " --interface ";
-        bool addQuote = _mcastInterface.find(':') != string::npos;
+        // Quote the interface if it contains a separator the endpoint parser would split on, such as a
+        // space (Windows adapter friendly names like "Ethernet 2") or a ':' (IPv6 address).
+        bool addQuote = _mcastInterface.find_first_of(" :\t\n\r") != string::npos;
         if (addQuote)
         {
             s << "\"";

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -175,9 +175,10 @@ repeat:
 
 #ifndef _WIN32
         // ENOBUFS means the socket send buffer is momentarily full; this is routine on macOS/BSD during
-        // bursts. UDP is best-effort, so drop this datagram instead of throwing, which would close the
-        // connection (fatal for the never-recreated shared incoming-datagram connection). Limited to
-        // non-Windows: on Windows noBuffers() also matches WSAEFAULT, which must not be silently dropped.
+        // bursts. UDP is best-effort, so drop this datagram instead of throwing. Throwing would close the
+        // connection, and a server's UDP adapter uses a single datagram socket that Ice never re-creates, so
+        // closing it would permanently stop the adapter from receiving datagrams. Limited to non-Windows: on
+        // Windows noBuffers() also matches WSAEFAULT, which must not be silently dropped.
         if (noBuffers())
         {
             buf.i = buf.b.end();

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -174,11 +174,10 @@ repeat:
         }
 
 #ifndef _WIN32
-        // ENOBUFS means the socket send buffer is momentarily full; this is routine on macOS/BSD during
-        // bursts. UDP is best-effort, so drop this datagram instead of throwing. Throwing would close the
-        // connection, and a server's UDP adapter uses a single datagram socket that Ice never re-creates, so
-        // closing it would permanently stop the adapter from receiving datagrams. Limited to non-Windows: on
-        // Windows noBuffers() also matches WSAEFAULT, which must not be silently dropped.
+        // ENOBUFS means the local send buffer is momentarily full. This is routine on macOS/BSD during bursts
+        // and is a transient local condition rather than a connection failure. UDP is best-effort, so drop this
+        // datagram instead of throwing (throwing would needlessly close the connection). Limited to non-Windows:
+        // there noBuffers() also matches WSAEFAULT, which must not be silently dropped.
         if (noBuffers())
         {
             buf.i = buf.b.end();

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -173,6 +173,18 @@ repeat:
             return SocketOperationWrite;
         }
 
+#ifndef _WIN32
+        // ENOBUFS means the socket send buffer is momentarily full; this is routine on macOS/BSD during
+        // bursts. UDP is best-effort, so drop this datagram instead of throwing, which would close the
+        // connection (fatal for the never-recreated shared incoming-datagram connection). Limited to
+        // non-Windows: on Windows noBuffers() also matches WSAEFAULT, which must not be silently dropped.
+        if (noBuffers())
+        {
+            buf.i = buf.b.end();
+            return SocketOperationNone;
+        }
+#endif
+
         throw SocketException(__FILE__, __LINE__, getSocketErrno());
     }
 

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -263,7 +263,7 @@ allTests(TestHelper* helper)
     test(b1 == communicator->stringToProxy(b1->ice_toString()));
 
     // A multicast interface containing a space (e.g. a Windows adapter friendly name) must round-trip
-    // through ice_toString(), i.e. it must be quoted (issue #5486 item 10).
+    // through ice_toString(), i.e. it must be quoted.
     b1 = communicator->stringToProxy(R"(test:udp --interface "Ethernet 2")");
     test(b1 == communicator->stringToProxy(b1->ice_toString()));
 

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -262,6 +262,11 @@ allTests(TestHelper* helper)
     b1 = communicator->stringToProxy(R"(test:udp --sourceAddress "::1" --interface "0:0:0:0:0:0:0:1%lo")");
     test(b1 == communicator->stringToProxy(b1->ice_toString()));
 
+    // A multicast interface containing a space (e.g. a Windows adapter friendly name) must round-trip
+    // through ice_toString(), i.e. it must be quoted (issue #5486 item 10).
+    b1 = communicator->stringToProxy(R"(test:udp --interface "Ethernet 2")");
+    test(b1 == communicator->stringToProxy(b1->ice_toString()));
+
     try
     {
         communicator->stringToProxy("test:tcp@adapterId");

--- a/csharp/src/Ice/Internal/UdpEndpointI.cs
+++ b/csharp/src/Ice/Internal/UdpEndpointI.cs
@@ -176,8 +176,11 @@ internal sealed class UdpEndpointI : IPEndpointI
 
         if (_mcastInterface.Length != 0)
         {
-            bool addQuote = _mcastInterface.Contains(':', StringComparison.Ordinal);
             s += " --interface ";
+            // Quote the interface if it contains a character that would be re-parsed as a separator: whitespace, on
+            // which the endpoint parser splits options (e.g. a Windows adapter name like "Ethernet 2"), or ':', on
+            // which the proxy-string parser splits endpoints (e.g. an IPv6 interface address).
+            bool addQuote = _mcastInterface.IndexOfAny([' ', ':', '\t', '\n', '\r']) != -1;
             if (addQuote)
             {
                 s += "\"";

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -90,6 +90,11 @@ public class AllTests : global::Test.AllTests
         b1 = communicator.stringToProxy("test:udp --sourceAddress \"::1\" --interface \"0:0:0:0:0:0:0:1%lo\"");
         test(b1.Equals(communicator.stringToProxy(b1.ToString())));
 
+        // A multicast interface containing a space (e.g. a Windows adapter friendly name) must round-trip
+        // through ToString(), i.e. it must be quoted.
+        b1 = communicator.stringToProxy("test:udp --interface \"Ethernet 2\"");
+        test(b1.Equals(communicator.stringToProxy(b1.ToString())));
+
         b1 = communicator.stringToProxy("");
         test(b1 == null);
         b1 = communicator.stringToProxy("\"\"");

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpEndpointI.java
@@ -146,7 +146,10 @@ final class UdpEndpointI extends IPEndpointI {
 
         if (!_mcastInterface.isEmpty()) {
             s += " --interface ";
-            boolean addQuote = _mcastInterface.indexOf(':') != -1;
+            // Quote the interface if it contains a character that would be re-parsed as a separator: whitespace, on
+            // which the endpoint parser splits options (e.g. a Windows adapter name like "Ethernet 2"), or ':', on
+            // which the proxy-string parser splits endpoints (e.g. an IPv6 interface address).
+            boolean addQuote = _mcastInterface.chars().anyMatch(ch -> " :\t\n\r".indexOf(ch) != -1);
             if (addQuote) {
                 s += "\"";
             }

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -146,6 +146,11 @@ public class AllTests {
                 "test:udp --sourceAddress \"::1\" --interface \"0:0:0:0:0:0:0:1%lo\"");
         test(b1.equals(communicator.stringToProxy(b1.toString())));
 
+        // A multicast interface containing a space (e.g. a Windows adapter friendly name) must round-trip
+        // through toString(), i.e. it must be quoted.
+        b1 = communicator.stringToProxy("test:udp --interface \"Ethernet 2\"");
+        test(b1.equals(communicator.stringToProxy(b1.toString())));
+
         b1 = communicator.stringToProxy("");
         test(b1 == null);
         b1 = communicator.stringToProxy("\"\"");


### PR DESCRIPTION
Addresses #5486 (items 9, 10). One of a set of PRs splitting the grouped transport audit.

- **Item 9 (C++/Unix):** a transient `ENOBUFS` on a UDP send is routine on macOS/BSD during bursts — a transient local condition, not a connection failure. It was treated as fatal and closed the connection; since UDP is best-effort, `UdpTransceiver::write` now drops the datagram instead of throwing. Limited to non-Windows, because `noBuffers()` also matches `WSAEFAULT` there, which must not be silently dropped.
- **Item 10 (C++, C#, Java):** a multicast `--interface` value was quoted only when it contained `:`, so a Windows adapter friendly name with a space (e.g. `"Ethernet 2"`) was emitted unquoted and failed to re-parse. It is now quoted whenever it contains a separator the parser splits on (whitespace or `:`). The same bug existed in all three mappings; JS has no `UdpEndpointI` (N/A).

Item 10 has a red→green round-trip test in `Ice/proxy` for C++, C#, and Java; `Ice/udp` passes with no regression.

No changelog: with the catastrophic server-adapter case (bidirectional UDP, slated for removal in #5362) out of scope, item 9's remaining impact — a transient `ENOBUFS` burst on UDP sends no longer closing the connection — is minor, consistent with how the #5679 fixes were treated. Codex-audited.
