### PR TITLE
Fix OpenSSL transport handshake correctness and error-path leaks (#5486)

### DIFF
--- a/changelog.d/cpp/openssl-cert-verification-reason.md
+++ b/changelog.d/cpp/openssl-cert-verification-reason.md
@@ -1,0 +1,3 @@
+- Fixed certificate verification error reporting in the OpenSSL-based IceSSL transport. A rejected peer
+  certificate now reports the specific reason (such as "certificate has expired") instead of a generic
+  "rejected by the certificate validation callback" message.

--- a/cpp/src/Ice/SSL/OpenSSLEngine.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLEngine.cpp
@@ -188,6 +188,12 @@ OpenSSL::SSLEngine::initialize()
             // First we try to load the certificate using PKCS12 format if that fails we fallback to PEM format.
             vector<char> buffer;
             readFile(*resolved, buffer);
+            if (buffer.empty())
+            {
+                ostringstream os;
+                os << "IceSSL: certificate file is empty '" << certFile << "'";
+                throw InitializationException(__FILE__, __LINE__, os.str());
+            }
             int success = 0;
 
             const unsigned char* b = reinterpret_cast<unsigned char*>(&buffer[0]);
@@ -252,6 +258,9 @@ OpenSSL::SSLEngine::initialize()
                         {
                             if (!SSL_CTX_add_extra_chain_cert(_ctx, c))
                             {
+                                // On failure ownership of c is not transferred to _ctx, so free it here;
+                                // the catch below only frees the certs still on the stack.
+                                X509_free(c);
                                 ostringstream os;
                                 os << "IceSSL: unable to add extra SSL certificate:\n" << sslErrors();
                                 throw InitializationException(__FILE__, __LINE__, os.str());

--- a/cpp/src/Ice/SSL/OpenSSLEngine.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLEngine.cpp
@@ -191,7 +191,7 @@ OpenSSL::SSLEngine::initialize()
             if (buffer.empty())
             {
                 ostringstream os;
-                os << "IceSSL: certificate file is empty '" << certFile << "'";
+                os << "IceSSL: certificate file is empty '" << *resolved << "'";
                 throw InitializationException(__FILE__, __LINE__, os.str());
             }
             int success = 0;

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -124,7 +124,8 @@ OpenSSL::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal::
 
         if (ret <= 0)
         {
-            switch (SSL_get_error(_ssl, ret))
+            int sslError = SSL_get_error(_ssl, ret);
+            switch (sslError)
             {
                 case SSL_ERROR_NONE:
                 {
@@ -200,6 +201,7 @@ OpenSSL::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal::
                     ostringstream os;
                     os << "SSL error occurred for new " << (_incoming ? "incoming" : "outgoing") << " connection:\n"
                        << _delegate->toString() << "\n"
+                       << "SSL_get_error returned " << sslError << " (ret=" << ret << ")\n"
                        << _engine->sslErrors();
                     throw ProtocolException(__FILE__, __LINE__, os.str());
                 }

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -83,6 +83,7 @@ OpenSSL::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal::
         _sslCtx = _localSSLContextSelectionCallback(_incoming ? _adapterName : _host);
         if (!_sslCtx)
         {
+            BIO_free(bio);
             throw SecurityException(__FILE__, __LINE__, "SSL error: the SSL context selection callback returned null");
         }
         _ssl = SSL_new(_sslCtx);
@@ -190,6 +191,17 @@ OpenSSL::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal::
 #if defined(SSL_R_UNEXPECTED_EOF_WHILE_READING)
                     }
 #endif
+                }
+                default:
+                {
+                    // Any other result (e.g. SSL_ERROR_WANT_X509_LOOKUP, SSL_ERROR_WANT_ASYNC or
+                    // SSL_ERROR_WANT_RETRY_VERIFY, reachable with a user-supplied SSL_CTX) is not driven by
+                    // this event loop. Throw instead of falling through and busy-spinning on the while loop.
+                    ostringstream os;
+                    os << "SSL error occurred for new " << (_incoming ? "incoming" : "outgoing") << " connection:\n"
+                       << _delegate->toString() << "\n"
+                       << _engine->sslErrors();
+                    throw ProtocolException(__FILE__, __LINE__, os.str());
                 }
             }
         }
@@ -564,7 +576,10 @@ OpenSSL::TransceiverI::verifyCallback(int ok, X509_STORE_CTX* ctx)
             dynamic_pointer_cast<ConnectionInfo>(getInfo(_incoming, _adapterName, "")));
         if (!verified)
         {
-            long result = SSL_get_verify_result(_ssl);
+            // Read the failure reason from the current verification context rather than from
+            // SSL_get_verify_result(_ssl), which is only finalized at the end of chain verification and is
+            // stale/generic inside this per-certificate callback.
+            int result = X509_STORE_CTX_get_error(ctx);
             if (result == X509_V_OK)
             {
                 throw SecurityException(

--- a/cpp/src/Ice/SSL/SSLUtil.cpp
+++ b/cpp/src/Ice/SSL/SSLUtil.cpp
@@ -666,6 +666,7 @@ Ice::SSL::decodeCertificate(const string& data)
     // Calling it with -1 for the side effects, this ensure that the extensions info is loaded
     if (X509_check_purpose(x, -1, -1) == -1)
     {
+        X509_free(x);
         throw CertificateReadException(__FILE__, __LINE__, "error loading certificate:\n" + getErrors());
     }
     return x;


### PR DESCRIPTION
Addresses #5486 (items 2, 3, 4, 6). One of a set of PRs splitting the grouped transport audit.

- Add a `default:` to the handshake `SSL_get_error` switch so results such as `SSL_ERROR_WANT_X509_LOOKUP`/`WANT_ASYNC` (reachable with a user-supplied `SSL_CTX`) throw instead of busy-spinning.
- Report the verify failure reason from `X509_STORE_CTX_get_error(ctx)` rather than the stale/generic `SSL_get_verify_result(_ssl)` inside the per-certificate verify callback.
- Reject an empty `IceSSL.CertFile` before dereferencing `&buffer[0]` (undefined behavior on a zero-byte file).
- Free leaked OpenSSL objects on error paths: the `BIO` when the context selection callback returns null, the popped extra-chain `X509` when `SSL_CTX_add_extra_chain_cert` fails, and the `X509` in `decodeCertificate` when `X509_check_purpose` fails.

The OpenSSL backend is not built on macOS; verified by review + codex (OpenSSL ownership semantics checked against the docs). CI exercises the Linux/OpenSSL build.
