### PR TITLE
Fix Java IceLocatorDiscovery request never completing on same-proxy retry

### DIFF
--- a/changelog.d/java/5660.md
+++ b/changelog.d/java/5660.md
@@ -1,0 +1,2 @@
+- Fixed a bug in Java IceLocatorDiscovery where a request could fail to complete (worst case, overflow the
+  stack) when a failed locator invocation was retried and locator rediscovery returned the same locator proxy.

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -77,8 +77,10 @@ class PluginI implements Plugin {
                     exception(ex);
                 }
             } else {
-                assert (_exception != null); // Don't retry if the proxy didn't change
-                exception(_exception);
+                // The proxy didn't change, so retrying would loop. Complete the request with the last failure,
+                // like C++ and the C# plug-in.
+                assert (_exception != null);
+                _future.completeExceptionally(_exception);
             }
         }
 

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -77,8 +77,7 @@ class PluginI implements Plugin {
                     exception(ex);
                 }
             } else {
-                // The proxy didn't change, so retrying would loop. Complete the request with the last failure,
-                // like C++ and the C# plug-in.
+                // The proxy didn't change, so retrying wont help.
                 assert (_exception != null);
                 _future.completeExceptionally(_exception);
             }


### PR DESCRIPTION
When a locator invocation fails with an unmapped exception and locator rediscovery resolves to a proxy equal to the one that just failed, `Request.invoke` (same-proxy `else` branch) called `exception(_exception)`, which re-entered the retry path instead of completing the request. As a result the `CompletableFuture` returned to the caller never completed (worst case, a `StackOverflowError` from the synchronous recursion).

This completes the future with the last failure in that branch, matching C++ and the C# plug-in.

Java counterpart of the C# fix #5497 / #5627.

Closes #5660