### PR TITLE
Drain transient IceStorm topics on shutdown

### DIFF
--- a/changelog.d/service-icestorm/icestorm-transient-drain.md
+++ b/changelog.d/service-icestorm/icestorm-transient-drain.md
@@ -1,0 +1,1 @@
+- Fixed a bug where a transient IceStorm service could drop queued events on shutdown instead of delivering them.

--- a/cpp/src/IceStorm/Service.cpp
+++ b/cpp/src/IceStorm/Service.cpp
@@ -109,8 +109,8 @@ ServiceI::start([[maybe_unused]] const string& serviceName, const CommunicatorPt
         _instance = make_shared<Instance>(instanceName, communicator, publishAdapter, topicAdapter, nullptr);
         try
         {
-            auto manager = make_shared<TransientTopicManagerImpl>(_instance);
-            _managerProxy = topicAdapter->add<TopicManagerPrx>(manager, topicManagerId);
+            _transientManager = make_shared<TransientTopicManagerImpl>(_instance);
+            _managerProxy = topicAdapter->add<TopicManagerPrx>(_transientManager, topicManagerId);
         }
         catch (const Ice::LocalException& ex)
         {
@@ -362,8 +362,8 @@ ServiceI::start(
 
     try
     {
-        auto manager = make_shared<TransientTopicManagerImpl>(_instance);
-        _managerProxy = topicAdapter->add<TopicManagerPrx>(manager, id);
+        _transientManager = make_shared<TransientTopicManagerImpl>(_instance);
+        _managerProxy = topicAdapter->add<TopicManagerPrx>(_transientManager, id);
     }
     catch (const Ice::LocalException& ex)
     {


### PR DESCRIPTION
Fixes #5468.

`IceStorm::Service` created the `TransientTopicManagerImpl` in a **local variable** on both transient start paths (the IceBox transient path and the IceGrid-embedded path) and never assigned it to the `_transientManager` member:

```cpp
auto manager = make_shared<TransientTopicManagerImpl>(_instance);   // local only
_managerProxy = topicAdapter->add<TopicManagerPrx>(manager, topicManagerId);
```

So `stop()`'s drain was dead code:

```cpp
if (_transientManager) { _transientManager->shutdown(); }   // member never set → always false
```

`TransientTopicManagerImpl::shutdown()` cascades `topic->shutdown()` → `Subscriber::shutdown()`, so on a transient IceStorm deployment (`IceStorm.Transient=1` or the IceGrid-embedded variant) transient topics and their subscribers were never drained on shutdown — unlike the persistent path, which drains via `_manager->shutdown()`. Outstanding/queued events were dropped instead of flushed.

The fix assigns the created manager to `_transientManager` on both paths.

Verified locally: `IceStorm/single` (which runs the `transient=True` configuration) passes, so the transient start→stop path now exercises the drain without regression.