### PR TITLE
Fix SSPI buffer leak on Schannel handshake failure (#5486)

### DIFF
--- a/changelog.d/cpp/schannel-handshake-leak.md
+++ b/changelog.d/cpp/schannel-handshake-leak.md
@@ -1,0 +1,3 @@
+- Fixed a memory leak in the Schannel-based IceSSL transport (Windows) where each failed TLS handshake leaked the
+  security-token and alert buffers allocated by Schannel. On a server, a peer repeatedly failing handshakes could leak
+  memory over time.

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -299,15 +299,13 @@ Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
             }
             else if (err != SEC_I_CONTINUE_NEEDED && err != SEC_E_OK)
             {
-                SecBuffer* outToken = getSecBufferWithType(outBufferDesc, SECBUFFER_TOKEN);
-                if (outToken && outToken->pvBuffer)
+                if (outBuffers[0].pvBuffer) // token
                 {
-                    FreeContextBuffer(outToken->pvBuffer);
+                    FreeContextBuffer(outBuffers[0].pvBuffer);
                 }
-                SecBuffer* outAlert = getSecBufferWithType(outBufferDesc, SECBUFFER_ALERT);
-                if (outAlert && outAlert->pvBuffer)
+                if (outBuffers[1].pvBuffer) // alert
                 {
-                    FreeContextBuffer(outAlert->pvBuffer);
+                    FreeContextBuffer(outBuffers[1].pvBuffer);
                 }
 
                 ostringstream os;

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -197,8 +197,6 @@ Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
                 0);
             if (err != SEC_E_OK && err != SEC_I_CONTINUE_NEEDED)
             {
-                // Free the token Schannel allocated via ISC_REQ_ALLOCATE_MEMORY before throwing; the
-                // FreeContextBuffer below this block runs only on the success path.
                 if (outBuffer.pvBuffer)
                 {
                     FreeContextBuffer(outBuffer.pvBuffer);

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -299,9 +299,6 @@ Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
             }
             else if (err != SEC_I_CONTINUE_NEEDED && err != SEC_E_OK)
             {
-                // Free the output buffers Schannel allocated via ASC_REQ/ISC_REQ_ALLOCATE_MEMORY before
-                // throwing; otherwise the security token and the TLS alert buffer leak on every failed
-                // handshake (the token free below this branch is never reached on failure).
                 SecBuffer* outToken = getSecBufferWithType(outBufferDesc, SECBUFFER_TOKEN);
                 if (outToken && outToken->pvBuffer)
                 {

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -197,6 +197,12 @@ Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
                 0);
             if (err != SEC_E_OK && err != SEC_I_CONTINUE_NEEDED)
             {
+                // Free the token Schannel allocated via ISC_REQ_ALLOCATE_MEMORY before throwing; the
+                // FreeContextBuffer below this block runs only on the success path.
+                if (outBuffer.pvBuffer)
+                {
+                    FreeContextBuffer(outBuffer.pvBuffer);
+                }
                 ostringstream os;
                 os << "SSL transport: handshake failure:\n" << IceInternal::errorToString(err);
                 throw SecurityException(__FILE__, __LINE__, os.str());
@@ -295,6 +301,20 @@ Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
             }
             else if (err != SEC_I_CONTINUE_NEEDED && err != SEC_E_OK)
             {
+                // Free the output buffers Schannel allocated via ASC_REQ/ISC_REQ_ALLOCATE_MEMORY before
+                // throwing; otherwise the security token and the TLS alert buffer leak on every failed
+                // handshake (the token free below this branch is never reached on failure).
+                SecBuffer* outToken = getSecBufferWithType(outBufferDesc, SECBUFFER_TOKEN);
+                if (outToken && outToken->pvBuffer)
+                {
+                    FreeContextBuffer(outToken->pvBuffer);
+                }
+                SecBuffer* outAlert = getSecBufferWithType(outBufferDesc, SECBUFFER_ALERT);
+                if (outAlert && outAlert->pvBuffer)
+                {
+                    FreeContextBuffer(outAlert->pvBuffer);
+                }
+
                 ostringstream os;
                 os << "SSL handshake failure:\n" << IceInternal::errorToString(err);
                 throw SecurityException(__FILE__, __LINE__, os.str());


### PR DESCRIPTION
Addresses #5486 (item 5). One of a set of PRs splitting the grouped transport audit.

A failed Schannel handshake threw before freeing the output buffers Schannel allocated via `ASC_REQ`/`ISC_REQ_ALLOCATE_MEMORY`, leaking the security token and the `SECBUFFER_ALERT` buffer on every failed handshake (the existing token free runs only on the success path). Both the handshake-loop branch and the initial `InitializeSecurityContext` branch now free their allocated buffers with `FreeContextBuffer` before throwing.

Windows-only; verified by review + codex (SSPI buffer-ownership checked against the Microsoft docs). CI exercises the Windows/Schannel build.
