### PR TITLE
Fix idle-check race aborting a connection that just received data (#5486)

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -2290,7 +2290,11 @@ void
 Ice::ConnectionI::idleCheck(const chrono::seconds& idleTimeout) noexcept
 {
     std::lock_guard lock(_mutex);
-    if (_state == StateActive && _idleTimeoutTransceiver->idleCheckEnabled())
+    // Skip the abort if the idle check timer task was rescheduled (because we received bytes) while this
+    // fired task was waiting for _mutex. This mirrors the guard in inactivityCheck and closes the race where
+    // Timer::run dequeues the one-shot task before invoking it.
+    if (_state == StateActive && _idleTimeoutTransceiver->idleCheckEnabled() &&
+        !_idleTimeoutTransceiver->idleCheckScheduled())
     {
         setState(
             StateClosed,

--- a/cpp/src/Ice/IdleTimeoutTransceiverDecorator.h
+++ b/cpp/src/Ice/IdleTimeoutTransceiverDecorator.h
@@ -69,6 +69,7 @@ namespace IceInternal
         void setBufferSize(int rcvSize, int sndSize) final { _decoratee->setBufferSize(rcvSize, sndSize); }
 
         [[nodiscard]] bool idleCheckEnabled() const noexcept { return _idleCheckEnabled; }
+        [[nodiscard]] bool idleCheckScheduled() const noexcept { return _timer->isScheduled(_idleCheckTimerTask); }
         void enableIdleCheck();
         void disableIdleCheck();
         void scheduleHeartbeat();

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1454,7 +1454,11 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
     {
         lock (_mutex)
         {
-            if (_state == StateActive && _idleTimeoutTransceiver!.idleCheckEnabled)
+            // Skip the abort if the read timer was rescheduled (because we received bytes) after this idle check was
+            // already triggered. This mirrors the guard in inactivityCheck.
+            if (_state == StateActive &&
+                _idleTimeoutTransceiver!.idleCheckEnabled &&
+                !_idleTimeoutTransceiver.idleCheckScheduled)
             {
                 int idleTimeoutInSeconds = (int)idleTimeout.TotalSeconds;
 

--- a/csharp/src/Ice/Internal/IdleTimeoutTransceiverDecorator.cs
+++ b/csharp/src/Ice/Internal/IdleTimeoutTransceiverDecorator.cs
@@ -16,8 +16,17 @@ internal sealed class IdleTimeoutTransceiverDecorator : Transceiver
     private readonly System.Threading.Timer? _readTimer;
     private readonly System.Threading.Timer _writeTimer;
 
+    // The TickCount64 value at which the read (idle-check) timer is next due to fire. Protected by ConnectionI's
+    // mutex.
+    private long _readTimerDeadline;
+
     // Called by ConnectionI with its mutex locked.
     internal bool idleCheckEnabled { get; private set; }
+
+    // Called by ConnectionI with its mutex locked. Returns true when the read (idle-check) timer is still due to fire
+    // later: System.Threading.Timer cannot recall a callback it already dispatched, so a read that rescheduled the
+    // timer moves this deadline forward and the already-fired idle check must not abort the connection.
+    internal bool idleCheckScheduled => Environment.TickCount64 < _readTimerDeadline;
 
     public override string ToString() => _decoratee.ToString()!;
 
@@ -146,7 +155,14 @@ internal sealed class IdleTimeoutTransceiverDecorator : Transceiver
 
     private void cancelWriteTimer() => _writeTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
-    private void rescheduleReadTimer() => _readTimer?.Change(_idleTimeout, Timeout.InfiniteTimeSpan);
+    private void rescheduleReadTimer()
+    {
+        // Set the deadline before arming the timer: any delay between the two makes the deadline slightly earlier
+        // than the timer's actual fire time, so the only failure mode is a benign spurious abort under an extreme
+        // pause - never a missed idle timeout (which is what computing the deadline after Change would risk).
+        _readTimerDeadline = Environment.TickCount64 + (long)_idleTimeout.TotalMilliseconds;
+        _readTimer?.Change(_idleTimeout, Timeout.InfiniteTimeSpan);
+    }
 
     private void rescheduleWriteTimer() => _writeTimer.Change(_idleTimeout / 2, Timeout.InfiniteTimeSpan);
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -974,7 +974,11 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
     }
 
     public synchronized void idleCheck(int idleTimeout) {
-        if (_state == StateActive && _idleTimeoutTransceiver.isIdleCheckEnabled()) {
+        // Skip the abort if the read timer was rescheduled (because we received bytes) after this idle check was
+        // already triggered. This mirrors the guard in inactivityCheck.
+        if (_state == StateActive
+                && _idleTimeoutTransceiver.isIdleCheckEnabled()
+                && !_idleTimeoutTransceiver.isIdleCheckScheduled()) {
             String msg = "Connection aborted by the idle check because it did not receive any bytes for "
                 + idleTimeout + "s.";
             setState(StateClosed, new ConnectionAbortedException(msg, false));

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IdleTimeoutTransceiverDecorator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IdleTimeoutTransceiverDecorator.java
@@ -125,6 +125,12 @@ final class IdleTimeoutTransceiverDecorator implements Transceiver {
         return _idleCheckEnabled;
     }
 
+    // Protected by ConnectionI's mutex. Returns true when the read timer is still due to fire later: a read
+    // reschedules the timer with a fresh future, so an idle check that already fired must not abort the connection.
+    boolean isIdleCheckScheduled() {
+        return _readTimerFuture != null && _readTimerFuture.getDelay(TimeUnit.NANOSECONDS) > 0;
+    }
+
     void enableIdleCheck() {
         if (!_idleCheckEnabled && _idleCheck != null) {
             rescheduleReadTimer();


### PR DESCRIPTION
Addresses #5486 (item 11). One of a set of PRs splitting the grouped transport audit.

`ConnectionI::idleCheck` aborted the connection whenever the idle timer task fired, even when the IO thread had rescheduled that one-shot task (because fresh bytes arrived) while the fired task was waiting for the connection mutex. `idleCheck` now skips the abort when the idle check task is still scheduled, mirroring the guard already used by `inactivityCheck`. Adds `IdleTimeoutTransceiverDecorator::idleCheckScheduled()`.

The race sub-window isn't deterministically testable; `Ice/idleTimeout` passes with no regression. Codex-audited (no deadlock / lock-order inversion).
