### PR TITLE
Fix IceBox ServiceManager pending-status-change race (C++, C#, Java)

### DIFF
--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -133,7 +133,7 @@ IceBox::ServiceManagerI::startService(string name, const Current&)
         {
             throw NoSuchServiceException();
         }
-        _pendingStatusChanges = true;
+        ++_pendingStatusChanges;
     }
 
     bool started = false;
@@ -175,7 +175,7 @@ IceBox::ServiceManagerI::startService(string name, const Current&)
                 break;
             }
         }
-        _pendingStatusChanges = false;
+        --_pendingStatusChanges;
         _conditionVariable.notify_all();
     }
 }
@@ -209,7 +209,7 @@ IceBox::ServiceManagerI::stopService(string name, const Current&)
         {
             throw NoSuchServiceException();
         }
-        _pendingStatusChanges = true;
+        ++_pendingStatusChanges;
     }
 
     bool stopped = false;
@@ -251,7 +251,7 @@ IceBox::ServiceManagerI::stopService(string name, const Current&)
                 break;
             }
         }
-        _pendingStatusChanges = false;
+        --_pendingStatusChanges;
         _conditionVariable.notify_all();
     }
 }
@@ -718,7 +718,7 @@ IceBox::ServiceManagerI::stopAll()
     //
     // First wait for any active startService/stopService calls to complete.
     //
-    _conditionVariable.wait(lock, [this] { return !_pendingStatusChanges; });
+    _conditionVariable.wait(lock, [this] { return _pendingStatusChanges == 0; });
 
     //
     // Services are stopped in the reverse order from which they are started.

--- a/cpp/src/IceBox/ServiceManagerI.h
+++ b/cpp/src/IceBox/ServiceManagerI.h
@@ -70,7 +70,7 @@ namespace IceBox
         Ice::LoggerPtr _logger;
         Ice::StringSeq _argv; // Filtered server argument vector, not including program name
         std::vector<ServiceInfo> _services;
-        bool _pendingStatusChanges{false};
+        int _pendingStatusChanges{0};
 
         std::set<ServiceObserverPrx> _observers;
         int _traceServiceObserver{0};

--- a/csharp/src/iceboxnet/ServiceManagerI.cs
+++ b/csharp/src/iceboxnet/ServiceManagerI.cs
@@ -70,7 +70,7 @@ internal class ServiceManagerI : ServiceManagerDisp_, IDisposable
             {
                 throw new NoSuchServiceException();
             }
-            _pendingStatusChanges = true;
+            ++_pendingStatusChanges;
         }
 
         bool started = false;
@@ -113,7 +113,7 @@ internal class ServiceManagerI : ServiceManagerDisp_, IDisposable
                     break;
                 }
             }
-            _pendingStatusChanges = false;
+            --_pendingStatusChanges;
             Monitor.PulseAll(_mutex);
         }
     }
@@ -146,7 +146,7 @@ internal class ServiceManagerI : ServiceManagerDisp_, IDisposable
             {
                 throw new NoSuchServiceException();
             }
-            _pendingStatusChanges = true;
+            ++_pendingStatusChanges;
         }
 
         bool stopped = false;
@@ -186,7 +186,7 @@ internal class ServiceManagerI : ServiceManagerDisp_, IDisposable
                     break;
                 }
             }
-            _pendingStatusChanges = false;
+            --_pendingStatusChanges;
             Monitor.PulseAll(_mutex);
         }
     }
@@ -684,7 +684,7 @@ internal class ServiceManagerI : ServiceManagerDisp_, IDisposable
             //
             // First wait for any active startService/stopService calls to complete.
             //
-            while (_pendingStatusChanges)
+            while (_pendingStatusChanges > 0)
             {
                 Monitor.Wait(_mutex);
             }
@@ -1020,7 +1020,7 @@ internal class ServiceManagerI : ServiceManagerDisp_, IDisposable
 #pragma warning restore CA2213
     private readonly string[] _argv; // Filtered server argument vector
     private readonly List<ServiceInfo> _services = new();
-    private bool _pendingStatusChanges;
+    private int _pendingStatusChanges;
     private readonly Dictionary<ServiceObserverPrx, bool> _observers = new();
     private readonly int _traceServiceObserver;
     private readonly object _mutex = new();

--- a/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
+++ b/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
@@ -79,7 +79,7 @@ final class ServiceManagerI implements ServiceManager {
             if (info == null) {
                 throw new NoSuchServiceException();
             }
-            _pendingStatusChanges = true;
+            ++_pendingStatusChanges;
         }
 
         boolean started = false;
@@ -112,7 +112,7 @@ final class ServiceManagerI implements ServiceManager {
                     break;
                 }
             }
-            _pendingStatusChanges = false;
+            --_pendingStatusChanges;
             notifyAll();
         }
     }
@@ -136,7 +136,7 @@ final class ServiceManagerI implements ServiceManager {
             if (info == null) {
                 throw new NoSuchServiceException();
             }
-            _pendingStatusChanges = true;
+            ++_pendingStatusChanges;
         }
 
         boolean stopped = false;
@@ -166,7 +166,7 @@ final class ServiceManagerI implements ServiceManager {
                     break;
                 }
             }
-            _pendingStatusChanges = false;
+            --_pendingStatusChanges;
             notifyAll();
         }
     }
@@ -549,7 +549,7 @@ final class ServiceManagerI implements ServiceManager {
 
     private synchronized void stopAll() {
         // First wait for any active startService/stopService calls to complete.
-        while (_pendingStatusChanges) {
+        while (_pendingStatusChanges > 0) {
             try {
                 wait();
             } catch (InterruptedException ex) {}
@@ -858,7 +858,7 @@ final class ServiceManagerI implements ServiceManager {
     private final Logger _logger;
     private final String[] _argv; // Filtered server argument vector
     private final List<ServiceInfo> _services = new LinkedList<>();
-    private boolean _pendingStatusChanges;
+    private int _pendingStatusChanges;
     private final HashSet<ServiceObserverPrx> _observers = new HashSet<>();
     private final int _traceServiceObserver;
     private Map<String, ClassLoader> _classLoaders;


### PR DESCRIPTION
## Bug

`IceBox::ServiceManagerI` tracked in-progress `startService`/`stopService` operations with a single `bool _pendingStatusChanges`. Both operations set it, ran `service->start()`/`stop()` outside the lock, then reset it. Whichever operation finished first reset the flag to `false`, releasing `stopAll()` (which waits on the flag) while the *other* operation was still running outside the lock. `stopAll()` could then tear down a service mid-start, or miss a service started after the reset.

## Fix

Make `_pendingStatusChanges` a counter: increment per in-flight operation, decrement on completion, and have `stopAll()` wait until it reaches zero. Shutdown now blocks until *all* in-flight status changes complete. Applied identically in the three mappings that share this design (C++, C#, Java).

## Reachability

**Extremely limited.** The bug requires two `startService`/`stopService` calls dispatched *concurrently*. These are admin operations on the `IceBox.ServiceManager` facet, hosted by the IceBox server communicator's `Ice.Admin` object adapter. That OA uses the shared server thread pool (or a dedicated `Ice.Admin.ThreadPool` if configured), and both default to `Size`/`SizeMax` = 1 — so admin dispatches are serialized and only one status change is ever in flight. Triggering the race requires deliberately raising `SizeMax >= 2` on the IceBox process's admin/server thread pool, which is not something done in practice. With the default single-threaded admin dispatch the original `bool` was already correct.

This is therefore a defensive correctness fix; no CHANGELOG entry.

Fixes #5485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)