### PR TITLE
Standardize NSError out-parameter nullability in the IceImpl Swift bridge

### DIFF
--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -300,7 +300,9 @@
     }
 }
 
-- (BOOL)addAdminFacet:(id<ICEDispatchAdapter>)dispatchAdapter facet:(NSString*)facet error:(NSError* _Nullable* _Nonnull)error
+- (BOOL)addAdminFacet:(id<ICEDispatchAdapter>)dispatchAdapter
+                facet:(NSString*)facet
+                error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -52,7 +52,7 @@
     return self.communicator->isShutdown();
 }
 
-- (id)stringToProxy:(NSString*)str error:(NSError**)error
+- (id)stringToProxy:(NSString*)str error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -70,7 +70,7 @@
     }
 }
 
-- (nullable id)propertyToProxy:(NSString*)property error:(NSError* _Nullable* _Nullable)error
+- (nullable id)propertyToProxy:(NSString*)property error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -90,12 +90,12 @@
 
 - (NSDictionary<NSString*, NSString*>*)proxyToProperty:(ICEObjectPrx*)prx
                                               property:(NSString*)property
-                                                 error:(NSError* _Nullable* _Nullable)error
+                                                 error:(NSError* _Nullable * _Nonnull)error
 {
     return toNSDictionary(self.communicator->proxyToProperty([prx prx], fromNSString(property)));
 }
 
-- (ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError* _Nullable* _Nullable)error
+- (ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -111,7 +111,7 @@
 
 - (ICEObjectAdapter*)createObjectAdapterWithEndpoints:(NSString*)name
                                             endpoints:(NSString*)endpoints
-                                                error:(NSError* _Nullable* _Nullable)error
+                                                error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -127,7 +127,7 @@
 
 - (ICEObjectAdapter*)createObjectAdapterWithRouter:(NSString*)name
                                             router:(ICEObjectPrx*)router
-                                             error:(NSError* _Nullable* _Nullable)error
+                                             error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -194,7 +194,7 @@
     }
 }
 
-- (BOOL)setDefaultRouter:(ICEObjectPrx*)router error:(NSError**)error
+- (BOOL)setDefaultRouter:(ICEObjectPrx*)router error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -226,7 +226,7 @@
     }
 }
 
-- (BOOL)setDefaultLocator:(ICEObjectPrx*)locator error:(NSError**)error
+- (BOOL)setDefaultLocator:(ICEObjectPrx*)locator error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -270,7 +270,7 @@
 - (nullable ICEObjectPrx*)createAdmin:(ICEObjectAdapter* _Nullable)adminAdapter
                                  name:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError**)error
+                                error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -286,7 +286,7 @@
     }
 }
 
-- (nullable id)getAdmin:(NSError**)error
+- (nullable id)getAdmin:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -300,7 +300,7 @@
     }
 }
 
-- (BOOL)addAdminFacet:(id<ICEDispatchAdapter>)dispatchAdapter facet:(NSString*)facet error:(NSError**)error
+- (BOOL)addAdminFacet:(id<ICEDispatchAdapter>)dispatchAdapter facet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -315,7 +315,7 @@
     }
 }
 
-- (id<ICEDispatchAdapter>)removeAdminFacet:(NSString*)facet error:(NSError**)error
+- (id<ICEDispatchAdapter>)removeAdminFacet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -329,7 +329,7 @@
     }
 }
 
-- (nullable id)findAdminFacet:(NSString*)facet error:(NSError**)error
+- (nullable id)findAdminFacet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -350,7 +350,7 @@
     }
 }
 
-- (nullable NSDictionary<NSString*, id<ICEDispatchAdapter>>*)findAllAdminFacets:(NSError**)error
+- (nullable NSDictionary<NSString*, id<ICEDispatchAdapter>>*)findAllAdminFacets:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -410,7 +410,7 @@
     return [factory createUnsupported:self];
 }
 
-- (BOOL)initializePlugins:(NSError**)error
+- (BOOL)initializePlugins:(NSError* _Nullable * _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -52,7 +52,7 @@
     return self.communicator->isShutdown();
 }
 
-- (id)stringToProxy:(NSString*)str error:(NSError* _Nullable * _Nonnull)error
+- (id)stringToProxy:(NSString*)str error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -70,7 +70,7 @@
     }
 }
 
-- (nullable id)propertyToProxy:(NSString*)property error:(NSError* _Nullable * _Nonnull)error
+- (nullable id)propertyToProxy:(NSString*)property error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -90,12 +90,12 @@
 
 - (NSDictionary<NSString*, NSString*>*)proxyToProperty:(ICEObjectPrx*)prx
                                               property:(NSString*)property
-                                                 error:(NSError* _Nullable * _Nonnull)error
+                                                 error:(NSError* _Nullable* _Nonnull)error
 {
     return toNSDictionary(self.communicator->proxyToProperty([prx prx], fromNSString(property)));
 }
 
-- (ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError* _Nullable * _Nonnull)error
+- (ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -111,7 +111,7 @@
 
 - (ICEObjectAdapter*)createObjectAdapterWithEndpoints:(NSString*)name
                                             endpoints:(NSString*)endpoints
-                                                error:(NSError* _Nullable * _Nonnull)error
+                                                error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -127,7 +127,7 @@
 
 - (ICEObjectAdapter*)createObjectAdapterWithRouter:(NSString*)name
                                             router:(ICEObjectPrx*)router
-                                             error:(NSError* _Nullable * _Nonnull)error
+                                             error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -194,7 +194,7 @@
     }
 }
 
-- (BOOL)setDefaultRouter:(ICEObjectPrx*)router error:(NSError* _Nullable * _Nonnull)error
+- (BOOL)setDefaultRouter:(ICEObjectPrx*)router error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -226,7 +226,7 @@
     }
 }
 
-- (BOOL)setDefaultLocator:(ICEObjectPrx*)locator error:(NSError* _Nullable * _Nonnull)error
+- (BOOL)setDefaultLocator:(ICEObjectPrx*)locator error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -270,7 +270,7 @@
 - (nullable ICEObjectPrx*)createAdmin:(ICEObjectAdapter* _Nullable)adminAdapter
                                  name:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError* _Nullable * _Nonnull)error
+                                error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -286,7 +286,7 @@
     }
 }
 
-- (nullable id)getAdmin:(NSError* _Nullable * _Nonnull)error
+- (nullable id)getAdmin:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -300,7 +300,7 @@
     }
 }
 
-- (BOOL)addAdminFacet:(id<ICEDispatchAdapter>)dispatchAdapter facet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error
+- (BOOL)addAdminFacet:(id<ICEDispatchAdapter>)dispatchAdapter facet:(NSString*)facet error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -315,7 +315,7 @@
     }
 }
 
-- (id<ICEDispatchAdapter>)removeAdminFacet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error
+- (id<ICEDispatchAdapter>)removeAdminFacet:(NSString*)facet error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -329,7 +329,7 @@
     }
 }
 
-- (nullable id)findAdminFacet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error
+- (nullable id)findAdminFacet:(NSString*)facet error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -350,7 +350,7 @@
     }
 }
 
-- (nullable NSDictionary<NSString*, id<ICEDispatchAdapter>>*)findAllAdminFacets:(NSError* _Nullable * _Nonnull)error
+- (nullable NSDictionary<NSString*, id<ICEDispatchAdapter>>*)findAllAdminFacets:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -410,7 +410,7 @@
     return [factory createUnsupported:self];
 }
 
-- (BOOL)initializePlugins:(NSError* _Nullable * _Nonnull)error
+- (BOOL)initializePlugins:(NSError* _Nullable* _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -33,7 +33,7 @@
         });
 }
 
-- (nullable ICEObjectPrx*)createProxy:(NSString*)name category:(NSString*)category error:(NSError* _Nullable * _Nonnull)error
+- (nullable ICEObjectPrx*)createProxy:(NSString*)name category:(NSString*)category error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -47,7 +47,7 @@
     }
 }
 
-- (BOOL)setAdapter:(ICEObjectAdapter* _Nullable)oa error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)setAdapter:(ICEObjectAdapter* _Nullable)oa error:(NSError* _Nullable* _Nonnull)error;
 {
     try
     {
@@ -96,7 +96,7 @@
     }
 }
 
-- (BOOL)setCloseCallback:(void (^)(ICEConnection*))callback error:(NSError* _Nullable * _Nonnull)error
+- (BOOL)setCloseCallback:(void (^)(ICEConnection*))callback error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -141,7 +141,7 @@
     return toNSString(self.connection->toString());
 }
 
-- (id)getInfo:(NSError* _Nullable * _Nonnull)error
+- (id)getInfo:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -155,7 +155,7 @@
     }
 }
 
-- (BOOL)setBufferSize:(int32_t)rcvSize sndSize:(int32_t)sndSize error:(NSError* _Nullable * _Nonnull)error
+- (BOOL)setBufferSize:(int32_t)rcvSize sndSize:(int32_t)sndSize error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -169,7 +169,7 @@
     }
 }
 
-- (BOOL)throwException:(NSError* _Nullable * _Nonnull)error
+- (BOOL)throwException:(NSError* _Nullable* _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -33,7 +33,9 @@
         });
 }
 
-- (nullable ICEObjectPrx*)createProxy:(NSString*)name category:(NSString*)category error:(NSError* _Nullable* _Nonnull)error
+- (nullable ICEObjectPrx*)createProxy:(NSString*)name
+                             category:(NSString*)category
+                                error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -33,7 +33,7 @@
         });
 }
 
-- (nullable ICEObjectPrx*)createProxy:(NSString*)name category:(NSString*)category error:(NSError**)error
+- (nullable ICEObjectPrx*)createProxy:(NSString*)name category:(NSString*)category error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -47,7 +47,7 @@
     }
 }
 
-- (BOOL)setAdapter:(ICEObjectAdapter* _Nullable)oa error:(NSError* _Nullable* _Nullable)error;
+- (BOOL)setAdapter:(ICEObjectAdapter* _Nullable)oa error:(NSError* _Nullable * _Nonnull)error;
 {
     try
     {
@@ -96,7 +96,7 @@
     }
 }
 
-- (BOOL)setCloseCallback:(void (^)(ICEConnection*))callback error:(NSError**)error
+- (BOOL)setCloseCallback:(void (^)(ICEConnection*))callback error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -141,7 +141,7 @@
     return toNSString(self.connection->toString());
 }
 
-- (id)getInfo:(NSError**)error
+- (id)getInfo:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -155,7 +155,7 @@
     }
 }
 
-- (BOOL)setBufferSize:(int32_t)rcvSize sndSize:(int32_t)sndSize error:(NSError**)error
+- (BOOL)setBufferSize:(int32_t)rcvSize sndSize:(int32_t)sndSize error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -169,7 +169,7 @@
     }
 }
 
-- (BOOL)throwException:(NSError**)error
+- (BOOL)throwException:(NSError* _Nullable * _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/IceUtil.mm
+++ b/swift/src/IceImpl/IceUtil.mm
@@ -48,7 +48,7 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
     return true;
 }
 
-+ (ICECommunicator*)initialize:(ICEProperties*)properties logger:(id<ICELoggerProtocol>)logger error:(NSError* _Nullable * _Nonnull)error
++ (ICECommunicator*)initialize:(ICEProperties*)properties logger:(id<ICELoggerProtocol>)logger error:(NSError* _Nullable* _Nonnull)error
 {
     assert(properties);
 
@@ -101,7 +101,7 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
 + (ICEProperties*)createProperties:(NSArray*)swiftArgs
                           defaults:(ICEProperties*)defaults
                            remArgs:(NSArray**)remArgs
-                             error:(NSError* _Nullable * _Nonnull)error
+                             error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -132,7 +132,7 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
 + (BOOL)stringToIdentity:(NSString*)str
                     name:(NSString* __strong _Nonnull* _Nonnull)name
                 category:(NSString* __strong _Nonnull* _Nonnull)category
-                   error:(NSError* _Nullable * _Nonnull)error
+                   error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/IceUtil.mm
+++ b/swift/src/IceImpl/IceUtil.mm
@@ -48,7 +48,9 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
     return true;
 }
 
-+ (ICECommunicator*)initialize:(ICEProperties*)properties logger:(id<ICELoggerProtocol>)logger error:(NSError* _Nullable* _Nonnull)error
++ (ICECommunicator*)initialize:(ICEProperties*)properties
+                        logger:(id<ICELoggerProtocol>)logger
+                         error:(NSError* _Nullable* _Nonnull)error
 {
     assert(properties);
 

--- a/swift/src/IceImpl/IceUtil.mm
+++ b/swift/src/IceImpl/IceUtil.mm
@@ -48,7 +48,7 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
     return true;
 }
 
-+ (ICECommunicator*)initialize:(ICEProperties*)properties logger:(id<ICELoggerProtocol>)logger error:(NSError**)error
++ (ICECommunicator*)initialize:(ICEProperties*)properties logger:(id<ICELoggerProtocol>)logger error:(NSError* _Nullable * _Nonnull)error
 {
     assert(properties);
 
@@ -101,7 +101,7 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
 + (ICEProperties*)createProperties:(NSArray*)swiftArgs
                           defaults:(ICEProperties*)defaults
                            remArgs:(NSArray**)remArgs
-                             error:(NSError**)error
+                             error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -132,7 +132,7 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
 + (BOOL)stringToIdentity:(NSString*)str
                     name:(NSString* __strong _Nonnull* _Nonnull)name
                 category:(NSString* __strong _Nonnull* _Nonnull)category
-                   error:(NSError* _Nullable* _Nullable)error
+                   error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/ObjectAdapter.mm
+++ b/swift/src/IceImpl/ObjectAdapter.mm
@@ -26,7 +26,7 @@
     return [ICECommunicator getHandle:comm];
 }
 
-- (BOOL)activate:(NSError* _Nullable* _Nullable)error
+- (BOOL)activate:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -94,7 +94,7 @@
 
 - (nullable ICEObjectPrx*)createProxy:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError* _Nullable* _Nullable)error
+                                error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -110,7 +110,7 @@
 
 - (nullable ICEObjectPrx*)createDirectProxy:(NSString*)name
                                    category:(NSString*)category
-                                      error:(NSError* _Nullable* _Nullable)error
+                                      error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -126,7 +126,7 @@
 
 - (nullable ICEObjectPrx*)createIndirectProxy:(NSString*)name
                                      category:(NSString*)category
-                                        error:(NSError* _Nullable* _Nullable)error
+                                        error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -188,7 +188,7 @@
     return toNSArray(self.objectAdapter->getPublishedEndpoints());
 }
 
-- (BOOL)setPublishedEndpoints:(NSArray<ICEEndpoint*>*)newEndpoints error:(NSError* _Nullable* _Nullable)error
+- (BOOL)setPublishedEndpoints:(NSArray<ICEEndpoint*>*)newEndpoints error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/ObjectAdapter.mm
+++ b/swift/src/IceImpl/ObjectAdapter.mm
@@ -26,7 +26,7 @@
     return [ICECommunicator getHandle:comm];
 }
 
-- (BOOL)activate:(NSError* _Nullable * _Nonnull)error
+- (BOOL)activate:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -94,7 +94,7 @@
 
 - (nullable ICEObjectPrx*)createProxy:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError* _Nullable * _Nonnull)error
+                                error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -110,7 +110,7 @@
 
 - (nullable ICEObjectPrx*)createDirectProxy:(NSString*)name
                                    category:(NSString*)category
-                                      error:(NSError* _Nullable * _Nonnull)error
+                                      error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -126,7 +126,7 @@
 
 - (nullable ICEObjectPrx*)createIndirectProxy:(NSString*)name
                                      category:(NSString*)category
-                                        error:(NSError* _Nullable * _Nonnull)error
+                                        error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -188,7 +188,7 @@
     return toNSArray(self.objectAdapter->getPublishedEndpoints());
 }
 
-- (BOOL)setPublishedEndpoints:(NSArray<ICEEndpoint*>*)newEndpoints error:(NSError* _Nullable * _Nonnull)error
+- (BOOL)setPublishedEndpoints:(NSArray<ICEEndpoint*>*)newEndpoints error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/ObjectPrx.mm
+++ b/swift/src/IceImpl/ObjectPrx.mm
@@ -37,7 +37,7 @@
     *category = toNSString(identity.category);
 }
 
-- (instancetype)ice_identity:(NSString*)name category:(NSString*)category error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_identity:(NSString*)name category:(NSString*)category error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -81,7 +81,7 @@
     return toNSString(_prx->ice_getAdapterId());
 }
 
-- (instancetype)ice_adapterId:(NSString*)id error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_adapterId:(NSString*)id error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -100,7 +100,7 @@
     return toNSArray(_prx->ice_getEndpoints());
 }
 
-- (instancetype)ice_endpoints:(NSArray<ICEEndpoint*>*)endpoints error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_endpoints:(NSArray<ICEEndpoint*>*)endpoints error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -123,7 +123,7 @@
     return static_cast<int32_t>(timeout.count());
 }
 
-- (instancetype)ice_locatorCacheTimeout:(int32_t)timeout error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_locatorCacheTimeout:(int32_t)timeout error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -142,7 +142,7 @@
     return static_cast<int32_t>(_prx->ice_getInvocationTimeout().count());
 }
 
-- (instancetype)ice_invocationTimeout:(int32_t)timeout error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_invocationTimeout:(int32_t)timeout error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -161,7 +161,7 @@
     return toNSString(_prx->ice_getConnectionId());
 }
 
-- (instancetype)ice_connectionId:(NSString*)connectionId error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_connectionId:(NSString*)connectionId error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -180,7 +180,7 @@
     return _prx->ice_isConnectionCached();
 }
 
-- (instancetype)ice_connectionCached:(bool)cached error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_connectionCached:(bool)cached error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -199,7 +199,7 @@
     return static_cast<std::uint8_t>(_prx->ice_getEndpointSelection());
 }
 
-- (instancetype)ice_endpointSelection:(std::uint8_t)type error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_endpointSelection:(std::uint8_t)type error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -241,7 +241,7 @@
     }
 }
 
-- (instancetype)ice_router:(ICEObjectPrx*)router error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_router:(ICEObjectPrx*)router error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -274,7 +274,7 @@
     }
 }
 
-- (instancetype)ice_locator:(ICEObjectPrx*)locator error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_locator:(ICEObjectPrx*)locator error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -364,7 +364,7 @@
     return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
 }
 
-- (instancetype)ice_fixed:(ICEConnection*)connection error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_fixed:(ICEConnection*)connection error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -442,7 +442,7 @@
     return _prx->ice_isCollocationOptimized();
 }
 
-- (instancetype)ice_collocationOptimized:(bool)collocated error:(NSError* _Nullable * _Nonnull)error
+- (instancetype)ice_collocationOptimized:(bool)collocated error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -461,7 +461,7 @@
     encodingMajor:(std::uint8_t)major
     encodingMinor:(std::uint8_t)minor
         bytesRead:(NSInteger*)bytesRead
-            error:(NSError* _Nullable * _Nonnull)error
+            error:(NSError* _Nullable* _Nonnull)error
 {
     std::pair<const std::byte*, const std::byte*> p;
     p.first = static_cast<const std::byte*>(data.bytes);
@@ -512,7 +512,7 @@
                 mode:(std::uint8_t)mode
             inParams:(NSData*)inParams
              context:(NSDictionary*)context
-               error:(NSError* _Nullable * _Nonnull)error
+               error:(NSError* _Nullable* _Nonnull)error
 {
     assert(_prx->ice_isBatchOneway() || _prx->ice_isBatchDatagram());
 

--- a/swift/src/IceImpl/ObjectPrx.mm
+++ b/swift/src/IceImpl/ObjectPrx.mm
@@ -37,7 +37,7 @@
     *category = toNSString(identity.category);
 }
 
-- (instancetype)ice_identity:(NSString*)name category:(NSString*)category error:(NSError**)error
+- (instancetype)ice_identity:(NSString*)name category:(NSString*)category error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -81,7 +81,7 @@
     return toNSString(_prx->ice_getAdapterId());
 }
 
-- (instancetype)ice_adapterId:(NSString*)id error:(NSError**)error
+- (instancetype)ice_adapterId:(NSString*)id error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -100,7 +100,7 @@
     return toNSArray(_prx->ice_getEndpoints());
 }
 
-- (instancetype)ice_endpoints:(NSArray<ICEEndpoint*>*)endpoints error:(NSError**)error
+- (instancetype)ice_endpoints:(NSArray<ICEEndpoint*>*)endpoints error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -123,7 +123,7 @@
     return static_cast<int32_t>(timeout.count());
 }
 
-- (instancetype)ice_locatorCacheTimeout:(int32_t)timeout error:(NSError**)error
+- (instancetype)ice_locatorCacheTimeout:(int32_t)timeout error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -142,7 +142,7 @@
     return static_cast<int32_t>(_prx->ice_getInvocationTimeout().count());
 }
 
-- (instancetype)ice_invocationTimeout:(int32_t)timeout error:(NSError**)error
+- (instancetype)ice_invocationTimeout:(int32_t)timeout error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -161,7 +161,7 @@
     return toNSString(_prx->ice_getConnectionId());
 }
 
-- (instancetype)ice_connectionId:(NSString*)connectionId error:(NSError**)error
+- (instancetype)ice_connectionId:(NSString*)connectionId error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -180,7 +180,7 @@
     return _prx->ice_isConnectionCached();
 }
 
-- (instancetype)ice_connectionCached:(bool)cached error:(NSError**)error
+- (instancetype)ice_connectionCached:(bool)cached error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -199,7 +199,7 @@
     return static_cast<std::uint8_t>(_prx->ice_getEndpointSelection());
 }
 
-- (instancetype)ice_endpointSelection:(std::uint8_t)type error:(NSError**)error
+- (instancetype)ice_endpointSelection:(std::uint8_t)type error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -241,7 +241,7 @@
     }
 }
 
-- (instancetype)ice_router:(ICEObjectPrx*)router error:(NSError**)error
+- (instancetype)ice_router:(ICEObjectPrx*)router error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -274,7 +274,7 @@
     }
 }
 
-- (instancetype)ice_locator:(ICEObjectPrx*)locator error:(NSError**)error
+- (instancetype)ice_locator:(ICEObjectPrx*)locator error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -364,7 +364,7 @@
     return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
 }
 
-- (instancetype)ice_fixed:(ICEConnection*)connection error:(NSError**)error
+- (instancetype)ice_fixed:(ICEConnection*)connection error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -442,7 +442,7 @@
     return _prx->ice_isCollocationOptimized();
 }
 
-- (instancetype)ice_collocationOptimized:(bool)collocated error:(NSError* _Nullable* _Nullable)error
+- (instancetype)ice_collocationOptimized:(bool)collocated error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -461,7 +461,7 @@
     encodingMajor:(std::uint8_t)major
     encodingMinor:(std::uint8_t)minor
         bytesRead:(NSInteger*)bytesRead
-            error:(NSError**)error
+            error:(NSError* _Nullable * _Nonnull)error
 {
     std::pair<const std::byte*, const std::byte*> p;
     p.first = static_cast<const std::byte*>(data.bytes);
@@ -512,7 +512,7 @@
                 mode:(std::uint8_t)mode
             inParams:(NSData*)inParams
              context:(NSDictionary*)context
-               error:(NSError**)error
+               error:(NSError* _Nullable * _Nonnull)error
 {
     assert(_prx->ice_isBatchOneway() || _prx->ice_isBatchDatagram());
 

--- a/swift/src/IceImpl/Properties.mm
+++ b/swift/src/IceImpl/Properties.mm
@@ -27,7 +27,7 @@
     return toNSString(self.properties->getPropertyWithDefault(fromNSString(key), fromNSString(value)));
 }
 
-- (BOOL)getPropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError* _Nullable * _Nonnull)error
+- (BOOL)getPropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError* _Nullable* _Nonnull)error
 {
     assert(value != nullptr);
     try
@@ -42,7 +42,7 @@
     }
 }
 
-- (BOOL)getIcePropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError* _Nullable * _Nonnull)error
+- (BOOL)getIcePropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError* _Nullable* _Nonnull)error
 {
     assert(value != nullptr);
     try
@@ -60,7 +60,7 @@
 - (BOOL)getPropertyAsIntWithDefault:(NSString*)key
                        defaultValue:(int32_t)defaultValue
                               value:(int32_t*)value
-                              error:(NSError* _Nullable * _Nonnull)error
+                              error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -96,7 +96,7 @@
     return toNSDictionary(self.properties->getPropertiesForPrefix(fromNSString(prefix)));
 }
 
-- (BOOL)setProperty:(NSString*)key value:(NSString*)value error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)setProperty:(NSString*)key value:(NSString*)value error:(NSError* _Nullable* _Nonnull)error;
 {
     try
     {
@@ -117,7 +117,7 @@
 
 - (NSArray<NSString*>*)parseCommandLineOptions:(NSString*)prefix
                                        options:(NSArray<NSString*>*)options
-                                         error:(NSError* _Nullable * _Nonnull)error;
+                                         error:(NSError* _Nullable* _Nonnull)error;
 {
     try
     {
@@ -132,7 +132,7 @@
     }
 }
 
-- (NSArray<NSString*>*)parseIceCommandLineOptions:(NSArray<NSString*>*)options error:(NSError* _Nullable * _Nonnull)error;
+- (NSArray<NSString*>*)parseIceCommandLineOptions:(NSArray<NSString*>*)options error:(NSError* _Nullable* _Nonnull)error;
 {
     try
     {
@@ -147,7 +147,7 @@
     }
 }
 
-- (BOOL)load:(NSString*)file error:(NSError* _Nullable * _Nonnull)error
+- (BOOL)load:(NSString*)file error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/Properties.mm
+++ b/swift/src/IceImpl/Properties.mm
@@ -132,7 +132,8 @@
     }
 }
 
-- (NSArray<NSString*>*)parseIceCommandLineOptions:(NSArray<NSString*>*)options error:(NSError* _Nullable* _Nonnull)error;
+- (NSArray<NSString*>*)parseIceCommandLineOptions:(NSArray<NSString*>*)options
+                                            error:(NSError* _Nullable* _Nonnull)error;
 {
     try
     {

--- a/swift/src/IceImpl/Properties.mm
+++ b/swift/src/IceImpl/Properties.mm
@@ -27,7 +27,7 @@
     return toNSString(self.properties->getPropertyWithDefault(fromNSString(key), fromNSString(value)));
 }
 
-- (BOOL)getPropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError**)error
+- (BOOL)getPropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError* _Nullable * _Nonnull)error
 {
     assert(value != nullptr);
     try
@@ -42,7 +42,7 @@
     }
 }
 
-- (BOOL)getIcePropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError**)error
+- (BOOL)getIcePropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError* _Nullable * _Nonnull)error
 {
     assert(value != nullptr);
     try
@@ -60,7 +60,7 @@
 - (BOOL)getPropertyAsIntWithDefault:(NSString*)key
                        defaultValue:(int32_t)defaultValue
                               value:(int32_t*)value
-                              error:(NSError**)error
+                              error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -96,7 +96,7 @@
     return toNSDictionary(self.properties->getPropertiesForPrefix(fromNSString(prefix)));
 }
 
-- (BOOL)setProperty:(NSString*)key value:(NSString*)value error:(NSError**)error;
+- (BOOL)setProperty:(NSString*)key value:(NSString*)value error:(NSError* _Nullable * _Nonnull)error;
 {
     try
     {
@@ -117,7 +117,7 @@
 
 - (NSArray<NSString*>*)parseCommandLineOptions:(NSString*)prefix
                                        options:(NSArray<NSString*>*)options
-                                         error:(NSError**)error;
+                                         error:(NSError* _Nullable * _Nonnull)error;
 {
     try
     {
@@ -132,7 +132,7 @@
     }
 }
 
-- (NSArray<NSString*>*)parseIceCommandLineOptions:(NSArray<NSString*>*)options error:(NSError**)error;
+- (NSArray<NSString*>*)parseIceCommandLineOptions:(NSArray<NSString*>*)options error:(NSError* _Nullable * _Nonnull)error;
 {
     try
     {
@@ -147,7 +147,7 @@
     }
 }
 
-- (BOOL)load:(NSString*)file error:(NSError**)error
+- (BOOL)load:(NSString*)file error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/PropertiesAdmin.mm
+++ b/swift/src/IceImpl/PropertiesAdmin.mm
@@ -22,7 +22,7 @@
     return self;
 }
 
-- (nullable NSString*)getProperty:(NSString*)key error:(NSError**)error
+- (nullable NSString*)getProperty:(NSString*)key error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -36,7 +36,7 @@
     }
 }
 
-- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix error:(NSError**)error
+- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {
@@ -50,7 +50,7 @@
     }
 }
 
-- (BOOL)setProperties:(NSDictionary<NSString*, NSString*>*)newProperties error:(NSError**)error
+- (BOOL)setProperties:(NSDictionary<NSString*, NSString*>*)newProperties error:(NSError* _Nullable * _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/PropertiesAdmin.mm
+++ b/swift/src/IceImpl/PropertiesAdmin.mm
@@ -22,7 +22,7 @@
     return self;
 }
 
-- (nullable NSString*)getProperty:(NSString*)key error:(NSError* _Nullable * _Nonnull)error
+- (nullable NSString*)getProperty:(NSString*)key error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -36,7 +36,7 @@
     }
 }
 
-- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix error:(NSError* _Nullable * _Nonnull)error
+- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -50,7 +50,7 @@
     }
 }
 
-- (BOOL)setProperties:(NSDictionary<NSString*, NSString*>*)newProperties error:(NSError* _Nullable * _Nonnull)error
+- (BOOL)setProperties:(NSDictionary<NSString*, NSString*>*)newProperties error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/PropertiesAdmin.mm
+++ b/swift/src/IceImpl/PropertiesAdmin.mm
@@ -36,7 +36,8 @@
     }
 }
 
-- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix error:(NSError* _Nullable* _Nonnull)error
+- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix
+                                                                 error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {

--- a/swift/src/IceImpl/include/Communicator.h
+++ b/swift/src/IceImpl/include/Communicator.h
@@ -16,9 +16,11 @@ ICEIMPL_API @interface ICECommunicator : ICELocalObject
 - (void)waitForShutdown;
 - (void)waitForShutdownAsync:(void (^)(void))completed NS_SWIFT_NAME(waitForShutdownAsync(_:));
 - (bool)isShutdown;
-- (nullable id)stringToProxy:(NSString*)str error:(NSError* _Nullable* _Nonnull)error NS_SWIFT_NAME(stringToProxy(str:));
+- (nullable id)stringToProxy:(NSString*)str
+                       error:(NSError* _Nullable* _Nonnull)error NS_SWIFT_NAME(stringToProxy(str:));
 ;
-- (nullable id)propertyToProxy:(NSString*)property error:(NSError* _Nullable* _Nonnull)error NS_SWIFT_NAME(propertyToProxy(property:));
+- (nullable id)propertyToProxy:(NSString*)property
+                         error:(NSError* _Nullable* _Nonnull)error NS_SWIFT_NAME(propertyToProxy(property:));
 - (nullable NSDictionary<NSString*, NSString*>*)proxyToProperty:(ICEObjectPrx*)prx
                                                        property:(NSString*)property
                                                           error:(NSError* _Nullable* _Nonnull)error

--- a/swift/src/IceImpl/include/Communicator.h
+++ b/swift/src/IceImpl/include/Communicator.h
@@ -16,45 +16,45 @@ ICEIMPL_API @interface ICECommunicator : ICELocalObject
 - (void)waitForShutdown;
 - (void)waitForShutdownAsync:(void (^)(void))completed NS_SWIFT_NAME(waitForShutdownAsync(_:));
 - (bool)isShutdown;
-- (nullable id)stringToProxy:(NSString*)str error:(NSError* _Nullable * _Nonnull)error NS_SWIFT_NAME(stringToProxy(str:));
+- (nullable id)stringToProxy:(NSString*)str error:(NSError* _Nullable* _Nonnull)error NS_SWIFT_NAME(stringToProxy(str:));
 ;
-- (nullable id)propertyToProxy:(NSString*)property error:(NSError* _Nullable * _Nonnull)error NS_SWIFT_NAME(propertyToProxy(property:));
+- (nullable id)propertyToProxy:(NSString*)property error:(NSError* _Nullable* _Nonnull)error NS_SWIFT_NAME(propertyToProxy(property:));
 - (nullable NSDictionary<NSString*, NSString*>*)proxyToProperty:(ICEObjectPrx*)prx
                                                        property:(NSString*)property
-                                                          error:(NSError* _Nullable * _Nonnull)error
+                                                          error:(NSError* _Nullable* _Nonnull)error
     NS_SWIFT_NAME(proxyToProperty(prx:property:));
 ;
-- (nullable ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError* _Nullable * _Nonnull)error;
+- (nullable ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError* _Nullable* _Nonnull)error;
 - (nullable ICEObjectAdapter*)createObjectAdapterWithEndpoints:(NSString*)name
                                                      endpoints:(NSString*)endpoints
-                                                         error:(NSError* _Nullable * _Nonnull)error
+                                                         error:(NSError* _Nullable* _Nonnull)error
     NS_SWIFT_NAME(createObjectAdapterWithEndpoints(name:endpoints:));
 ;
 - (nullable ICEObjectAdapter*)createObjectAdapterWithRouter:(NSString*)name
                                                      router:(ICEObjectPrx*)router
-                                                      error:(NSError* _Nullable * _Nonnull)error
+                                                      error:(NSError* _Nullable* _Nonnull)error
     NS_SWIFT_NAME(createObjectAdapterWithRouter(name:router:));
 - (nullable ICEObjectAdapter*)getDefaultObjectAdapter;
 - (void)setDefaultObjectAdapter:(ICEObjectAdapter* _Nullable)adapter;
 - (nullable ICEImplicitContext*)getImplicitContext;
 - (id<ICELoggerProtocol>)getLogger;
 - (nullable ICEObjectPrx*)getDefaultRouter;
-- (BOOL)setDefaultRouter:(ICEObjectPrx* _Nullable)router error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)setDefaultRouter:(ICEObjectPrx* _Nullable)router error:(NSError* _Nullable* _Nonnull)error;
 - (nullable ICEObjectPrx*)getDefaultLocator;
-- (BOOL)setDefaultLocator:(ICEObjectPrx* _Nullable)locator error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)setDefaultLocator:(ICEObjectPrx* _Nullable)locator error:(NSError* _Nullable* _Nonnull)error;
 - (void)flushBatchRequests:(uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^)(bool))sent;
 - (nullable ICEObjectPrx*)createAdmin:(ICEObjectAdapter* _Nullable)adminAdapter
                                  name:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError* _Nullable * _Nonnull)error;
-- (nullable id)getAdmin:(NSError* _Nullable * _Nonnull)error;
-- (BOOL)addAdminFacet:(id<ICEDispatchAdapter>)servant facet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error;
-- (nullable id<ICEDispatchAdapter>)removeAdminFacet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error;
-- (nullable id)findAdminFacet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error;
-- (nullable NSDictionary<NSString*, id<ICEDispatchAdapter>>*)findAllAdminFacets:(NSError* _Nullable * _Nonnull)error;
+                                error:(NSError* _Nullable* _Nonnull)error;
+- (nullable id)getAdmin:(NSError* _Nullable* _Nonnull)error;
+- (BOOL)addAdminFacet:(id<ICEDispatchAdapter>)servant facet:(NSString*)facet error:(NSError* _Nullable* _Nonnull)error;
+- (nullable id<ICEDispatchAdapter>)removeAdminFacet:(NSString*)facet error:(NSError* _Nullable* _Nonnull)error;
+- (nullable id)findAdminFacet:(NSString*)facet error:(NSError* _Nullable* _Nonnull)error;
+- (nullable NSDictionary<NSString*, id<ICEDispatchAdapter>>*)findAllAdminFacets:(NSError* _Nullable* _Nonnull)error;
 - (ICEProperties*)getProperties;
 
-- (BOOL)initializePlugins:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)initializePlugins:(NSError* _Nullable* _Nonnull)error;
 @end
 
 #ifdef __cplusplus

--- a/swift/src/IceImpl/include/Communicator.h
+++ b/swift/src/IceImpl/include/Communicator.h
@@ -16,45 +16,45 @@ ICEIMPL_API @interface ICECommunicator : ICELocalObject
 - (void)waitForShutdown;
 - (void)waitForShutdownAsync:(void (^)(void))completed NS_SWIFT_NAME(waitForShutdownAsync(_:));
 - (bool)isShutdown;
-- (nullable id)stringToProxy:(NSString*)str error:(NSError**)error NS_SWIFT_NAME(stringToProxy(str:));
+- (nullable id)stringToProxy:(NSString*)str error:(NSError* _Nullable * _Nonnull)error NS_SWIFT_NAME(stringToProxy(str:));
 ;
-- (nullable id)propertyToProxy:(NSString*)property error:(NSError**)error NS_SWIFT_NAME(propertyToProxy(property:));
+- (nullable id)propertyToProxy:(NSString*)property error:(NSError* _Nullable * _Nonnull)error NS_SWIFT_NAME(propertyToProxy(property:));
 - (nullable NSDictionary<NSString*, NSString*>*)proxyToProperty:(ICEObjectPrx*)prx
                                                        property:(NSString*)property
-                                                          error:(NSError**)error
+                                                          error:(NSError* _Nullable * _Nonnull)error
     NS_SWIFT_NAME(proxyToProperty(prx:property:));
 ;
-- (nullable ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError**)error;
+- (nullable ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError* _Nullable * _Nonnull)error;
 - (nullable ICEObjectAdapter*)createObjectAdapterWithEndpoints:(NSString*)name
                                                      endpoints:(NSString*)endpoints
-                                                         error:(NSError**)error
+                                                         error:(NSError* _Nullable * _Nonnull)error
     NS_SWIFT_NAME(createObjectAdapterWithEndpoints(name:endpoints:));
 ;
 - (nullable ICEObjectAdapter*)createObjectAdapterWithRouter:(NSString*)name
                                                      router:(ICEObjectPrx*)router
-                                                      error:(NSError**)error
+                                                      error:(NSError* _Nullable * _Nonnull)error
     NS_SWIFT_NAME(createObjectAdapterWithRouter(name:router:));
 - (nullable ICEObjectAdapter*)getDefaultObjectAdapter;
 - (void)setDefaultObjectAdapter:(ICEObjectAdapter* _Nullable)adapter;
 - (nullable ICEImplicitContext*)getImplicitContext;
 - (id<ICELoggerProtocol>)getLogger;
 - (nullable ICEObjectPrx*)getDefaultRouter;
-- (BOOL)setDefaultRouter:(ICEObjectPrx* _Nullable)router error:(NSError* _Nullable* _Nullable)error;
+- (BOOL)setDefaultRouter:(ICEObjectPrx* _Nullable)router error:(NSError* _Nullable * _Nonnull)error;
 - (nullable ICEObjectPrx*)getDefaultLocator;
-- (BOOL)setDefaultLocator:(ICEObjectPrx* _Nullable)locator error:(NSError* _Nullable* _Nullable)error;
+- (BOOL)setDefaultLocator:(ICEObjectPrx* _Nullable)locator error:(NSError* _Nullable * _Nonnull)error;
 - (void)flushBatchRequests:(uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^)(bool))sent;
 - (nullable ICEObjectPrx*)createAdmin:(ICEObjectAdapter* _Nullable)adminAdapter
                                  name:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError**)error;
-- (nullable id)getAdmin:(NSError**)error;
-- (BOOL)addAdminFacet:(id<ICEDispatchAdapter>)servant facet:(NSString*)facet error:(NSError**)error;
-- (nullable id<ICEDispatchAdapter>)removeAdminFacet:(NSString*)facet error:(NSError* _Nullable* _Nullable)error;
-- (nullable id)findAdminFacet:(NSString*)facet error:(NSError* _Nullable* _Nullable)error;
-- (nullable NSDictionary<NSString*, id<ICEDispatchAdapter>>*)findAllAdminFacets:(NSError* _Nullable* _Nullable)error;
+                                error:(NSError* _Nullable * _Nonnull)error;
+- (nullable id)getAdmin:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)addAdminFacet:(id<ICEDispatchAdapter>)servant facet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error;
+- (nullable id<ICEDispatchAdapter>)removeAdminFacet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error;
+- (nullable id)findAdminFacet:(NSString*)facet error:(NSError* _Nullable * _Nonnull)error;
+- (nullable NSDictionary<NSString*, id<ICEDispatchAdapter>>*)findAllAdminFacets:(NSError* _Nullable * _Nonnull)error;
 - (ICEProperties*)getProperties;
 
-- (BOOL)initializePlugins:(NSError**)error;
+- (BOOL)initializePlugins:(NSError* _Nullable * _Nonnull)error;
 @end
 
 #ifdef __cplusplus

--- a/swift/src/IceImpl/include/Connection.h
+++ b/swift/src/IceImpl/include/Connection.h
@@ -12,19 +12,19 @@ ICEIMPL_API @interface ICEConnection : ICELocalObject
 - (void)close:(void (^)(NSError* _Nullable error))completionHandler; // auto-mapped to Swift 'func close() async throws'
 - (nullable ICEObjectPrx*)createProxy:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError* _Nullable* _Nullable)error;
-- (BOOL)setAdapter:(ICEObjectAdapter* _Nullable)oa error:(NSError* _Nullable* _Nullable)error;
+                                error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)setAdapter:(ICEObjectAdapter* _Nullable)oa error:(NSError* _Nullable * _Nonnull)error;
 - (nullable ICEObjectAdapter*)getAdapter;
 - (ICEEndpoint*)getEndpoint;
 - (void)flushBatchRequests:(uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^)(bool))sent;
-- (BOOL)setCloseCallback:(nullable void (^)(ICEConnection*))callback error:(NSError* _Nullable* _Nullable)error;
+- (BOOL)setCloseCallback:(nullable void (^)(ICEConnection*))callback error:(NSError* _Nullable * _Nonnull)error;
 - (void)disableInactivityCheck;
 
 - (NSString*)type;
 - (NSString*)toString;
-- (nullable id)getInfo:(NSError* _Nullable* _Nullable)error;
-- (BOOL)setBufferSize:(int32_t)rcvSize sndSize:(int32_t)sndSize error:(NSError* _Nullable* _Nullable)error;
-- (BOOL)throwException:(NSError* _Nullable* _Nullable)error;
+- (nullable id)getInfo:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)setBufferSize:(int32_t)rcvSize sndSize:(int32_t)sndSize error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)throwException:(NSError* _Nullable * _Nonnull)error;
 @end
 
 // TODO: revise function signatures to be proper ObjC.

--- a/swift/src/IceImpl/include/Connection.h
+++ b/swift/src/IceImpl/include/Connection.h
@@ -12,19 +12,19 @@ ICEIMPL_API @interface ICEConnection : ICELocalObject
 - (void)close:(void (^)(NSError* _Nullable error))completionHandler; // auto-mapped to Swift 'func close() async throws'
 - (nullable ICEObjectPrx*)createProxy:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError* _Nullable * _Nonnull)error;
-- (BOOL)setAdapter:(ICEObjectAdapter* _Nullable)oa error:(NSError* _Nullable * _Nonnull)error;
+                                error:(NSError* _Nullable* _Nonnull)error;
+- (BOOL)setAdapter:(ICEObjectAdapter* _Nullable)oa error:(NSError* _Nullable* _Nonnull)error;
 - (nullable ICEObjectAdapter*)getAdapter;
 - (ICEEndpoint*)getEndpoint;
 - (void)flushBatchRequests:(uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^)(bool))sent;
-- (BOOL)setCloseCallback:(nullable void (^)(ICEConnection*))callback error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)setCloseCallback:(nullable void (^)(ICEConnection*))callback error:(NSError* _Nullable* _Nonnull)error;
 - (void)disableInactivityCheck;
 
 - (NSString*)type;
 - (NSString*)toString;
-- (nullable id)getInfo:(NSError* _Nullable * _Nonnull)error;
-- (BOOL)setBufferSize:(int32_t)rcvSize sndSize:(int32_t)sndSize error:(NSError* _Nullable * _Nonnull)error;
-- (BOOL)throwException:(NSError* _Nullable * _Nonnull)error;
+- (nullable id)getInfo:(NSError* _Nullable* _Nonnull)error;
+- (BOOL)setBufferSize:(int32_t)rcvSize sndSize:(int32_t)sndSize error:(NSError* _Nullable* _Nonnull)error;
+- (BOOL)throwException:(NSError* _Nullable* _Nonnull)error;
 @end
 
 // TODO: revise function signatures to be proper ObjC.

--- a/swift/src/IceImpl/include/IceUtil.h
+++ b/swift/src/IceImpl/include/IceUtil.h
@@ -27,18 +27,18 @@ ICEIMPL_API @interface ICEUtil : NSObject
 
 + (nullable ICECommunicator*)initialize:(ICEProperties*)properties
                                  logger:(id<ICELoggerProtocol> _Nullable)logger
-                                  error:(NSError* _Nullable * _Nonnull)error;
+                                  error:(NSError* _Nullable* _Nonnull)error;
 
 + (ICEProperties*)createProperties;
 
 + (nullable ICEProperties*)createProperties:(NSArray* _Nullable)swiftArgs
                                    defaults:(ICEProperties* _Nullable)defaults
                                     remArgs:(NSArray* _Null_unspecified* _Null_unspecified)remArgs
-                                      error:(NSError* _Nullable * _Nonnull)error;
+                                      error:(NSError* _Nullable* _Nonnull)error;
 + (BOOL)stringToIdentity:(NSString*)str
                     name:(NSString* __strong _Nonnull* _Nonnull)name
                 category:(NSString* __strong _Nonnull* _Nonnull)category
-                   error:(NSError* _Nullable * _Nonnull)error NS_SWIFT_NAME(stringToIdentity(str:name:category:));
+                   error:(NSError* _Nullable* _Nonnull)error NS_SWIFT_NAME(stringToIdentity(str:name:category:));
 
 + (NSString*)identityToString:(NSString*)name
                      category:(NSString*)category

--- a/swift/src/IceImpl/include/IceUtil.h
+++ b/swift/src/IceImpl/include/IceUtil.h
@@ -27,18 +27,18 @@ ICEIMPL_API @interface ICEUtil : NSObject
 
 + (nullable ICECommunicator*)initialize:(ICEProperties*)properties
                                  logger:(id<ICELoggerProtocol> _Nullable)logger
-                                  error:(NSError* _Nullable* _Nullable)error;
+                                  error:(NSError* _Nullable * _Nonnull)error;
 
 + (ICEProperties*)createProperties;
 
 + (nullable ICEProperties*)createProperties:(NSArray* _Nullable)swiftArgs
                                    defaults:(ICEProperties* _Nullable)defaults
                                     remArgs:(NSArray* _Null_unspecified* _Null_unspecified)remArgs
-                                      error:(NSError* _Nullable* _Nullable)error;
+                                      error:(NSError* _Nullable * _Nonnull)error;
 + (BOOL)stringToIdentity:(NSString*)str
                     name:(NSString* __strong _Nonnull* _Nonnull)name
                 category:(NSString* __strong _Nonnull* _Nonnull)category
-                   error:(NSError* _Nullable* _Nullable)error NS_SWIFT_NAME(stringToIdentity(str:name:category:));
+                   error:(NSError* _Nullable * _Nonnull)error NS_SWIFT_NAME(stringToIdentity(str:name:category:));
 
 + (NSString*)identityToString:(NSString*)name
                      category:(NSString*)category

--- a/swift/src/IceImpl/include/ObjectAdapter.h
+++ b/swift/src/IceImpl/include/ObjectAdapter.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 ICEIMPL_API @interface ICEObjectAdapter : ICELocalObject
 - (NSString*)getName;
 - (ICECommunicator*)getCommunicator;
-- (BOOL)activate:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)activate:(NSError* _Nullable* _Nonnull)error;
 - (void)hold;
 - (void)waitForHold;
 - (void)deactivate;
@@ -21,20 +21,20 @@ ICEIMPL_API @interface ICEObjectAdapter : ICELocalObject
 - (void)destroy;
 - (nullable ICEObjectPrx*)createProxy:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError* _Nullable * _Nonnull)error NS_SWIFT_NAME(createProxy(name:category:));
+                                error:(NSError* _Nullable* _Nonnull)error NS_SWIFT_NAME(createProxy(name:category:));
 - (nullable ICEObjectPrx*)createDirectProxy:(NSString*)name
                                    category:(NSString*)category
-                                      error:(NSError* _Nullable * _Nonnull)error
+                                      error:(NSError* _Nullable* _Nonnull)error
     NS_SWIFT_NAME(createDirectProxy(name:category:));
 - (nullable ICEObjectPrx*)createIndirectProxy:(NSString*)name
                                      category:(NSString*)category
-                                        error:(NSError* _Nullable * _Nonnull)error
+                                        error:(NSError* _Nullable* _Nonnull)error
     NS_SWIFT_NAME(createIndirectProxy(name:category:));
 - (void)setLocator:(ICEObjectPrx* _Nullable)locator;
 - (nullable ICEObjectPrx*)getLocator;
 - (NSArray<ICEEndpoint*>*)getEndpoints;
 - (NSArray<ICEEndpoint*>*)getPublishedEndpoints;
-- (BOOL)setPublishedEndpoints:(NSArray<ICEEndpoint*>*)newEndpoints error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)setPublishedEndpoints:(NSArray<ICEEndpoint*>*)newEndpoints error:(NSError* _Nullable* _Nonnull)error;
 - (void)registerDispatchAdapter:(id<ICEDispatchAdapter>)dispatchAdapter NS_SWIFT_NAME(registerDispatchAdapter(_:));
 @end
 

--- a/swift/src/IceImpl/include/ObjectAdapter.h
+++ b/swift/src/IceImpl/include/ObjectAdapter.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 ICEIMPL_API @interface ICEObjectAdapter : ICELocalObject
 - (NSString*)getName;
 - (ICECommunicator*)getCommunicator;
-- (BOOL)activate:(NSError* _Nullable* _Nullable)error;
+- (BOOL)activate:(NSError* _Nullable * _Nonnull)error;
 - (void)hold;
 - (void)waitForHold;
 - (void)deactivate;
@@ -21,20 +21,20 @@ ICEIMPL_API @interface ICEObjectAdapter : ICELocalObject
 - (void)destroy;
 - (nullable ICEObjectPrx*)createProxy:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError* _Nullable* _Nullable)error NS_SWIFT_NAME(createProxy(name:category:));
+                                error:(NSError* _Nullable * _Nonnull)error NS_SWIFT_NAME(createProxy(name:category:));
 - (nullable ICEObjectPrx*)createDirectProxy:(NSString*)name
                                    category:(NSString*)category
-                                      error:(NSError* _Nullable* _Nullable)error
+                                      error:(NSError* _Nullable * _Nonnull)error
     NS_SWIFT_NAME(createDirectProxy(name:category:));
 - (nullable ICEObjectPrx*)createIndirectProxy:(NSString*)name
                                      category:(NSString*)category
-                                        error:(NSError* _Nullable* _Nullable)error
+                                        error:(NSError* _Nullable * _Nonnull)error
     NS_SWIFT_NAME(createIndirectProxy(name:category:));
 - (void)setLocator:(ICEObjectPrx* _Nullable)locator;
 - (nullable ICEObjectPrx*)getLocator;
 - (NSArray<ICEEndpoint*>*)getEndpoints;
 - (NSArray<ICEEndpoint*>*)getPublishedEndpoints;
-- (BOOL)setPublishedEndpoints:(NSArray<ICEEndpoint*>*)newEndpoints error:(NSError* _Nullable* _Nullable)error;
+- (BOOL)setPublishedEndpoints:(NSArray<ICEEndpoint*>*)newEndpoints error:(NSError* _Nullable * _Nonnull)error;
 - (void)registerDispatchAdapter:(id<ICEDispatchAdapter>)dispatchAdapter NS_SWIFT_NAME(registerDispatchAdapter(_:));
 @end
 

--- a/swift/src/IceImpl/include/ObjectPrx.h
+++ b/swift/src/IceImpl/include/ObjectPrx.h
@@ -20,31 +20,31 @@ ICEIMPL_API @interface ICEObjectPrx : NSObject
                category:(NSString* __strong _Nonnull* _Nonnull)category;
 - (nullable instancetype)ice_identity:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError* _Nullable * _Nonnull)error;
+                                error:(NSError* _Nullable* _Nonnull)error;
 - (nonnull NSDictionary<NSString*, NSString*>*)ice_getContext;
 - (nonnull instancetype)ice_context:(NSDictionary<NSString*, NSString*>*)context;
 - (nonnull NSString*)ice_getFacet;
 - (nonnull instancetype)ice_facet:(NSString*)facet;
 - (nonnull NSString*)ice_getAdapterId;
-- (nullable instancetype)ice_adapterId:(NSString*)id error:(NSError* _Nullable * _Nonnull)error;
+- (nullable instancetype)ice_adapterId:(NSString*)id error:(NSError* _Nullable* _Nonnull)error;
 - (nonnull NSArray<ICEEndpoint*>*)ice_getEndpoints;
-- (nullable instancetype)ice_endpoints:(NSArray<ICEEndpoint*>*)endpoints error:(NSError* _Nullable * _Nonnull)error;
+- (nullable instancetype)ice_endpoints:(NSArray<ICEEndpoint*>*)endpoints error:(NSError* _Nullable* _Nonnull)error;
 - (int32_t)ice_getLocatorCacheTimeout;
-- (nullable instancetype)ice_locatorCacheTimeout:(int32_t)timeout error:(NSError* _Nullable * _Nonnull)error;
+- (nullable instancetype)ice_locatorCacheTimeout:(int32_t)timeout error:(NSError* _Nullable* _Nonnull)error;
 - (int32_t)ice_getInvocationTimeout;
-- (nullable instancetype)ice_invocationTimeout:(int32_t)timeout error:(NSError* _Nullable * _Nonnull)error;
+- (nullable instancetype)ice_invocationTimeout:(int32_t)timeout error:(NSError* _Nullable* _Nonnull)error;
 - (nonnull NSString*)ice_getConnectionId;
-- (nullable instancetype)ice_connectionId:(NSString*)connectionId error:(NSError* _Nullable * _Nonnull)error;
+- (nullable instancetype)ice_connectionId:(NSString*)connectionId error:(NSError* _Nullable* _Nonnull)error;
 - (bool)ice_isConnectionCached;
-- (nullable instancetype)ice_connectionCached:(bool)cached error:(NSError* _Nullable * _Nonnull)error;
+- (nullable instancetype)ice_connectionCached:(bool)cached error:(NSError* _Nullable* _Nonnull)error;
 - (uint8_t)ice_getEndpointSelection;
-- (nullable instancetype)ice_endpointSelection:(uint8_t)type error:(NSError* _Nullable * _Nonnull)error;
+- (nullable instancetype)ice_endpointSelection:(uint8_t)type error:(NSError* _Nullable* _Nonnull)error;
 - (nonnull instancetype)ice_encodingVersion:(uint8_t)major minor:(uint8_t)minor;
 - (void)ice_getEncodingVersion:(uint8_t*)major minor:(uint8_t*)minor;
 - (nullable ICEObjectPrx*)ice_getRouter;
-- (nullable instancetype)ice_router:(ICEObjectPrx* _Nullable)router error:(NSError* _Nullable * _Nonnull)error;
+- (nullable instancetype)ice_router:(ICEObjectPrx* _Nullable)router error:(NSError* _Nullable* _Nonnull)error;
 - (nullable ICEObjectPrx*)ice_getLocator;
-- (nullable instancetype)ice_locator:(ICEObjectPrx* _Nullable)locator error:(NSError* _Nullable * _Nonnull)error;
+- (nullable instancetype)ice_locator:(ICEObjectPrx* _Nullable)locator error:(NSError* _Nullable* _Nonnull)error;
 - (bool)ice_isTwoway;
 - (nonnull instancetype)ice_twoway;
 - (bool)ice_isOneway;
@@ -58,14 +58,14 @@ ICEIMPL_API @interface ICEObjectPrx : NSObject
 // id represents Any in Swift which we use as an Optional int32_t
 - (nullable id)ice_getCompress;
 - (nonnull instancetype)ice_compress:(bool)compress;
-- (nullable instancetype)ice_fixed:(ICEConnection*)connection error:(NSError* _Nullable * _Nonnull)error;
+- (nullable instancetype)ice_fixed:(ICEConnection*)connection error:(NSError* _Nullable* _Nonnull)error;
 - (bool)ice_isFixed;
 - (void)ice_getConnection:(void (^)(ICEConnection* _Nullable))response exception:(void (^)(NSError*))exception;
 - (nullable ICEConnection*)ice_getCachedConnection;
 - (void)ice_flushBatchRequests:(void (^)(NSError*))exception
                           sent:(void (^)(bool))sent NS_SWIFT_NAME(ice_flushBatchRequests(exception:sent:));
 - (bool)ice_isCollocationOptimized;
-- (nullable instancetype)ice_collocationOptimized:(bool)collocated error:(NSError* _Nullable * _Nonnull)error;
+- (nullable instancetype)ice_collocationOptimized:(bool)collocated error:(NSError* _Nullable* _Nonnull)error;
 
 // Either ICEObjectPrx or NSNull
 + (nullable id)ice_read:(NSData*)data
@@ -73,7 +73,7 @@ ICEIMPL_API @interface ICEObjectPrx : NSObject
           encodingMajor:(uint8_t)major
           encodingMinor:(uint8_t)minor
               bytesRead:(NSInteger*)bytesRead
-                  error:(NSError* _Nullable * _Nonnull)error;
+                  error:(NSError* _Nullable* _Nonnull)error;
 
 - (void)ice_write:(id<ICEOutputStreamHelper>)os
     encodingMajor:(uint8_t)encodingMajor
@@ -84,7 +84,7 @@ ICEIMPL_API @interface ICEObjectPrx : NSObject
                 mode:(uint8_t)mode
             inParams:(NSData*)inParams
              context:(NSDictionary* _Nullable)context
-               error:(NSError* _Nullable * _Nonnull)error;
+               error:(NSError* _Nullable* _Nonnull)error;
 
 - (void)invoke:(NSString* _Nonnull)op
           mode:(uint8_t)mode

--- a/swift/src/IceImpl/include/ObjectPrx.h
+++ b/swift/src/IceImpl/include/ObjectPrx.h
@@ -20,31 +20,31 @@ ICEIMPL_API @interface ICEObjectPrx : NSObject
                category:(NSString* __strong _Nonnull* _Nonnull)category;
 - (nullable instancetype)ice_identity:(NSString*)name
                              category:(NSString*)category
-                                error:(NSError* _Nullable* _Nullable)error;
+                                error:(NSError* _Nullable * _Nonnull)error;
 - (nonnull NSDictionary<NSString*, NSString*>*)ice_getContext;
 - (nonnull instancetype)ice_context:(NSDictionary<NSString*, NSString*>*)context;
 - (nonnull NSString*)ice_getFacet;
 - (nonnull instancetype)ice_facet:(NSString*)facet;
 - (nonnull NSString*)ice_getAdapterId;
-- (nullable instancetype)ice_adapterId:(NSString*)id error:(NSError* _Nullable* _Nullable)error;
+- (nullable instancetype)ice_adapterId:(NSString*)id error:(NSError* _Nullable * _Nonnull)error;
 - (nonnull NSArray<ICEEndpoint*>*)ice_getEndpoints;
-- (nullable instancetype)ice_endpoints:(NSArray<ICEEndpoint*>*)endpoints error:(NSError* _Nullable* _Nullable)error;
+- (nullable instancetype)ice_endpoints:(NSArray<ICEEndpoint*>*)endpoints error:(NSError* _Nullable * _Nonnull)error;
 - (int32_t)ice_getLocatorCacheTimeout;
-- (nullable instancetype)ice_locatorCacheTimeout:(int32_t)timeout error:(NSError* _Nullable* _Nullable)error;
+- (nullable instancetype)ice_locatorCacheTimeout:(int32_t)timeout error:(NSError* _Nullable * _Nonnull)error;
 - (int32_t)ice_getInvocationTimeout;
-- (nullable instancetype)ice_invocationTimeout:(int32_t)timeout error:(NSError* _Nullable* _Nullable)error;
+- (nullable instancetype)ice_invocationTimeout:(int32_t)timeout error:(NSError* _Nullable * _Nonnull)error;
 - (nonnull NSString*)ice_getConnectionId;
-- (nullable instancetype)ice_connectionId:(NSString*)connectionId error:(NSError* _Nullable* _Nullable)error;
+- (nullable instancetype)ice_connectionId:(NSString*)connectionId error:(NSError* _Nullable * _Nonnull)error;
 - (bool)ice_isConnectionCached;
-- (nullable instancetype)ice_connectionCached:(bool)cached error:(NSError* _Nullable* _Nullable)error;
+- (nullable instancetype)ice_connectionCached:(bool)cached error:(NSError* _Nullable * _Nonnull)error;
 - (uint8_t)ice_getEndpointSelection;
-- (nullable instancetype)ice_endpointSelection:(uint8_t)type error:(NSError* _Nullable* _Nullable)error;
+- (nullable instancetype)ice_endpointSelection:(uint8_t)type error:(NSError* _Nullable * _Nonnull)error;
 - (nonnull instancetype)ice_encodingVersion:(uint8_t)major minor:(uint8_t)minor;
 - (void)ice_getEncodingVersion:(uint8_t*)major minor:(uint8_t*)minor;
 - (nullable ICEObjectPrx*)ice_getRouter;
-- (nullable instancetype)ice_router:(ICEObjectPrx* _Nullable)router error:(NSError* _Nullable* _Nullable)error;
+- (nullable instancetype)ice_router:(ICEObjectPrx* _Nullable)router error:(NSError* _Nullable * _Nonnull)error;
 - (nullable ICEObjectPrx*)ice_getLocator;
-- (nullable instancetype)ice_locator:(ICEObjectPrx* _Nullable)locator error:(NSError* _Nullable* _Nullable)error;
+- (nullable instancetype)ice_locator:(ICEObjectPrx* _Nullable)locator error:(NSError* _Nullable * _Nonnull)error;
 - (bool)ice_isTwoway;
 - (nonnull instancetype)ice_twoway;
 - (bool)ice_isOneway;
@@ -58,14 +58,14 @@ ICEIMPL_API @interface ICEObjectPrx : NSObject
 // id represents Any in Swift which we use as an Optional int32_t
 - (nullable id)ice_getCompress;
 - (nonnull instancetype)ice_compress:(bool)compress;
-- (nullable instancetype)ice_fixed:(ICEConnection*)connection error:(NSError* _Nullable* _Nullable)error;
+- (nullable instancetype)ice_fixed:(ICEConnection*)connection error:(NSError* _Nullable * _Nonnull)error;
 - (bool)ice_isFixed;
 - (void)ice_getConnection:(void (^)(ICEConnection* _Nullable))response exception:(void (^)(NSError*))exception;
 - (nullable ICEConnection*)ice_getCachedConnection;
 - (void)ice_flushBatchRequests:(void (^)(NSError*))exception
                           sent:(void (^)(bool))sent NS_SWIFT_NAME(ice_flushBatchRequests(exception:sent:));
 - (bool)ice_isCollocationOptimized;
-- (nullable instancetype)ice_collocationOptimized:(bool)collocated error:(NSError* _Nullable* _Nullable)error;
+- (nullable instancetype)ice_collocationOptimized:(bool)collocated error:(NSError* _Nullable * _Nonnull)error;
 
 // Either ICEObjectPrx or NSNull
 + (nullable id)ice_read:(NSData*)data
@@ -73,7 +73,7 @@ ICEIMPL_API @interface ICEObjectPrx : NSObject
           encodingMajor:(uint8_t)major
           encodingMinor:(uint8_t)minor
               bytesRead:(NSInteger*)bytesRead
-                  error:(NSError* _Nullable* _Nullable)error;
+                  error:(NSError* _Nullable * _Nonnull)error;
 
 - (void)ice_write:(id<ICEOutputStreamHelper>)os
     encodingMajor:(uint8_t)encodingMajor
@@ -84,7 +84,7 @@ ICEIMPL_API @interface ICEObjectPrx : NSObject
                 mode:(uint8_t)mode
             inParams:(NSData*)inParams
              context:(NSDictionary* _Nullable)context
-               error:(NSError* _Nullable* _Nullable)error;
+               error:(NSError* _Nullable * _Nonnull)error;
 
 - (void)invoke:(NSString* _Nonnull)op
           mode:(uint8_t)mode

--- a/swift/src/IceImpl/include/Properties.h
+++ b/swift/src/IceImpl/include/Properties.h
@@ -7,14 +7,14 @@ ICEIMPL_API @interface ICEProperties : ICELocalObject
 - (NSString*)getProperty:(NSString*)key;
 - (NSString*)getIceProperty:(NSString*)key;
 - (NSString*)getPropertyWithDefault:(NSString*)key value:(NSString*)value;
-- (BOOL)getPropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)getPropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError* _Nullable* _Nonnull)error;
 - (BOOL)getIcePropertyAsInt:(NSString*)key
                       value:(int32_t*)value
-                      error:(NSError* _Nullable * _Nonnull)error NS_SWIFT_NAME(getIcePropertyAsInt(key:value:));
+                      error:(NSError* _Nullable* _Nonnull)error NS_SWIFT_NAME(getIcePropertyAsInt(key:value:));
 - (BOOL)getPropertyAsIntWithDefault:(NSString*)key
                        defaultValue:(int32_t)defaultValue
                               value:(int32_t*)value
-                              error:(NSError* _Nullable * _Nonnull)error
+                              error:(NSError* _Nullable* _Nonnull)error
     NS_SWIFT_NAME(getPropertyAsIntWithDefault(key:defaultValue:value:));
 - (NSArray<NSString*>*)getPropertyAsList:(NSString* _Nonnull)key;
 - (NSArray<NSString*>*)getIcePropertyAsList:(NSString* _Nonnull)key NS_SWIFT_NAME(getIcePropertyAsList(_:));
@@ -23,14 +23,14 @@ ICEIMPL_API @interface ICEProperties : ICELocalObject
     NS_SWIFT_NAME(getPropertyAsListWithDefault(key:value:));
 - (NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString* _Nonnull)prefix
     NS_SWIFT_NAME(getPropertiesForPrefix(_:));
-- (BOOL)setProperty:(NSString*)key value:(NSString*)value error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)setProperty:(NSString*)key value:(NSString*)value error:(NSError* _Nullable* _Nonnull)error;
 - (NSArray<NSString*>*)getCommandLineOptions;
 - (nullable NSArray<NSString*>*)parseCommandLineOptions:(NSString*)prefix
                                                 options:(NSArray<NSString*>*)options
-                                                  error:(NSError* _Nullable * _Nonnull)error;
+                                                  error:(NSError* _Nullable* _Nonnull)error;
 - (nullable NSArray<NSString*>*)parseIceCommandLineOptions:(NSArray<NSString*>*)options
-                                                     error:(NSError* _Nullable * _Nonnull)error;
-- (BOOL)load:(NSString*)file error:(NSError* _Nullable * _Nonnull)error;
+                                                     error:(NSError* _Nullable* _Nonnull)error;
+- (BOOL)load:(NSString*)file error:(NSError* _Nullable* _Nonnull)error;
 - (ICEProperties*)clone;
 @end
 

--- a/swift/src/IceImpl/include/Properties.h
+++ b/swift/src/IceImpl/include/Properties.h
@@ -7,14 +7,14 @@ ICEIMPL_API @interface ICEProperties : ICELocalObject
 - (NSString*)getProperty:(NSString*)key;
 - (NSString*)getIceProperty:(NSString*)key;
 - (NSString*)getPropertyWithDefault:(NSString*)key value:(NSString*)value;
-- (BOOL)getPropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError* _Nullable* _Nullable)error;
+- (BOOL)getPropertyAsInt:(NSString*)key value:(int32_t*)value error:(NSError* _Nullable * _Nonnull)error;
 - (BOOL)getIcePropertyAsInt:(NSString*)key
                       value:(int32_t*)value
-                      error:(NSError* _Nullable* _Nullable)error NS_SWIFT_NAME(getIcePropertyAsInt(key:value:));
+                      error:(NSError* _Nullable * _Nonnull)error NS_SWIFT_NAME(getIcePropertyAsInt(key:value:));
 - (BOOL)getPropertyAsIntWithDefault:(NSString*)key
                        defaultValue:(int32_t)defaultValue
                               value:(int32_t*)value
-                              error:(NSError* _Nullable* _Nullable)error
+                              error:(NSError* _Nullable * _Nonnull)error
     NS_SWIFT_NAME(getPropertyAsIntWithDefault(key:defaultValue:value:));
 - (NSArray<NSString*>*)getPropertyAsList:(NSString* _Nonnull)key;
 - (NSArray<NSString*>*)getIcePropertyAsList:(NSString* _Nonnull)key NS_SWIFT_NAME(getIcePropertyAsList(_:));
@@ -23,14 +23,14 @@ ICEIMPL_API @interface ICEProperties : ICELocalObject
     NS_SWIFT_NAME(getPropertyAsListWithDefault(key:value:));
 - (NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString* _Nonnull)prefix
     NS_SWIFT_NAME(getPropertiesForPrefix(_:));
-- (BOOL)setProperty:(NSString*)key value:(NSString*)value error:(NSError* _Nullable* _Nullable)error;
+- (BOOL)setProperty:(NSString*)key value:(NSString*)value error:(NSError* _Nullable * _Nonnull)error;
 - (NSArray<NSString*>*)getCommandLineOptions;
 - (nullable NSArray<NSString*>*)parseCommandLineOptions:(NSString*)prefix
                                                 options:(NSArray<NSString*>*)options
-                                                  error:(NSError* _Nullable* _Nullable)error;
+                                                  error:(NSError* _Nullable * _Nonnull)error;
 - (nullable NSArray<NSString*>*)parseIceCommandLineOptions:(NSArray<NSString*>*)options
-                                                     error:(NSError* _Nullable* _Nullable)error;
-- (BOOL)load:(NSString*)file error:(NSError* _Nullable* _Nullable)error;
+                                                     error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)load:(NSString*)file error:(NSError* _Nullable * _Nonnull)error;
 - (ICEProperties*)clone;
 @end
 

--- a/swift/src/IceImpl/include/PropertiesAdmin.h
+++ b/swift/src/IceImpl/include/PropertiesAdmin.h
@@ -4,9 +4,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 ICEIMPL_API @interface ICEPropertiesAdmin : NSObject
-- (nullable NSString*)getProperty:(NSString*)key error:(NSError**)error;
-- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix error:(NSError**)error;
-- (BOOL)setProperties:(NSDictionary<NSString*, NSString*>*)newProperties error:(NSError**)error;
+- (nullable NSString*)getProperty:(NSString*)key error:(NSError* _Nullable * _Nonnull)error;
+- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix error:(NSError* _Nullable * _Nonnull)error;
+- (BOOL)setProperties:(NSDictionary<NSString*, NSString*>*)newProperties error:(NSError* _Nullable * _Nonnull)error;
 - (void (^)(void))addUpdateCallback:(void (^)(NSDictionary<NSString*, NSString*>*))cb;
 @end
 

--- a/swift/src/IceImpl/include/PropertiesAdmin.h
+++ b/swift/src/IceImpl/include/PropertiesAdmin.h
@@ -4,9 +4,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 ICEIMPL_API @interface ICEPropertiesAdmin : NSObject
-- (nullable NSString*)getProperty:(NSString*)key error:(NSError* _Nullable * _Nonnull)error;
-- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix error:(NSError* _Nullable * _Nonnull)error;
-- (BOOL)setProperties:(NSDictionary<NSString*, NSString*>*)newProperties error:(NSError* _Nullable * _Nonnull)error;
+- (nullable NSString*)getProperty:(NSString*)key error:(NSError* _Nullable* _Nonnull)error;
+- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix error:(NSError* _Nullable* _Nonnull)error;
+- (BOOL)setProperties:(NSDictionary<NSString*, NSString*>*)newProperties error:(NSError* _Nullable* _Nonnull)error;
 - (void (^)(void))addUpdateCallback:(void (^)(NSDictionary<NSString*, NSString*>*))cb;
 @end
 

--- a/swift/src/IceImpl/include/PropertiesAdmin.h
+++ b/swift/src/IceImpl/include/PropertiesAdmin.h
@@ -5,7 +5,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 ICEIMPL_API @interface ICEPropertiesAdmin : NSObject
 - (nullable NSString*)getProperty:(NSString*)key error:(NSError* _Nullable* _Nonnull)error;
-- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix error:(NSError* _Nullable* _Nonnull)error;
+- (nullable NSDictionary<NSString*, NSString*>*)getPropertiesForPrefix:(NSString*)prefix
+                                                                 error:(NSError* _Nullable* _Nonnull)error;
 - (BOOL)setProperties:(NSDictionary<NSString*, NSString*>*)newProperties error:(NSError* _Nullable* _Nonnull)error;
 - (void (^)(void))addUpdateCallback:(void (^)(NSDictionary<NSString*, NSString*>*))cb;
 @end


### PR DESCRIPTION
Standardizes every `error:` out-parameter in the IceImpl Swift bridge on `NSError* _Nullable* _Nonnull`, replacing the mixed bare `NSError**` and `NSError* _Nullable* _Nullable` spellings. The outer pointer is non-null because Swift's `throws` bridging always passes the address of a local `NSError?`, so the unconditional `*error = ...` in the catch blocks is correct and needs no nil guard.

Annotation-only; no runtime behavior change. Fixes #5714.
