### PR TITLE
Fix two IceBT resource leaks on error paths

### DIFF
--- a/cpp/src/IceBT/DBus.cpp
+++ b/cpp/src/IceBT/DBus.cpp
@@ -766,7 +766,9 @@ namespace
             if (!::dbus_pending_call_set_notify(_call, pendingCallCompletedCallback, self, pendingCallFree))
             {
                 ::dbus_pending_call_cancel(_call);
-                ::dbus_pending_call_unref(_call);
+                // set_notify failed, so dbus won't call pendingCallFree: free self ourselves. _call is unref'd by the
+                // destructor.
+                pendingCallFree(self);
                 throw ExceptionI("dbus_pending_call_set_notify failed");
             }
 

--- a/cpp/src/IceBT/Engine.cpp
+++ b/cpp/src/IceBT/Engine.cpp
@@ -485,10 +485,11 @@ namespace IceBT
             ProfilePtr profile = make_shared<ServerProfile>(cb);
 
             string path = generatePath();
+            _dbusConnection->addService(path, profile);
 
             try
             {
-                DBus::AsyncResultPtr ar = registerProfileImpl(_dbusConnection, path, uuid, name, channel, profile);
+                DBus::AsyncResultPtr ar = registerProfileImpl(_dbusConnection, path, uuid, name, channel);
                 DBus::MessagePtr reply = ar->waitUntilFinished(); // Block until finished.
                 if (reply->isError())
                 {
@@ -497,6 +498,9 @@ namespace IceBT
             }
             catch (const DBus::Exception& ex)
             {
+                // Undo the addService above so we don't leak the profile and its callback chain on the long-lived
+                // DBus connection.
+                _dbusConnection->removeService(path);
                 throw BluetoothException{__FILE__, __LINE__, ex.reason};
             }
 
@@ -767,10 +771,10 @@ namespace IceBT
             const string& path,
             const string& uuid,
             const string& name,
-            int channel,
-            const ProfilePtr& profile)
+            int channel)
         {
-            conn->addService(path, profile);
+            // The caller is responsible for adding the service for 'path' before calling this method, and for removing
+            // it if the registration fails.
 
             //
             // Invoke RegisterProfile on the profile manager object.
@@ -1134,7 +1138,10 @@ namespace IceBT
                 //
                 // Register a client profile. Client profiles are not advertised in SDP.
                 //
-                DBus::AsyncResultPtr r = registerProfileImpl(dbusConn, path, uuid, string(), -1, profile);
+                // On failure, the service added here is removed when we call conn->close() in the cleanup below.
+                //
+                dbusConn->addService(path, profile);
+                DBus::AsyncResultPtr r = registerProfileImpl(dbusConn, path, uuid, string(), -1);
                 DBus::MessagePtr reply = r->waitUntilFinished();
                 if (reply->isError())
                 {

--- a/cpp/src/IceBT/Engine.cpp
+++ b/cpp/src/IceBT/Engine.cpp
@@ -485,10 +485,10 @@ namespace IceBT
             ProfilePtr profile = make_shared<ServerProfile>(cb);
 
             string path = generatePath();
-            _dbusConnection->addService(path, profile);
 
             try
             {
+                _dbusConnection->addService(path, profile);
                 DBus::AsyncResultPtr ar = registerProfileImpl(_dbusConnection, path, uuid, name, channel);
                 DBus::MessagePtr reply = ar->waitUntilFinished(); // Block until finished.
                 if (reply->isError())
@@ -499,7 +499,7 @@ namespace IceBT
             catch (const DBus::Exception& ex)
             {
                 // Undo the addService above so we don't leak the profile and its callback chain on the long-lived
-                // DBus connection.
+                // DBus connection. removeService is a no-op if addService never succeeded.
                 _dbusConnection->removeService(path);
                 throw BluetoothException{__FILE__, __LINE__, ex.reason};
             }


### PR DESCRIPTION
Two independent resource leaks on IceBT error paths.

## 1. Double `dbus_pending_call_unref` + leaked `self` on `set_notify` failure

In `DBus::AsyncResultI::init()`, when `dbus_pending_call_set_notify` fails, the error branch unref'd `_call` a second time — `~AsyncResultI` already unrefs it — causing a refcount underflow / use-after-free inside libdbus. It also leaked the heap-allocated `self` (`shared_ptr<AsyncResultI>*`), since `pendingCallFree` is only invoked by libdbus on success.

Fix: free `self` via `pendingCallFree(self)` (symmetric with the success path) and let the destructor own the single `_call` unref. The `dbus_pending_call_cancel` is kept.

## 2. Profile/service leak when `RegisterProfile` fails

`registerProfileImpl` did `conn->addService(path, profile)` internally, leaving the caller responsible for removing it on failure. `registerProfile` never did, so a failed `RegisterProfile` (error reply or thrown exception) leaked the `ServerProfile` and its callback chain on the **long-lived** `_dbusConnection`. (`unregisterProfile` already removed the service.)

Fix: pull `addService` out of `registerProfileImpl` into the callers, making the add/remove pairing explicit:
- `registerProfile` adds the service, then removes it in its `catch`.
- `runConnectThread` adds the service on its own private connection; the existing `conn->close()` cleanup (which clears the connection's services) removes it on failure.

All failure modes of the calls in `registerProfile`'s `try` throw `DBus::Exception` (`ExceptionI` derives from it), so the `catch` reliably triggers the `removeService`.

No CHANGELOG entry: internal IceBT fixes.

Addresses items 1–2 of #5492 (the remaining IceDiscovery/IceLocatorDiscovery items are handled separately); leaving that issue open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)