### PR TITLE
Close the UDP socket when UdpTransceiver construction fails

### DIFF
--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -1273,15 +1273,24 @@ void
 IceInternal::setMcastInterface(SOCKET fd, const string& intf, const Address& addr)
 {
     int rc;
-    if (addr.saStorage.ss_family == AF_INET)
+    try
     {
-        struct in_addr iface = getInterfaceAddress(intf);
-        rc = setsockopt(fd, IPPROTO_IP, IP_MULTICAST_IF, reinterpret_cast<char*>(&iface), int(sizeof(iface)));
+        if (addr.saStorage.ss_family == AF_INET)
+        {
+            struct in_addr iface = getInterfaceAddress(intf);
+            rc = setsockopt(fd, IPPROTO_IP, IP_MULTICAST_IF, reinterpret_cast<char*>(&iface), int(sizeof(iface)));
+        }
+        else
+        {
+            int interfaceNum = getInterfaceIndex(intf);
+            rc = setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, reinterpret_cast<char*>(&interfaceNum), int(sizeof(int)));
+        }
     }
-    else
+    catch (const Ice::SocketException&)
     {
-        int interfaceNum = getInterfaceIndex(intf);
-        rc = setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, reinterpret_cast<char*>(&interfaceNum), int(sizeof(int)));
+        // getInterfaceAddress and getInterfaceIndex throw if the interface cannot be resolved.
+        closeSocketNoThrow(fd);
+        throw;
     }
     if (rc == SOCKET_ERROR)
     {

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -1293,7 +1293,12 @@ IceInternal::setMcastInterface(SOCKET fd, const string& intf, const Address& add
         else
         {
             int interfaceNum = getInterfaceIndex(intf);
-            rc = setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, reinterpret_cast<char*>(&interfaceNum), int(sizeof(int)));
+            rc = setsockopt(
+                fd,
+                IPPROTO_IPV6,
+                IPV6_MULTICAST_IF,
+                reinterpret_cast<char*>(&interfaceNum),
+                int(sizeof(int)));
         }
     }
     catch (const Ice::SocketException&)

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -716,7 +716,16 @@ IceInternal::UdpTransceiver::setBufSize(int rcvSize, int sndSize)
         //
         if (sizeRequested == -1)
         {
-            sizeRequested = _instance->properties()->getPropertyAsIntWithDefault(prop, dfltSize);
+            try
+            {
+                sizeRequested = _instance->properties()->getPropertyAsIntWithDefault(prop, dfltSize);
+            }
+            catch (const Ice::PropertyException&)
+            {
+                // getPropertyAsIntWithDefault throws if the property is set to a non-integer value.
+                closeSocketNoThrow(_fd);
+                throw;
+            }
         }
         //
         // Check for sanity.

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -724,6 +724,7 @@ IceInternal::UdpTransceiver::setBufSize(int rcvSize, int sndSize)
             {
                 // getPropertyAsIntWithDefault throws if the property is set to a non-integer value.
                 closeSocketNoThrow(_fd);
+                _fd = INVALID_SOCKET;
                 throw;
             }
         }

--- a/csharp/src/Ice/Internal/UdpTransceiver.cs
+++ b/csharp/src/Ice/Internal/UdpTransceiver.cs
@@ -645,6 +645,9 @@ internal sealed class UdpTransceiver : Transceiver
         }
         catch (Ice.LocalException)
         {
+            _readEventArgs?.Dispose();
+            _writeEventArgs?.Dispose();
+            Network.closeSocketNoThrow(_fd);
             _fd = null;
             throw;
         }
@@ -687,6 +690,7 @@ internal sealed class UdpTransceiver : Transceiver
         {
             _readEventArgs?.Dispose();
             _writeEventArgs?.Dispose();
+            Network.closeSocketNoThrow(_fd);
             _fd = null;
             throw;
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
@@ -300,7 +300,10 @@ final class UdpTransceiver implements Transceiver {
             Network.doConnect(_fd, _addr, sourceAddr);
             _state = StateConnected; // We're connected now
         } catch (LocalException ex) {
-            _fd = null;
+            if (_fd != null) {
+                Network.closeSocketNoThrow(_fd);
+                _fd = null;
+            }
             throw ex;
         }
     }
@@ -326,7 +329,10 @@ final class UdpTransceiver implements Transceiver {
             setBufSize(-1, -1);
             Network.setBlock(_fd, false);
         } catch (LocalException ex) {
-            _fd = null;
+            if (_fd != null) {
+                Network.closeSocketNoThrow(_fd);
+                _fd = null;
+            }
             throw ex;
         }
     }


### PR DESCRIPTION
## Description

The `UdpTransceiver` constructors create a socket and then perform setup that can throw — resolving a multicast interface, and reading an integer UDP buffer-size property. If that setup threw *after* the socket was created, the socket was not closed:

- **C++** — the constructor has no try/catch and the destructor never runs, so the raw fd leaked. Fixed by restoring the invariant that every socket helper closes the fd before throwing: `setMcastInterface`'s `getInterfaceAddress`/`getInterfaceIndex` path and `setBufSize`'s `getPropertyAsIntWithDefault`. (Avoiding a constructor-level try/catch sidesteps a double-close of a reused fd, since `setBlock`/`setMcastTtl`/`doConnect` already self-close.)
- **Java / C#** — the constructor's `catch` only nulled the field, dropping the open socket to the GC/finalizer. Now it closes the socket in the existing `catch`. Managed `close()`/`Close()` is idempotent on the object (no fd-reuse race), so this is safe even if a helper already closed it. The C# outgoing constructor also now disposes its `SocketAsyncEventArgs` on failure, matching the incoming constructor.

Fixes #5446.

## Note

This is **code hardening only — there is no real leak.** The triggering errors (an unresolvable multicast `--interface`, a non-integer `Ice.UDP.RcvSize`/`Ice.UDP.SndSize`) are fatal and abort construction immediately; they fail the same way on every attempt rather than being retried, so no descriptor-exhaustion scenario is reachable. In Java and C# the socket is a managed object reclaimed by the GC/finalizer anyway. Hence no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)