### PR TITLE
Fix IceDiscovery stale-round failure counting and replica-group latency window (C++, C#, Java)

### DIFF
--- a/cpp/src/IceDiscovery/LookupI.cpp
+++ b/cpp/src/IceDiscovery/LookupI.cpp
@@ -30,6 +30,7 @@ IceDiscovery::Request::retry()
 void
 IceDiscovery::Request::invoke(const string& domainId, const vector<pair<LookupPrx, LookupReplyPrx>>& lookups)
 {
+    ++_invokeId;
     _lookupCount = lookups.size();
     _failureCount = 0;
     Ice::Identity id;
@@ -42,8 +43,15 @@ IceDiscovery::Request::invoke(const string& domainId, const vector<pair<LookupPr
 }
 
 bool
-IceDiscovery::Request::exception()
+IceDiscovery::Request::exception(size_t invokeId)
 {
+    // Ignore a delayed failure from an earlier invocation round: it must not count against the current round, which
+    // reset _failureCount and may still have outstanding lookups.
+    if (invokeId != _invokeId)
+    {
+        return false;
+    }
+
     // If all the invocations on all the lookup proxies failed, report it to the locator.
     if (++_failureCount == _lookupCount)
     {
@@ -69,7 +77,17 @@ AdapterRequest::AdapterRequest(const LookupIPtr& lookup, const std::string& adap
 bool
 AdapterRequest::retry()
 {
-    return _proxies.empty() && --_retryCount >= 0;
+    if (_proxies.empty() && --_retryCount >= 0)
+    {
+        // We only reach here with _proxies empty, i.e. no replica-group response arrived. _latency is set only
+        // together with inserting into _proxies, so the latency timer is not running.
+        assert(_latency == chrono::nanoseconds::zero());
+
+        // Restart the replica-group latency window so it's measured from this round rather than from request creation.
+        _start = chrono::steady_clock::now();
+        return true;
+    }
+    return false;
 }
 
 bool
@@ -127,7 +145,8 @@ AdapterRequest::invokeWithLookup(const string& domainId, const LookupPrx& lookup
         _id,
         lookupReply,
         nullptr,
-        [self = shared_from_this()](exception_ptr ex) { self->_lookup->adapterRequestException(self, ex); });
+        [self = shared_from_this(), invokeId = _invokeId](exception_ptr ex)
+        { self->_lookup->adapterRequestException(self, ex, invokeId); });
 }
 
 void
@@ -155,7 +174,8 @@ ObjectRequest::invokeWithLookup(const string& domainId, const LookupPrx& lookup,
         _id,
         lookupReply,
         nullptr,
-        [self = shared_from_this()](exception_ptr ex) { self->_lookup->objectRequestException(self, ex); });
+        [self = shared_from_this(), invokeId = _invokeId](exception_ptr ex)
+        { self->_lookup->objectRequestException(self, ex, invokeId); });
 }
 
 void
@@ -390,7 +410,7 @@ LookupI::objectRequestTimedOut(const ObjectRequestPtr& request)
 }
 
 void
-LookupI::adapterRequestException(const AdapterRequestPtr& request, exception_ptr ex)
+LookupI::adapterRequestException(const AdapterRequestPtr& request, exception_ptr ex, size_t invokeId)
 {
     lock_guard lock(_mutex);
     auto p = _adapterRequests.find(request->getId());
@@ -399,7 +419,7 @@ LookupI::adapterRequestException(const AdapterRequestPtr& request, exception_ptr
         return;
     }
 
-    if (request->exception())
+    if (request->exception(invokeId))
     {
         if (_warnOnce)
         {
@@ -448,7 +468,7 @@ LookupI::adapterRequestTimedOut(const AdapterRequestPtr& request)
 }
 
 void
-LookupI::objectRequestException(const ObjectRequestPtr& request, exception_ptr ex)
+LookupI::objectRequestException(const ObjectRequestPtr& request, exception_ptr ex, size_t invokeId)
 {
     lock_guard lock(_mutex);
     auto p = _objectRequests.find(request->getId());
@@ -457,7 +477,7 @@ LookupI::objectRequestException(const ObjectRequestPtr& request, exception_ptr e
         return;
     }
 
-    if (request->exception())
+    if (request->exception(invokeId))
     {
         if (_warnOnce)
         {

--- a/cpp/src/IceDiscovery/LookupI.cpp
+++ b/cpp/src/IceDiscovery/LookupI.cpp
@@ -30,7 +30,7 @@ IceDiscovery::Request::retry()
 void
 IceDiscovery::Request::invoke(const string& domainId, const vector<pair<LookupPrx, LookupReplyPrx>>& lookups)
 {
-    ++_invokeId;
+    ++_generation;
     _lookupCount = lookups.size();
     _failureCount = 0;
     Ice::Identity id;
@@ -43,11 +43,11 @@ IceDiscovery::Request::invoke(const string& domainId, const vector<pair<LookupPr
 }
 
 bool
-IceDiscovery::Request::exception(size_t invokeId)
+IceDiscovery::Request::exception(size_t generation)
 {
     // Ignore a delayed failure from an earlier invocation round: it must not count against the current round, which
     // reset _failureCount and may still have outstanding lookups.
-    if (invokeId != _invokeId)
+    if (generation != _generation)
     {
         return false;
     }
@@ -95,6 +95,7 @@ AdapterRequest::response(const ObjectPrx& proxy, bool isReplicaGroup)
 {
     if (isReplicaGroup)
     {
+        _proxies.insert(proxy);
         if (_latency == chrono::nanoseconds::zero())
         {
             _latency = chrono::duration_cast<chrono::nanoseconds>(chrono::steady_clock::now() - _start) *
@@ -102,7 +103,6 @@ AdapterRequest::response(const ObjectPrx& proxy, bool isReplicaGroup)
             _lookup->timer()->cancel(shared_from_this());
             _lookup->timer()->schedule(shared_from_this(), _latency);
         }
-        _proxies.insert(proxy);
         return false;
     }
     finished(proxy);
@@ -145,8 +145,8 @@ AdapterRequest::invokeWithLookup(const string& domainId, const LookupPrx& lookup
         _id,
         lookupReply,
         nullptr,
-        [self = shared_from_this(), invokeId = _invokeId](exception_ptr ex)
-        { self->_lookup->adapterRequestException(self, ex, invokeId); });
+        [self = shared_from_this(), generation = _generation](exception_ptr ex)
+        { self->_lookup->adapterRequestException(self, ex, generation); });
 }
 
 void
@@ -174,8 +174,8 @@ ObjectRequest::invokeWithLookup(const string& domainId, const LookupPrx& lookup,
         _id,
         lookupReply,
         nullptr,
-        [self = shared_from_this(), invokeId = _invokeId](exception_ptr ex)
-        { self->_lookup->objectRequestException(self, ex, invokeId); });
+        [self = shared_from_this(), generation = _generation](exception_ptr ex)
+        { self->_lookup->objectRequestException(self, ex, generation); });
 }
 
 void
@@ -410,7 +410,7 @@ LookupI::objectRequestTimedOut(const ObjectRequestPtr& request)
 }
 
 void
-LookupI::adapterRequestException(const AdapterRequestPtr& request, exception_ptr ex, size_t invokeId)
+LookupI::adapterRequestException(const AdapterRequestPtr& request, exception_ptr ex, size_t generation)
 {
     lock_guard lock(_mutex);
     auto p = _adapterRequests.find(request->getId());
@@ -419,7 +419,7 @@ LookupI::adapterRequestException(const AdapterRequestPtr& request, exception_ptr
         return;
     }
 
-    if (request->exception(invokeId))
+    if (request->exception(generation))
     {
         if (_warnOnce)
         {
@@ -468,7 +468,7 @@ LookupI::adapterRequestTimedOut(const AdapterRequestPtr& request)
 }
 
 void
-LookupI::objectRequestException(const ObjectRequestPtr& request, exception_ptr ex, size_t invokeId)
+LookupI::objectRequestException(const ObjectRequestPtr& request, exception_ptr ex, size_t generation)
 {
     lock_guard lock(_mutex);
     auto p = _objectRequests.find(request->getId());
@@ -477,7 +477,7 @@ LookupI::objectRequestException(const ObjectRequestPtr& request, exception_ptr e
         return;
     }
 
-    if (request->exception(invokeId))
+    if (request->exception(generation))
     {
         if (_warnOnce)
         {

--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -22,7 +22,7 @@ namespace IceDiscovery
 
         virtual bool retry();
         void invoke(const std::string&, const std::vector<std::pair<LookupPrx, LookupReplyPrx>>&);
-        bool exception(size_t invokeId);
+        bool exception(size_t generation);
         [[nodiscard]] std::string getRequestId() const;
 
         virtual void finished(const std::optional<Ice::ObjectPrx>&) = 0;
@@ -39,7 +39,7 @@ namespace IceDiscovery
         // Incremented on each invoke() (i.e. each retry round). The exception callbacks capture the value current when
         // they were sent, so a delayed failure from an earlier round can be ignored instead of counting against the
         // current round.
-        size_t _invokeId{0};
+        size_t _generation{0};
     };
     using RequestPtr = std::shared_ptr<Request>;
 
@@ -133,9 +133,9 @@ namespace IceDiscovery
         void foundAdapter(const std::string&, const std::string&, const Ice::ObjectPrx&, bool);
 
         void adapterRequestTimedOut(const AdapterRequestPtr&);
-        void adapterRequestException(const AdapterRequestPtr&, std::exception_ptr, size_t invokeId);
+        void adapterRequestException(const AdapterRequestPtr&, std::exception_ptr, size_t generation);
         void objectRequestTimedOut(const ObjectRequestPtr&);
-        void objectRequestException(const ObjectRequestPtr&, std::exception_ptr, size_t invokeId);
+        void objectRequestException(const ObjectRequestPtr&, std::exception_ptr, size_t generation);
 
         const IceInternal::TimerPtr& timer() { return _timer; }
 

--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -22,7 +22,7 @@ namespace IceDiscovery
 
         virtual bool retry();
         void invoke(const std::string&, const std::vector<std::pair<LookupPrx, LookupReplyPrx>>&);
-        bool exception();
+        bool exception(size_t invokeId);
         [[nodiscard]] std::string getRequestId() const;
 
         virtual void finished(const std::optional<Ice::ObjectPrx>&) = 0;
@@ -35,6 +35,11 @@ namespace IceDiscovery
         int _retryCount;
         size_t _lookupCount{0};
         size_t _failureCount{0};
+
+        // Incremented on each invoke() (i.e. each retry round). The exception callbacks capture the value current when
+        // they were sent, so a delayed failure from an earlier round can be ignored instead of counting against the
+        // current round.
+        size_t _invokeId{0};
     };
     using RequestPtr = std::shared_ptr<Request>;
 
@@ -128,9 +133,9 @@ namespace IceDiscovery
         void foundAdapter(const std::string&, const std::string&, const Ice::ObjectPrx&, bool);
 
         void adapterRequestTimedOut(const AdapterRequestPtr&);
-        void adapterRequestException(const AdapterRequestPtr&, std::exception_ptr);
+        void adapterRequestException(const AdapterRequestPtr&, std::exception_ptr, size_t invokeId);
         void objectRequestTimedOut(const ObjectRequestPtr&);
-        void objectRequestException(const ObjectRequestPtr&, std::exception_ptr);
+        void objectRequestException(const ObjectRequestPtr&, std::exception_ptr, size_t invokeId);
 
         const IceInternal::TimerPtr& timer() { return _timer; }
 

--- a/csharp/src/IceDiscovery/LookupI.cs
+++ b/csharp/src/IceDiscovery/LookupI.cs
@@ -27,7 +27,7 @@ internal abstract class Request<T>
 
     public void invoke(string domainId, Dictionary<LookupPrx, LookupReplyPrx> lookups)
     {
-        ++_invokeId;
+        ++_generation;
         _lookupCount = lookups.Count;
         _failureCount = 0;
         var id = new Ice.Identity(_requestId, "");
@@ -40,11 +40,11 @@ internal abstract class Request<T>
         }
     }
 
-    public bool exception(int invokeId)
+    public bool exception(int generation)
     {
         // Ignore a delayed failure from an earlier invocation round: it must not count against the current round, which
         // reset _failureCount and may still have outstanding lookups.
-        if (invokeId != _invokeId)
+        if (generation != _generation)
         {
             return false;
         }
@@ -72,7 +72,7 @@ internal abstract class Request<T>
 
     // Incremented on each invoke() (i.e. each retry round). The exception callbacks capture the value current when they
     // were sent, so a delayed failure from an earlier round is ignored instead of counting against the current round.
-    protected int _invokeId;
+    protected int _generation;
     protected List<TaskCompletionSource<Ice.ObjectPrx>> callbacks_ = new List<TaskCompletionSource<Ice.ObjectPrx>>();
 
     protected T _id;
@@ -147,7 +147,7 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
 
     protected override void invokeWithLookup(string domainId, LookupPrx lookup, LookupReplyPrx lookupReply)
     {
-        int invokeId = _invokeId;
+        int generation = _generation;
         lookup.findAdapterByIdAsync(domainId, _id, lookupReply).ContinueWith(
             task =>
             {
@@ -157,7 +157,7 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
                 }
                 catch (AggregateException ex)
                 {
-                    lookup_.adapterRequestException(this, ex.InnerException, invokeId);
+                    lookup_.adapterRequestException(this, ex.InnerException, generation);
                 }
             },
             lookup.ice_scheduler());
@@ -204,7 +204,7 @@ internal class ObjectRequest : Request<Ice.Identity>, Ice.Internal.TimerTask
 
     protected override void invokeWithLookup(string domainId, LookupPrx lookup, LookupReplyPrx lookupReply)
     {
-        int invokeId = _invokeId;
+        int generation = _generation;
         lookup.findObjectByIdAsync(domainId, _id, lookupReply).ContinueWith(
             task =>
             {
@@ -214,7 +214,7 @@ internal class ObjectRequest : Request<Ice.Identity>, Ice.Internal.TimerTask
                 }
                 catch (AggregateException ex)
                 {
-                    lookup_.objectRequestException(this, ex.InnerException, invokeId);
+                    lookup_.objectRequestException(this, ex.InnerException, generation);
                 }
             },
             lookup.ice_scheduler());
@@ -444,7 +444,7 @@ internal class LookupI : LookupDisp_
         }
     }
 
-    internal void objectRequestException(ObjectRequest request, Exception ex, int invokeId)
+    internal void objectRequestException(ObjectRequest request, Exception ex, int generation)
     {
         lock (_mutex)
         {
@@ -453,7 +453,7 @@ internal class LookupI : LookupDisp_
                 return;
             }
 
-            if (request.exception(invokeId))
+            if (request.exception(generation))
             {
                 if (_warnOnce)
                 {
@@ -501,7 +501,7 @@ internal class LookupI : LookupDisp_
         }
     }
 
-    internal void adapterRequestException(AdapterRequest request, Exception ex, int invokeId)
+    internal void adapterRequestException(AdapterRequest request, Exception ex, int generation)
     {
         lock (_mutex)
         {
@@ -510,7 +510,7 @@ internal class LookupI : LookupDisp_
                 return;
             }
 
-            if (request.exception(invokeId))
+            if (request.exception(generation))
             {
                 if (_warnOnce)
                 {

--- a/csharp/src/IceDiscovery/LookupI.cs
+++ b/csharp/src/IceDiscovery/LookupI.cs
@@ -27,6 +27,7 @@ internal abstract class Request<T>
 
     public void invoke(string domainId, Dictionary<LookupPrx, LookupReplyPrx> lookups)
     {
+        ++_invokeId;
         _lookupCount = lookups.Count;
         _failureCount = 0;
         var id = new Ice.Identity(_requestId, "");
@@ -39,8 +40,15 @@ internal abstract class Request<T>
         }
     }
 
-    public bool exception()
+    public bool exception(int invokeId)
     {
+        // Ignore a delayed failure from an earlier invocation round: it must not count against the current round, which
+        // reset _failureCount and may still have outstanding lookups.
+        if (invokeId != _invokeId)
+        {
+            return false;
+        }
+
         if (++_failureCount == _lookupCount)
         {
             finished(null);
@@ -61,6 +69,10 @@ internal abstract class Request<T>
     protected int retryCount_;
     protected int _lookupCount;
     protected int _failureCount;
+
+    // Incremented on each invoke() (i.e. each retry round). The exception callbacks capture the value current when they
+    // were sent, so a delayed failure from an earlier round is ignored instead of counting against the current round.
+    protected int _invokeId;
     protected List<TaskCompletionSource<Ice.ObjectPrx>> callbacks_ = new List<TaskCompletionSource<Ice.ObjectPrx>>();
 
     protected T _id;
@@ -71,7 +83,21 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
     public AdapterRequest(LookupI lookup, string id, int retryCount)
         : base(lookup, id, retryCount) => _start = DateTime.Now.Ticks;
 
-    public override bool retry() => _proxies.Count == 0 && --retryCount_ >= 0;
+    public override bool retry()
+    {
+        if (_proxies.Count == 0 && --retryCount_ >= 0)
+        {
+            // We only reach here with _proxies empty, i.e. no replica-group response arrived. _latency is set only
+            // together with inserting into _proxies, so the latency timer is not running.
+            Debug.Assert(_latency == 0);
+
+            // Restart the replica-group latency window so it's measured from this round rather than from request
+            // creation.
+            _start = DateTime.Now.Ticks;
+            return true;
+        }
+        return false;
+    }
 
     public bool response(Ice.ObjectPrx proxy, bool isReplicaGroup)
     {
@@ -121,6 +147,7 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
 
     protected override void invokeWithLookup(string domainId, LookupPrx lookup, LookupReplyPrx lookupReply)
     {
+        int invokeId = _invokeId;
         lookup.findAdapterByIdAsync(domainId, _id, lookupReply).ContinueWith(
             task =>
             {
@@ -130,7 +157,7 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
                 }
                 catch (AggregateException ex)
                 {
-                    lookup_.adapterRequestException(this, ex.InnerException);
+                    lookup_.adapterRequestException(this, ex.InnerException, invokeId);
                 }
             },
             lookup.ice_scheduler());
@@ -151,7 +178,7 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
     // also sent the request to multiple interfaces.
     //
     private readonly HashSet<Ice.ObjectPrx> _proxies = new HashSet<Ice.ObjectPrx>();
-    private readonly long _start;
+    private long _start;
     private long _latency;
 }
 
@@ -177,6 +204,7 @@ internal class ObjectRequest : Request<Ice.Identity>, Ice.Internal.TimerTask
 
     protected override void invokeWithLookup(string domainId, LookupPrx lookup, LookupReplyPrx lookupReply)
     {
+        int invokeId = _invokeId;
         lookup.findObjectByIdAsync(domainId, _id, lookupReply).ContinueWith(
             task =>
             {
@@ -186,7 +214,7 @@ internal class ObjectRequest : Request<Ice.Identity>, Ice.Internal.TimerTask
                 }
                 catch (AggregateException ex)
                 {
-                    lookup_.objectRequestException(this, ex.InnerException);
+                    lookup_.objectRequestException(this, ex.InnerException, invokeId);
                 }
             },
             lookup.ice_scheduler());
@@ -416,7 +444,7 @@ internal class LookupI : LookupDisp_
         }
     }
 
-    internal void objectRequestException(ObjectRequest request, Exception ex)
+    internal void objectRequestException(ObjectRequest request, Exception ex, int invokeId)
     {
         lock (_mutex)
         {
@@ -425,7 +453,7 @@ internal class LookupI : LookupDisp_
                 return;
             }
 
-            if (request.exception())
+            if (request.exception(invokeId))
             {
                 if (_warnOnce)
                 {
@@ -473,7 +501,7 @@ internal class LookupI : LookupDisp_
         }
     }
 
-    internal void adapterRequestException(AdapterRequest request, Exception ex)
+    internal void adapterRequestException(AdapterRequest request, Exception ex, int invokeId)
     {
         lock (_mutex)
         {
@@ -482,7 +510,7 @@ internal class LookupI : LookupDisp_
                 return;
             }
 
-            if (request.exception())
+            if (request.exception(invokeId))
             {
                 if (_warnOnce)
                 {

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
@@ -47,7 +47,7 @@ class LookupI implements Lookup {
         }
 
         void invoke(String domainId, Map<LookupPrx, LookupReplyPrx> lookups) {
-            ++_invokeId;
+            ++_generation;
             _lookupCount = lookups.size();
             _failureCount = 0;
             final Identity id = new Identity(_requestId, "");
@@ -59,10 +59,10 @@ class LookupI implements Lookup {
             }
         }
 
-        boolean exception(int invokeId) {
+        boolean exception(int generation) {
             // Ignore a delayed failure from an earlier invocation round: it must not count against the current round,
             // which reset _failureCount and may still have outstanding lookups.
-            if (invokeId != _invokeId) {
+            if (generation != _generation) {
                 return false;
             }
 
@@ -100,7 +100,7 @@ class LookupI implements Lookup {
         // Incremented on each invoke() (i.e. each retry round). The exception callbacks capture the value current when
         // they were sent, so a delayed failure from an earlier round is ignored instead of counting against the current
         // round.
-        protected int _invokeId;
+        protected int _generation;
         protected List<CompletableFuture<Ret>> _futures = new ArrayList<>();
         protected T _id;
         protected Future<?> _future;
@@ -171,12 +171,12 @@ class LookupI implements Lookup {
 
         @Override
         protected void invokeWithLookup(String domainId, LookupPrx lookup, LookupReplyPrx lookupReply) {
-            final int invokeId = _invokeId;
+            final int generation = _generation;
             lookup.findAdapterByIdAsync(domainId, _id, lookupReply)
                 .whenCompleteAsync(
                     (v, ex) -> {
                         if (ex != null) {
-                            adapterRequestException(AdapterRequest.this, ex, invokeId);
+                            adapterRequestException(AdapterRequest.this, ex, generation);
                         }
                     },
                     lookup.ice_executor());
@@ -221,12 +221,12 @@ class LookupI implements Lookup {
 
         @Override
         protected void invokeWithLookup(String domainId, LookupPrx lookup, LookupReplyPrx lookupReply) {
-            final int invokeId = _invokeId;
+            final int generation = _generation;
             lookup.findObjectByIdAsync(domainId, _id, lookupReply)
                 .whenCompleteAsync(
                     (v, ex) -> {
                         if (ex != null) {
-                            objectRequestException(ObjectRequest.this, ex, invokeId);
+                            objectRequestException(ObjectRequest.this, ex, generation);
                         }
                     },
                     lookup.ice_executor());
@@ -384,13 +384,13 @@ class LookupI implements Lookup {
         _objectRequests.remove(request.getId());
     }
 
-    synchronized void objectRequestException(ObjectRequest request, Throwable ex, int invokeId) {
+    synchronized void objectRequestException(ObjectRequest request, Throwable ex, int generation) {
         ObjectRequest r = _objectRequests.get(request.getId());
         if (r == null || r != request) {
             return;
         }
 
-        if (request.exception(invokeId)) {
+        if (request.exception(generation)) {
             if (_warnOnce) {
                 StringBuilder s = new StringBuilder();
                 s.append("failed to lookup object `");
@@ -425,13 +425,13 @@ class LookupI implements Lookup {
         _adapterRequests.remove(request.getId());
     }
 
-    synchronized void adapterRequestException(AdapterRequest request, Throwable ex, int invokeId) {
+    synchronized void adapterRequestException(AdapterRequest request, Throwable ex, int generation) {
         AdapterRequest r = _adapterRequests.get(request.getId());
         if (r == null || r != request) {
             return;
         }
 
-        if (request.exception(invokeId)) {
+        if (request.exception(generation)) {
             if (_warnOnce) {
                 StringBuilder s = new StringBuilder();
                 s.append("failed to lookup adapter `");

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
@@ -47,6 +47,7 @@ class LookupI implements Lookup {
         }
 
         void invoke(String domainId, Map<LookupPrx, LookupReplyPrx> lookups) {
+            ++_invokeId;
             _lookupCount = lookups.size();
             _failureCount = 0;
             final Identity id = new Identity(_requestId, "");
@@ -58,7 +59,13 @@ class LookupI implements Lookup {
             }
         }
 
-        boolean exception() {
+        boolean exception(int invokeId) {
+            // Ignore a delayed failure from an earlier invocation round: it must not count against the current round,
+            // which reset _failureCount and may still have outstanding lookups.
+            if (invokeId != _invokeId) {
+                return false;
+            }
+
             if (++_failureCount == _lookupCount) {
                 finished(null);
                 return true;
@@ -89,6 +96,11 @@ class LookupI implements Lookup {
         protected int _retryCount;
         protected int _lookupCount;
         protected int _failureCount;
+
+        // Incremented on each invoke() (i.e. each retry round). The exception callbacks capture the value current when
+        // they were sent, so a delayed failure from an earlier round is ignored instead of counting against the current
+        // round.
+        protected int _invokeId;
         protected List<CompletableFuture<Ret>> _futures = new ArrayList<>();
         protected T _id;
         protected Future<?> _future;
@@ -103,7 +115,17 @@ class LookupI implements Lookup {
 
         @Override
         boolean retry() {
-            return _proxies.isEmpty() && --_retryCount >= 0;
+            if (_proxies.isEmpty() && --_retryCount >= 0) {
+                // We only reach here with _proxies empty, i.e. no replica-group response arrived. _latency is set only
+                // together with adding to _proxies, so the latency timer is not running.
+                assert _latency == 0;
+
+                // Restart the replica-group latency window so it's measured from this round rather than from request
+                // creation.
+                _start = System.nanoTime();
+                return true;
+            }
+            return false;
         }
 
         boolean response(ObjectPrx proxy, boolean isReplicaGroup) {
@@ -149,11 +171,12 @@ class LookupI implements Lookup {
 
         @Override
         protected void invokeWithLookup(String domainId, LookupPrx lookup, LookupReplyPrx lookupReply) {
+            final int invokeId = _invokeId;
             lookup.findAdapterByIdAsync(domainId, _id, lookupReply)
                 .whenCompleteAsync(
                     (v, ex) -> {
                         if (ex != null) {
-                            adapterRequestException(AdapterRequest.this, ex);
+                            adapterRequestException(AdapterRequest.this, ex, invokeId);
                         }
                     },
                     lookup.ice_executor());
@@ -198,11 +221,12 @@ class LookupI implements Lookup {
 
         @Override
         protected void invokeWithLookup(String domainId, LookupPrx lookup, LookupReplyPrx lookupReply) {
+            final int invokeId = _invokeId;
             lookup.findObjectByIdAsync(domainId, _id, lookupReply)
                 .whenCompleteAsync(
                     (v, ex) -> {
                         if (ex != null) {
-                            objectRequestException(ObjectRequest.this, ex);
+                            objectRequestException(ObjectRequest.this, ex, invokeId);
                         }
                     },
                     lookup.ice_executor());
@@ -360,13 +384,13 @@ class LookupI implements Lookup {
         _objectRequests.remove(request.getId());
     }
 
-    synchronized void objectRequestException(ObjectRequest request, Throwable ex) {
+    synchronized void objectRequestException(ObjectRequest request, Throwable ex, int invokeId) {
         ObjectRequest r = _objectRequests.get(request.getId());
         if (r == null || r != request) {
             return;
         }
 
-        if (request.exception()) {
+        if (request.exception(invokeId)) {
             if (_warnOnce) {
                 StringBuilder s = new StringBuilder();
                 s.append("failed to lookup object `");
@@ -401,13 +425,13 @@ class LookupI implements Lookup {
         _adapterRequests.remove(request.getId());
     }
 
-    synchronized void adapterRequestException(AdapterRequest request, Throwable ex) {
+    synchronized void adapterRequestException(AdapterRequest request, Throwable ex, int invokeId) {
         AdapterRequest r = _adapterRequests.get(request.getId());
         if (r == null || r != request) {
             return;
         }
 
-        if (request.exception()) {
+        if (request.exception(invokeId)) {
             if (_warnOnce) {
                 StringBuilder s = new StringBuilder();
                 s.append("failed to lookup adapter `");


### PR DESCRIPTION
An IceDiscovery lookup request is retried in place — the **same `Request` object** is re-`invoke()`d when its round times out. Two issues stemmed from per-round state not being scoped to the round. Both are present identically in C++, C#, and Java (no JS IceDiscovery).

## 1. Stale-round failure counting (correctness)

`invoke()` resets `_failureCount = 0` for the new round, but the per-lookup exception callbacks (one per multicast interface) carried no round identifier. A *delayed* failure callback from an earlier round could increment the new round's `_failureCount` and drive it to `_lookupCount`, finishing the request with "not found" while the current round's datagrams were still outstanding → spurious lookup failure.

The object-identity guard in the exception handlers (`request != the one in the map`) can't catch this, because a retry reuses the same object with the same `_requestId`.

Fix: tag each round with a `_generation` counter (incremented in `invoke()`). The exception callbacks capture the value current when they were sent; `exception(generation)` ignores a callback whose round no longer matches before touching `_failureCount`. Responses still match on the stable `_requestId`, so valid late responses are unaffected — only failure *counting* becomes round-aware.

## 2. Replica-group latency window measured from the wrong point

`AdapterRequest` measures the replica-group aggregation window from `_start`, which was set once at construction and never reset. After a failed round, the window therefore included the earlier timeout, making the request wait an unnecessarily long extra window before aggregating replica endpoints.

Fix: reset `_start` when a new round begins (in `retry()`). An `assert(_latency == 0)` documents/guards the invariant that the latency timer can't already be running on the retry path — `_latency` is only set together with a non-empty `_proxies`, and `retry()` only proceeds when `_proxies` is empty.

This is primarily an efficiency fix (less extra latency). One caveat: because responses match on the stable `_requestId`, a delayed replica-group *reply* from a timed-out earlier round can land in the new round and trigger the window against the freshly-reset `_start`, producing a window too short to collect the current round's replicas — and thus a *smaller* (degraded, not wrong) replica set than the base code. This only occurs when replica RTT ≳ the round timeout, a high-latency regime where discovery is already marginal, so it's a reasonable trade-off.

## Reachability

Low. The exception callbacks come from the UDP multicast lookup invocations, which only fail on a local datagram-send error; item 1 additionally requires such a failure to straddle a retry timeout. Item 2 is an efficiency nit with no correctness impact. No CHANGELOG entry.

Addresses items 3–4 of #5492 (items 1–2 are in a separate PR; item 5 is tracked separately); leaving that issue open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
