### PR TITLE
Fix Ice::Service --daemon treating EOF as a readiness signal

### DIFF
--- a/changelog.d/cpp/service-daemon-eof-readiness.md
+++ b/changelog.d/cpp/service-daemon-eof-readiness.md
@@ -1,0 +1,3 @@
+- Fixed `Ice::Service` in `--daemon` mode reporting success when the daemon exited during startup before
+  signaling readiness (for example after being killed by a signal or aborting in a plug-in). The parent process
+  now exits with a non-zero status so service supervisors don't conclude the service started.

--- a/changelog.d/cpp/service-daemon-eof-readiness.md
+++ b/changelog.d/cpp/service-daemon-eof-readiness.md
@@ -1,3 +1,0 @@
-- Fixed `Ice::Service` in `--daemon` mode reporting success when the daemon exited during startup before
-  signaling readiness (for example after being killed by a signal or aborting in a plug-in). The parent process
-  now exits with a non-zero status so service supervisors don't conclude the service started.

--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -1473,7 +1473,8 @@ Ice::Service::runDaemon(int argc, char* argv[], InitializationData initData)
         char c = 0;
         while (true)
         {
-            if (read(fds[0], &c, 1) == -1)
+            ssize_t rc = read(fds[0], &c, 1);
+            if (rc == -1)
             {
                 if (IceInternal::interrupted())
                 {
@@ -1485,6 +1486,20 @@ Ice::Service::runDaemon(int argc, char* argv[], InitializationData initData)
                     consoleErr << argv[0] << ": ";
                 }
                 consoleErr << IceInternal::errorToString(errno) << endl;
+                _exit(EXIT_FAILURE);
+            }
+            else if (rc == 0)
+            {
+                //
+                // EOF before the readiness byte: the daemon exited during startup without signaling readiness
+                // (e.g. it was killed by a signal or aborted in a plug-in). Report a failure so supervisors don't
+                // conclude the service started successfully.
+                //
+                if (argv[0])
+                {
+                    consoleErr << argv[0] << ": ";
+                }
+                consoleErr << "daemon exited during startup before signaling readiness" << endl;
                 _exit(EXIT_FAILURE);
             }
             break;


### PR DESCRIPTION
Fixes #5456.

In `--daemon` mode the parent reads a readiness byte from the daemon over a pipe but only handled `read() == -1`. A return of `0` (EOF — the daemon exited during startup before writing the byte, e.g. killed by a signal or `abort()` in a plug-in, bypassing the C++ exception handlers) left the readiness byte at its initial `0`, so the parent reported success and `_exit(EXIT_SUCCESS)`, misleading service supervisors.

The parent now treats EOF before the readiness byte as a startup failure: it reports `daemon exited during startup before signaling readiness` and exits with a non-zero status. The normal ready (byte `0`) and failure (byte `1` + message) paths are unchanged — `read()` returns 1 there.

Verified against the source (the byte protocol + the pipe write-end lifecycle across the double fork), an AddressSanitizer standalone repro of the parent read loop (red→green, normal paths unregressed), and a codex cross-check. Not a regression — 3.7 has the identical gap. No in-tree test: `--daemon` double-forks/detaches and the trigger is a mid-startup kill, disproportionate to reproduce reliably in CI.
