### PR TITLE
Honor the paCred ownership contract in the Schannel transport

### DIFF
--- a/changelog.d/cpp/schannel-pacred-leak.md
+++ b/changelog.d/cpp/schannel-pacred-leak.md
@@ -1,4 +1,1 @@
-- Fixed a certificate context leak in the Schannel (Windows) SSL transport. It now takes ownership of the
-  certificate contexts supplied by a credentials-selection callback and releases them on close, honoring the
-  `ClientAuthenticationOptions`/`ServerAuthenticationOptions` contract; a custom callback that transferred
-  ownership per that contract previously leaked one reference per certificate per connection.
+- Fixed a certificate context leak in the Schannel (Windows) SSL transport.

--- a/changelog.d/cpp/schannel-pacred-leak.md
+++ b/changelog.d/cpp/schannel-pacred-leak.md
@@ -1,0 +1,4 @@
+- Fixed a certificate context leak in the Schannel (Windows) SSL transport. It now takes ownership of the
+  certificate contexts supplied by a credentials-selection callback and releases them on close, honoring the
+  `ClientAuthenticationOptions`/`ServerAuthenticationOptions` contract; a custom callback that transferred
+  ownership per that contract previously leaked one reference per certificate per connection.

--- a/cpp/src/Ice/SSL/SchannelEngine.cpp
+++ b/cpp/src/Ice/SSL/SchannelEngine.cpp
@@ -1284,9 +1284,18 @@ Schannel::SSLEngine::createClientAuthenticationOptions(const string& host) const
         .clientCredentialsSelectionCallback =
             [this](const string&)
         {
-            // The caller (TransceiverI) duplicates each paCred context into its own list and frees those in close(),
-            // so the credentials we return must not bump the reference count here — doing so leaks one reference per
-            // certificate per connection and prevents the certificate store from ever closing cleanly.
+            // The transport takes ownership of the returned paCred contexts and releases them when the connection
+            // is closed (see ClientAuthenticationOptions). Bump the reference count of each certificate so the
+            // reference handed to the transport is independent of the engine's _allCerts, which outlives the
+            // individual connections.
+            for (const auto& cert : _allCerts)
+            {
+                // CertDuplicateCertificateContext returns the same pointer with an incremented reference count and
+                // cannot fail for a non-null context; the assert guards that invariant.
+                [[maybe_unused]] PCCERT_CONTEXT duplicate = CertDuplicateCertificateContext(cert);
+                assert(duplicate == cert);
+            }
+
             return SCH_CREDENTIALS{
                 .dwVersion = SCH_CREDENTIALS_VERSION,
                 .cCreds = static_cast<DWORD>(_allCerts.size()),
@@ -1327,9 +1336,18 @@ Schannel::SSLEngine::createServerAuthenticationOptions() const
             [this](const string&)
         {
             {
-                // The caller (TransceiverI) duplicates each paCred context into its own list and frees those in
-                // close(), so the credentials we return must not bump the reference count here — doing so leaks one
-                // reference per certificate per connection and prevents the certificate store from closing cleanly.
+                // The transport takes ownership of the returned paCred contexts and releases them when the
+                // connection is closed (see ServerAuthenticationOptions). Bump the reference count of each
+                // certificate so the reference handed to the transport is independent of the engine's _allCerts,
+                // which outlives the individual connections.
+                for (const auto& cert : _allCerts)
+                {
+                    // CertDuplicateCertificateContext returns the same pointer with an incremented reference count
+                    // and cannot fail for a non-null context; the assert guards that invariant.
+                    [[maybe_unused]] PCCERT_CONTEXT duplicate = CertDuplicateCertificateContext(cert);
+                    assert(duplicate == cert);
+                }
+
                 return SCH_CREDENTIALS{
                     .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = static_cast<DWORD>(_allCerts.size()),

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -136,6 +136,13 @@ Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
 
         if (_credentials.cCreds > 0)
         {
+            if (!_credentials.paCred)
+            {
+                throw SecurityException(
+                    __FILE__,
+                    __LINE__,
+                    "SSL transport: the provided SCH_CREDENTIALS sets cCreds but paCred is null.");
+            }
             for (DWORD i = 0; i < _credentials.cCreds; ++i)
             {
                 if (!_credentials.paCred[i])
@@ -145,7 +152,10 @@ Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
                         __LINE__,
                         "SSL transport: invalid null certificate in the provided SCH_CREDENTIALS.");
                 }
-                _allCerts.push_back(CertDuplicateCertificateContext(_credentials.paCred[i]));
+                // The credentials callback transfers ownership of the paCred contexts to the transport (see
+                // ClientAuthenticationOptions / ServerAuthenticationOptions); retain them here and release them in
+                // close().
+                _allCerts.push_back(_credentials.paCred[i]);
             }
             _credentials.paCred = &_allCerts[0];
         }

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -143,21 +143,24 @@ Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
                     __LINE__,
                     "SSL transport: the provided SCH_CREDENTIALS sets cCreds but paCred is null.");
             }
-            for (DWORD i = 0; i < _credentials.cCreds; ++i)
+
+            // The credentials callback transfers ownership of the paCred contexts to the transport (see
+            // ClientAuthenticationOptions / ServerAuthenticationOptions). Record ownership of every context
+            // before validating below, so close() releases the full transferred set even if validation throws
+            // (CertFreeCertificateContext(nullptr) is a no-op). They are released in close().
+            _allCerts.assign(_credentials.paCred, _credentials.paCred + _credentials.cCreds);
+            _credentials.paCred = &_allCerts[0];
+
+            for (PCCERT_CONTEXT certificate : _allCerts)
             {
-                if (!_credentials.paCred[i])
+                if (!certificate)
                 {
                     throw SecurityException(
                         __FILE__,
                         __LINE__,
                         "SSL transport: invalid null certificate in the provided SCH_CREDENTIALS.");
                 }
-                // The credentials callback transfers ownership of the paCred contexts to the transport (see
-                // ClientAuthenticationOptions / ServerAuthenticationOptions); retain them here and release them in
-                // close().
-                _allCerts.push_back(_credentials.paCred[i]);
             }
-            _credentials.paCred = &_allCerts[0];
         }
 
         err = AcquireCredentialsHandle(

--- a/cpp/test/IceSSL/configuration/SchannelTests.cpp
+++ b/cpp/test/IceSSL/configuration/SchannelTests.cpp
@@ -686,9 +686,13 @@ serverHotCertificateReload(Test::TestHelper* helper, const string& certificatesP
     try
     {
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCredentialsSelectionCallback = [&serverState](const string&)
+            .serverCredentialsSelectionCallback =
+                [&serverState, certificateContext = PCCERT_CONTEXT{}](const string&) mutable
             {
-                PCCERT_CONTEXT certificateContext = serverState.serverCertificateContext();
+                // certificateContext is a stable closure member so paCred remains valid after this callback
+                // returns and the transport reads it. It is refreshed on each call to pick up a reloaded
+                // certificate.
+                certificateContext = serverState.serverCertificateContext();
                 CertDuplicateCertificateContext(certificateContext);
                 return SCH_CREDENTIALS{
                     .dwVersion = SCH_CREDENTIALS_VERSION,


### PR DESCRIPTION
Fixes #5448.

### Problem
`ClientAuthenticationOptions` / `ServerAuthenticationOptions` document that the transport **takes ownership** of the `paCred` certificate contexts returned by the credentials-selection callback and releases them when the connection is closed. The transport honors this for `hRootStore`, but for `paCred` it instead **duplicates** each context into its own list and frees only those duplicates in `close()` — it never releases the contexts the callback handed it.

The built-in engine callback avoided a leak only by *not* bumping the reference count (contrary to the documented contract). But a **custom credentials callback that follows the documented contract** (creates/duplicates a context and transfers ownership) leaks one reference per certificate per connection.

### Fix
Align the implementation with the existing documented contract (rather than changing the contract in a patch release):
- The built-in engine callbacks now `CertDuplicateCertificateContext` each certificate, transferring a reference to the transport.
- The transport **retains** the contexts it is given (no extra duplicate) and releases them in `close()`.

Reference counts balance: `+1` per certificate per connection in the engine callback, `-1` in the transceiver's `close()`; the engine's base reference is freed in its destructor. This matches how `hRootStore` is already handled.

### Testing
:warning: Windows-only code; I could not build it locally. Relies on CI (Windows build) and review. The built-in engine remains leak-free, and custom callbacks that follow the documented ownership contract no longer leak.