### PR TITLE
Fix DataStorm getLastIds null dereference on multi-key element detach

### DIFF
--- a/changelog.d/datastorm/5722-multikey-getlastids-crash.md
+++ b/changelog.d/datastorm/5722-multikey-getlastids-crash.md
@@ -1,0 +1,2 @@
+- Fixed a crash in DataStorm (a null-pointer dereference during session (re)attachment) that could occur after a
+  multi-key reader or writer was destroyed.

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1147,10 +1147,19 @@ SessionI::getLastIds(int64_t topicId, int64_t keyOrFilterId, const std::shared_p
         else
         {
             // Key subscription: report this element's lastId for each remote element it's subscribed to under this
-            // key. Key subscriptions are indexed by remote key id, so look the key up directly.
+            // key. Key subscriptions are indexed by remote key id, so look the key up directly. An element id can
+            // remain in the key map after its ElementSubscribers was removed (e.g. a multi-key element detaches
+            // under one key but its other keys are still counted), so skip ids with no live subscriber, like the
+            // filter branch above.
             for (const auto& [elementId, _] : subscriber.keys[keyOrFilterId].second)
             {
-                lastIds.emplace(elementId, subscriber.get(elementId)->getSubscriber(element)->lastId);
+                if (auto* elementSubscribers = subscriber.get(elementId))
+                {
+                    if (auto* s = elementSubscribers->getSubscriber(element))
+                    {
+                        lastIds.emplace(elementId, s->lastId);
+                    }
+                }
             }
         }
     }

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -91,6 +91,28 @@ void ::Reader::run(int argc, char* argv[])
         test(aapl->lastBid == 13.0f); // AAPL's own bid, not GOOG's 101
         test(aapl->lastAsk == 14.0f); // AAPL's own ask, not GOOG's 102
     }
+
+    // A persistent multi-key reader attaches to writer 1 under both keys; writer 1's detach leaves a stale entry
+    // in the reader's per-key subscriber map, and writer 2's attach drives SessionI::getLastIds over it, which
+    // must not dereference null.
+    Topic<string, int> detachTopic(node, "multiKeyDetach");
+    detachTopic.setReaderDefaultConfig(config);
+    Topic<string, int> detachBarrier(node, "multiKeyDetachBarrier");
+    {
+        auto reader = makeMultiKeyReader(detachTopic, {"k1", "k2"});
+        auto sample = reader.getNextUnread(); // from writer 1
+        test(sample.getValue() == 1);
+
+        // Wait until writer 1's detach has been processed (this is what leaves the stale per-key entry), then
+        // tell the writer it can create writer 2.
+        reader.waitForNoWriters();
+        auto barrier = makeSingleKeyWriter(detachBarrier, "barrier");
+        barrier.waitForReaders();
+        barrier.update(0);
+
+        sample = reader.getNextUnread(); // from writer 2: attach runs getLastIds over the stale entry
+        test(sample.getValue() == 2);
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -59,6 +59,30 @@ void ::Writer::run(int argc, char* argv[])
         writer.waitForNoReaders();
     }
     cout << "ok" << endl;
+
+    // Destroying a multi-key writer leaves a stale entry in the reader's per-key subscriber map
+    // (DataElementI::detachKey detaches every key with the element's first key id). A later attach then drives
+    // SessionI::getLastIds over the stale entry, which must not crash the reader.
+    Topic<string, int> detachTopic(node, "multiKeyDetach");
+    detachTopic.setWriterDefaultConfig(config);
+    Topic<string, int> detachBarrier(node, "multiKeyDetachBarrier");
+    cout << "testing multi-key writer detach then reattach... " << flush;
+    {
+        {
+            auto writer = makeMultiKeyWriter(detachTopic, {"k1", "k2"});
+            writer.waitForReaders();
+            writer.add("k1", 1);
+        } // writer destroyed here -> detachElements -> stale per-key entry on the reader
+
+        // Wait for the reader to confirm it has processed the detach before creating the second writer, so the
+        // second attach is guaranteed to run getLastIds over the stale entry.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(detachBarrier, "barrier").getNextUnread();
+
+        auto writer = makeMultiKeyWriter(detachTopic, {"k1", "k2"});
+        writer.waitForReaders();
+        writer.add("k2", 2);
+    }
+    cout << "ok" << endl;
 }
 
 DEFINE_TEST(::Writer)


### PR DESCRIPTION
Fixes #5722.

`SessionI::getLastIds` dereferenced `subscriber.get(elementId)` and `getSubscriber(element)` without a null check in its **key** branch, while the sibling **filter** branch guards the identical lookup. The codebase's own model already allows the null — `SessionI::unsubscribeFromKey` treats `get(elementId) == nullptr` as a normal case.

**Root cause:** `DataElementI::detachKey` unsubscribes *every* key of an element with the element's **first** key id (`subscriber->id`), not the key actually being detached. So when a multi-key element under `{k1, k2}` detaches, `k1`'s counter is decremented twice and **`k2`'s entry is left dangling** (pointing at the now-removed element). A later `getLastIds(…, k2, …)` — driven from `TopicI::getElementSpecs` during (re)attach — then dereferences null and crashes the node.

**Fix:** guard the key branch like the filter branch. Skipping an element that is no longer present is correct — there is nothing to resume for it. (The deeper `detachKey` accounting fix — passing the actual per-key id — is tracked separately as the more invasive change.)

**Red → green test** (`DataStorm/partial`): a persistent multi-key reader attaches to a multi-key writer under both keys; the writer is destroyed (detach → stale key entry) and a second writer attaches, driving `getLastIds` over the stale entry. Verified locally:
- **Without the fix:** the reader process **SIGSEGVs** (`EXC_BAD_ACCESS` / `KERN_INVALID_ADDRESS`) with the faulting stack through `TopicI::getElementSpecs` → `SessionI::getLastIds`.
- **With the fix:** `testing multi-key writer detach then reattach... ok` (both plain and multicast configs).