### PR TITLE
Fix data race in BatchRequestQueue (C# and Java)

### DIFF
--- a/changelog.d/csharp/batch-request-finish-race.md
+++ b/changelog.d/csharp/batch-request-finish-race.md
@@ -1,0 +1,3 @@
+- Fixed a data race in batch request queuing that could corrupt batch-message framing (or crash) when one thread
+  flushed batch requests on a connection, proxy, or communicator while another thread was making batch invocations on
+  the same batch queue.

--- a/changelog.d/java/batch-request-finish-race.md
+++ b/changelog.d/java/batch-request-finish-race.md
@@ -1,0 +1,3 @@
+- Fixed a data race in batch request queuing that could corrupt batch-message framing (or crash) when one thread
+  flushed batch requests on a connection, proxy, or communicator while another thread was making batch invocations on
+  the same batch queue.

--- a/csharp/src/Ice/Internal/BatchRequestQueue.cs
+++ b/csharp/src/Ice/Internal/BatchRequestQueue.cs
@@ -64,7 +64,12 @@ internal sealed class BatchRequestQueue
             {
                 throw _exception;
             }
-            waitStreamInUse(false);
+
+            // This is similar to a mutex lock in that the stream is only "locked" while marshaling.
+            while (_batchStreamInUse)
+            {
+                Monitor.Wait(_mutex);
+            }
             _batchStreamInUse = true;
             _batchStream.swap(os);
         }
@@ -72,17 +77,19 @@ internal sealed class BatchRequestQueue
 
     internal void finishBatchRequest(OutputStream os, ObjectPrx proxy, string operation)
     {
-        //
-        // No need for synchronization, no other threads are supposed
-        // to modify the queue since we set _batchStreamInUse to true.
-        //
-        Debug.Assert(_batchStreamInUse);
-        _batchStream.swap(os);
+        lock (_mutex)
+        {
+            // Bring the request stream back and become the owner so this thread's own auto-flush below can
+            // re-enter swap(). swap() lets only _batchStreamOwner through while the stream is in use, and only
+            // after passing that gate does it read the queue's bookkeeping; no other thread can touch the
+            // queue, so the mutations below need no further synchronization.
+            Debug.Assert(_batchStreamInUse);
+            _batchStream.swap(os);
+            _batchStreamOwner = Thread.CurrentThread;
+        }
 
         try
         {
-            _batchStreamCanFlush = true; // Allow flush to proceed even if the stream is marked in use.
-
             if (_maxSize > 0 && _batchStream.size() >= _maxSize)
             {
                 _ = proxy.ice_flushBatchRequestsAsync(); // Auto flush
@@ -111,7 +118,7 @@ internal sealed class BatchRequestQueue
             {
                 _batchStream.resize(_batchMarker);
                 _batchStreamInUse = false;
-                _batchStreamCanFlush = false;
+                _batchStreamOwner = null;
                 Monitor.PulseAll(_mutex);
             }
         }
@@ -135,13 +142,24 @@ internal sealed class BatchRequestQueue
     {
         lock (_mutex)
         {
+            // Only the thread that currently owns the in-use stream may bypass the wait, to run its own
+            // auto-flush; every other caller waits for the in-progress batch request to finish.
+            if (_batchStreamOwner != Thread.CurrentThread)
+            {
+                while (_batchStreamInUse)
+                {
+                    Monitor.Wait(_mutex);
+                }
+            }
+
+            // Read the bookkeeping only after passing the gate above: finishBatchRequest mutates these scalars
+            // without the lock while it owns the in-use stream, so reading _batchRequestNum before the wait
+            // would race those writes.
             if (_batchRequestNum == 0)
             {
                 compress = false;
                 return 0;
             }
-
-            waitStreamInUse(true);
 
             byte[] lastRequest = null;
             if (_batchMarker < _batchStream.size())
@@ -180,20 +198,6 @@ internal sealed class BatchRequestQueue
         }
     }
 
-    private void waitStreamInUse(bool flush)
-    {
-        //
-        // This is similar to a mutex lock in that the stream is
-        // only "locked" while marshaling. As such we don't permit the wait
-        // to be interrupted. Instead the interrupted status is saved and
-        // restored.
-        //
-        while (_batchStreamInUse && !(flush && _batchStreamCanFlush))
-        {
-            Monitor.Wait(_mutex);
-        }
-    }
-
     internal void enqueueBatchRequest(ObjectPrx proxy)
     {
         Debug.Assert(_batchMarker < _batchStream.size());
@@ -211,7 +215,12 @@ internal sealed class BatchRequestQueue
     private readonly System.Action<BatchRequest, int, int> _interceptor;
     private readonly OutputStream _batchStream;
     private bool _batchStreamInUse;
-    private bool _batchStreamCanFlush;
+
+    // While finishBatchRequest holds the in-use stream, this is its thread: the only thread allowed to
+    // re-enter swap() (for its own auto-flush). A null owner means no thread may flush the in-use stream, so
+    // other threads wait for _batchStreamInUse to clear.
+    private Thread _batchStreamOwner;
+
     private int _batchRequestNum;
     private int _batchMarker;
     private bool _batchCompress;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BatchRequestQueue.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BatchRequestQueue.java
@@ -66,21 +66,23 @@ class BatchRequestQueue {
             throw (LocalException) _exception.fillInStackTrace();
         }
 
-        waitStreamInUse(false);
+        waitStreamInUse();
         _batchStreamInUse = true;
         _batchStream.swap(os);
     }
 
     public void finishBatchRequest(OutputStream os, ObjectPrx proxy, String operation) {
-        // No need for synchronization, no other threads are supposed to modify the queue since we
-        // set _batchStreamInUse to true.
-        assert _batchStreamInUse;
-        _batchStream.swap(os);
+        synchronized (this) {
+            // Bring the request stream back and become the owner so this thread's own auto-flush below can
+            // re-enter swap(). swap() lets only _batchStreamOwner through while the stream is in use, and only
+            // after passing that gate does it read the queue's bookkeeping; no other thread can touch the
+            // queue, so the mutations below need no further synchronization.
+            assert _batchStreamInUse;
+            _batchStream.swap(os);
+            _batchStreamOwner = Thread.currentThread();
+        }
 
         try {
-            // Allow flush to proceed even if the stream is marked in use.
-            _batchStreamCanFlush = true;
-
             if (_maxSize > 0 && _batchStream.size() >= _maxSize) {
                 proxy.ice_flushBatchRequestsAsync(); // Auto flush
             }
@@ -101,7 +103,7 @@ class BatchRequestQueue {
             synchronized (this) {
                 _batchStream.resize(_batchMarker);
                 _batchStreamInUse = false;
-                _batchStreamCanFlush = false;
+                _batchStreamOwner = null;
                 notifyAll();
             }
         }
@@ -122,11 +124,18 @@ class BatchRequestQueue {
     }
 
     public synchronized SwapResult swap(OutputStream os) {
+        // Only the thread that currently owns the in-use stream may bypass the wait, to run its own
+        // auto-flush; every other caller waits for the in-progress batch request to finish.
+        if (_batchStreamOwner != Thread.currentThread()) {
+            waitStreamInUse();
+        }
+
+        // Read the bookkeeping only after passing the gate above: finishBatchRequest mutates these scalars
+        // without the lock while it owns the in-use stream, so reading _batchRequestNum before the wait would
+        // race those writes.
         if (_batchRequestNum == 0) {
             return null;
         }
-
-        waitStreamInUse(true);
 
         byte[] lastRequest = null;
         if (_batchMarker < _batchStream.size()) {
@@ -157,12 +166,12 @@ class BatchRequestQueue {
         _exception = ex;
     }
 
-    private void waitStreamInUse(boolean flush) {
+    private void waitStreamInUse() {
         // This is similar to a mutex lock in that the stream is only "locked" while marshaling.
         // As such we don't permit the wait to be interrupted.
         // Instead the interrupted status is saved and restored.
         boolean interrupted = false;
-        while (_batchStreamInUse && !(flush && _batchStreamCanFlush)) {
+        while (_batchStreamInUse) {
             try {
                 wait();
             } catch (InterruptedException ex) {
@@ -189,7 +198,12 @@ class BatchRequestQueue {
     private final BatchRequestInterceptor _interceptor;
     private final OutputStream _batchStream;
     private boolean _batchStreamInUse;
-    private boolean _batchStreamCanFlush;
+
+    // While finishBatchRequest holds the in-use stream, this is its thread: the only thread allowed to
+    // re-enter swap() (for its own auto-flush). A null owner means no thread may flush the in-use stream, so
+    // other threads wait for _batchStreamInUse to clear.
+    private Thread _batchStreamOwner;
+
     private int _batchRequestNum;
     private int _batchMarker;
     private boolean _batchCompress;


### PR DESCRIPTION
Ports the C++ data-race fix (#5702) to the C# and Java `BatchRequestQueue` mappings, which had the identical bug. Fixes #5708.

### The bug
`finishBatchRequest` mutates the queue's bookkeeping (`_batchStream`, `_batchMarker`, `_batchRequestNum`, `_batchCompress`) **without the lock**, relying on `_batchStreamInUse == true` to keep other threads out. To let its own synchronous auto-flush re-enter `swap()`, it set `_batchStreamCanFlush = true`, and `swap()`'s wait let a flush through when that flag was set.

The flaw: `_batchStreamCanFlush` was not scoped to the finishing thread, so a flush from **another** thread (proxy / connection / communicator `flushBatchRequests`) also slipped through the in-use gate and raced the unlocked mutations — corrupting batch-message framing or crashing.

### The fix
- Replace `_batchStreamCanFlush` with an owner-thread identity (`_batchStreamOwner`): only the owning thread's own auto-flush bypasses the in-use stream; every other caller waits for the in-progress batch request to finish.
- Move `swap()`'s `_batchRequestNum == 0` early-return *after* the wait, so that read is gated too (it was a secondary, lower-severity instance of the same race).

### Substantive structural change worth noting
The owner check is now a **one-time guard before the wait** rather than a term inside the wait condition:

```csharp
if (_batchStreamOwner != Thread.CurrentThread)
{
    while (_batchStreamInUse)
    {
        Monitor.Wait(_mutex);
    }
}
```

This is *not* just a stylistic move — it reflects that the owner term never needed to be in the wait condition in the first place. `_batchStreamOwner` (like the `_batchStreamCanFlush` it replaces) is **only ever updated by `finishBatchRequest`, never while a thread is parked on this wait**. A thread becomes the owner only by running `finishBatchRequest`, which it cannot do while blocked in `swap()`'s wait. So the term is loop-invariant for any thread that actually blocks, and evaluating it once up front is equivalent to re-evaluating it on every wake-up. The C++ PR (#5702) makes the same simplification.

Note: the C++ "wedge on a non-`std::exception`" hardening does not apply here — C# and Java already reset state in a `finally` block.

JavaScript is single-threaded and not affected.

### Testing
`Ice/operations` (batch oneway, batch AMI oneway, batch request interceptor) and `Ice/ami` (batch flush via proxy / connection / communicator) pass for both C# and Java.

### Note on minor C#/Java divergence
C# inlines the in-use wait at both call sites (a two-line `while`/`Monitor.Wait`). Java keeps a small `waitStreamInUse` helper, because its `InterruptedException` save/restore handling is noisier to duplicate.