### PR TITLE
Publish slimmed-down indexed PDBs zip on stable releases

### DIFF
--- a/.github/workflows/publish-symbols-sources.yml
+++ b/.github/workflows/publish-symbols-sources.yml
@@ -123,6 +123,14 @@ jobs:
 
       - name: Publish Symbols and Sources to S3
         run: |
+          # Create a zip which includes the version
+          $version = "${{ steps.version.outputs.ice_version }}"
+          $zipName = "windows-indexed-pdbs-$version.zip"
+          Compress-Archive -Path "staging/windows-indexed-pdbs" -DestinationPath "staging/$zipName"
+
+          # Upload zip to S3
+          aws s3 cp "staging/$zipName" "s3://zeroc-downloads/ice/${{ inputs.channel }}/$zipName"
+
           # Upload sources to S3
           aws s3 sync "staging/windows-symbols-sources/sources/" "s3://${{ env.S3_BUCKET }}/sources/ice/"
 


### PR DESCRIPTION
The stable `publish-symbols-sources` job updated the symbol store and synced sources, but never produced the downloadable `windows-indexed-pdbs-<version>.zip` that the nightly job uploads. This adds that step to the stable job so stable releases expose the same archive at `s3://zeroc-downloads/ice/<channel>/`.

Uses `Compress-Archive` (stable runs on `windows-2022`/pwsh, no `zip`), producing the same top-level `windows-indexed-pdbs/` layout as the nightly `zip -r`.