### PR TITLE
Invoke properties admin update callbacks outside the admin lock (C++, C#, Java)

### DIFF
--- a/cpp/src/Ice/NativePropertiesAdmin.cpp
+++ b/cpp/src/Ice/NativePropertiesAdmin.cpp
@@ -38,7 +38,7 @@ Ice::NativePropertiesAdmin::getPropertiesForPrefix(string prefix, const Current&
 void
 Ice::NativePropertiesAdmin::setProperties(PropertyDict props, const Current&)
 {
-    lock_guard lock{_mutex};
+    unique_lock lock{_mutex};
 
     PropertyDict old = _properties->getPropertiesForPrefix("");
     PropertyDict::const_iterator p;
@@ -157,8 +157,11 @@ Ice::NativePropertiesAdmin::setProperties(PropertyDict props, const Current&)
         changes.insert(changed.begin(), changed.end());
         changes.insert(removed.begin(), removed.end());
 
-        // Copy callbacks to allow callbacks to update callbacks
+        // Copy the callbacks and release the lock before invoking them. This allows the callbacks to update the
+        // callbacks, and avoids a lock-order inversion: a callback may acquire an application lock, while another
+        // thread may call into the admin (e.g. add/removeUpdateCallback) while holding that same lock.
         auto callbacks = _updateCallbacks;
+        lock.unlock();
         for (const auto& cb : callbacks)
         {
             cb(changes);

--- a/csharp/src/Ice/NativePropertiesAdmin.cs
+++ b/csharp/src/Ice/NativePropertiesAdmin.cs
@@ -22,6 +22,12 @@ public sealed class NativePropertiesAdmin : PropertiesAdminDisp_
 
     public override void setProperties(Dictionary<string, string> newProperties, Current current)
     {
+        // The callbacks and the change set to pass to them, captured under the lock and invoked after releasing it.
+        // This avoids a lock-order inversion: a callback may acquire an application lock, while another thread may
+        // call into the admin (e.g. add/removeUpdateCallback) while holding that same lock.
+        List<Action<Dictionary<string, string>>>? callbacks = null;
+        Dictionary<string, string>? changes = null;
+
         lock (_mutex)
         {
             Dictionary<string, string> old = _properties.getPropertiesForPrefix("");
@@ -148,7 +154,7 @@ public sealed class NativePropertiesAdmin : PropertiesAdminDisp_
 
             if (_updateCallbacks.Count > 0)
             {
-                var changes = new Dictionary<string, string>(added);
+                changes = new Dictionary<string, string>(added);
                 foreach (KeyValuePair<string, string> e in changed)
                 {
                     changes.Add(e.Key, e.Value);
@@ -158,14 +164,17 @@ public sealed class NativePropertiesAdmin : PropertiesAdminDisp_
                     changes.Add(e.Key, e.Value);
                 }
 
-                // Copy callbacks to allow callbacks to update callbacks
-                foreach (
-                    Action<Dictionary<string, string>> callback in
-                    new List<System.Action<Dictionary<string, string>>>(_updateCallbacks))
-                {
-                    // The callback should not throw any exception.
-                    callback(changes);
-                }
+                // Copy the callbacks to allow callbacks to update the callbacks.
+                callbacks = new List<Action<Dictionary<string, string>>>(_updateCallbacks);
+            }
+        }
+
+        if (callbacks is not null)
+        {
+            foreach (Action<Dictionary<string, string>> callback in callbacks)
+            {
+                // The callback should not throw any exception.
+                callback(changes!);
             }
         }
     }

--- a/csharp/src/Ice/NativePropertiesAdmin.cs
+++ b/csharp/src/Ice/NativePropertiesAdmin.cs
@@ -2,6 +2,8 @@
 
 #nullable enable
 
+using System.Diagnostics;
+
 namespace Ice;
 
 /// <summary>
@@ -169,8 +171,9 @@ public sealed class NativePropertiesAdmin : PropertiesAdminDisp_
             }
         }
 
-        if (callbacks is not null && changes is not null)
+        if (callbacks is not null)
         {
+            Debug.Assert(changes is not null);
             foreach (Action<Dictionary<string, string>> callback in callbacks)
             {
                 // The callback should not throw any exception.

--- a/csharp/src/Ice/NativePropertiesAdmin.cs
+++ b/csharp/src/Ice/NativePropertiesAdmin.cs
@@ -169,12 +169,12 @@ public sealed class NativePropertiesAdmin : PropertiesAdminDisp_
             }
         }
 
-        if (callbacks is not null)
+        if (callbacks is not null && changes is not null)
         {
             foreach (Action<Dictionary<string, string>> callback in callbacks)
             {
                 // The callback should not throw any exception.
-                callback(changes!);
+                callback(changes);
             }
         }
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NativePropertiesAdmin.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NativePropertiesAdmin.java
@@ -30,110 +30,122 @@ public class NativePropertiesAdmin implements PropertiesAdmin {
     }
 
     @Override
-    public synchronized void setProperties(Map<String, String> props, Current current) {
-        Map<String, String> old = _properties.getPropertiesForPrefix("");
-        final int traceLevel = _properties.getIcePropertyAsInt("Ice.Trace.Admin.Properties");
+    public void setProperties(Map<String, String> props, Current current) {
+        // The callbacks and the change set to pass to them, captured under the lock and invoked after releasing it.
+        // This avoids a lock-order inversion: a callback may acquire an application lock, while another thread may
+        // call into the admin (e.g. add/removeUpdateCallback) while holding that same lock.
+        List<Consumer<Map<String, String>>> callbacks = null;
+        Map<String, String> changes = null;
 
-        // Compute the difference between the new property set and the existing property set:
-        //
-        // 1) Any properties in the new set that were not defined in the existing set.
-        //
-        // 2) Any properties that appear in both sets but with different values.
-        //
-        // 3) Any properties not present in the new set but present in the existing set.
-        //    In other words, the property has been removed.
+        synchronized (this) {
+            Map<String, String> old = _properties.getPropertiesForPrefix("");
+            final int traceLevel = _properties.getIcePropertyAsInt("Ice.Trace.Admin.Properties");
 
-        Map<String, String> added = new HashMap<>();
-        Map<String, String> changed = new HashMap<>();
-        Map<String, String> removed = new HashMap<>();
-        for (Map.Entry<String, String> e : props.entrySet()) {
-            final String key = e.getKey();
-            final String value = e.getValue();
-            if (!old.containsKey(key)) {
-                if (!value.isEmpty()) {
-                    // This property is new.
-                    added.put(key, value);
+            // Compute the difference between the new property set and the existing property set:
+            //
+            // 1) Any properties in the new set that were not defined in the existing set.
+            //
+            // 2) Any properties that appear in both sets but with different values.
+            //
+            // 3) Any properties not present in the new set but present in the existing set.
+            //    In other words, the property has been removed.
+
+            Map<String, String> added = new HashMap<>();
+            Map<String, String> changed = new HashMap<>();
+            Map<String, String> removed = new HashMap<>();
+            for (Map.Entry<String, String> e : props.entrySet()) {
+                final String key = e.getKey();
+                final String value = e.getValue();
+                if (!old.containsKey(key)) {
+                    if (!value.isEmpty()) {
+                        // This property is new.
+                        added.put(key, value);
+                    }
+                } else {
+                    if (!value.equals(old.get(key))) {
+                        if (value.isEmpty()) {
+                            // This property was removed.
+                            removed.put(key, value);
+                        } else {
+                            // This property has changed.
+                            changed.put(key, value);
+                        }
+                    }
+
+                    old.remove(key);
                 }
-            } else {
-                if (!value.equals(old.get(key))) {
-                    if (value.isEmpty()) {
-                        // This property was removed.
-                        removed.put(key, value);
-                    } else {
-                        // This property has changed.
-                        changed.put(key, value);
+            }
+
+            if (traceLevel > 0 && (!added.isEmpty() || !changed.isEmpty() || !removed.isEmpty())) {
+                StringBuilder out = new StringBuilder(128);
+                out.append("Summary of property changes");
+
+                if (!added.isEmpty()) {
+                    out.append("\nNew properties:");
+                    for (Map.Entry<String, String> e : added.entrySet()) {
+                        out.append("\n  ");
+                        out.append(e.getKey());
+                        if (traceLevel > 1) {
+                            out.append(" = ");
+                            out.append(e.getValue());
+                        }
                     }
                 }
 
-                old.remove(key);
-            }
-        }
-
-        if (traceLevel > 0 && (!added.isEmpty() || !changed.isEmpty() || !removed.isEmpty())) {
-            StringBuilder out = new StringBuilder(128);
-            out.append("Summary of property changes");
-
-            if (!added.isEmpty()) {
-                out.append("\nNew properties:");
-                for (Map.Entry<String, String> e : added.entrySet()) {
-                    out.append("\n  ");
-                    out.append(e.getKey());
-                    if (traceLevel > 1) {
-                        out.append(" = ");
-                        out.append(e.getValue());
+                if (!changed.isEmpty()) {
+                    out.append("\nChanged properties:");
+                    for (Map.Entry<String, String> e : changed.entrySet()) {
+                        out.append("\n  ");
+                        out.append(e.getKey());
+                        if (traceLevel > 1) {
+                            out.append(" = ");
+                            out.append(e.getValue());
+                            out.append(" (old value = ");
+                            out.append(_properties.getProperty(e.getKey()));
+                            out.append(')');
+                        }
                     }
                 }
-            }
 
-            if (!changed.isEmpty()) {
-                out.append("\nChanged properties:");
-                for (Map.Entry<String, String> e : changed.entrySet()) {
-                    out.append("\n  ");
-                    out.append(e.getKey());
-                    if (traceLevel > 1) {
-                        out.append(" = ");
-                        out.append(e.getValue());
-                        out.append(" (old value = ");
-                        out.append(_properties.getProperty(e.getKey()));
-                        out.append(')');
+                if (!removed.isEmpty()) {
+                    out.append("\nRemoved properties:");
+                    for (Map.Entry<String, String> e : removed.entrySet()) {
+                        out.append("\n  ");
+                        out.append(e.getKey());
                     }
                 }
+
+                _logger.trace(_traceCategory, out.toString());
             }
 
-            if (!removed.isEmpty()) {
-                out.append("\nRemoved properties:");
-                for (Map.Entry<String, String> e : removed.entrySet()) {
-                    out.append("\n  ");
-                    out.append(e.getKey());
-                }
+            //
+            // Update the property set.
+            //
+
+            for (Map.Entry<String, String> e : added.entrySet()) {
+                _properties.setProperty(e.getKey(), e.getValue());
             }
 
-            _logger.trace(_traceCategory, out.toString());
+            for (Map.Entry<String, String> e : changed.entrySet()) {
+                _properties.setProperty(e.getKey(), e.getValue());
+            }
+
+            for (Map.Entry<String, String> e : removed.entrySet()) {
+                _properties.setProperty(e.getKey(), "");
+            }
+
+            if (!_updateCallbacks.isEmpty()) {
+                changes = new HashMap<>(added);
+                changes.putAll(changed);
+                changes.putAll(removed);
+
+                // Copy the callbacks to allow callbacks to update the callbacks.
+                callbacks = new ArrayList<>(_updateCallbacks);
+            }
         }
 
-        //
-        // Update the property set.
-        //
-
-        for (Map.Entry<String, String> e : added.entrySet()) {
-            _properties.setProperty(e.getKey(), e.getValue());
-        }
-
-        for (Map.Entry<String, String> e : changed.entrySet()) {
-            _properties.setProperty(e.getKey(), e.getValue());
-        }
-
-        for (Map.Entry<String, String> e : removed.entrySet()) {
-            _properties.setProperty(e.getKey(), "");
-        }
-
-        if (!_updateCallbacks.isEmpty()) {
-            Map<String, String> changes = new HashMap<>(added);
-            changes.putAll(changed);
-            changes.putAll(removed);
-
-            // Copy the callbacks to allow callbacks to update the callbacks.
-            for (Consumer<Map<String, String>> callback : new ArrayList<>(_updateCallbacks)) {
+        if (callbacks != null) {
+            for (Consumer<Map<String, String>> callback : callbacks) {
                 callback.accept(changes);
             }
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NativePropertiesAdmin.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NativePropertiesAdmin.java
@@ -144,7 +144,7 @@ public class NativePropertiesAdmin implements PropertiesAdmin {
             }
         }
 
-        if (callbacks != null) {
+        if (callbacks != null && changes != null) {
             for (Consumer<Map<String, String>> callback : callbacks) {
                 callback.accept(changes);
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NativePropertiesAdmin.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NativePropertiesAdmin.java
@@ -144,7 +144,8 @@ public class NativePropertiesAdmin implements PropertiesAdmin {
             }
         }
 
-        if (callbacks != null && changes != null) {
+        if (callbacks != null) {
+            assert changes != null;
             for (Consumer<Map<String, String>> callback : callbacks) {
                 callback.accept(changes);
             }


### PR DESCRIPTION
`NativePropertiesAdmin::setProperties` invoked the registered property-update callbacks while holding the admin mutex, which is a lock-order inversion hazard: a callback that acquires an application lock runs under the admin lock, so if another thread holds that application lock and then calls into the admin (e.g. `addUpdateCallback` / `removeUpdateCallback`), the two locks can be acquired in opposite orders.

This copies the callbacks (and the change set passed to them) under the lock and invokes them after releasing it, consistently across all three mappings. C++ switches the whole-method `lock_guard` to a `unique_lock` and unlocks before the loop; C# and Java capture the callbacks into method-scope locals and run the invocation loop after the locked region exits. Each mapping already copied the callback list before iterating, so callbacks that (de)register during the call remain handled.

Fixes #5669.