### PR TITLE
Fix IceBT transceiver fd leak and data race on aborted outgoing connection

### DIFF
--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -58,11 +58,26 @@ IceBT::TransceiverI::closing(bool initiator, exception_ptr)
 void
 IceBT::TransceiverI::close()
 {
-    if (_connection)
+    ConnectionPtr connection;
     {
-        _connection->close();
+        lock_guard lock(_mutex);
+        //
+        // Flag the transceiver as closed so a connection completion that races this call
+        // disposes of the late-delivered fd and connection instead of installing them.
+        //
+        _closed = true;
+        connection = std::move(_connection);
+        _stream->close();
     }
-    _stream->close();
+
+    //
+    // Close the connection without holding _mutex: ConnectionI::close() blocks (it makes a
+    // DisconnectProfile D-Bus call and joins the connection's I/O thread).
+    //
+    if (connection)
+    {
+        connection->close();
+    }
 }
 
 IceInternal::SocketOperation
@@ -174,13 +189,26 @@ IceBT::TransceiverI::~TransceiverI() = default;
 void
 IceBT::TransceiverI::connectCompleted(int fd, const ConnectionPtr& conn)
 {
-    lock_guard lock(_mutex);
-    _connection = conn;
-    _stream->setFd(fd);
-    //
-    // Triggers a call to write() from a different thread.
-    //
-    _stream->ready(IceInternal::SocketOperationConnect, true);
+    {
+        lock_guard lock(_mutex);
+        if (!_closed)
+        {
+            _connection = conn;
+            _stream->setFd(fd);
+            //
+            // Triggers a call to write() from a different thread.
+            //
+            _stream->ready(IceInternal::SocketOperationConnect, true);
+            return;
+        }
+    }
+
+    // The transceiver was already closed before the connection completed. We must not install the fd into the abandoned
+    // stream (nothing would ever close it), so close the socket here instead. We deliberately don't close 'conn': we
+    // run on the connection's own I/O thread, where a blocking close would deadlock. This leaks the connection's I/O
+    // thread and system-bus connection, but only on the rare race between an aborted outgoing connection and its
+    // completion.
+    IceInternal::closeSocketNoThrow(fd);
 }
 
 void

--- a/cpp/src/IceBT/TransceiverI.h
+++ b/cpp/src/IceBT/TransceiverI.h
@@ -40,6 +40,7 @@ namespace IceBT
         std::string _addr;
         std::string _uuid;
         bool _needConnect;
+        bool _closed{false};
         std::exception_ptr _exception;
         std::mutex _mutex;
         void connectCompleted(int, const ConnectionPtr&);


### PR DESCRIPTION
Fixes #5443.

`IceBT::TransceiverI::close()` read `_connection` and closed `_stream` without holding `_mutex`, racing `connectCompleted`/`connectFailed`, which mutate those members under the lock from the connection's I/O thread.

- `close()` now takes `_mutex`, flags the transceiver closed, and moves out `_connection`/closes `_stream` under the lock. The connection is closed *outside* the lock, since its `close()` blocks on a D-Bus `DisconnectProfile` call and joins the connection's I/O thread.
- A connection completion that arrives after `close()` no longer installs the fd into the abandoned stream; it closes the socket instead, fixing the descriptor leak and a debug-build assertion failure.

As discussed in the issue, the late-completion path deliberately does not close the D-Bus connection: `connectCompleted` runs on the connection's own I/O thread, where a blocking close would deadlock (and self-join). That leaves a connection/thread leak on this rare race only; fully reclaiming it requires off-thread disposal, which isn't warranted for a patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)