### PR TITLE
Fix IceDiscovery Java replica-group latency window (~10x too long)

### DIFF
--- a/changelog.d/java/icediscovery-latency-window.md
+++ b/changelog.d/java/icediscovery-latency-window.md
@@ -1,0 +1,3 @@
+- Fixed a bug in IceDiscovery where the replica-group endpoint aggregation window was about 10 times longer than
+  intended, due to an incorrect nanosecond-to-millisecond conversion. As a result, resolving an indirect proxy bound to
+  a replica group took noticeably longer than the configured `IceDiscovery.LatencyMultiplier` implies.

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
@@ -110,10 +110,10 @@ class LookupI implements Lookup {
             if (isReplicaGroup) {
                 _proxies.add(proxy);
                 if (_latency == 0) {
-                    _latency = (long) ((System.nanoTime() - _start) * _latencyMultiplier / 100000.0);
-                    if (_latency == 0) {
-                        _latency = 1; // 1ms
-                    }
+                    // The aggregation window is the measured response time, scaled by IceDiscovery.LatencyMultiplier,
+                    // with a 1ms floor so we never schedule a degenerate zero-length window.
+                    long responseTimeMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - _start);
+                    _latency = Math.max(1, responseTimeMillis * _latencyMultiplier);
                     cancelTimer();
                     scheduleTimer(_latency);
                 }


### PR DESCRIPTION
Follow-up to #5719 (found during pepone's review). Pre-existing bug in the **Java** IceDiscovery mapping; the C++ and C# mappings are correct.

## Bug

`AdapterRequest.response()` measures the replica-group aggregation window as the response time scaled by `IceDiscovery.LatencyMultiplier`. The Java code converted the elapsed time from nanoseconds (`System.nanoTime()`) to milliseconds with the wrong divisor:

```java
_latency = (long) ((System.nanoTime() - _start) * _latencyMultiplier / 100000.0);
```

ns→ms needs `1000000.0`, not `100000.0`, so the window was about **10× longer** than intended — and ~10× longer than C++/C#. As a result, resolving an indirect proxy bound to a replica group waited noticeably longer than the configured multiplier implies.

For comparison:
- C# uses `DateTime.Ticks` (100 ns units) with `/ 10000.0` — correct.
- C++ uses typed `chrono::nanoseconds` — correct.

## Fix + readability

Rather than just correcting the divisor, replace the hand-rolled conversion with `TimeUnit.NANOSECONDS.toMillis(...)` so the unit conversion is explicit and the wrong-divisor class of mistake can't recur. The separate `if (_latency == 0) _latency = 1;` clamp is folded into `Math.max(1, ...)`, keeping the 1ms floor:

```java
long responseTimeMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - _start);
_latency = Math.max(1, responseTimeMillis * _latencyMultiplier);
```

Behavior is unchanged for the default `IceDiscovery.LatencyMultiplier = 1`. (Sub-millisecond response times truncate to 0 and hit the 1ms floor, same as before.)

CHANGELOG: `changelog.d/java/icediscovery-latency-window.md` (user-visible latency regression).

Fixes #5727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)