### PR TITLE
Bracket IPv6 addresses in addrToString (#5450)

### DIFF
--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -814,7 +814,15 @@ IceInternal::addrToString(const Address& addr)
     if (isAddressValid(addr))
     {
         ostringstream s;
-        s << inetAddrToString(addr) << ':' << getPort(addr);
+        // An IPv6 address is enclosed in square brackets in the host:port form, e.g. [::1]:4061.
+        if (addr.saStorage.ss_family == AF_INET6)
+        {
+            s << '[' << inetAddrToString(addr) << "]:" << getPort(addr);
+        }
+        else
+        {
+            s << inetAddrToString(addr) << ':' << getPort(addr);
+        }
         return s.str();
     }
     else

--- a/csharp/src/Ice/Internal/Network.cs
+++ b/csharp/src/Ice/Internal/Network.cs
@@ -732,11 +732,6 @@ internal sealed class Network
         return addressAndPortToString(endpointAddressToString(endpoint), endpointPort(endpoint));
     }
 
-    // Combines an address and port into a host:port string, enclosing an IPv6 address in square brackets,
-    // e.g. [::1]:4061.
-    private static string addressAndPortToString(string address, int port) =>
-        (address.Contains(':') ? $"[{address}]" : address) + ":" + port;
-
     internal static EndPoint getLocalAddress(Socket socket)
     {
         try
@@ -760,6 +755,11 @@ internal sealed class Network
         }
         return null;
     }
+
+    // Combines an address and port into a host:port string, enclosing an IPv6 address in square brackets,
+    // e.g. [::1]:4061.
+    private static string addressAndPortToString(string address, int port) =>
+        address.Contains(':', StringComparison.Ordinal) ? $"[{address}]:{port}" : $"{address}:{port}";
 
     private static IPAddress getInterfaceAddress(string iface, AddressFamily family)
     {

--- a/csharp/src/Ice/Internal/Network.cs
+++ b/csharp/src/Ice/Internal/Network.cs
@@ -712,7 +712,7 @@ internal sealed class Network
     }
 
     internal static string
-    addrToString(EndPoint addr) => endpointAddressToString(addr) + ":" + endpointPort(addr);
+    addrToString(EndPoint addr) => addressAndPortToString(endpointAddressToString(addr), endpointPort(addr));
 
     internal static string localAddrToString(EndPoint endpoint)
     {
@@ -720,7 +720,7 @@ internal sealed class Network
         {
             return "<not bound>";
         }
-        return endpointAddressToString(endpoint) + ":" + endpointPort(endpoint);
+        return addressAndPortToString(endpointAddressToString(endpoint), endpointPort(endpoint));
     }
 
     internal static string remoteAddrToString(EndPoint endpoint)
@@ -729,8 +729,13 @@ internal sealed class Network
         {
             return "<not connected>";
         }
-        return endpointAddressToString(endpoint) + ":" + endpointPort(endpoint);
+        return addressAndPortToString(endpointAddressToString(endpoint), endpointPort(endpoint));
     }
+
+    // Combines an address and port into a host:port string, enclosing an IPv6 address in square brackets,
+    // e.g. [::1]:4061.
+    private static string addressAndPortToString(string address, int port) =>
+        (address.Contains(':') ? $"[{address}]" : address) + ":" + port;
 
     internal static EndPoint getLocalAddress(Socket socket)
     {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
@@ -761,7 +761,12 @@ public final class Network {
 
     public static String addrToString(InetSocketAddress addr) {
         StringBuilder s = new StringBuilder(128);
-        s.append(addr.getAddress().getHostAddress());
+        // An IPv6 address is enclosed in square brackets in the host:port form, e.g. [::1]:4061.
+        if (addr.getAddress() instanceof Inet6Address) {
+            s.append('[').append(addr.getAddress().getHostAddress()).append(']');
+        } else {
+            s.append(addr.getAddress().getHostAddress());
+        }
         s.append(':');
         s.append(addr.getPort());
         return s.toString();
@@ -784,6 +789,9 @@ public final class Network {
 
         if (addr == null || addr.isAnyLocalAddress()) {
             s.append("<not available>");
+        } else if (addr instanceof Inet6Address) {
+            // An IPv6 address is enclosed in square brackets in the host:port form, e.g. [::1]:4061.
+            s.append('[').append(addr.getHostAddress()).append(']');
         } else {
             s.append(addr.getHostAddress());
         }

--- a/js/packages/ice/src/Ice/IPEndpointI.js
+++ b/js/packages/ice/src/Ice/IPEndpointI.js
@@ -154,7 +154,9 @@ export class IPEndpointI extends EndpointI {
     // Convert the endpoint to its Connector string form
     //
     toConnectorString() {
-        return this._host + ":" + this._port;
+        // An IPv6 address is enclosed in square brackets in the host:port form, e.g. [::1]:4061.
+        const host = this._host.includes(":") ? `[${this._host}]` : this._host;
+        return host + ":" + this._port;
     }
 
     streamWriteImpl(s) {

--- a/js/packages/ice/src/Ice/TcpTransceiver.js
+++ b/js/packages/ice/src/Ice/TcpTransceiver.js
@@ -279,6 +279,7 @@ function addrToString(host, port) {
 }
 
 function addressesToString(localHost, localPort, remoteHost, remotePort, targetAddr) {
+    localHost = localHost === undefined ? null : localHost;
     remoteHost = remoteHost === undefined ? null : remoteHost;
     targetAddr = targetAddr === undefined ? null : targetAddr;
 

--- a/js/packages/ice/src/Ice/TcpTransceiver.js
+++ b/js/packages/ice/src/Ice/TcpTransceiver.js
@@ -272,13 +272,19 @@ function translateError(state, err, address) {
     return new SocketException(`Socket error on ${address}.`, { cause: err });
 }
 
+// Combines an address and port into a host:port string, enclosing an IPv6 address in square brackets,
+// e.g. [::1]:4061.
+function addrToString(host, port) {
+    return (host !== null && host.includes(":") ? `[${host}]` : host) + ":" + port;
+}
+
 function addressesToString(localHost, localPort, remoteHost, remotePort, targetAddr) {
     remoteHost = remoteHost === undefined ? null : remoteHost;
     targetAddr = targetAddr === undefined ? null : targetAddr;
 
     const s = [];
     s.push("local address = ");
-    s.push(localHost + ":" + localPort);
+    s.push(addrToString(localHost, localPort));
 
     if (remoteHost === null && targetAddr !== null) {
         remoteHost = targetAddr.host;
@@ -289,7 +295,7 @@ function addressesToString(localHost, localPort, remoteHost, remotePort, targetA
         s.push("\nremote address = <not connected>");
     } else {
         s.push("\nremote address = ");
-        s.push(remoteHost + ":" + remotePort);
+        s.push(addrToString(remoteHost, remotePort));
     }
 
     return s.join("");

--- a/js/packages/ice/src/Ice/WSTransceiver.js
+++ b/js/packages/ice/src/Ice/WSTransceiver.js
@@ -30,7 +30,9 @@ class WSTransceiver {
 
         let url = secure ? "wss" : "ws";
         const isIPv6 = addr.host.includes(":");
-        url += "://" + (isIPv6 ? `[${addr.host}]` : addr.host);
+        // An IPv6 address is enclosed in square brackets in the host:port and URI authority forms.
+        const hostForUri = isIPv6 ? `[${addr.host}]` : addr.host;
+        url += "://" + hostForUri;
         if (addr.port !== (secure ? 443 : 80)) {
             url += ":" + addr.port;
         }
@@ -39,7 +41,7 @@ class WSTransceiver {
         this._url = url;
         this._fd = null;
         this._addr = addr;
-        this._desc = "local address = <not available>\nremote address = " + addr.host + ":" + addr.port;
+        this._desc = `local address = <not available>\nremote address = ${hostForUri}:${addr.port}`;
         this._state = StateNeedConnect;
         this._secure = secure;
         this._exception = null;
@@ -310,7 +312,9 @@ class WSTransceiver {
 }
 
 function fdToString(address) {
-    return `local address = <not available>\nremote address = ${address.host}:${address.port}`;
+    // An IPv6 address is enclosed in square brackets in the host:port form, e.g. [::1]:4061.
+    const host = address.host.includes(":") ? `[${address.host}]` : address.host;
+    return `local address = <not available>\nremote address = ${host}:${address.port}`;
 }
 
 export { WSTransceiver };


### PR DESCRIPTION
Fixes #5450 (C++, C#, and Java — same helper ported across the mappings; JS aligned for consistency).

## The bug

`addrToString` assembled the `host:port` form without enclosing IPv6 literals in square brackets, producing an ambiguous authority such as `2001:db8::1:4061` where the port is indistinguishable from the address.

The visible symptom (#5450) was a malformed HTTP-proxy `CONNECT` request line and `Host:` header for IPv6 targets:

```
CONNECT 2001:db8::1:4061 HTTP/1.1
```

which a conforming proxy rejects.

## The fix

Enclose IPv6 literals in square brackets in `addrToString` itself, producing the canonical `[2001:db8::1]:4061`. IPv4 output is unchanged.

The `CONNECT` assembly builds its authority by calling `addrToString`, so fixing the helper fixes `CONNECT` — and, as a bonus, renders IPv6 unambiguously in **all** network tracing and connect/connection-lost exception messages. `addrToString`'s output is only ever used for diagnostics/exceptions and the `CONNECT` authority; it is never parsed back (the structured/endpoint-string path uses separate helpers that already bracket IPv6), so this is safe.

- **C++** (`cpp/src/Ice/Network.cpp`) — bracket when `ss_family == AF_INET6`
- **C#** (`csharp/src/Ice/Internal/Network.cs`) — shared `addressAndPortToString` brackets when the address contains `:`; also applied to `localAddrToString`/`remoteAddrToString`
- **Java** (`.../Network.java`) — bracket when `addr instanceof Inet6Address`, in both `addrToString` overloads

### JavaScript

JS has no single `addrToString` helper and no HTTP proxy, but it assembles `host:port` strings for network tracing and the connector-string form in a few spots. Bracketed for consistency:

- `TcpTransceiver` `addressesToString` (local/remote trace)
- `WSTransceiver` `_desc` and `fdToString` (remote-address trace)
- `IPEndpointI` `toConnectorString` (network trace only)

The WebSocket URL already bracketed IPv6 correctly.

This supersedes #5673, which fixed only the `CONNECT` assembly (per review feedback, fixing the shared helper is cleaner and corrects the diagnostics too).

## Testing

C++ Ice (`make -j12`), C# Ice, and Java `:ice:compileJava` all build clean; JS lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)