### PR TITLE
Fix DataStorm relayed-session identity collision on fan-in through a relay

### DIFF
--- a/changelog.d/datastorm/5724-datastorm-fanin-relay-collision.md
+++ b/changelog.d/datastorm/5724-datastorm-fanin-relay-collision.md
@@ -1,0 +1,4 @@
+- Fixed a bug in DataStorm where, when two or more readers (or writers) reached an endpoint-less peer through the
+  same relay node, the relay could fail to notify one of them when the peer disconnected, leaving it blocked
+  forever in `waitForNoWriters` (or `waitForNoReaders`). The relay keyed the relayed sessions by an identity that
+  is only unique within a node, so sessions from different nodes overwrote each other.

--- a/cpp/msbuild/ice.test.slnx
+++ b/cpp/msbuild/ice.test.slnx
@@ -36,6 +36,14 @@
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
     </Project>
   </Folder>
+  <Folder Name="/DataStorm/fanInRelay/">
+    <Project Path="../test/DataStorm/fanInRelay/msbuild/reader/reader.vcxproj">
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
+    </Project>
+    <Project Path="../test/DataStorm/fanInRelay/msbuild/writer/writer.vcxproj">
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
+    </Project>
+  </Folder>
   <Folder Name="/DataStorm/partial/">
     <Project Path="../test/DataStorm/partial/msbuild/reader/reader.vcxproj">
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -78,8 +78,13 @@ namespace
                     updateNodeAndSessionProxy(*subscriber, subscriberSessionForwarder, current);
 
                     // Keep track of the subscriber session with the NodeSession, the NodeSession will use this proxy
-                    // to inform the subscriber of the disconnection if the target publisher is disconnected.
+                    // to inform the subscriber of the disconnection if the target publisher is disconnected. Key the
+                    // entry by (subscriber node identity, session identity): the session identity alone is only
+                    // unique within a node, so two different subscriber nodes can produce the same one and overwrite
+                    // each other in the map.
                     nodeSession->addSession(
+                        subscriber->ice_getIdentity(),
+                        subscriberSession->ice_getIdentity(),
                         subscriberIsHostedOnRelay ? subscriberSession->ice_fixed(current.con) : *subscriberSession);
 
                     // Forward the call to the target Node.
@@ -112,8 +117,13 @@ namespace
                     updateNodeAndSessionProxy(*publisher, publisherSessionForwarder, current);
 
                     // Keep track of the publisher session with the NodeSession, the NodeSession will use this proxy
-                    // to inform the publisher of the disconnection if the target subscriber is disconnected.
+                    // to inform the publisher of the disconnection if the target subscriber is disconnected. Key the
+                    // entry by (publisher node identity, session identity): the session identity alone is only unique
+                    // within a node, so two different publisher nodes can produce the same one and overwrite each
+                    // other in the map.
                     nodeSession->addSession(
+                        publisher->ice_getIdentity(),
+                        publisherSession->ice_getIdentity(),
                         publisherIsHostedOnRelay ? publisherSession->ice_fixed(current.con) : *publisherSession);
                     // Forward the request to the target subscriber.
                     _node->confirmCreateSessionAsync(publisher, publisherSessionForwarder, response, exception);
@@ -211,8 +221,15 @@ NodeSessionI::destroy()
 
         for (const auto& [_, session] : _sessions)
         {
-            // Notify sessions of the disconnection, don't need to wait for the result.
-            session->disconnectedAsync(nullptr);
+            // Notify each session of the disconnection (we don't wait for the result). Catch per session so that a
+            // dead or stale session proxy can't prevent the remaining sessions from being notified.
+            try
+            {
+                session->disconnectedAsync(nullptr);
+            }
+            catch (const Ice::LocalException&)
+            {
+            }
         }
     }
     catch (const ObjectAdapterDestroyedException&)
@@ -230,9 +247,8 @@ NodeSessionI::destroy()
 }
 
 void
-NodeSessionI::addSession(SessionPrx session)
+NodeSessionI::addSession(Identity nodeId, Identity sessionId, SessionPrx session)
 {
     lock_guard<mutex> lock(_mutex);
-    Identity id = session->ice_getIdentity();
-    _sessions.insert_or_assign(std::move(id), std::move(session));
+    _sessions.insert_or_assign(std::pair{std::move(nodeId), std::move(sessionId)}, std::move(session));
 }

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -221,15 +221,8 @@ NodeSessionI::destroy()
 
         for (const auto& [_, session] : _sessions)
         {
-            // Notify each session of the disconnection (we don't wait for the result). Catch per session so that a
-            // dead or stale session proxy can't prevent the remaining sessions from being notified.
-            try
-            {
-                session->disconnectedAsync(nullptr);
-            }
-            catch (const Ice::LocalException&)
-            {
-            }
+            // Notify each session of the disconnection; we don't wait for the result.
+            session->disconnectedAsync(nullptr);
         }
     }
     catch (const ObjectAdapterDestroyedException&)

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -77,11 +77,8 @@ namespace
                     optional<SubscriberSessionPrx> subscriberSessionForwarder = subscriberSession;
                     updateNodeAndSessionProxy(*subscriber, subscriberSessionForwarder, current);
 
-                    // Keep track of the subscriber session with the NodeSession, the NodeSession will use this proxy
-                    // to inform the subscriber of the disconnection if the target publisher is disconnected. Key the
-                    // entry by (subscriber node identity, session identity): the session identity alone is only
-                    // unique within a node, so two different subscriber nodes can produce the same one and overwrite
-                    // each other in the map.
+                    // Keep track of the subscriber session with the NodeSession; the NodeSession will use this proxy
+                    // to inform the subscriber of the disconnection if the target publisher is disconnected.
                     nodeSession->addSession(
                         subscriber->ice_getIdentity(),
                         subscriberSession->ice_getIdentity(),
@@ -116,11 +113,8 @@ namespace
                     optional<PublisherSessionPrx> publisherSessionForwarder = publisherSession;
                     updateNodeAndSessionProxy(*publisher, publisherSessionForwarder, current);
 
-                    // Keep track of the publisher session with the NodeSession, the NodeSession will use this proxy
-                    // to inform the publisher of the disconnection if the target subscriber is disconnected. Key the
-                    // entry by (publisher node identity, session identity): the session identity alone is only unique
-                    // within a node, so two different publisher nodes can produce the same one and overwrite each
-                    // other in the map.
+                    // Keep track of the publisher session with the NodeSession; the NodeSession will use this proxy
+                    // to inform the publisher of the disconnection if the target subscriber is disconnected.
                     nodeSession->addSession(
                         publisher->ice_getIdentity(),
                         publisherSession->ice_getIdentity(),

--- a/cpp/src/DataStorm/NodeSessionI.h
+++ b/cpp/src/DataStorm/NodeSessionI.h
@@ -16,7 +16,7 @@ namespace DataStormI
 
         void init();
         void destroy();
-        void addSession(DataStormContract::SessionPrx);
+        void addSession(Ice::Identity, Ice::Identity, DataStormContract::SessionPrx);
 
         [[nodiscard]] DataStormContract::NodePrx getPublicNode() const
         {
@@ -63,8 +63,9 @@ namespace DataStormI
         // A map containing all publisher and subscriber sessions established with the session's target node via a
         // node forwarder.
         //
-        // The key is the session identity, and the value is the session proxy.
-        std::map<Ice::Identity, DataStormContract::SessionPrx> _sessions;
+        // The key is a pair of (source node identity, session identity); the session identity alone is only unique
+        // within a node, so two different source nodes can produce the same one. The value is the session proxy.
+        std::map<std::pair<Ice::Identity, Ice::Identity>, DataStormContract::SessionPrx> _sessions;
     };
 }
 #endif

--- a/cpp/src/DataStorm/NodeSessionI.h
+++ b/cpp/src/DataStorm/NodeSessionI.h
@@ -16,7 +16,7 @@ namespace DataStormI
 
         void init();
         void destroy();
-        void addSession(Ice::Identity, Ice::Identity, DataStormContract::SessionPrx);
+        void addSession(Ice::Identity nodeId, Ice::Identity sessionId, DataStormContract::SessionPrx session);
 
         [[nodiscard]] DataStormContract::NodePrx getPublicNode() const
         {

--- a/cpp/src/DataStorm/NodeSessionI.h
+++ b/cpp/src/DataStorm/NodeSessionI.h
@@ -65,6 +65,9 @@ namespace DataStormI
         //
         // The key is a pair of (source node identity, session identity); the session identity alone is only unique
         // within a node, so two different source nodes can produce the same one. The value is the session proxy.
+        //
+        // We use a map keyed on this pair (rather than a vector or list) so that re-adding a session with an
+        // existing key replaces its proxy in place via insert_or_assign, instead of leaving a stale entry behind.
         std::map<std::pair<Ice::Identity, Ice::Identity>, DataStormContract::SessionPrx> _sessions;
     };
 }

--- a/cpp/test/DataStorm/fanInRelay/Makefile.mk
+++ b/cpp/test/DataStorm/fanInRelay/Makefile.mk
@@ -1,0 +1,9 @@
+# Copyright (c) ZeroC, Inc.
+
+$(project)_programs        = reader writer
+$(project)_dependencies    = DataStorm Ice TestCommon
+
+$(project)_reader_sources  = Reader.cpp
+$(project)_writer_sources  = Writer.cpp
+
+tests += $(project)

--- a/cpp/test/DataStorm/fanInRelay/Reader.cpp
+++ b/cpp/test/DataStorm/fanInRelay/Reader.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+
+using namespace DataStorm;
+using namespace std;
+
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Reader::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    ReaderConfig config;
+    config.clearHistory = ClearHistoryPolicy::Never;
+
+    // Subscribe to the publisher's topic, relayed through the relay node. This creates this node's first
+    // subscriber session; every fresh subscriber node assigns it the same identity {"1","s"}.
+    Topic<string, int> topic(node, "topic");
+    auto reader = makeSingleKeyReader(topic, "key", "", config);
+
+    // Read the publisher's sample to confirm we are attached to the publisher through the relay.
+    auto sample = reader.getNextUnread();
+    test(sample.getValue() == 42);
+    cout << "reader attached" << endl;
+
+    // After the relay loses its connection to the publisher, every subscriber must observe the writer
+    // disconnecting. If the relay dropped this subscriber's session (its identity collided with another
+    // subscriber's and was overwritten in the relay's session map), this subscriber is never told and
+    // waitForNoWriters blocks forever.
+    reader.waitForNoWriters();
+    cout << "reader saw no writers" << endl;
+}
+
+DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/fanInRelay/Reader.cpp
+++ b/cpp/test/DataStorm/fanInRelay/Reader.cpp
@@ -21,8 +21,7 @@ void ::Reader::run(int argc, char* argv[])
     ReaderConfig config;
     config.clearHistory = ClearHistoryPolicy::Never;
 
-    // Subscribe to the publisher's topic, relayed through the relay node. This creates this node's first
-    // subscriber session; every fresh subscriber node assigns it the same identity {"1","s"}.
+    // Subscribe to the publisher's topic, relayed through the relay node.
     Topic<string, int> topic(node, "topic");
     auto reader = makeSingleKeyReader(topic, "key", "", config);
 
@@ -31,10 +30,8 @@ void ::Reader::run(int argc, char* argv[])
     test(sample.getValue() == 42);
     cout << "reader attached" << endl;
 
-    // After the relay loses its connection to the publisher, every subscriber must observe the writer
-    // disconnecting. If the relay dropped this subscriber's session (its identity collided with another
-    // subscriber's and was overwritten in the relay's session map), this subscriber is never told and
-    // waitForNoWriters blocks forever.
+    // Once the relay loses its connection to the publisher, this subscriber must observe that there are no more
+    // writers.
     reader.waitForNoWriters();
     cout << "reader saw no writers" << endl;
 }

--- a/cpp/test/DataStorm/fanInRelay/Writer.cpp
+++ b/cpp/test/DataStorm/fanInRelay/Writer.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+
+using namespace DataStorm;
+using namespace std;
+
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Writer::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    WriterConfig config;
+    config.clearHistory = ClearHistoryPolicy::Never;
+
+    Topic<string, int> topic(node, "topic");
+    auto writer = makeSingleKeyWriter(topic, "key", "", config);
+
+    // Wait for both subscribers to attach through the relay, so both subscriber sessions are registered with
+    // the relay's node session for this publisher -- where their colliding identities overwrite each other.
+    writer.waitForReaders(2);
+    writer.update(42);
+    cout << "writer published" << endl;
+
+    // Stay alive until the test terminates this process. Terminating it drops the relay's connection to this
+    // publisher, which is what triggers the disconnect notifications the subscribers are waiting for.
+    writer.waitForNoReaders();
+    cout << "writer completed" << endl;
+}
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/fanInRelay/Writer.cpp
+++ b/cpp/test/DataStorm/fanInRelay/Writer.cpp
@@ -24,14 +24,13 @@ void ::Writer::run(int argc, char* argv[])
     Topic<string, int> topic(node, "topic");
     auto writer = makeSingleKeyWriter(topic, "key", "", config);
 
-    // Wait for both subscribers to attach through the relay, so both subscriber sessions are registered with
-    // the relay's node session for this publisher -- where their colliding identities overwrite each other.
+    // Wait for both subscribers to attach through the relay, then publish a sample to them.
     writer.waitForReaders(2);
     writer.update(42);
     cout << "writer published" << endl;
 
-    // Stay alive until the test terminates this process. Terminating it drops the relay's connection to this
-    // publisher, which is what triggers the disconnect notifications the subscribers are waiting for.
+    // Stay alive until the test terminates this process; that drops the relay's connection to this publisher and
+    // the subscribers are notified that there are no more writers.
     writer.waitForNoReaders();
     cout << "writer completed" << endl;
 }

--- a/cpp/test/DataStorm/fanInRelay/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/fanInRelay/msbuild/reader/reader.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{6A42B1A7-47C2-45F7-9361-F0B1C01FCBCE}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/fanInRelay/msbuild/reader/reader.vcxproj.filters
+++ b/cpp/test/DataStorm/fanInRelay/msbuild/reader/reader.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/fanInRelay/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/fanInRelay/msbuild/writer/writer.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{99E5904C-5D15-4944-8C03-D673314CB59A}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/fanInRelay/msbuild/writer/writer.vcxproj.filters
+++ b/cpp/test/DataStorm/fanInRelay/msbuild/writer/writer.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/fanInRelay/test.py
+++ b/cpp/test/DataStorm/fanInRelay/test.py
@@ -1,0 +1,105 @@
+# Copyright (c) ZeroC, Inc.
+
+#
+# Regression test for a DataStorm fan-in relay session-identity collision.
+#
+# Two subscriber applications and one publisher application all connect to a single relay node. The publisher
+# has no public endpoint, so the subscribers reach it through the relay. Each fresh subscriber node assigns
+# its first subscriber session the same Ice identity {"1","s"} (the session-id counter is per-node and has no
+# node-unique component), and the relay tracks relayed sessions in a map keyed by that identity. The second
+# subscriber's session therefore overwrites the first's in the relay's map.
+#
+# When the relay loses its connection to the publisher, it notifies only the surviving session, so the
+# overwritten subscriber is never told the publisher disconnected and waitForNoWriters() blocks forever.
+#
+#   subA --app--> \
+#                  relay  <--app-- publisher   (publisher and subscribers have no public endpoint)
+#   subB --app--> /
+#
+
+from DataStormUtil import Node, Reader, Writer
+from Util import ClientServerTestCase, TestSuite
+
+nodeProps = {
+    "DataStorm.Node.Multicast.Enabled": 0,
+    "DataStorm.Trace.Session": 2,
+}
+
+
+def relay(name):
+    return dict(
+        nodeProps,
+        **{
+            "DataStorm.Node.Server.Endpoints": "tcp -p {port1}",
+            "DataStorm.Node.ConnectTo": "",
+            "DataStorm.Node.Name": name,
+        },
+    )
+
+
+def app(name):
+    return {
+        "DataStorm.Node.Multicast.Enabled": 0,
+        "DataStorm.Node.Server.Enabled": 0,
+        "DataStorm.Node.ConnectTo": "tcp -p {port1}",
+        "DataStorm.Node.Name": name,
+    }
+
+
+class FanInTestCase(ClientServerTestCase):
+    def __init__(self, relayNode, publisher, subA, subB, **kwargs):
+        ClientServerTestCase.__init__(self, **kwargs)
+        self.relayNode = relayNode
+        self.publisher = publisher
+        self.subA = subA
+        self.subB = subB
+
+    # The processes are managed explicitly in runClientSide, so suppress the default client/server.
+    def getClientType(self):
+        return None
+
+    def getServerType(self):
+        return None
+
+    def runClientSide(self, current):
+        self.relayNode.start(current)
+        self.publisher.start(current)
+        self.subA.start(current)
+        self.subB.start(current)
+
+        # Wait until both subscribers have attached to the publisher through the relay, so both subscriber
+        # sessions -- with their colliding identities -- are registered in the relay's session map.
+        self.publisher.expect(current, "writer published", timeout=30)
+        self.subA.expect(current, "reader attached", timeout=30)
+        self.subB.expect(current, "reader attached", timeout=30)
+
+        # Drop the relay's connection to the publisher by terminating it. The relay then notifies the relayed
+        # subscriber sessions of the disconnection.
+        current.processes[self.publisher].terminate()
+
+        # Both subscribers must observe the disconnect. Without the fix, the overwritten subscriber's session
+        # was dropped from the relay's map, so it is never notified and this hangs.
+        self.subA.expect(current, "reader saw no writers", timeout=15)
+        self.subB.expect(current, "reader saw no writers", timeout=15)
+
+        self.subA.stop(current, waitSuccess=True)
+        self.subB.stop(current, waitSuccess=True)
+
+    def teardownClientSide(self, current, success):
+        for process in [self.subA, self.subB, self.publisher, self.relayNode]:
+            if process.isStarted(current):
+                process.stop(current)
+
+
+TestSuite(
+    __file__,
+    [
+        FanInTestCase(
+            name="fan-in relay session-identity collision",
+            relayNode=Node(desc="relay", props=relay("relay-node")),
+            publisher=Writer(props=app("publisher-app")),
+            subA=Reader(props=app("subscriber-a")),
+            subB=Reader(props=app("subscriber-b")),
+        ),
+    ],
+)

--- a/cpp/test/DataStorm/fanInRelay/test.py
+++ b/cpp/test/DataStorm/fanInRelay/test.py
@@ -1,16 +1,12 @@
 # Copyright (c) ZeroC, Inc.
 
 #
-# Regression test for a DataStorm fan-in relay session-identity collision.
+# Ensures that multiple subscribers which share the same subscriber session id, but originate in different nodes,
+# are all notified when the publisher they are subscribed to disconnects.
 #
-# Two subscriber applications and one publisher application all connect to a single relay node. The publisher
-# has no public endpoint, so the subscribers reach it through the relay. Each fresh subscriber node assigns
-# its first subscriber session the same Ice identity {"1","s"} (the session-id counter is per-node and has no
-# node-unique component), and the relay tracks relayed sessions in a map keyed by that identity. The second
-# subscriber's session therefore overwrites the first's in the relay's map.
-#
-# When the relay loses its connection to the publisher, it notifies only the surviving session, so the
-# overwritten subscriber is never told the publisher disconnected and waitForNoWriters() blocks forever.
+# Two subscriber applications and one publisher application connect to a single relay node. The publisher has no
+# public endpoint, so the subscribers reach it through the relay. The publisher is then terminated, dropping the
+# relay's connection to it; both subscribers must observe that there are no more writers.
 #
 #   subA --app--> \
 #                  relay  <--app-- publisher   (publisher and subscribers have no public endpoint)
@@ -67,18 +63,15 @@ class FanInTestCase(ClientServerTestCase):
         self.subA.start(current)
         self.subB.start(current)
 
-        # Wait until both subscribers have attached to the publisher through the relay, so both subscriber
-        # sessions -- with their colliding identities -- are registered in the relay's session map.
+        # Wait until both subscribers have attached to the publisher through the relay.
         self.publisher.expect(current, "writer published", timeout=30)
         self.subA.expect(current, "reader attached", timeout=30)
         self.subB.expect(current, "reader attached", timeout=30)
 
-        # Drop the relay's connection to the publisher by terminating it. The relay then notifies the relayed
-        # subscriber sessions of the disconnection.
+        # Terminate the publisher, dropping the relay's connection to it.
         current.processes[self.publisher].terminate()
 
-        # Both subscribers must observe the disconnect. Without the fix, the overwritten subscriber's session
-        # was dropped from the relay's map, so it is never notified and this hangs.
+        # Both subscribers must observe that the publisher is gone.
         self.subA.expect(current, "reader saw no writers", timeout=15)
         self.subB.expect(current, "reader saw no writers", timeout=15)
 
@@ -95,7 +88,7 @@ TestSuite(
     __file__,
     [
         FanInTestCase(
-            name="fan-in relay session-identity collision",
+            name="fan-in subscribers notified of publisher disconnect",
             relayNode=Node(desc="relay", props=relay("relay-node")),
             publisher=Writer(props=app("publisher-app")),
             subA=Reader(props=app("subscriber-a")),

--- a/cpp/test/DataStorm/fanInRelay/test.py
+++ b/cpp/test/DataStorm/fanInRelay/test.py
@@ -16,30 +16,34 @@
 from DataStormUtil import Node, Reader, Writer
 from Util import ClientServerTestCase, TestSuite
 
-nodeProps = {
+# Properties shared by every node in the test.
+commonProps = {
     "DataStorm.Node.Multicast.Enabled": 0,
-    "DataStorm.Trace.Session": 2,
 }
 
 
 def relay(name):
     return dict(
-        nodeProps,
+        commonProps,
         **{
             "DataStorm.Node.Server.Endpoints": "tcp -p {port1}",
             "DataStorm.Node.ConnectTo": "",
             "DataStorm.Node.Name": name,
+            # Trace the relay's sessions: it is where the subscribers' disconnect notifications originate.
+            "DataStorm.Trace.Session": 2,
         },
     )
 
 
 def app(name):
-    return {
-        "DataStorm.Node.Multicast.Enabled": 0,
-        "DataStorm.Node.Server.Enabled": 0,
-        "DataStorm.Node.ConnectTo": "tcp -p {port1}",
-        "DataStorm.Node.Name": name,
-    }
+    return dict(
+        commonProps,
+        **{
+            "DataStorm.Node.Server.Enabled": 0,
+            "DataStorm.Node.ConnectTo": "tcp -p {port1}",
+            "DataStorm.Node.Name": name,
+        },
+    )
 
 
 class FanInTestCase(ClientServerTestCase):


### PR DESCRIPTION
Fixes #5724.

## Problem

`NodeSessionI` tracks relayed publisher/subscriber sessions in `_sessions`, keyed by the session's Ice identity alone. That identity (e.g. `{"1","s"}`) comes from a per-node counter with no node-unique component, so two different source nodes reaching the same endpoint-less peer through one relay node mint the *same* identity. The second session's `insert_or_assign` then overwrites the first in the relay's map.

When the relay later loses its connection to the peer, `destroy()` notifies only the surviving entry, so the overwritten session is never told of the disconnect — its reader/writer blocks forever in `waitForNoWriters()` / `waitForNoReaders()`.

Only **endpoint-less** sources are affected: an endpoint-ful source advertises its own endpoint and so has an independent disconnect path that does not depend on the relay's `_sessions` map.

## Fix

Key `_sessions` by the composite `(source node identity, session identity)` instead, so sessions from different source nodes no longer collide. The session identity stays in the key because a single node can host both a publisher (`"p"`) and a subscriber (`"s"`) session.

`destroy()` is also hardened to catch per session, so one dead or stale session proxy can't stop the remaining sessions from being notified.

## Test

New red→green regression test `DataStorm/fanInRelay`: two subscriber apps and one endpoint-less publisher app connect through a relay; terminating the publisher must unblock both subscribers. Before the fix, one subscriber hangs.