### PR TITLE
Fix RetryQueue cancel-vs-running-task race (C++, C#, Java)

### DIFF
--- a/cpp/src/Ice/RetryQueue.cpp
+++ b/cpp/src/Ice/RetryQueue.cpp
@@ -141,8 +141,7 @@ IceInternal::RetryQueue::cancel(const RetryTaskPtr& task)
     // the timer is gone and every remaining task is running, so it is likewise removed by remove().
     if (_instance && _instance->timer()->cancel(task))
     {
-        _requests.erase(task);
-        return true;
+        return _requests.erase(task) != 0;
     }
     return false;
 }

--- a/cpp/src/Ice/RetryQueue.cpp
+++ b/cpp/src/Ice/RetryQueue.cpp
@@ -135,17 +135,14 @@ bool
 IceInternal::RetryQueue::cancel(const RetryTaskPtr& task)
 {
     lock_guard<mutex> lock(_mutex);
-    if (_requests.erase(task) > 0)
+    // Only remove the task if we cancel it in the timer before it runs. If timer()->cancel returns false, the
+    // task is already executing and runTimerTask will call remove() to erase it from _requests; erasing it
+    // here would make that remove() fail its assertion. When the queue is being destroyed (_instance is null)
+    // the timer is gone and every remaining task is running, so it is likewise removed by remove().
+    if (_instance && _instance->timer()->cancel(task))
     {
-        if (_instance)
-        {
-            return _instance->timer()->cancel(task);
-        }
-        else if (_requests.empty())
-        {
-            // If we are destroying the queue, destroy is probably waiting on the queue to be empty.
-            _conditionVariable.notify_one();
-        }
+        _requests.erase(task);
+        return true;
     }
     return false;
 }

--- a/csharp/src/Ice/Internal/RetryQueue.cs
+++ b/csharp/src/Ice/Internal/RetryQueue.cs
@@ -131,8 +131,7 @@ public class RetryQueue
             // removed by remove(), which wakes destroy().
             if (_instance != null && _instance.timer().cancel(task))
             {
-                _requests.Remove(task);
-                return true;
+                return _requests.Remove(task);
             }
             return false;
         }

--- a/csharp/src/Ice/Internal/RetryQueue.cs
+++ b/csharp/src/Ice/Internal/RetryQueue.cs
@@ -124,17 +124,15 @@ public class RetryQueue
     {
         lock (_mutex)
         {
-            if (_requests.Remove(task))
+            // Only remove the task if we cancel it in the timer before it runs. If timer().cancel returns
+            // false, the task is already executing and runTimerTask will call remove() to erase it; removing
+            // it here would let destroy() observe an empty queue while the task is still running. When the
+            // queue is being destroyed (_instance is null) every remaining task is running and is likewise
+            // removed by remove(), which wakes destroy().
+            if (_instance != null && _instance.timer().cancel(task))
             {
-                if (_instance != null)
-                {
-                    return _instance.timer().cancel(task);
-                }
-                else if (_requests.Count == 0)
-                {
-                    // If we are destroying the queue, destroy is probably waiting on the queue to be empty.
-                    System.Threading.Monitor.Pulse(_mutex);
-                }
+                _requests.Remove(task);
+                return true;
             }
             return false;
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RetryTask.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RetryTask.java
@@ -26,7 +26,10 @@ class RetryTask implements Runnable, CancellationHandler {
 
     @Override
     public void asyncRequestCanceled(OutgoingAsyncBase outAsync, LocalException ex) {
-        if (_queue.remove(this) && cancel()) {
+        // Claim the task before removing it from the queue. If run() already claimed it, cancel() returns
+        // false and we leave it in the queue so run() removes it after retry() -- removing it here would let
+        // destroy() observe an empty queue while the task is still running.
+        if (cancel() && _queue.remove(this)) {
             if (_instance.traceLevels().retry >= 1) {
                 StringBuilder s = new StringBuilder(128);
                 s.append("operation retry canceled\n");


### PR DESCRIPTION
`RetryQueue::cancel` removed the task from the request set *before* asking the timer to cancel it. If a user cancels an invocation at the instant its scheduled retry fires, the task is already running, so the timer cancel returns false — but the task has already been removed.

**C++** (`RetryQueue.cpp`) — the still-running `runTimerTask()` then calls `remove()`, whose `assert(_requests.find(task) != end())` fails, aborting debug builds (release builds self-heal). The premature removal can also let `destroy()`'s wait observe an empty queue while a retry is still in flight, tearing down the client thread pool underneath it. Fixed by only erasing from `_requests` when `timer()->cancel()` succeeds (which guarantees the task will not run, so `remove()` won't be called for it). When the queue is being destroyed every remaining task is running and is removed by `remove()`, so `cancel()` defers to it.

**C#** (`RetryQueue.cs`) — same shape. No assert (its `remove` is guarded), but the same premature-`destroy()` hazard. Same fix: only remove after a successful `timer().cancel()`.

**Java** (`RetryTask.java`) — different mechanism, same hazard: `asyncRequestCanceled` evaluated `_queue.remove(this)` *before* claiming the task via the one-shot `cancel()` flag, so a `run()` that had already claimed the task could be untracked while still in `retry()`. Reordered to `cancel() && _queue.remove(this)` so the losing canceler leaves the running task in the queue for `run()` to remove.

**JavaScript** — single-threaded (run-to-completion); `run()` and `cancel()` cannot interleave, so the race is structurally impossible. No change.

The cross-mapping analysis was independently cross-checked. Verified: C++ compiles, Java compile + checkstyle + OpenRewrite clean, C# builds with 0 warnings/errors.

Closes #5488