### PR TITLE
Reject mid-stream TLS renegotiation in the Schannel transport

### DIFF
--- a/changelog.d/cpp/schannel-renegotiation.md
+++ b/changelog.d/cpp/schannel-renegotiation.md
@@ -1,0 +1,2 @@
+- Fixed the Schannel (Windows) SSL transport to reject mid-stream TLS renegotiation with a clear error instead of
+  aborting the connection with a mislabeled `ConnectionLostException`.

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -458,12 +458,9 @@ Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
         throw SecurityException(__FILE__, __LINE__, os.str());
     }
 
-    assert(!_peerCertificate || _sslConnectionRenegotiating);
-    if (_peerCertificate)
-    {
-        CertFreeCertificateContext(_peerCertificate);
-        _peerCertificate = nullptr;
-    }
+    // sslHandshake only runs for the initial handshake (mid-stream renegotiation is rejected), so the peer
+    // certificate has not been queried yet.
+    assert(!_peerCertificate);
 
     err = QueryContextAttributes(&_ssl, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &_peerCertificate);
     if (err != SEC_E_OK && err != SEC_E_NO_CREDENTIALS)
@@ -565,34 +562,16 @@ Schannel::TransceiverI::decryptMessage(IceInternal::Buffer& buffer)
         }
         else if (err == SEC_I_RENEGOTIATE)
         {
-            if (_incoming)
-            {
-                // Reject peer-initiated TLS renegotiation on the server side: it is a CPU-asymmetric
-                // denial-of-service primitive on TLS 1.2 and is removed entirely in TLS 1.3.
-                throw ProtocolException(
-                    __FILE__,
-                    __LINE__,
-                    "SSL transport: peer-initiated TLS renegotiation is not supported on the server side.");
-            }
-            if (_sslConnectionRenegotiating)
-            {
-                throw ProtocolException(
-                    __FILE__,
-                    __LINE__,
-                    "SSL transport: peer requested renegotiation while we are already renegotiating.");
-            }
-            // The peer has requested a renegotiation.
-            SecBuffer* extraBuffer = getSecBufferWithType(inBufferDesc, SECBUFFER_EXTRA);
-            _sslConnectionRenegotiating = true;
-            _state = StateHandshakeReadContinue;
-            if (extraBuffer)
-            {
-                _extraBuffer.b.resize(extraBuffer->cbBuffer);
-                _extraBuffer.i = _extraBuffer.b.begin();
-                memcpy(_extraBuffer.i, extraBuffer->pvBuffer, extraBuffer->cbBuffer);
-                _extraBuffer.i += extraBuffer->cbBuffer;
-            }
-            return 0;
+            // Ice does not support mid-stream TLS renegotiation. On the server side it is a CPU-asymmetric
+            // denial-of-service primitive on TLS 1.2 (and is removed entirely in TLS 1.3). On the client side,
+            // completing the renegotiation would require driving the SSL handshake from the established read/write
+            // data path, which the transport does not support. Reject it with a clear error instead of attempting
+            // the renegotiation and later dropping the connection with a mislabeled ConnectionLostException.
+            throw ProtocolException(
+                __FILE__,
+                __LINE__,
+                _incoming ? "SSL transport: peer-initiated TLS renegotiation is not supported on the server side."
+                          : "SSL transport: peer-initiated TLS renegotiation is not supported on the client side.");
         }
         else if (err == SEC_I_CONTEXT_EXPIRED)
         {
@@ -816,23 +795,6 @@ Schannel::TransceiverI::read(IceInternal::Buffer& buf)
         }
 
         size_t decrypted = decryptMessage(buf);
-        if (_sslConnectionRenegotiating)
-        {
-            // The peer has requested a renegotiation.
-            SecBuffer extraBuffer{
-                static_cast<DWORD>(_extraBuffer.i - _extraBuffer.b.begin()),
-                SECBUFFER_EXTRA,
-                _extraBuffer.b.begin()};
-            IceInternal::SocketOperation op = sslHandshake(&extraBuffer);
-            _extraBuffer.b.clear();
-            if (op == IceInternal::SocketOperationNone)
-            {
-                _sslConnectionRenegotiating = false;
-                continue;
-            }
-            throw ConnectionLostException(__FILE__, __LINE__);
-        }
-
         if (decrypted == 0)
         {
             if (!readRaw(_readBuffer))
@@ -912,33 +874,7 @@ Schannel::TransceiverI::finishRead(IceInternal::Buffer& buf)
     _delegate->finishRead(_readBuffer);
     if (_state == StateHandshakeComplete)
     {
-        size_t decrypted;
-        while (true)
-        {
-            decrypted = decryptMessage(buf);
-            if (_sslConnectionRenegotiating)
-            {
-                // The peer has requested a renegotiation.
-                SecBuffer extraBuffer{
-                    static_cast<DWORD>(_extraBuffer.i - _extraBuffer.b.begin()),
-                    SECBUFFER_EXTRA,
-                    _extraBuffer.b.begin()};
-                IceInternal::SocketOperation op = sslHandshake(&extraBuffer);
-                _extraBuffer.b.clear();
-                if (op == IceInternal::SocketOperationNone)
-                {
-                    _sslConnectionRenegotiating = false;
-                    if (buf.i != buf.b.begin())
-                    {
-                        continue;
-                    }
-                    break;
-                }
-                throw ConnectionLostException(__FILE__, __LINE__);
-            }
-            break;
-        }
-
+        size_t decrypted = decryptMessage(buf);
         if (decrypted > 0)
         {
             buf.i += decrypted;
@@ -1019,8 +955,7 @@ Schannel::TransceiverI::TransceiverI(
       _remoteCertificateValidationCallback(serverAuthenticationOptions.clientCertificateValidationCallback),
       _rootStore(serverAuthenticationOptions.trustedRootCertificates),
       _ssl({}),
-      _chainEngine(nullptr),
-      _sslConnectionRenegotiating(false)
+      _chainEngine(nullptr)
 {
     if (!_remoteCertificateValidationCallback)
     {
@@ -1067,8 +1002,7 @@ Schannel::TransceiverI::TransceiverI(
       _remoteCertificateValidationCallback(clientAuthenticationOptions.serverCertificateValidationCallback),
       _rootStore(clientAuthenticationOptions.trustedRootCertificates),
       _ssl({}),
-      _chainEngine(nullptr),
-      _sslConnectionRenegotiating(false)
+      _chainEngine(nullptr)
 {
     if (_rootStore && !_remoteCertificateValidationCallback)
     {

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.h
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.h
@@ -77,7 +77,6 @@ namespace Ice::SSL::Schannel
         const IceInternal::TransceiverPtr _delegate;
         State _state;
         DWORD _ctxFlags;
-        bool _sslConnectionRenegotiating;
 
         // Buffered encrypted data that has not been written.
         IceInternal::Buffer _writeBuffer;
@@ -85,9 +84,6 @@ namespace Ice::SSL::Schannel
 
         // Buffered data that has not been decrypted.
         IceInternal::Buffer _readBuffer;
-
-        // Extra buffer used for SSL renegotiation.
-        IceInternal::Buffer _extraBuffer;
 
         // Buffered data that was decrypted but not yet processed.
         IceInternal::Buffer _readUnprocessed;


### PR DESCRIPTION
Fixes #5449.

### Problem
On Windows (Schannel), a peer-initiated mid-stream TLS renegotiation aborted the client connection with a mislabeled `ConnectionLostException`. `sslHandshake` legitimately returns `SocketOperationRead`/`SocketOperationWrite` when a resumed renegotiation needs network I/O (a TLS 1.2 renegotiation always needs a round trip), but `read()`/`finishRead()` treated anything other than `SocketOperationNone` as fatal — and cleared the saved `_extraBuffer` bytes before throwing, so resumption was impossible.

### Why not make renegotiation work
Completing a renegotiation means driving the full SSL handshake (which needs both reads and writes) from the established data path. That does not fit the transport IO model: the post-handshake read path cannot drive writes, and on the IOCP path `finishRead()` is `void`, so it cannot defer for I/O at all. Supporting it would require re-entering a handshake IO state at the `ConnectionI` level.

The server side already rejects peer-initiated renegotiation outright (a CPU-asymmetric DoS vector on TLS 1.2). This makes the client consistent with it.

### Fix
Reject a peer-initiated renegotiation with a clear `ProtocolException` at the point it is detected in `decryptMessage` (symmetric with the existing server-side rejection), instead of attempting it and later aborting with a mislabeled `ConnectionLostException`. The now-dead renegotiation handling in `read()`/`finishRead()` and the unused `_extraBuffer`/`_sslConnectionRenegotiating` members are removed.

### Testing
:warning: Windows-only code; I could not build or exercise live TLS 1.2 renegotiation locally. This relies on CI (Windows build) and review. The change only removes paths and converts the renegotiation case into a clear rejection.