### PR TITLE
Fix HTTP proxy hang on invalid CONNECT response (C++, C#, Java)

### DIFF
--- a/changelog.d/general/http-proxy-malformed-response-hang.md
+++ b/changelog.d/general/http-proxy-malformed-response-hang.md
@@ -1,0 +1,2 @@
+- Fixed the handling of an invalid response from an HTTP proxy (configured with `Ice.HTTPProxyHost`). Connection
+  establishment now fails promptly with a `ProtocolException`, instead of hanging until the connection times out.

--- a/cpp/src/Ice/NetworkProxy.cpp
+++ b/cpp/src/Ice/NetworkProxy.cpp
@@ -248,7 +248,14 @@ void
 HTTPNetworkProxy::finish(Buffer& readBuffer, Buffer&)
 {
     HttpParser parser;
-    parser.parse(readBuffer.b.begin(), readBuffer.b.end());
+    try
+    {
+        parser.parse(readBuffer.b.begin(), readBuffer.b.end());
+    }
+    catch (const WebSocketException& ex)
+    {
+        throw Ice::ProtocolException{__FILE__, __LINE__, "malformed HTTP proxy response: " + ex.reason};
+    }
     if (parser.status() != 200)
     {
         throw Ice::ConnectFailedException{

--- a/csharp/src/Ice/Internal/NetworkProxy.cs
+++ b/csharp/src/Ice/Internal/NetworkProxy.cs
@@ -234,7 +234,7 @@ public sealed class HTTPNetworkProxy : NetworkProxy
         }
         catch (WebSocketException ex)
         {
-            throw new Ice.ProtocolException("malformed HTTP proxy response: " + ex.Message);
+            throw new Ice.ProtocolException("malformed HTTP proxy response", ex);
         }
         if (parser.status() != 200)
         {

--- a/csharp/src/Ice/Internal/NetworkProxy.cs
+++ b/csharp/src/Ice/Internal/NetworkProxy.cs
@@ -228,7 +228,14 @@ public sealed class HTTPNetworkProxy : NetworkProxy
     public void finish(Buffer readBuffer, Buffer writeBuffer)
     {
         var parser = new HttpParser();
-        parser.parse(readBuffer.b, 0, readBuffer.b.position());
+        try
+        {
+            parser.parse(readBuffer.b, 0, readBuffer.b.position());
+        }
+        catch (WebSocketException ex)
+        {
+            throw new Ice.ProtocolException("malformed HTTP proxy response: " + ex.Message);
+        }
         if (parser.status() != 200)
         {
             throw new Ice.ConnectFailedException(_address);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HTTPNetworkProxy.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HTTPNetworkProxy.java
@@ -72,7 +72,11 @@ final class HTTPNetworkProxy implements NetworkProxy {
     @Override
     public void finish(Buffer readBuffer, Buffer writeBuffer) {
         HttpParser parser = new HttpParser();
-        parser.parse(readBuffer.b, 0, readBuffer.b.position());
+        try {
+            parser.parse(readBuffer.b, 0, readBuffer.b.position());
+        } catch (WebSocketException ex) {
+            throw new ProtocolException("malformed HTTP proxy response: " + ex.getMessage());
+        }
         if (parser.status() != 200) {
             throw new ConnectFailedException();
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HTTPNetworkProxy.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HTTPNetworkProxy.java
@@ -75,7 +75,7 @@ final class HTTPNetworkProxy implements NetworkProxy {
         try {
             parser.parse(readBuffer.b, 0, readBuffer.b.position());
         } catch (WebSocketException ex) {
-            throw new ProtocolException("malformed HTTP proxy response: " + ex.getMessage());
+            throw new ProtocolException("malformed HTTP proxy response", ex);
         }
         if (parser.status() != 200) {
             throw new ConnectFailedException();


### PR DESCRIPTION
## Summary

When connecting through an HTTP proxy (`Ice.HTTPProxyHost`), `HTTPNetworkProxy::finish` parses the proxy's `CONNECT` response with `HttpParser::parse`, which throws `WebSocketException` on malformed input. That exception is not handled on the connection-establishment path — only `WSTransceiver` catches it — so it escaped the connection state machine: `setState(StateClosed, …)` never ran, and the connect attempt hung until `Ice.Override.ConnectTimeout` expired, or indefinitely when no connect timeout is configured.

The `WebSocketException` name is a misnomer here: `HttpParser` is a general HTTP parser shared by the `ws`/`wss` transport and the HTTP proxy; this path has nothing to do with WebSockets.

## Fix

Translate `WebSocketException` to `ProtocolException` in `finish()`, mirroring what `WSTransceiver` already does for the same parser. The connect attempt now fails promptly and deterministically.

## Cross-mapping

The original audit flagged C++ only, but the same defect is present identically in C# (`WebSocketException : System.Exception`) and Java (`WebSocketException extends RuntimeException`): in both, the exception escapes the `LocalException`-only catch in the connection's `message()` and lands in the thread pool's catch-all, which only logs. Fixed in all three mappings.

Fixes zeroc-ice/ice-audit#56

🤖 Generated with [Claude Code](https://claude.com/claude-code)