### PR TITLE
Treat ENOBUFS as a connection error on the OpenSSL transport

### DIFF
--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -343,12 +343,6 @@ OpenSSL::TransceiverI::write(IceInternal::Buffer& buf)
                         continue;
                     }
 
-                    if (IceInternal::noBuffers() && packetSize > 1024)
-                    {
-                        packetSize /= 2;
-                        continue;
-                    }
-
                     if (IceInternal::wouldBlock())
                     {
                         assert(SSL_want_write(_ssl));
@@ -433,12 +427,6 @@ OpenSSL::TransceiverI::read(IceInternal::Buffer& buf)
                 {
                     if (IceInternal::interrupted())
                     {
-                        continue;
-                    }
-
-                    if (IceInternal::noBuffers() && packetSize > 1024)
-                    {
-                        packetSize /= 2;
                         continue;
                     }
 


### PR DESCRIPTION
Fixes #5444.

## Summary

Removes an incorrect, copied-from-TCP retry heuristic from the OpenSSL transceiver. On a `send()`/`recv()` `ENOBUFS` (surfaced as `SSL_ERROR_SYSCALL`), it halved `packetSize` and retried `SSL_write`/`SSL_read` with a **smaller** length:

```cpp
if (IceInternal::noBuffers() && packetSize > 1024) { packetSize /= 2; continue; }
```

This is invalid for `SSL_write`: a non-completed write must be retried with the **same** length while a record is pending (`SSL_write(3)`: *"it must be repeated with the same arguments … the data and length should still be the same"*). OpenSSL enforces this in `ssl3_write_bytes` (`len < wnum + wpend_tot` → `SSL_R_BAD_LENGTH`), so the smaller retry would turn the condition into a bogus *"SSL protocol error during write."*

The fix removes the halving in both directions and lets `ENOBUFS` fall through to a `SocketException` (a connection error) — matching curl and nginx, which do not retry SSL writes on `ENOBUFS`; none of curl, nginx, Boost.Asio, stunnel, CPython, or Node.js shrink an `SSL_write` length on retry.

## Reachability — this is cleanup, not a hot-path fix

OpenSSL is the Linux SSL backend, and on Linux this condition is effectively never hit:
- `send(2)`: *"ENOBUFS … Normally, this does not occur in Linux. Packets are just silently dropped when a device queue overflows."*
- `recv(2)`: `ENOBUFS` is **not a documented error at all** (a recv resource failure is `ENOMEM`), so the read-side block was strictly dead code.

So this removes incorrect/dead code rather than fixing a frequently-hit bug. Surviving a genuine transient `ENOBUFS` would need a bounded backoff (a naive would-block retry can busy-spin, since `ENOBUFS` isn't cleared by socket writability like `EWOULDBLOCK`); that complexity isn't warranted for a condition this rare, so we err on the simple, contract-correct side.
