### PR TITLE
Fix SOCKS4 proxy error message and IOCP accept-context socket (#5486)

### DIFF
--- a/cpp/src/Ice/NetworkProxy.cpp
+++ b/cpp/src/Ice/NetworkProxy.cpp
@@ -142,7 +142,7 @@ SOCKSNetworkProxy::finish(Buffer& readBuffer, Buffer&)
         throw Ice::ConnectFailedException{
             __FILE__,
             __LINE__,
-            "connection establishment failed due to an HTTP proxy error"};
+            "connection establishment failed due to a SOCKS4 proxy error"};
     }
 }
 

--- a/cpp/src/Ice/TcpAcceptor.cpp
+++ b/cpp/src/Ice/TcpAcceptor.cpp
@@ -123,8 +123,9 @@ IceInternal::TcpAcceptor::accept()
     {
         throw SocketException(__FILE__, __LINE__, _acceptError);
     }
-    if (setsockopt(_acceptFd, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, (char*)&_acceptFd, sizeof(_acceptFd)) ==
-        SOCKET_ERROR)
+    // SO_UPDATE_ACCEPT_CONTEXT takes the listening socket (_fd) as its option value, not the accepted
+    // socket (_acceptFd); see the WinSock AcceptEx/SO_UPDATE_ACCEPT_CONTEXT contract.
+    if (setsockopt(_acceptFd, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, (char*)&_fd, sizeof(_fd)) == SOCKET_ERROR)
     {
         closeSocketNoThrow(_acceptFd);
         _acceptFd = INVALID_SOCKET;

--- a/cpp/src/Ice/TcpAcceptor.cpp
+++ b/cpp/src/Ice/TcpAcceptor.cpp
@@ -123,8 +123,6 @@ IceInternal::TcpAcceptor::accept()
     {
         throw SocketException(__FILE__, __LINE__, _acceptError);
     }
-    // SO_UPDATE_ACCEPT_CONTEXT takes the listening socket (_fd) as its option value, not the accepted
-    // socket (_acceptFd); see the WinSock AcceptEx/SO_UPDATE_ACCEPT_CONTEXT contract.
     if (setsockopt(_acceptFd, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, (char*)&_fd, sizeof(_fd)) == SOCKET_ERROR)
     {
         closeSocketNoThrow(_acceptFd);


### PR DESCRIPTION
Addresses #5486 (items 1, 12). One of a set of PRs splitting the grouped transport audit.

- A rejected SOCKS4 proxy connection reported an "HTTP proxy error" (copy-pasted from the HTTP proxy path); it now names the SOCKS4 proxy.
- `TcpAcceptor` passed the accepted socket as the `SO_UPDATE_ACCEPT_CONTEXT` option value; per the WinSock `AcceptEx` contract it must be the listening socket. It now passes `_fd` (the listening socket) instead of `_acceptFd`.

Item 1 compiles on macOS; item 12 is Windows-only (verified against the Microsoft `AcceptEx` docs). Codex-audited.
