### PR TITLE
Simplify IceStorm Subscriber proxy setup

### DIFF
--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -425,8 +425,7 @@ Subscriber::create(const shared_ptr<Instance>& instance, const SubscriberRecord&
             throw BadQoS("invalid reliability: " + reliability);
         }
 
-        // Override the invocation timeout with the send timeout. ice_invocationTimeout is a local operation that
-        // works on any proxy, including a fixed proxy (which rec.obj can be when IceStorm is collocated).
+        // Override the invocation timeout with the send timeout. 
         Ice::ObjectPrx newObj = rec.obj->ice_invocationTimeout(instance->sendTimeout());
 
         p = rec.theQoS.find("locatorCacheTimeout");

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -425,7 +425,7 @@ Subscriber::create(const shared_ptr<Instance>& instance, const SubscriberRecord&
             throw BadQoS("invalid reliability: " + reliability);
         }
 
-        // Override the invocation timeout with the send timeout. 
+        // Override the invocation timeout with the send timeout.
         Ice::ObjectPrx newObj = rec.obj->ice_invocationTimeout(instance->sendTimeout());
 
         p = rec.theQoS.find("locatorCacheTimeout");

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -425,18 +425,10 @@ Subscriber::create(const shared_ptr<Instance>& instance, const SubscriberRecord&
             throw BadQoS("invalid reliability: " + reliability);
         }
 
-        // Override the invocation timeout.
-        optional<Ice::ObjectPrx> newObj;
-        try
-        {
-            newObj = rec.obj->ice_invocationTimeout(instance->sendTimeout());
-        }
-        catch (const Ice::FixedProxyException&)
-        {
-            // In the event IceStorm is collocated this could be a fixed proxy in which case its not possible to
-            // set the timeout.
-            newObj = rec.obj;
-        }
+        // Override the invocation timeout, unless rec.obj is a fixed proxy. When IceStorm is collocated, rec.obj
+        // may be a fixed proxy, whose invocation timeout cannot be changed.
+        Ice::ObjectPrx newObj =
+            rec.obj->ice_isFixed() ? *rec.obj : rec.obj->ice_invocationTimeout(instance->sendTimeout());
 
         p = rec.theQoS.find("locatorCacheTimeout");
         if (p != rec.theQoS.end())
@@ -478,16 +470,16 @@ Subscriber::create(const shared_ptr<Instance>& instance, const SubscriberRecord&
             {
                 throw BadQoS("ordered reliability requires a twoway proxy");
             }
-            subscriber = make_shared<SubscriberTwoway>(instance, rec, proxy, retryCount, 1, *newObj);
+            subscriber = make_shared<SubscriberTwoway>(instance, rec, proxy, retryCount, 1, newObj);
         }
         else if (newObj->ice_isOneway() || newObj->ice_isDatagram())
         {
-            subscriber = make_shared<SubscriberOneway>(instance, rec, proxy, retryCount, *newObj);
+            subscriber = make_shared<SubscriberOneway>(instance, rec, proxy, retryCount, newObj);
         }
         else // if(newObj->ice_isTwoway())
         {
             assert(newObj->ice_isTwoway());
-            subscriber = make_shared<SubscriberTwoway>(instance, rec, proxy, retryCount, 5, *newObj);
+            subscriber = make_shared<SubscriberTwoway>(instance, rec, proxy, retryCount, 5, newObj);
         }
         per->setSubscriber(subscriber);
 

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -425,10 +425,9 @@ Subscriber::create(const shared_ptr<Instance>& instance, const SubscriberRecord&
             throw BadQoS("invalid reliability: " + reliability);
         }
 
-        // Override the invocation timeout, unless rec.obj is a fixed proxy. When IceStorm is collocated, rec.obj
-        // may be a fixed proxy, whose invocation timeout cannot be changed.
-        Ice::ObjectPrx newObj =
-            rec.obj->ice_isFixed() ? *rec.obj : rec.obj->ice_invocationTimeout(instance->sendTimeout());
+        // Override the invocation timeout with the send timeout. ice_invocationTimeout is a local operation that
+        // works on any proxy, including a fixed proxy (which rec.obj can be when IceStorm is collocated).
+        Ice::ObjectPrx newObj = rec.obj->ice_invocationTimeout(instance->sendTimeout());
 
         p = rec.theQoS.find("locatorCacheTimeout");
         if (p != rec.theQoS.end())


### PR DESCRIPTION
Fixes #5663.

Cleanup of the subscriber proxy setup in `Subscriber::create`:

- Use `ice_isFixed()` to decide whether to override the invocation timeout, instead of catching `FixedProxyException` for control flow.
- Make `newObj` a plain `Ice::ObjectPrx` instead of `std::optional<Ice::ObjectPrx>` (downstream `newObj->...` calls keep working via `ObjectPrx::operator->`).

```cpp
Ice::ObjectPrx newObj =
    rec.obj->ice_isFixed() ? *rec.obj : rec.obj->ice_invocationTimeout(instance->sendTimeout());
```

No behavior change: a fixed proxy (possible when IceStorm is collocated) is used as-is since its invocation timeout can't be changed, otherwise the timeout is overridden — same as the previous try/catch.

Verified locally: builds, and `IceStorm/single` passes (covers oneway/twoway/batch/datagram/ordered subscribers and the transient configuration).