### PR TITLE
Fix Swift LocalExceptions text and guard proxyToProperty

### DIFF
--- a/swift/src/Ice/LocalExceptions.swift
+++ b/swift/src/Ice/LocalExceptions.swift
@@ -342,7 +342,7 @@ public final class ConnectionAbortedException: LocalException, @unchecked Sendab
 
 /// This exception indicates the connection was closed gracefully.
 public final class ConnectionClosedException: LocalException, @unchecked Sendable {
-    /// When true, the connection was aborted by the application. When false, the connection was aborted by the Ice
+    /// When true, the connection was closed by the application. When false, the connection was closed by the Ice
     /// runtime.
     public let closedByApplication: Bool
 
@@ -446,7 +446,7 @@ public final class ObjectAdapterIdInUseException: LocalException, @unchecked Sen
     ///   - file: The file where the exception was thrown.
     ///   - line: The line where the exception was thrown.
     public convenience init(id: String, file: String = #fileID, line: Int32 = #line) {
-        self.init("an object adapter with adapter ID'\(id)' is already active", file: file, line: line)
+        self.init("an object adapter with adapter ID '\(id)' is already active", file: file, line: line)
     }
 }
 

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -92,7 +92,15 @@
                                               property:(NSString*)property
                                                  error:(NSError* _Nullable* _Nullable)error
 {
-    return toNSDictionary(self.communicator->proxyToProperty([prx prx], fromNSString(property)));
+    try
+    {
+        return toNSDictionary(self.communicator->proxyToProperty([prx prx], fromNSString(property)));
+    }
+    catch (...)
+    {
+        *error = convertException(std::current_exception());
+        return nil;
+    }
 }
 
 - (ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError* _Nullable* _Nullable)error


### PR DESCRIPTION
Fixes #5557
Fixes #5556

Two low-severity Swift audit findings:

- **#5557** (`LocalExceptions.swift`, text only):
  - `ObjectAdapterIdInUseException`'s message was missing the space before the adapter ID (`adapter ID'foo'` → `adapter ID 'foo'`).
  - `ConnectionClosedException.closedByApplication`'s doc comment said the connection was "aborted" (copy-pasted from `ConnectionAbortedException`); this exception represents a graceful close, so it now says "closed".
- **#5556** (`Communicator.mm`): `proxyToProperty` was the only `error:`-bearing bridge method whose body called the C++ core without the standard `try/catch` + `convertException` guard. A C++ exception escaping there is undefined behavior across the C++/Objective-C++/Swift boundary. Wrapped the body in the same guard the sibling methods use, so it surfaces as a Swift error instead. (The currently-known throwing path is unreachable — fixed router/locator proxies throw at install time — so this is a defensive-symmetry fix.)

Text/doc and a defensive bridge guard; no behavioral change on any reachable path, so no test. Swift build + `swift format --strict` clean.
