### PR TITLE
Fix IceLocatorDiscovery stale-round failure counting (C++, C#, Java)

### DIFF
--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -76,7 +76,7 @@ namespace
 
         vector<Ice::LocatorPrx> getLocators(const string&, const chrono::milliseconds&);
 
-        void exception(std::exception_ptr);
+        void exception(std::exception_ptr, size_t generation);
 
     private:
         void runTimerTask() final;
@@ -99,6 +99,10 @@ namespace
         bool _pending{false};
         int _pendingRetryCount{0};
         size_t _failureCount{0};
+        // Incremented at the start of each lookup round. The findLocatorAsync exception callbacks capture the value
+        // current when they were sent, so a delayed failure from an earlier round is ignored instead of counting
+        // against the current round.
+        size_t _generation{0};
         bool _warnOnce{true};
         vector<RequestPtr> _pendingRequests;
         std::mutex _mutex;
@@ -629,6 +633,7 @@ LocatorI::invoke(const optional<Ice::LocatorPrx>& locator, const RequestPtr& req
         {
             _pending = true;
             _failureCount = 0;
+            ++_generation;
             _pendingRetryCount = _retryCount;
             try
             {
@@ -647,7 +652,8 @@ LocatorI::invoke(const optional<Ice::LocatorPrx>& locator, const RequestPtr& req
                         _instanceName,
                         l.second,
                         nullptr,
-                        [self = shared_from_this()](exception_ptr ex) { self->exception(ex); });
+                        [self = shared_from_this(), generation = _generation](exception_ptr ex)
+                        { self->exception(ex, generation); });
                 }
                 _timer->schedule(shared_from_this(), _timeout);
             }
@@ -677,9 +683,15 @@ LocatorI::invoke(const optional<Ice::LocatorPrx>& locator, const RequestPtr& req
 }
 
 void
-LocatorI::exception(std::exception_ptr ex)
+LocatorI::exception(std::exception_ptr ex, size_t generation)
 {
     lock_guard lock(_mutex);
+    // Ignore a delayed failure from an earlier lookup round: it must not count against the current round, which reset
+    // _failureCount and may still have outstanding lookups.
+    if (generation != _generation)
+    {
+        return;
+    }
     if (++_failureCount == _lookups.size() && _pending)
     {
         //
@@ -762,13 +774,15 @@ LocatorI::runTimerTask()
                 }
             }
             _failureCount = 0;
+            ++_generation;
             for (const auto& l : _lookups)
             {
                 l.first->findLocatorAsync(
                     _instanceName,
                     l.second,
                     nullptr,
-                    [self = shared_from_this()](exception_ptr ex) { self->exception(ex); });
+                    [self = shared_from_this(), generation = _generation](exception_ptr ex)
+                    { self->exception(ex, generation); });
             }
             _timer->schedule(shared_from_this(), _timeout);
             return;

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -350,6 +350,7 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
                     _pending = true;
                     _pendingRetryCount = _retryCount;
                     _failureCount = 0;
+                    ++_generation;
                     try
                     {
                         if (_traceLevel > 1)
@@ -365,7 +366,7 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
 
                         foreach (KeyValuePair<LookupPrx, LookupReplyPrx> l in _lookups)
                         {
-                            _ = performFindLocatorAsync(l.Key, l.Value);
+                            _ = performFindLocatorAsync(l.Key, l.Value, _generation);
                         }
                         _timer.schedule(this, _timeout);
                     }
@@ -395,7 +396,7 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
             }
         }
 
-        async Task performFindLocatorAsync(LookupPrx lookupPrx, LookupReplyPrx lookupReplyPrx)
+        async Task performFindLocatorAsync(LookupPrx lookupPrx, LookupReplyPrx lookupReplyPrx, int generation)
         {
             // Exit the mutex lock before proceeding.
             await Task.Yield();
@@ -407,15 +408,21 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
             }
             catch (System.Exception ex)
             {
-                exception(ex);
+                exception(ex, generation);
             }
         }
     }
 
-    private void exception(Exception ex)
+    private void exception(Exception ex, int generation)
     {
         lock (_mutex)
         {
+            // Ignore a delayed failure from an earlier lookup round: it must not count against the current round, which
+            // reset _failureCount and may still have outstanding lookups.
+            if (generation != _generation)
+            {
+                return;
+            }
             if (++_failureCount == _lookups.Count && _pending)
             {
                 //
@@ -487,6 +494,9 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
                         _lookup.ice_getCommunicator().getLogger().trace("Lookup", s.ToString());
                     }
 
+                    _failureCount = 0;
+                    ++_generation;
+                    int generation = _generation;
                     foreach (KeyValuePair<LookupPrx, LookupReplyPrx> l in _lookups)
                     {
                         l.Key.findLocatorAsync(_instanceName, l.Value).ContinueWith(
@@ -498,7 +508,7 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
                                 }
                                 catch (AggregateException ex)
                                 {
-                                    exception(ex.InnerException);
+                                    exception(ex.InnerException, generation);
                                 }
                             },
                             l.Key.ice_scheduler()); // Send multicast request.
@@ -555,6 +565,11 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
     private bool _pending;
     private int _pendingRetryCount;
     private int _failureCount;
+
+    // Incremented at the start of each lookup round. The findLocatorAsync exception callbacks capture the value current
+    // when they were sent, so a delayed failure from an earlier round is ignored instead of counting against the
+    // current round.
+    private int _generation;
     private bool _warnOnce = true;
     private readonly List<Request> _pendingRequests = new List<Request>();
     private long _nextRetry;

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -339,6 +339,8 @@ class PluginI implements Plugin {
                     _pending = true;
                     _pendingRetryCount = _retryCount;
                     _failureCount = 0;
+                    ++_generation;
+                    final int generation = _generation;
                     try {
                         if (_traceLevel > 1) {
                             StringBuilder s = new StringBuilder("looking up locator:\nlookup = ");
@@ -354,7 +356,7 @@ class PluginI implements Plugin {
                                 .whenCompleteAsync(
                                     (v, ex) -> {
                                         if (ex != null) {
-                                            exception(ex);
+                                            exception(ex, generation);
                                         }
                                     },
                                     entry.getKey()
@@ -383,7 +385,12 @@ class PluginI implements Plugin {
             }
         }
 
-        synchronized void exception(Throwable ex) {
+        synchronized void exception(Throwable ex, int generation) {
+            // Ignore a delayed failure from an earlier lookup round: it must not count against the current round, which
+            // reset _failureCount and may still have outstanding lookups.
+            if (generation != _generation) {
+                return;
+            }
             if (++_failureCount == _lookups.size() && _pending) {
                 // All the lookup calls failed, cancel the timer and propagate the error to the requests.
                 _future.cancel(false);
@@ -446,13 +453,15 @@ class PluginI implements Plugin {
                                 }
 
                                 _failureCount = 0;
+                                ++_generation;
+                                final int generation = _generation;
                                 for (Map.Entry<LookupPrx, LookupReplyPrx> entry : _lookups.entrySet()) {
                                     entry.getKey()
                                         .findLocatorAsync(_instanceName, entry.getValue())
                                         .whenCompleteAsync(
                                             (v, ex) -> {
                                                 if (ex != null) {
-                                                    exception(ex);
+                                                    exception(ex, generation);
                                                 }
                                             },
                                             entry.getKey().ice_executor()); // Send multicast request.
@@ -506,6 +515,11 @@ class PluginI implements Plugin {
         private boolean _pending;
         private int _pendingRetryCount;
         private int _failureCount;
+
+        // Incremented at the start of each lookup round. The findLocatorAsync exception callbacks capture the value
+        // current when they were sent, so a delayed failure from an earlier round is ignored instead of counting
+        // against the current round.
+        private int _generation;
         private boolean _warnOnce;
         private List<Request> _pendingRequests = new ArrayList<>();
         private long _nextRetry;


### PR DESCRIPTION
Follow-up to #5719, which fixed the same class of bug in **IceDiscovery**. These are the IceLocatorDiscovery counterparts (issues #5725 and #5726).

## 1. Stale-round failure counting (correctness)

`LocatorI` retries a locator lookup in place — the **singleton** is reused across rounds. `runTimerTask` resets `_failureCount = 0` and re-sends `findLocatorAsync` to every lookup proxy, but the per-lookup exception callbacks carried **no round identifier**. A *delayed* failure callback from an earlier round could increment the new round's `_failureCount` and drive it to `_lookups.size()`, finishing the request with the void locator while the current round's datagrams were still outstanding → spurious lookup failure.

Because `LocatorI` is a singleton, there is no per-request object-identity guard at all (unlike a per-`Request` object).

Fix: tag each round with a `_generation` counter (incremented where `_failureCount` is reset, in both the initial `invoke()` path and the `runTimerTask` retry path). The `findLocatorAsync` exception callbacks capture the value current when they were sent; `exception(generation)` ignores a callback whose round no longer matches before touching `_failureCount`. This mirrors the `_generation` fix applied to IceDiscovery in #5719.

## 2. C# `runTimerTask` missing `_failureCount` reset

Independently, the **C#** `runTimerTask` retry path re-sent `findLocatorAsync` to all lookups **without** resetting `_failureCount = 0` — C++ and Java already reset it. So even without a delayed callback, the carried-over count made `++_failureCount == _lookups.Count` trip early on a subsequent round. This PR adds the missing reset (alongside the `_generation` increment).

## Reachability

Low, same as #5719: the exception callbacks come from the UDP multicast lookup invocations, which only fail on a local datagram-send error; the stale-round race additionally requires such a failure to straddle a retry timeout. The C# missing-reset bug is also low-impact (requires a send failure on a retried round). No CHANGELOG entry.

Fixes #5725.
Fixes #5726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)