### PR TITLE
Fix data race in BatchRequestQueue between finishBatchRequest and a concurrent flush

### DIFF
--- a/changelog.d/cpp/batch-request-finish-race.md
+++ b/changelog.d/cpp/batch-request-finish-race.md
@@ -1,0 +1,3 @@
+- Fixed a data race in batch request queuing that could corrupt batch-message framing (or crash) when one thread
+  flushed batch requests on a connection, proxy, or communicator while another thread was making batch invocations on
+  the same batch queue.

--- a/cpp/src/Ice/BatchRequestQueue.cpp
+++ b/cpp/src/Ice/BatchRequestQueue.cpp
@@ -81,12 +81,13 @@ BatchRequestQueue::finishBatchRequest(OutputStream* os, const Ice::ObjectPrx& pr
 {
     {
         // Bring the request stream back and become the owner so this thread's own auto-flush below can
-        // re-enter swap(). swap() lets only _batchStreamOwner through while the stream is in use, so no
-        // other thread can touch the queue: the mutations below need no further synchronization.
+        // re-enter swap(). swap() lets only _batchStreamOwnerId through while the stream is in use, and only
+        // after passing that gate does it read the queue's bookkeeping; no other thread can touch the queue,
+        // so the mutations below need no further synchronization.
         lock_guard lock(_mutex);
         assert(_batchStreamInUse);
         _batchStream.swap(*os);
-        _batchStreamOwner = this_thread::get_id();
+        _batchStreamOwnerId = std::this_thread::get_id();
     }
 
     try
@@ -116,15 +117,18 @@ BatchRequestQueue::finishBatchRequest(OutputStream* os, const Ice::ObjectPrx& pr
         lock_guard lock(_mutex);
         _batchStream.resize(_batchMarker);
         _batchStreamInUse = false;
-        _batchStreamOwner = thread::id{};
+        _batchStreamOwnerId = std::thread::id{};
         _conditionVariable.notify_all();
     }
-    catch (const std::exception&)
+    catch (...)
     {
+        // Restore the queue to a usable state on any exception, including a non-std::exception escaping the
+        // interceptor. Otherwise _batchStreamInUse would stay set and wedge the queue (all future
+        // prepareBatchRequest/swap calls would block forever).
         lock_guard lock(_mutex);
         _batchStream.resize(_batchMarker);
         _batchStreamInUse = false;
-        _batchStreamOwner = thread::id{};
+        _batchStreamOwnerId = std::thread::id{};
         _conditionVariable.notify_all();
         throw;
     }
@@ -147,10 +151,6 @@ int
 BatchRequestQueue::swap(OutputStream* os, bool& compress) noexcept
 {
     unique_lock lock(_mutex);
-    if (_batchRequestNum == 0)
-    {
-        return 0;
-    }
 
     _conditionVariable.wait(
         lock,
@@ -158,9 +158,17 @@ BatchRequestQueue::swap(OutputStream* os, bool& compress) noexcept
         {
             // Only the owner thread may proceed while the stream is in use (for its own auto-flush);
             // other threads wait until the in-progress batch request is finished. A default-constructed
-            // _batchStreamOwner matches no thread, so nobody bypasses _batchStreamInUse outside that window.
-            return !_batchStreamInUse || _batchStreamOwner == this_thread::get_id();
+            // _batchStreamOwnerId matches no thread, so nobody bypasses _batchStreamInUse outside that window.
+            return !_batchStreamInUse || _batchStreamOwnerId == std::this_thread::get_id();
         });
+
+    // Read the bookkeeping only after passing the gate above: finishBatchRequest mutates these scalars
+    // without the lock while it owns the in-use stream, so reading _batchRequestNum before the wait would
+    // race those writes.
+    if (_batchRequestNum == 0)
+    {
+        return 0;
+    }
 
     vector<byte> lastRequest;
     if (_batchMarker < _batchStream.b.size())

--- a/cpp/src/Ice/BatchRequestQueue.cpp
+++ b/cpp/src/Ice/BatchRequestQueue.cpp
@@ -79,17 +79,18 @@ BatchRequestQueue::prepareBatchRequest(OutputStream* os)
 void
 BatchRequestQueue::finishBatchRequest(OutputStream* os, const Ice::ObjectPrx& proxy, string_view operation)
 {
-    //
-    // No need for synchronization, no other threads are supposed
-    // to modify the queue since we set _batchStreamInUse to true.
-    //
-    assert(_batchStreamInUse);
-    _batchStream.swap(*os);
+    {
+        // Bring the request stream back and become the owner so this thread's own auto-flush below can
+        // re-enter swap(). swap() lets only _batchStreamOwner through while the stream is in use, so no
+        // other thread can touch the queue: the mutations below need no further synchronization.
+        lock_guard lock(_mutex);
+        assert(_batchStreamInUse);
+        _batchStream.swap(*os);
+        _batchStreamOwner = this_thread::get_id();
+    }
 
     try
     {
-        _batchStreamCanFlush = true; // Allow flush to proceed even if the stream is marked in use.
-
         if (_maxSize > 0 && _batchStream.b.size() >= static_cast<size_t>(_maxSize))
         {
             proxy->ice_flushBatchRequestsAsync(nullptr); // auto-flush, don't wait for response
@@ -115,7 +116,7 @@ BatchRequestQueue::finishBatchRequest(OutputStream* os, const Ice::ObjectPrx& pr
         lock_guard lock(_mutex);
         _batchStream.resize(_batchMarker);
         _batchStreamInUse = false;
-        _batchStreamCanFlush = false;
+        _batchStreamOwner = thread::id{};
         _conditionVariable.notify_all();
     }
     catch (const std::exception&)
@@ -123,7 +124,7 @@ BatchRequestQueue::finishBatchRequest(OutputStream* os, const Ice::ObjectPrx& pr
         lock_guard lock(_mutex);
         _batchStream.resize(_batchMarker);
         _batchStreamInUse = false;
-        _batchStreamCanFlush = false;
+        _batchStreamOwner = thread::id{};
         _conditionVariable.notify_all();
         throw;
     }
@@ -151,7 +152,15 @@ BatchRequestQueue::swap(OutputStream* os, bool& compress) noexcept
         return 0;
     }
 
-    _conditionVariable.wait(lock, [this] { return !_batchStreamInUse || _batchStreamCanFlush; });
+    _conditionVariable.wait(
+        lock,
+        [this]
+        {
+            // Only the owner thread may proceed while the stream is in use (for its own auto-flush);
+            // other threads wait until the in-progress batch request is finished. A default-constructed
+            // _batchStreamOwner matches no thread, so nobody bypasses _batchStreamInUse outside that window.
+            return !_batchStreamInUse || _batchStreamOwner == this_thread::get_id();
+        });
 
     vector<byte> lastRequest;
     if (_batchMarker < _batchStream.b.size())

--- a/cpp/src/Ice/BatchRequestQueue.cpp
+++ b/cpp/src/Ice/BatchRequestQueue.cpp
@@ -152,15 +152,13 @@ BatchRequestQueue::swap(OutputStream* os, bool& compress) noexcept
 {
     unique_lock lock(_mutex);
 
-    _conditionVariable.wait(
-        lock,
-        [this]
-        {
-            // Only the owner thread may proceed while the stream is in use (for its own auto-flush);
-            // other threads wait until the in-progress batch request is finished. A default-constructed
-            // _batchStreamOwnerId matches no thread, so nobody bypasses _batchStreamInUse outside that window.
-            return !_batchStreamInUse || _batchStreamOwnerId == std::this_thread::get_id();
-        });
+    // Only the thread that currently owns the in-use stream may bypass the wait, to run its own auto-flush;
+    // every other caller waits for the in-progress batch request to finish. (The owner can't change while we
+    // block here: a thread becomes the owner only inside finishBatchRequest, never while parked in this wait.)
+    if (_batchStreamOwnerId != std::this_thread::get_id())
+    {
+        _conditionVariable.wait(lock, [this] { return !_batchStreamInUse; });
+    }
 
     // Read the bookkeeping only after passing the gate above: finishBatchRequest mutates these scalars
     // without the lock while it owns the in-use stream, so reading _batchRequestNum before the wait would

--- a/cpp/src/Ice/BatchRequestQueue.h
+++ b/cpp/src/Ice/BatchRequestQueue.h
@@ -11,6 +11,7 @@
 #include <condition_variable>
 #include <functional>
 #include <mutex>
+#include <thread>
 
 namespace IceInternal
 {
@@ -33,7 +34,10 @@ namespace IceInternal
         std::function<void(const Ice::BatchRequest&, int, int)> _interceptor;
         Ice::OutputStream _batchStream;
         bool _batchStreamInUse{false};
-        bool _batchStreamCanFlush{false};
+        // While finishBatchRequest holds the in-use stream, this is its thread: the only thread allowed to
+        // re-enter swap() (for its own auto-flush). A default-constructed id means no thread may flush the
+        // in-use stream, so other threads wait for _batchStreamInUse to clear.
+        std::thread::id _batchStreamOwner{};
         bool _batchCompress{false};
         int _batchRequestNum{0};
         size_t _batchMarker;

--- a/cpp/src/Ice/BatchRequestQueue.h
+++ b/cpp/src/Ice/BatchRequestQueue.h
@@ -37,7 +37,7 @@ namespace IceInternal
         // While finishBatchRequest holds the in-use stream, this is its thread: the only thread allowed to
         // re-enter swap() (for its own auto-flush). A default-constructed id means no thread may flush the
         // in-use stream, so other threads wait for _batchStreamInUse to clear.
-        std::thread::id _batchStreamOwner{};
+        std::thread::id _batchStreamOwnerId{};
         bool _batchCompress{false};
         int _batchRequestNum{0};
         size_t _batchMarker;


### PR DESCRIPTION
Fixes #5451.

`finishBatchRequest` sets `_batchStreamCanFlush` so that its own size-triggered auto-flush can re-enter `swap()` while the batch stream is still marked in use (otherwise the same-thread reentrant `swap()` would deadlock on `_batchStreamInUse`). The problem is that `swap()`'s wait predicate — `!_batchStreamInUse || _batchStreamCanFlush` — also let **another** thread's flush proceed: a concurrent `proxy->ice_flushBatchRequestsAsync()`, `connection->flushBatchRequestsAsync()`, or `communicator->flushBatchRequests()` on the same batch queue would slip through on the flag the owning thread set for its own reentrancy, and race the unlocked mutations in `finishBatchRequest`. In C++ that's concurrent `std::vector` mutation — corrupted batch framing or a crash.

This PR replaces the `_batchStreamCanFlush` boolean with a `_batchStreamOwner` thread id. `swap()` now bypasses the in-use stream only for the owning thread (its own auto-flush); any other thread's flush waits for the in-progress batch request to finish, which is the correct behavior for it anyway. A default-constructed id matches no thread, so it doubles as the "no flush allowed" state the boolean used to provide. The flag write also moves under `_mutex`.

The same bug exists in the C# and Java mappings (identical structure); it will be fixed in a follow-up PR. JavaScript is single-threaded and not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)