### PR TITLE
Fix CFStream selector ready() data race on _ready (iOS)

### DIFF
--- a/changelog.d/cpp/cfstream-selector-ready-race.md
+++ b/changelog.d/cpp/cfstream-selector-ready-race.md
@@ -1,0 +1,1 @@
+- Fixed a bug in the iOS (CFStream) transport where a connection could intermittently stall.

--- a/cpp/src/Ice/Selector.cpp
+++ b/cpp/src/Ice/Selector.cpp
@@ -1120,6 +1120,9 @@ Selector::finish(EventHandler* handler, bool closeNow)
 void
 Selector::ready(EventHandler* handler, SocketOperation status, bool value)
 {
+    // Hold _mutex across the read-modify-write of handler->_ready. The run-loop thread reads _ready under _mutex
+    // (in startSelect/finishSelect, via EventHandlerWrapper), so updating it unlocked here would be a data race.
+    lock_guard lock(_mutex);
     if (((handler->_ready & status) != 0) == value)
     {
         return; // Nothing to do if ready state already correctly set.
@@ -1134,7 +1137,6 @@ Selector::ready(EventHandler* handler, SocketOperation status, bool value)
         handler->_ready = static_cast<SocketOperation>(handler->_ready & ~status);
     }
 
-    lock_guard lock(_mutex);
     std::map<EventHandler*, EventHandlerWrapperPtr>::iterator p = _wrappers.find(handler);
     assert(p != _wrappers.end());
     p->second->checkReady();


### PR DESCRIPTION
Fixes #5453.

On iOS (CFStream selector), `Selector::ready(EventHandler*, SocketOperation, bool)` modified `handler->_ready` **before** acquiring `_mutex`:

```cpp
if (((handler->_ready & status) != 0) == value) { return; }   // read, unlocked
if (value) handler->_ready |= status; else handler->_ready &= ~status;   // write, unlocked
lock_guard lock(_mutex);   // lock taken only here
...
```

The dedicated run-loop thread reads `handler->_ready` **under** `_mutex` (in `startSelect`/`finishSelect`, via `EventHandlerWrapper::checkReady()`/`readyOp()`). So a `ready()` update from a thread-pool thread races with the run-loop reads: the transition can be lost (the handler is never added to the ready set → stalled connection) or read torn.

Take `_mutex` at the top of `ready()` so the read-modify-write of `_ready` and the run-loop reads serialize on the same lock. The epoll/kqueue and IOCP selectors don't have this race — they have no separate run-loop thread, so all access is serialized by the thread-pool mutex; only the CFStream variant has its own lock plus a foreign thread.

Verified with clang-format and a `-fsyntax-only -DICE_USE_CFSTREAM` compile (CoreFoundation is available on macOS); the iOS CI is the full build/test.