### PR TITLE
Fix data race between observer updaters and Instance::destroy() (C++, C#, Java)

### DIFF
--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -1823,10 +1823,25 @@ IceInternal::Instance::updateConnectionObservers()
 {
     try
     {
-        assert(_outgoingConnectionFactory);
-        _outgoingConnectionFactory->updateConnectionObservers();
-        assert(_objectAdapterFactory);
-        _objectAdapterFactory->updateObservers(&ObjectAdapterI::updateConnectionObservers);
+        // This updater can run concurrently with destroy(). Copy the subsystem pointers under the mutex, and bail out
+        // once destruction has started: destroy() tears down these subsystems (while _state is StateDestroyInProgress)
+        // before nulling them (when it sets _state to StateDestroyed).
+        OutgoingConnectionFactoryPtr outgoingConnectionFactory;
+        ObjectAdapterFactoryPtr objectAdapterFactory;
+        {
+            lock_guard lock(_mutex);
+            if (_state >= StateDestroyInProgress)
+            {
+                return;
+            }
+            outgoingConnectionFactory = _outgoingConnectionFactory;
+            objectAdapterFactory = _objectAdapterFactory;
+        }
+
+        assert(outgoingConnectionFactory);
+        outgoingConnectionFactory->updateConnectionObservers();
+        assert(objectAdapterFactory);
+        objectAdapterFactory->updateObservers(&ObjectAdapterI::updateConnectionObservers);
     }
     catch (const Ice::CommunicatorDestroyedException&)
     {
@@ -1838,23 +1853,44 @@ IceInternal::Instance::updateThreadObservers()
 {
     try
     {
-        if (_clientThreadPool)
+        // This updater can run concurrently with destroy(). Copy the subsystem pointers under the mutex, and bail out
+        // once destruction has started: destroy() tears down these subsystems (while _state is StateDestroyInProgress)
+        // before nulling them (when it sets _state to StateDestroyed).
+        ThreadPoolPtr clientThreadPool;
+        ThreadPoolPtr serverThreadPool;
+        ObjectAdapterFactoryPtr objectAdapterFactory;
+        EndpointHostResolverPtr endpointHostResolver;
+        ThreadObserverTimerPtr timer;
         {
-            _clientThreadPool->updateObservers();
+            lock_guard lock(_mutex);
+            if (_state >= StateDestroyInProgress)
+            {
+                return;
+            }
+            clientThreadPool = _clientThreadPool;
+            serverThreadPool = _serverThreadPool;
+            objectAdapterFactory = _objectAdapterFactory;
+            endpointHostResolver = _endpointHostResolver;
+            timer = _timer;
         }
-        if (_serverThreadPool)
+
+        if (clientThreadPool)
         {
-            _serverThreadPool->updateObservers();
+            clientThreadPool->updateObservers();
         }
-        assert(_objectAdapterFactory);
-        _objectAdapterFactory->updateObservers(&ObjectAdapterI::updateThreadObservers);
-        if (_endpointHostResolver)
+        if (serverThreadPool)
         {
-            _endpointHostResolver->updateObserver();
+            serverThreadPool->updateObservers();
         }
-        if (_timer)
+        assert(objectAdapterFactory);
+        objectAdapterFactory->updateObservers(&ObjectAdapterI::updateThreadObservers);
+        if (endpointHostResolver)
         {
-            _timer->updateObserver(_initData.observer);
+            endpointHostResolver->updateObserver();
+        }
+        if (timer)
+        {
+            timer->updateObserver(_initData.observer);
         }
     }
     catch (const Ice::CommunicatorDestroyedException&)

--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -1210,12 +1210,27 @@ public sealed class Instance
     {
         try
         {
-            Debug.Assert(_outgoingConnectionFactory != null);
-            _outgoingConnectionFactory.updateConnectionObservers();
-            Debug.Assert(_objectAdapterFactory != null);
-            _objectAdapterFactory.updateConnectionObservers();
+            // This updater can run concurrently with destroy(). Copy the subsystem references under the lock, and bail
+            // out once destruction has started: destroy() tears down these subsystems (while _state is
+            // StateDestroyInProgress) before nulling them (when it sets _state to StateDestroyed).
+            OutgoingConnectionFactory outgoingConnectionFactory;
+            ObjectAdapterFactory objectAdapterFactory;
+            lock (_mutex)
+            {
+                if (_state >= StateDestroyInProgress)
+                {
+                    return;
+                }
+                outgoingConnectionFactory = _outgoingConnectionFactory;
+                objectAdapterFactory = _objectAdapterFactory;
+            }
+
+            Debug.Assert(outgoingConnectionFactory != null);
+            outgoingConnectionFactory.updateConnectionObservers();
+            Debug.Assert(objectAdapterFactory != null);
+            objectAdapterFactory.updateConnectionObservers();
         }
-        catch (Ice.CommunicatorDestroyedException)
+        catch (CommunicatorDestroyedException)
         {
         }
     }
@@ -1224,14 +1239,35 @@ public sealed class Instance
     {
         try
         {
-            _clientThreadPool?.updateObservers();
-            _serverThreadPool?.updateObservers();
-            Debug.Assert(_objectAdapterFactory != null);
-            _objectAdapterFactory.updateThreadObservers();
-            _endpointHostResolver?.updateObserver();
-            _timer?.updateObserver(_initData.observer);
+            // This updater can run concurrently with destroy(). Copy the subsystem references under the lock, and bail
+            // out once destruction has started: destroy() tears down these subsystems (while _state is
+            // StateDestroyInProgress) before nulling them (when it sets _state to StateDestroyed).
+            ThreadPool clientThreadPool;
+            ThreadPool serverThreadPool;
+            ObjectAdapterFactory objectAdapterFactory;
+            EndpointHostResolver endpointHostResolver;
+            Timer timer;
+            lock (_mutex)
+            {
+                if (_state >= StateDestroyInProgress)
+                {
+                    return;
+                }
+                clientThreadPool = _clientThreadPool;
+                serverThreadPool = _serverThreadPool;
+                objectAdapterFactory = _objectAdapterFactory;
+                endpointHostResolver = _endpointHostResolver;
+                timer = _timer;
+            }
+
+            clientThreadPool?.updateObservers();
+            serverThreadPool?.updateObservers();
+            Debug.Assert(objectAdapterFactory != null);
+            objectAdapterFactory.updateThreadObservers();
+            endpointHostResolver?.updateObserver();
+            timer?.updateObserver(_initData.observer);
         }
-        catch (Ice.CommunicatorDestroyedException)
+        catch (CommunicatorDestroyedException)
         {
         }
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -1112,28 +1112,60 @@ public final class Instance {
 
     private void updateConnectionObservers() {
         try {
-            assert (_outgoingConnectionFactory != null);
-            _outgoingConnectionFactory.updateConnectionObservers();
-            assert (_objectAdapterFactory != null);
-            _objectAdapterFactory.updateConnectionObservers();
+            // This updater can run concurrently with destroy(). Copy the subsystem references under the lock, and bail
+            // out once destruction has started: destroy() tears down these subsystems (while _state is
+            // StateDestroyInProgress) before nulling them (when it sets _state to StateDestroyed).
+            OutgoingConnectionFactory outgoingConnectionFactory;
+            ObjectAdapterFactory objectAdapterFactory;
+            synchronized (this) {
+                if (_state >= StateDestroyInProgress) {
+                    return;
+                }
+                outgoingConnectionFactory = _outgoingConnectionFactory;
+                objectAdapterFactory = _objectAdapterFactory;
+            }
+
+            assert (outgoingConnectionFactory != null);
+            outgoingConnectionFactory.updateConnectionObservers();
+            assert (objectAdapterFactory != null);
+            objectAdapterFactory.updateConnectionObservers();
         } catch (CommunicatorDestroyedException ex) {}
     }
 
     private void updateThreadObservers() {
         try {
-            if (_clientThreadPool != null) {
-                _clientThreadPool.updateObservers();
+            // This updater can run concurrently with destroy(). Copy the subsystem references under the lock, and bail
+            // out once destruction has started: destroy() tears down these subsystems (while _state is
+            // StateDestroyInProgress) before nulling them (when it sets _state to StateDestroyed).
+            ThreadPool clientThreadPool;
+            ThreadPool serverThreadPool;
+            ObjectAdapterFactory objectAdapterFactory;
+            EndpointHostResolver endpointHostResolver;
+            Timer timer;
+            synchronized (this) {
+                if (_state >= StateDestroyInProgress) {
+                    return;
+                }
+                clientThreadPool = _clientThreadPool;
+                serverThreadPool = _serverThreadPool;
+                objectAdapterFactory = _objectAdapterFactory;
+                endpointHostResolver = _endpointHostResolver;
+                timer = _timer;
             }
-            if (_serverThreadPool != null) {
-                _serverThreadPool.updateObservers();
+
+            if (clientThreadPool != null) {
+                clientThreadPool.updateObservers();
             }
-            assert (_objectAdapterFactory != null);
-            _objectAdapterFactory.updateThreadObservers();
-            if (_endpointHostResolver != null) {
-                _endpointHostResolver.updateObserver();
+            if (serverThreadPool != null) {
+                serverThreadPool.updateObservers();
             }
-            if (_timer != null) {
-                _timer.updateObserver(_initData.observer);
+            assert (objectAdapterFactory != null);
+            objectAdapterFactory.updateThreadObservers();
+            if (endpointHostResolver != null) {
+                endpointHostResolver.updateObserver();
+            }
+            if (timer != null) {
+                timer.updateObserver(_initData.observer);
             }
         } catch (CommunicatorDestroyedException ex) {}
     }


### PR DESCRIPTION
## Bug

`Instance::updateConnectionObservers()` and `updateThreadObservers()` read the subsystem members (`_outgoingConnectionFactory`, `_objectAdapterFactory`, the client/server thread pools, `_endpointHostResolver`, `_timer`) **without holding the lock**, while `destroy()` tears those subsystems down and clears the same members **under** the lock. Every other reader of these members goes through accessors that take the lock and gate on `_state`; these two updaters bypassed that protocol.

The updaters are driven by instrumentation callbacks (the IceMX metrics facet / metrics property updates), so they run on admin/property-update threads and can execute concurrently with a communicator `destroy()`. The result is a data race on the `shared_ptr` members in C++ (undefined behavior — asserts or null deref at best), and a null dereference / assert in C# and Java.

## Fix

Snapshot the needed members under the lock into locals, then operate on the locals (the actual `updateObservers()` calls happen outside the lock). Bail out early if `_state >= StateDestroyInProgress`: `destroy()` tears these subsystems down while `_state` is `StateDestroyInProgress`, *before* nulling the members when it transitions to `StateDestroyed`, so there is nothing useful to update once destruction has begun. The existing `catch (CommunicatorDestroyedException)` still covers the residual narrow window between the snapshot and the call.

Applied identically in the three mappings that share this design (C++, C#, Java). JavaScript is single-threaded and not affected.

## Reachability

Limited. The updaters fire only when IceMX metrics views are (re)configured at runtime — via the Metrics/Properties admin facet or a metrics property update — and the race requires that reconfiguration to land concurrently with communicator `destroy()`. In C++ the consequence is a genuine data race on the `shared_ptr` members (potential crash); in C# and Java it is a caught/benign null dereference or a debug assert.

No CHANGELOG entry: internal shutdown-hardening with a narrow, admin-driven trigger.

Fixes #5454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)