### PR TITLE
Fix IceGridGUI Swing thread-safety (off-EDT dialog, EDT join freeze)

### DIFF
--- a/changelog.d/service-icegrid/icegridgui-logfile-freeze.md
+++ b/changelog.d/service-icegrid/icegridgui-logfile-freeze.md
@@ -1,0 +1,3 @@
+- Fixed the IceGrid GUI freezing when a log file window was closed or stopped while a read against an
+  unresponsive node was still in progress. The log reader is now joined off the UI thread, keeping the GUI
+  responsive.

--- a/changelog.d/service-icegrid/icegridgui-logfile-freeze.md
+++ b/changelog.d/service-icegrid/icegridgui-logfile-freeze.md
@@ -1,3 +1,3 @@
 - Fixed the IceGrid GUI freezing when a log file window was closed or stopped while a read against an
-  unresponsive node was still in progress. The log reader is now joined off the UI thread, keeping the GUI
-  responsive.
+  unresponsive node was still in progress. Stopping or closing a log window no longer blocks the UI thread
+  waiting for the in-progress read to return.

--- a/changelog.d/service-icegrid/icegridgui-metricsview-uithread.md
+++ b/changelog.d/service-icegrid/icegridgui-metricsview-uithread.md
@@ -1,0 +1,3 @@
+- Fixed a Swing threading violation in the IceGrid GUI: when refreshing a metrics view failed synchronously,
+  the error dialog was created off the UI thread, which could corrupt the display or deadlock. The dialog is
+  now shown on the UI thread.

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsView.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsView.java
@@ -250,11 +250,16 @@ class MetricsView extends TreeNode {
                         });
             } catch (CommunicatorDestroyedException e) {} catch (LocalException e) {
                 MetricsViewEditor.stopRefresh();
-                JOptionPane.showMessageDialog(
-                    getCoordinator().getMainFrame(),
-                    "Error: " + e.toString(),
-                    "Error",
-                    JOptionPane.ERROR_MESSAGE);
+                // fetchMetricsView runs on the coordinator's scheduled-executor thread, not the UI thread,
+                // so marshal the Swing dialog to the UI thread, like the asynchronous failure path above.
+                SwingUtilities.invokeLater(
+                    () -> {
+                        JOptionPane.showMessageDialog(
+                            getCoordinator().getMainFrame(),
+                            "Error: " + e.toString(),
+                            "Error",
+                            JOptionPane.ERROR_MESSAGE);
+                    });
             }
         }
     }

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsView.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsView.java
@@ -248,7 +248,8 @@ class MetricsView extends TreeNode {
                                     });
                             }
                         });
-            } catch (CommunicatorDestroyedException e) {} catch (LocalException e) {
+            } catch (CommunicatorDestroyedException e) {
+            } catch (LocalException e) {
                 MetricsViewEditor.stopRefresh();
                 // fetchMetricsView runs on the coordinator's scheduled-executor thread, not the UI thread,
                 // so marshal the Swing dialog to the UI thread, like the asynchronous failure path above.

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowLogFileDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowLogFileDialog.java
@@ -100,6 +100,8 @@ class ShowLogFileDialog extends JDialog {
 
     private class ReaderThread extends Thread {
         ReaderThread() {
+            // Daemon so a reader blocked on a hung remote read can't keep the JVM alive after stopReading().
+            setDaemon(true);
             _threadMaxLines = _maxLines;
             _threadMaxSize = _maxSize;
             _threadInitialLines = _initialLines;
@@ -523,35 +525,14 @@ class ShowLogFileDialog extends JDialog {
 
     void stopReading() {
         if (_thread != null) {
-            final ReaderThread thread = _thread;
-
-            // Update the toolbar synchronously on the UI thread: clear _thread, and disable Pause and Play.
-            // Clearing _thread stops a concurrent stopReading or the reader's own stop callback from acting on
-            // the terminating reader; disabling Play prevents a new reader from starting before this one has
-            // fully terminated, which would let the two readers interfere.
+            // Don't join the reader here: it may be blocked in a synchronous remote read against an
+            // unresponsive node, which would freeze the UI. The reader is a daemon that destroys its own
+            // file iterator and exits on its own, so just terminate it and move on.
+            _thread.terminate();
             _thread = null;
-            thread.terminate();
             _stopItem.setSelected(true);
             _stopButton.setSelected(true);
             _pause.setEnabled(false);
-            _play.setEnabled(false);
-
-            // The reader may be blocked in a synchronous remote read, so join it off the UI thread instead
-            // of freezing the UI until the read returns. The reader destroys its own file iterator. Re-enable
-            // Play once the reader is gone so the log can be read again. This joiner is a daemon thread so a
-            // reader stuck on a hung read cannot keep the JVM alive.
-            Thread joiner =
-                new Thread(
-                    () -> {
-                        try {
-                            thread.join();
-                        } catch (InterruptedException e) {
-                        }
-                        SwingUtilities.invokeLater(() -> _play.setEnabled(true));
-                    },
-                    "IceGridGUI.ShowLogFileDialog.stopReading");
-            joiner.setDaemon(true);
-            joiner.start();
         }
     }
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowLogFileDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowLogFileDialog.java
@@ -523,16 +523,35 @@ class ShowLogFileDialog extends JDialog {
 
     void stopReading() {
         if (_thread != null) {
-            _thread.terminate();
+            final ReaderThread thread = _thread;
 
-            try {
-                _thread.join();
-            } catch (InterruptedException e) {}
-
+            // Update the toolbar synchronously on the UI thread: clear _thread, and disable Pause and Play.
+            // Clearing _thread stops a concurrent stopReading or the reader's own stop callback from acting on
+            // the terminating reader; disabling Play prevents a new reader from starting before this one has
+            // fully terminated, which would let the two readers interfere.
             _thread = null;
+            thread.terminate();
             _stopItem.setSelected(true);
             _stopButton.setSelected(true);
             _pause.setEnabled(false);
+            _play.setEnabled(false);
+
+            // The reader may be blocked in a synchronous remote read, so join it off the UI thread instead
+            // of freezing the UI until the read returns. The reader destroys its own file iterator. Re-enable
+            // Play once the reader is gone so the log can be read again. This joiner is a daemon thread so a
+            // reader stuck on a hung read cannot keep the JVM alive.
+            Thread joiner =
+                new Thread(
+                    () -> {
+                        try {
+                            thread.join();
+                        } catch (InterruptedException e) {
+                        }
+                        SwingUtilities.invokeLater(() -> _play.setEnabled(true));
+                    },
+                    "IceGridGUI.ShowLogFileDialog.stopReading");
+            joiner.setDaemon(true);
+            joiner.start();
         }
     }
 


### PR DESCRIPTION
Fixes #5509
Fixes #5508

Two Swing thread-safety fixes in the IceGrid GUI (both Audit-Medium):

- **#5509** — `MetricsView.fetchMetricsView` is invoked on the coordinator's scheduled-executor thread (`Pinger`), not the UI thread. Its asynchronous failure path already marshals to the UI thread, but the **synchronous** `catch (LocalException)` showed a `JOptionPane` directly on the executor thread (a Swing single-thread-rule violation that can corrupt the display or deadlock). It now wraps the dialog in `SwingUtilities.invokeLater`, matching the async path.
- **#5508** — `ShowLogFileDialog.stopReading()` ran `_thread.join()` on the UI thread. `terminate()` cannot interrupt the reader while it is blocked in the synchronous remote `FileIterator.read`, and no finite invocation timeout is applied (runtime default is infinite), so the UI thread could freeze unboundedly against an unresponsive node. It now joins the reader **off the UI thread**, clears the reader and **disables Play synchronously** on the UI thread so a new reader can't start and interfere before the old one terminates, then re-enables Play once it's gone.

No automated test: IceGridGUI is a Swing app with no headless test harness, and reproducing the freeze needs a live GUI + a hung node. Verified by inspection + a GPT-5.5 review of the threading; compiles, checkstyle + OpenRewrite clean.


