### PR TITLE
Add copilot-setup-steps.yml to provision the Copilot coding agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -12,6 +12,9 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     # Use a dedicated GitHub-hosted larger runner rather than the shared

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,51 @@
+name: Copilot Setup Steps
+
+# This workflow provisions the environment for the GitHub Copilot coding agent.
+# The job must be named `copilot-setup-steps` for Copilot to pick it up.
+# It mirrors the toolchain setup used by the Linux jobs in ci.yml.
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    # Use a dedicated GitHub-hosted larger runner rather than the shared
+    # `ubuntu-*` pool, which is sometimes exhausted and leaves the Copilot
+    # agent waiting for a runner. GitHub Actions has no availability-based
+    # fallback (a `runs-on` array is AND-matched, not OR), so we pin the
+    # custom runner directly.
+    runs-on: linux-latest-copilot
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Print System Info
+        uses: ./.github/actions/system-info
+
+      - name: Setup C++
+        uses: ./.github/actions/setup-cpp
+
+      - name: Setup PHP
+        uses: ./.github/actions/setup-php
+
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet
+        with:
+          include_net10: true
+
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Setup Ruby
+        uses: ./.github/actions/setup-ruby


### PR DESCRIPTION
This adds a `copilot-setup-steps.yml` workflow so the GitHub Copilot coding agent provisions a working build environment before it starts. The job mirrors the toolchain setup used by the Linux jobs in `ci.yml` (C++, PHP, Python, .NET, Java, Node, and Ruby) so the agent can build and test the various language mappings.

It runs on our dedicated `linux-latest-copilot` runner (which I just created) rather than the shared `ubuntu-*` pool, which is sometimes exhausted by CI and leaves Copilot waiting for a runner. Routing both the coding agent and code review onto the dedicated runner (the latter via the org-level Copilot runner-type setting) keeps them out of that contention (hopefully).

The primary goal is to mitigate: 

<img width="784" height="141" alt="Screenshot 2026-06-26 at 1 36 13 PM" src="https://github.com/user-attachments/assets/62cb935f-5350-4af4-8a61-8b3a6337f87d" />
