### PR TITLE
Propagate a located servant's dispatch error in Swift ServantManager

### DIFF
--- a/swift/src/Ice/ServantManager.swift
+++ b/swift/src/Ice/ServantManager.swift
@@ -203,7 +203,7 @@ final class ServantManager: Dispatcher {
                 } catch {
                     // The locator returned a servant, so finished must run once no matter what. Then let the
                     // dispatch error propagate (instead of converting it here) so error-inspecting middleware
-                    // observes it, like the plain-servant path above and the C# and JS implementations.
+                    // observes it.
                     try locator.finished(curr: current, servant: servant, cookie: cookie)
                     throw error
                 }

--- a/swift/src/Ice/ServantManager.swift
+++ b/swift/src/Ice/ServantManager.swift
@@ -201,10 +201,14 @@ final class ServantManager: Dispatcher {
                 do {
                     response = try await servant.dispatch(request)
                 } catch {
-                    response = current.makeOutgoingResponse(error: error)
+                    // The locator returned a servant, so finished must run once no matter what. Then let the
+                    // dispatch error propagate (instead of converting it here) so error-inspecting middleware
+                    // observes it, like the plain-servant path above and the C# and JS implementations.
+                    try locator.finished(curr: current, servant: servant, cookie: cookie)
+                    throw error
                 }
 
-                // If the locator returned a servant, we must execute finished once no matter what.
+                // Success path: the locator returned a servant, so finished must run once.
                 try locator.finished(curr: current, servant: servant, cookie: cookie)
 
                 return response

--- a/swift/test/Ice/middleware/AllTests.swift
+++ b/swift/test/Ice/middleware/AllTests.swift
@@ -72,8 +72,7 @@ func allTests(_ helper: TestHelper) async throws {
         }
 
         // The located servant always throws, so the client must see a dispatch error, and the middleware
-        // must have observed it as a throw. Before the fix, ServantManager converts the located servant's
-        // error to a response, so the middleware never sees the throw.
+        // must have observed it as a throw.
         try test(threw)
         try await test(log.observed)
 

--- a/swift/test/Ice/middleware/AllTests.swift
+++ b/swift/test/Ice/middleware/AllTests.swift
@@ -48,7 +48,7 @@ func allTests(_ helper: TestHelper) async throws {
     }
 
     // Verifies that a dispatch error from a servant returned by a ServantLocator propagates through the
-    // middleware pipeline, instead of being converted to a response inside ServantManager (issue #5555).
+    // middleware pipeline, instead of being converted to a response inside ServantManager.
     func testMiddlewareObservesLocatorDispatchError(_ communicator: Communicator, _ output: TextWriter)
         async throws
     {

--- a/swift/test/Ice/middleware/AllTests.swift
+++ b/swift/test/Ice/middleware/AllTests.swift
@@ -12,6 +12,7 @@ func allTests(_ helper: TestHelper) async throws {
     let output = helper.getWriter()
 
     try await testMiddlewareExecutionOrder(communicator, output)
+    try await testMiddlewareObservesLocatorDispatchError(communicator, output)
 
     // Verifies the middleware execute in installation order.
     func testMiddlewareExecutionOrder(_ communicator: Communicator, _ output: TextWriter) async throws {
@@ -44,6 +45,78 @@ func allTests(_ helper: TestHelper) async throws {
 
         output.writeLine("ok")
         oa.destroy()
+    }
+
+    // Verifies that a dispatch error from a servant returned by a ServantLocator propagates through the
+    // middleware pipeline, instead of being converted to a response inside ServantManager (issue #5555).
+    func testMiddlewareObservesLocatorDispatchError(_ communicator: Communicator, _ output: TextWriter)
+        async throws
+    {
+        output.write("testing middleware observes a servant-locator dispatch error... ")
+
+        let oa = try communicator.createObjectAdapterWithEndpoints(
+            name: "MyOA2", endpoints: "tcp -h 127.0.0.1 -p 0")
+        try oa.addServantLocator(locator: ThrowingServantLocator(), category: "")
+
+        let log = ThrowObservedLog()
+        oa.use { next in ErrorObservingMiddleware(next, log) }
+
+        // We're actually using colloc so no need to activate oa.
+        let p = try uncheckedCast(prx: oa.createProxy(Ice.Identity(name: "test")), type: MyObjectPrx.self)
+
+        var threw = false
+        do {
+            _ = try await p.getName()
+        } catch {
+            threw = true
+        }
+
+        // The located servant always throws, so the client must see a dispatch error, and the middleware
+        // must have observed it as a throw. Before the fix, ServantManager converts the located servant's
+        // error to a response, so the middleware never sees the throw.
+        try test(threw)
+        try await test(log.observed)
+
+        output.writeLine("ok")
+        oa.destroy()
+    }
+
+    final class ThrowingObjectI: MyObject {
+        func getName(current: Ice.Current) throws -> String {
+            throw Ice.ObjectNotExistException()
+        }
+    }
+
+    final class ThrowingServantLocator: Ice.ServantLocator {
+        func locate(_ curr: Ice.Current) throws -> (returnValue: Ice.Dispatcher?, cookie: AnyObject?) {
+            (ThrowingObjectI(), nil)
+        }
+        func finished(curr: Ice.Current, servant: Ice.Dispatcher, cookie: AnyObject?) throws {}
+        func deactivate(_ category: String) {}
+    }
+
+    final class ErrorObservingMiddleware: Dispatcher {
+        private let next: Dispatcher
+        private let log: ThrowObservedLog
+
+        init(_ next: Dispatcher, _ log: ThrowObservedLog) {
+            self.next = next
+            self.log = log
+        }
+
+        func dispatch(_ request: sending IncomingRequest) async throws -> OutgoingResponse {
+            do {
+                return try await next.dispatch(request)
+            } catch {
+                await log.observe()
+                throw error
+            }
+        }
+    }
+
+    actor ThrowObservedLog {
+        var observed = false
+        func observe() { observed = true }
     }
 
     final class Middleware: Dispatcher {


### PR DESCRIPTION
Fixes #5555.

In `ServantManager.dispatch`'s servant-locator path, the located servant's dispatch error was caught and converted to a response in place via `makeOutgoingResponse(error:)`. Because `ServantManager` is the innermost dispatcher, this short-circuited any error-inspecting middleware — it never observed the throw. The plain-servant path in the same dispatcher, and the C# and JS runtimes, instead let the error propagate (running `locator.finished` in a `finally`).

`ServantManager` now runs `locator.finished` once on both the success and error paths and re-throws the dispatch error, so error-inspecting middleware observes it — restoring consistency with the plain-servant path and C#/JS. No wire-format change for clients.

Added a probing test in `Ice/middleware` (a `ServantLocator` returning a throwing servant + an error-observing middleware): it fails before the fix (the middleware sees a converted response) and passes after (it observes the throw). Verified red→green; `swift format --strict` clean.
