### PR TITLE
Document re-entrancy constraint on IceLocatorDiscovery Request retry

### DIFF
--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -377,9 +377,11 @@ Request::exception(std::exception_ptr ex)
     catch (...)
     {
         _exception = ex;
-        // Reached only from the asynchronous invocation completion, not synchronously from Request::invoke: the local
-        // exceptions invoke() can throw synchronously are all handled by the catch clauses above. That matters because
-        // the retry below re-enters LocatorI::invoke and re-locks the non-recursive LocatorI::_mutex.
+        // This catch-all is reached only from the asynchronous ice_invokeAsync completion (which runs off
+        // LocatorI::_mutex), never synchronously from Request::invoke: the local exceptions ice_invokeAsync can throw
+        // synchronously (caught by Request::invoke's own catch clause and passed to exception() in-line) are all
+        // handled by the specific catch clauses above. That matters because the retry below re-enters
+        // LocatorI::invoke and re-locks the non-recursive LocatorI::_mutex.
         _locator->invoke(_locatorPrx, shared_from_this()); // Retry with new locator proxy
     }
 }

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -377,6 +377,9 @@ Request::exception(std::exception_ptr ex)
     catch (...)
     {
         _exception = ex;
+        // Reached only from the asynchronous invocation completion, not synchronously from Request::invoke: the local
+        // exceptions invoke() can throw synchronously are all handled by the catch clauses above. That matters because
+        // the retry below re-enters LocatorI::invoke and re-locks the non-recursive LocatorI::_mutex.
         _locator->invoke(_locatorPrx, shared_from_this()); // Retry with new locator proxy
     }
 }


### PR DESCRIPTION
Documentation-only change (no functional change).

`Request::exception`'s catch-all retries by calling `LocatorI::invoke`, which re-locks the **non-recursive** `LocatorI::_mutex` that `Request::invoke` already runs under (it's called from `LocatorI::invoke`/`foundLocator`). At a glance this looks like a re-entrant-deadlock bug — but it's safe: the catch-all is reached only from the **asynchronous** invocation completion (off the mutex), because the local exceptions `ice_invokeAsync` can throw *synchronously* are all handled by the specific `catch` clauses above the catch-all.

Adding a comment so the re-entrant-looking call isn't mistaken for a bug (as it was during an audit pass).

The C# and Java mappings have the same call structure but use recursive locks (`Monitor`/`synchronized`), so the re-entry wouldn't deadlock there regardless — this is C++-specific. No functional fix is warranted: no exception currently reaches the catch-all synchronously.

Addresses item 5 of #5492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)