### PR TITLE
Detach old metrics observer outside the factory mutex

### DIFF
--- a/cpp/src/Ice/MetricsObserverI.h
+++ b/cpp/src/Ice/MetricsObserverI.h
@@ -493,30 +493,34 @@ namespace IceMX
                 return getObserver(helper);
             }
 
-            std::lock_guard lock(_mutex);
-            if (!_metrics)
             {
-                return nullptr;
-            }
-
-            typename ObserverImplType::EntrySeqType metricsObjects;
-            for (const auto& map : _maps)
-            {
-                typename ObserverImplType::EntryPtrType entry = map->getMatching(helper, old->getEntry(map.get()));
-                if (entry)
+                std::lock_guard lock(_mutex);
+                if (!_metrics)
                 {
-                    metricsObjects.push_back(entry);
+                    return nullptr;
+                }
+
+                typename ObserverImplType::EntrySeqType metricsObjects;
+                for (const auto& map : _maps)
+                {
+                    typename ObserverImplType::EntryPtrType entry = map->getMatching(helper, old->getEntry(map.get()));
+                    if (entry)
+                    {
+                        metricsObjects.push_back(entry);
+                    }
+                }
+                if (!metricsObjects.empty())
+                {
+                    ObserverImplPtrType obsv = std::make_shared<ObserverImplType>();
+                    obsv->init(helper, metricsObjects, old.get());
+                    return obsv;
                 }
             }
-            if (metricsObjects.empty())
-            {
-                old->detach();
-                return nullptr;
-            }
 
-            ObserverImplPtrType obsv = std::make_shared<ObserverImplType>();
-            obsv->init(helper, metricsObjects, old.get());
-            return obsv;
+            // No map matched the updated observer: detach the old observer outside the factory mutex, since
+            // detach() can call into a user-supplied instrumentation delegate.
+            old->detach();
+            return nullptr;
         }
 
         template<typename SubMapMetricsType>

--- a/csharp/src/Ice/MetricsObserverI.cs
+++ b/csharp/src/Ice/MetricsObserverI.cs
@@ -359,17 +359,18 @@ public class ObserverFactory<T, O> where T : Metrics, new() where O : Observer<T
 
     public O getObserver(MetricsHelper<T> helper, object observer)
     {
+        O old = null;
+        try
+        {
+            old = (O)observer;
+        }
+        catch (InvalidCastException)
+        {
+        }
+
         lock (_mutex)
         {
             List<MetricsMap<T>.Entry> metricsObjects = null;
-            O old = null;
-            try
-            {
-                old = (O)observer;
-            }
-            catch (InvalidCastException)
-            {
-            }
             foreach (MetricsMap<T> m in _maps)
             {
                 MetricsMap<T>.Entry e = m.getMatching(helper, old?.getEntry(m));
@@ -380,25 +381,27 @@ public class ObserverFactory<T, O> where T : Metrics, new() where O : Observer<T
                 }
             }
 
-            if (metricsObjects == null)
+            if (metricsObjects != null)
             {
-                old?.detach();
-                return null;
+                O obsv;
+                try
+                {
+                    obsv = new O();
+                }
+                catch (Exception)
+                {
+                    Debug.Assert(false);
+                    return null;
+                }
+                obsv.init(helper, metricsObjects, old);
+                return obsv;
             }
-
-            O obsv;
-            try
-            {
-                obsv = new O();
-            }
-            catch (Exception)
-            {
-                Debug.Assert(false);
-                return null;
-            }
-            obsv.init(helper, metricsObjects, old);
-            return obsv;
         }
+
+        // No map matched the updated observer: detach the old observer outside the factory lock, since
+        // detach() can call into a user-supplied instrumentation delegate.
+        old?.detach();
+        return null;
     }
 
     public void registerSubMap<S>(string subMap, System.Reflection.FieldInfo field)

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/IceMX/ObserverFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/IceMX/ObserverFactory.java
@@ -58,38 +58,43 @@ public class ObserverFactory<T extends Metrics, O extends Observer<T>> {
      * @return the observer instance, or null if no metrics maps are enabled
      */
     @SuppressWarnings("unchecked")
-    public synchronized O getObserver(MetricsHelper<T> helper, Object observer, Class<O> cl) {
+    public O getObserver(MetricsHelper<T> helper, Object observer, Class<O> cl) {
         O old = null;
         try {
             old = (O) observer;
         } catch (ClassCastException ex) {}
-        List<MetricsMap<T>.Entry> metricsObjects = null;
-        for (MetricsMap<T> m : _maps) {
-            MetricsMap<T>.Entry e = m.getMatching(helper, old != null ? old.getEntry(m) : null);
-            if (e != null) {
-                if (metricsObjects == null) {
-                    metricsObjects = new ArrayList<>(_maps.size());
+
+        synchronized (this) {
+            List<MetricsMap<T>.Entry> metricsObjects = null;
+            for (MetricsMap<T> m : _maps) {
+                MetricsMap<T>.Entry e = m.getMatching(helper, old != null ? old.getEntry(m) : null);
+                if (e != null) {
+                    if (metricsObjects == null) {
+                        metricsObjects = new ArrayList<>(_maps.size());
+                    }
+                    metricsObjects.add(e);
                 }
-                metricsObjects.add(e);
+            }
+
+            if (metricsObjects != null) {
+                O obsv;
+                try {
+                    obsv = cl.getDeclaredConstructor().newInstance();
+                } catch (Exception ex) {
+                    assert false;
+                    return null;
+                }
+                obsv.init(helper, metricsObjects, old);
+                return obsv;
             }
         }
 
-        if (metricsObjects == null) {
-            if (old != null) {
-                old.detach();
-            }
-            return null;
+        // No map matched the updated observer: detach the old observer outside the factory monitor, since
+        // detach() can call into a user-supplied instrumentation delegate.
+        if (old != null) {
+            old.detach();
         }
-
-        O obsv;
-        try {
-            obsv = cl.getDeclaredConstructor().newInstance();
-        } catch (Exception ex) {
-            assert false;
-            return null;
-        }
-        obsv.init(helper, metricsObjects, old);
-        return obsv;
+        return null;
     }
 
     /**


### PR DESCRIPTION
Fixes #5455.

`ObserverFactoryT::getObserver` detached the old metrics observer while holding the factory mutex. `detach()` forwards to the user-supplied instrumentation delegate (`Ice::InitializationData::observer`), so running it under the lock is a deadlock hazard if the delegate re-enters the factory.

This captures the old observer under the lock and calls `detach()` after releasing it. The same bug was present in C++, C#, and Java, so all three are fixed.

No CHANGELOG entry: the only way `detach()` calls out (and can block/re-enter) is via a custom user-supplied observer delegate. With Ice's own observers, `detach()` is pure metric bookkeeping under the MetricsMap mutex — it never re-enters the factory or calls user code, so there is no user-facing impact for the common case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)