### PR TITLE
Pin GitHub Actions to commit SHAs and extend Dependabot to the 3.8 and 3.7 branches

### DIFF
--- a/.github/actions/build-slice-compiler/action.yml
+++ b/.github/actions/build-slice-compiler/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Sign Compiler Artifact
       if: runner.os == 'Windows' && inputs.authenticode_sign == 'true'
-      uses: azure/trusted-signing-action@v0
+      uses: azure/trusted-signing-action@1d365fec12862c4aa68fcac418143d73f0cea293 # v0.5.11
       with:
         azure-tenant-id: ${{ env.AZURE_TENANT_ID }}
         azure-client-id: ${{ env.AZURE_CLIENT_ID }}

--- a/.github/actions/install-windows-debug-tools/action.yml
+++ b/.github/actions/install-windows-debug-tools/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Upload SDK install log
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: sdk-install-log
         path: ${{ runner.temp }}/sdk.log

--- a/.github/actions/setup-cache/action.yml
+++ b/.github/actions/setup-cache/action.yml
@@ -45,7 +45,7 @@ runs:
       shell: bash
 
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
       with:
         create-symlink: false
         append-timestamp: false

--- a/.github/actions/setup-cpp/action.yml
+++ b/.github/actions/setup-cpp/action.yml
@@ -51,7 +51,7 @@ runs:
       if: runner.os == 'Linux'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v3
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
       with:
         msbuild-architecture: x64
       if: runner.os == 'Windows'

--- a/.github/actions/setup-dotnet/action.yml
+++ b/.github/actions/setup-dotnet/action.yml
@@ -10,12 +10,12 @@ runs:
   using: "composite"
   steps:
     - name: Setup .NET 8
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: 8.0.x
 
     - name: Setup .NET 10
       if: inputs.include_net10 == 'true'
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: 10.0.x

--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Oracle Java 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
         distribution: "oracle"
         java-version: "17"

--- a/.github/actions/setup-matlab/action.yml
+++ b/.github/actions/setup-matlab/action.yml
@@ -8,7 +8,7 @@ runs:
     #
     - name: Setup MATLAB
       id: setup-matlab
-      uses: matlab-actions/setup-matlab@v3
+      uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v3.0.1
       with:
         release: "R2025b"
 

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -3,6 +3,6 @@ description: Installs Node.js 22 using the actions/setup-node action.
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "22"

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -3,6 +3,6 @@ description: Installs Ruby 3.4 using the ruby/setup-ruby action.
 runs:
   using: "composite"
   steps:
-    - uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         ruby-version: "3.4"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,9 +78,6 @@ updates:
       interval: monthly
     cooldown:
       default-days: 7
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
     groups:
       github-actions:
         patterns:
@@ -142,8 +139,7 @@ updates:
       swift-minor-and-patch:
         update-types: ["minor", "patch"]
 
-  # 3.7 is in maintenance, so only its GitHub Actions are kept up to date
-  # (majors ignored, as on 3.8).
+  # 3.7 is in maintenance, so only its GitHub Actions are kept up to date.
   - package-ecosystem: "github-actions"
     # Two entries are required: "/" is the special value that scans
     # .github/workflows (plus any root action.yml); "/.github/actions/*"
@@ -156,9 +152,6 @@ updates:
       interval: monthly
     cooldown:
       default-days: 7
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     cooldown:
       default-days: 7
     groups:
@@ -54,6 +54,82 @@ updates:
 
   - package-ecosystem: "swift"
     directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+    groups:
+      swift-minor-and-patch:
+        update-types: ["minor", "patch"]
+      swift-major:
+        update-types: ["major"]
+
+  # The blocks below mirror the ones above with target-branch: "3.8" so
+  # Dependabot also opens version-update PRs against the 3.8 release branch.
+  # (Dependabot reads this config from the default branch only; security
+  # updates always target the default branch and cannot be pointed at 3.8.)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "3.8"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/js"
+    target-branch: "3.8"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+    groups:
+      js-minor-and-patch:
+        update-types: ["minor", "patch"]
+      js-major:
+        update-types: ["major"]
+
+  - package-ecosystem: "pip"
+    directory: "/python"
+    target-branch: "3.8"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+    groups:
+      python-minor-and-patch:
+        update-types: ["minor", "patch"]
+      python-major:
+        update-types: ["major"]
+
+  - package-ecosystem: "pip"
+    directory: "/python/docs"
+    target-branch: "3.8"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    groups:
+      python-docs:
+        patterns: ["*"]
+
+  - package-ecosystem: "swift"
+    directory: "/"
+    target-branch: "3.8"
     schedule:
       interval: "monthly"
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -141,3 +141,25 @@ updates:
     groups:
       swift-minor-and-patch:
         update-types: ["minor", "patch"]
+
+  # 3.7 is in maintenance, so only its GitHub Actions are kept up to date
+  # (majors ignored, as on 3.8).
+  - package-ecosystem: "github-actions"
+    # Two entries are required: "/" is the special value that scans
+    # .github/workflows (plus any root action.yml); "/.github/actions/*"
+    # covers the composite actions, which each have their own action.yml.
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    target-branch: "3.7"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    # Two entries are required: "/" is the special value that scans
+    # .github/workflows (plus any root action.yml); "/.github/actions/*"
+    # covers the composite actions, which each have their own action.yml.
     directories:
       - "/"
       - "/.github/actions/*"
@@ -64,6 +67,9 @@ updates:
   # reads this config from the default branch only, and security updates always
   # target the default branch (they cannot be pointed at 3.8).
   - package-ecosystem: "github-actions"
+    # Two entries are required: "/" is the special value that scans
+    # .github/workflows (plus any root action.yml); "/.github/actions/*"
+    # covers the composite actions, which each have their own action.yml.
     directories:
       - "/"
       - "/.github/actions/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: monthly
     cooldown:
@@ -72,7 +74,9 @@ updates:
   # (Dependabot reads this config from the default branch only; security
   # updates always target the default branch and cannot be pointed at 3.8.)
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     target-branch: "3.8"
     schedule:
       interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,10 +62,9 @@ updates:
       swift-major:
         update-types: ["major"]
 
-  # The blocks below mirror the ones above with target-branch: "3.8". 3.8 is a
-  # stable release branch, so major version updates are ignored there. Dependabot
-  # reads this config from the default branch only, and security updates always
-  # target the default branch (they cannot be pointed at 3.8).
+  # 3.8 only receives GitHub Actions updates here; its language deps are kept in
+  # sync with main by cherry-pick. (Config is read from the default branch only,
+  # and security updates always target the default branch.)
   - package-ecosystem: "github-actions"
     # Two entries are required: "/" is the special value that scans
     # .github/workflows (plus any root action.yml); "/.github/actions/*"
@@ -82,62 +81,6 @@ updates:
       github-actions:
         patterns:
           - "*"
-
-  - package-ecosystem: "npm"
-    directory: "/js"
-    target-branch: "3.8"
-    schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      js-minor-and-patch:
-        update-types: ["minor", "patch"]
-
-  - package-ecosystem: "pip"
-    directory: "/python"
-    target-branch: "3.8"
-    schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      python-minor-and-patch:
-        update-types: ["minor", "patch"]
-
-  - package-ecosystem: "pip"
-    directory: "/python/docs"
-    target-branch: "3.8"
-    schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      python-docs:
-        patterns: ["*"]
-
-  - package-ecosystem: "swift"
-    directory: "/"
-    target-branch: "3.8"
-    schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      swift-minor-and-patch:
-        update-types: ["minor", "patch"]
 
   # 3.7 is in maintenance, so only its GitHub Actions are kept up to date.
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,13 +16,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/js"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
     groups:
       js-minor-and-patch:
         update-types: ["minor", "patch"]
@@ -32,13 +28,9 @@ updates:
   - package-ecosystem: "pip"
     directory: "/python"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
     groups:
       python-minor-and-patch:
         update-types: ["minor", "patch"]
@@ -48,8 +40,9 @@ updates:
   - package-ecosystem: "pip"
     directory: "/python/docs"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 2
+      interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       python-docs:
         patterns: ["*"]
@@ -57,22 +50,19 @@ updates:
   - package-ecosystem: "swift"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
     groups:
       swift-minor-and-patch:
         update-types: ["minor", "patch"]
       swift-major:
         update-types: ["major"]
 
-  # The blocks below mirror the ones above with target-branch: "3.8" so
-  # Dependabot also opens version-update PRs against the 3.8 release branch.
-  # (Dependabot reads this config from the default branch only; security
-  # updates always target the default branch and cannot be pointed at 3.8.)
+  # The blocks below mirror the ones above with target-branch: "3.8". 3.8 is a
+  # stable release branch, so major version updates are ignored there. Dependabot
+  # reads this config from the default branch only, and security updates always
+  # target the default branch (they cannot be pointed at 3.8).
   - package-ecosystem: "github-actions"
     directories:
       - "/"
@@ -82,6 +72,9 @@ updates:
       interval: monthly
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       github-actions:
         patterns:
@@ -91,42 +84,40 @@ updates:
     directory: "/js"
     target-branch: "3.8"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       js-minor-and-patch:
         update-types: ["minor", "patch"]
-      js-major:
-        update-types: ["major"]
 
   - package-ecosystem: "pip"
     directory: "/python"
     target-branch: "3.8"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       python-minor-and-patch:
         update-types: ["minor", "patch"]
-      python-major:
-        update-types: ["major"]
 
   - package-ecosystem: "pip"
     directory: "/python/docs"
     target-branch: "3.8"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 2
+      interval: monthly
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       python-docs:
         patterns: ["*"]
@@ -135,14 +126,12 @@ updates:
     directory: "/"
     target-branch: "3.8"
     schedule:
-      interval: "monthly"
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       swift-minor-and-patch:
         update-types: ["minor", "patch"]
-      swift-major:
-        update-types: ["major"]

--- a/.github/workflows/build-brew-packages.yml
+++ b/.github/workflows/build-brew-packages.yml
@@ -41,7 +41,7 @@ jobs:
     if: ${{ inputs.quality == 'nightly' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -68,7 +68,7 @@ jobs:
           ./packaging/brew/update-nightly-tap.sh "${{ inputs.channel }}" "${{ inputs.quality }}" "${{ inputs.ice_version }}" "${{ steps.icegridgui.outputs.icegridgui_dmg_sha256 }}"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: homebrew-bottle
           path: |

--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ice
 
@@ -100,10 +100,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -163,15 +163,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ice
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice

--- a/.github/workflows/build-cpp-nuget-packages.yml
+++ b/.github/workflows/build-cpp-nuget-packages.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -52,7 +52,7 @@ jobs:
         working-directory: cpp/msbuild
 
       - name: Upload NuGet Packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-cpp-nuget-packages
           path: |

--- a/.github/workflows/build-cpp-swift-deps.yml
+++ b/.github/workflows/build-cpp-swift-deps.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -67,7 +67,7 @@ jobs:
           cp cpp/bin/slice2swift-*.artifactbundle.zip staging/
 
       - name: Upload C++ Dependencies for Swift
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cpp-swift-deps
           path: staging/

--- a/.github/workflows/build-cpp-windows-binaries.yml
+++ b/.github/workflows/build-cpp-windows-binaries.yml
@@ -31,7 +31,7 @@ jobs:
         configuration: [Release, Debug]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -43,7 +43,7 @@ jobs:
 
       - name: Sign C++ Binaries with Trusted Signing
         if: ${{ inputs.authenticode_sign }}
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -58,7 +58,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Upload C++ Build
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-cpp-${{ matrix.platform }}-${{ matrix.configuration }}-build
           path: |
@@ -69,7 +69,7 @@ jobs:
             cpp/src/**/msbuild/**/${{ matrix.platform }}/${{ matrix.configuration }}/*.h
 
       - name: Upload C++ Slice Tools
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # We only need to upload the Slice Tools once (Release x64 build) which are included in the Nuget packages
         if: ${{ matrix.configuration == 'Release' && matrix.platform == 'x64' }}
         with:

--- a/.github/workflows/build-deb-ice-repo-packages.yml
+++ b/.github/workflows/build-deb-ice-repo-packages.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ice
 
@@ -28,10 +28,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -65,7 +65,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deb-packages-${{ matrix.distribution }}
           path: |

--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -61,7 +61,7 @@ jobs:
       DEB_BUILD_OPTIONS: "nocheck parallel=4"
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ice
 
@@ -71,10 +71,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -108,7 +108,7 @@ jobs:
         shell: bash
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deb-packages-${{ matrix.distribution }}-${{ matrix.arch }}
           path: |

--- a/.github/workflows/build-dotnet-packages.yml
+++ b/.github/workflows/build-dotnet-packages.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -59,7 +59,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
       - name: Upload Compiler Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: slice2cs-${{ matrix.target }}
           path: ${{ matrix.artifact-path }}
@@ -70,13 +70,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
 
       - name: Download All slice2cs Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: slice2cs-*
 
@@ -119,7 +119,7 @@ jobs:
 
       - name: Sign .NET Assemblies with Trusted Signing
         if: ${{ inputs.authenticode_sign }}
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -138,7 +138,7 @@ jobs:
           SLICE2CS_STAGING_PATH: "${{ github.workspace }}\\tools"
 
       - name: Upload NuGet Packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dotnet-nuget-packages
           path: |

--- a/.github/workflows/build-gem-packages.yml
+++ b/.github/workflows/build-gem-packages.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -39,7 +39,7 @@ jobs:
         run: rake
 
       - name: Upload Gem Packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gem-packages
           path: ruby/zeroc-ice-*.gem

--- a/.github/workflows/build-icegridgui-jar.yml
+++ b/.github/workflows/build-icegridgui-jar.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -44,7 +44,7 @@ jobs:
         working-directory: java
 
       - name: Upload IceGrid GUI JAR
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: icegridgui-jar-${{ runner.os }}
           path: |

--- a/.github/workflows/build-icegridgui-macos-app.yml
+++ b/.github/workflows/build-icegridgui-macos-app.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Java
         uses: ./.github/actions/setup-java
@@ -89,7 +89,7 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
 
       - name: Upload IceGrid GUI macOS App
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: icegridgui-macos-app
           path: |

--- a/.github/workflows/build-java-packages.yml
+++ b/.github/workflows/build-java-packages.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -39,7 +39,7 @@ jobs:
         working-directory: java
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: java-packages
           path: |

--- a/.github/workflows/build-matlab-packages.yml
+++ b/.github/workflows/build-matlab-packages.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -67,7 +67,7 @@ jobs:
           Add-Content -Path "${{ github.workspace }}\catalog.txt" -Value "cpp\bin\x64\Release\slice2matlab.exe"
 
       - name: Sign C++ Binaries
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         if: runner.os == 'Windows' && inputs.authenticode_sign
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -86,7 +86,7 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: matlab-packages-${{ matrix.os }}
           path: matlab/toolbox/*.mltbx

--- a/.github/workflows/build-npm-packages.yml
+++ b/.github/workflows/build-npm-packages.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -63,7 +63,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
       - name: Upload Compiler Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: slice2js-${{ matrix.target }}
           path: ${{ matrix.artifact-path }}
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ice
 
@@ -84,7 +84,7 @@ jobs:
         uses: ./ice/.github/actions/setup-node
 
       - name: Download All slice2js Compiler Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: slice2js-*
@@ -134,7 +134,7 @@ jobs:
         working-directory: ice/js/packages/slice2js
 
       - name: Upload NPM Packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: js-npm-packages
           path: |

--- a/.github/workflows/build-pip-packages.yml
+++ b/.github/workflows/build-pip-packages.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -41,7 +41,7 @@ jobs:
         run: python3 -m build --sdist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pip-sdist
           path: python/dist/zeroc_ice-*.tar.gz
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -86,7 +86,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Download sdist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pip-sdist
           path: sdist
@@ -105,7 +105,7 @@ jobs:
           pip wheel (Get-ChildItem sdist\*.tar.gz).FullName --no-deps -w dist/
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pip-packages-${{ matrix.os }}-${{ matrix.python-version }}
           path: dist/zeroc_ice-*.whl

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Configure build
         id: configure

--- a/.github/workflows/build-rpm-ice-repo-packages.yml
+++ b/.github/workflows/build-rpm-ice-repo-packages.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ice
 
@@ -28,10 +28,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -65,7 +65,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rpm-packages-${{ matrix.distribution }}
           path: |

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ice
 
@@ -33,10 +33,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -54,7 +54,7 @@ jobs:
             /workspace/ice/packaging/rpm/build-package.sh
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rpm-packages-${{ matrix.distribution }}-${{ matrix.arch }}
           path: |

--- a/.github/workflows/build-slice-tools-packages.yml
+++ b/.github/workflows/build-slice-tools-packages.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -62,7 +62,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
       - name: Upload Compiler Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: slice2java-${{ matrix.target }}
           path: ${{ matrix.artifact-path }}
@@ -75,12 +75,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ice
 
       - name: Download All slice2java Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: slice2java-*
@@ -120,7 +120,7 @@ jobs:
         working-directory: ice/java/tools/slice-tools
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: slice-tools-packages
           path: |

--- a/.github/workflows/build-symbols-sources-store.yml
+++ b/.github/workflows/build-symbols-sources-store.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set ICE_VERSION
         shell: bash
@@ -93,7 +93,7 @@ jobs:
             /compress
 
       - name: Upload Symbols and Sources
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-symbols-sources
           path: |
@@ -103,7 +103,7 @@ jobs:
       # Use symbols-sources as the root directory so that the unzipped artifact as a pdb directory.
       # This means we need to exclude the symbols and sources directories.
       - name: Upload Indexed PDBs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-indexed-pdbs
           path: |

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -54,7 +54,7 @@ jobs:
 
       - name: Sign MSI with Trusted Signing
         if: ${{ inputs.authenticode_sign }}
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Sign Burn engine with Trusted Signing
         if: ${{ inputs.authenticode_sign }}
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Sign Bundle installer with Trusted Signing
         if: ${{ inputs.authenticode_sign }}
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -127,7 +127,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Upload Installer
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-installer
           path: |

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Load version info
         run: |
@@ -91,10 +91,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -121,7 +121,7 @@ jobs:
             "
 
       - name: Upload test logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ matrix.distribution }}-${{ matrix.arch }}
           path: cpp/**/*.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Print System Info
         uses: ./.github/actions/system-info
@@ -295,7 +295,7 @@ jobs:
         if: matrix.config == 'release' && runner.os == 'macOS'
 
       - name: Upload test logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ matrix.config }}-${{ matrix.os }}
           path: ${{ '.' }}/**/*.log
@@ -311,7 +311,7 @@ jobs:
         shell: bash
 
       - name: Upload Linux crash dump reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: crash-dumps-${{ matrix.config }}-${{ matrix.os }}
           path: ${{ github.workspace }}/LinuxDumpReports/*
@@ -319,7 +319,7 @@ jobs:
         if: runner.os == 'Linux' && always()
 
       - name: Upload macOS crash diagnostics
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: crash-diagnostics-${{ matrix.config }}-${{ matrix.os }}
           path: ~/Library/Logs/DiagnosticReports/*.ips
@@ -340,7 +340,7 @@ jobs:
               --cdb "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe"
 
       - name: Upload Windows crash dump reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: crash-dumps-${{ matrix.config }}-${{ matrix.os }}
           path: ${{ github.workspace }}/LocalDumpReports/*

--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -23,12 +23,12 @@ jobs:
         os: [macos-26, ubuntu-24.04, ubuntu-24.04-arm, windows-2025]
     steps:
       - name: Checkout HEAD
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: head
 
       - name: Checkout stable (${{ env.STABLE_TAG }})
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.STABLE_TAG }}
           path: stable
@@ -182,7 +182,7 @@ jobs:
             ${{ matrix.os == 'ubuntu-24.04' && '--languages=cpp,csharp,java' || '--languages=cpp' }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: compat-test-results-${{ matrix.os }}
           path: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -93,7 +93,7 @@ jobs:
           dotnet-coverage shutdown dotnet-coverage
 
       - name: Generate Coverage Reports
-        uses: danielpalme/ReportGenerator-GitHub-Action@5.5.10
+        uses: danielpalme/ReportGenerator-GitHub-Action@049f7ec958c672fd31d5cc1cb01622dc8d2e23ab # 5.5.10
         with:
           reports: csharp/coverage.cobertura.xml
           targetdir: coveragereport
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Clang Format
         run: |
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Ice
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -79,7 +79,7 @@ jobs:
         run: bear -- make
 
       - name: Select files to check
-        uses: tj-actions/glob@v22
+        uses: tj-actions/glob@2deae40528141fc53131606d56b4e4ce2a486b29 # v22.0.2
         id: glob
         with:
           files: |
@@ -95,7 +95,7 @@ jobs:
           run-clang-tidy-19 -j$(nproc) -quiet ${{ steps.glob.outputs.paths }}
 
       - name: Select files to check for IcePy
-        uses: tj-actions/glob@v22
+        uses: tj-actions/glob@2deae40528141fc53131606d56b4e4ce2a486b29 # v22.0.2
         id: globpy
         with:
           files: |

--- a/.github/workflows/dispatch-compat-nightly.yml
+++ b/.github/workflows/dispatch-compat-nightly.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Dispatch binary compat test for 3.8 (5:00 UTC)
         if: github.event.schedule == '0 5 * * *'

--- a/.github/workflows/dispatch-container-image-builds.yml
+++ b/.github/workflows/dispatch-container-image-builds.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Dispatch container image builds for main (6:00 UTC)
         if: github.event.schedule == '0 6 * * 6'

--- a/.github/workflows/dispatch-nightly-release.yml
+++ b/.github/workflows/dispatch-nightly-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Dispatch nightly build for main (2:00 UTC)
         if: github.event.schedule == '0 2 * * *'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "latest"
 
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "latest"
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >-
             --config .lychee.toml

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -35,7 +35,7 @@ jobs:
         shell: bash
 
       - name: Upload Analyzer Report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: matlab-analyzer-report
           path: ./matlab/config/result.json

--- a/.github/workflows/prune-nightly-artifacts.yml
+++ b/.github/workflows/prune-nightly-artifacts.yml
@@ -17,7 +17,7 @@ jobs:
 
         steps:
           - name: Checkout repository
-            uses: actions/checkout@v7.0.0
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
           - name: Prune nightly artifacts
             env:

--- a/.github/workflows/publish-brew-packages.yml
+++ b/.github/workflows/publish-brew-packages.yml
@@ -36,7 +36,7 @@ jobs:
       QUALITY: ${{ inputs.quality }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download Homebrew Bottle XCFramework artifacts
         env:

--- a/.github/workflows/publish-deb-packages.yml
+++ b/.github/workflows/publish-deb-packages.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ice
 

--- a/.github/workflows/publish-java-packages.yml
+++ b/.github/workflows/publish-java-packages.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download Java artifacts
         env:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -59,7 +59,7 @@ jobs:
           QUALITY: ${{ inputs.quality }}
           NEXUS_NIGHTLY_NPM_AUTH_TOKEN: ${{ secrets.NEXUS_NIGHTLY_NPM_AUTH_TOKEN }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: ${{ inputs.quality == 'stable' }}
         with:
           node-version: '24'

--- a/.github/workflows/publish-rpm-packages.yml
+++ b/.github/workflows/publish-rpm-packages.yml
@@ -41,7 +41,7 @@ jobs:
       MCPP_VERSION: v2.7.2.20
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ice
 

--- a/.github/workflows/publish-slice-tools-packages.yml
+++ b/.github/workflows/publish-slice-tools-packages.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download Slice Tools artifacts
         env:

--- a/.github/workflows/publish-swift-packages.yml
+++ b/.github/workflows/publish-swift-packages.yml
@@ -34,7 +34,7 @@ jobs:
     if: ${{ inputs.quality == 'nightly' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download C++ Dependencies for Swift
         env:

--- a/.github/workflows/publish-symbols-sources.yml
+++ b/.github/workflows/publish-symbols-sources.yml
@@ -79,7 +79,7 @@ jobs:
       S3_BUCKET: ${{ vars.S3_SYMBOLS_BUCKET }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Windows Debug Tools
         uses: ./.github/actions/install-windows-debug-tools

--- a/.github/workflows/publish-windows-installer.yml
+++ b/.github/workflows/publish-windows-installer.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Load version
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/setup-python
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install Python dependencies
         working-directory: python

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,7 +18,7 @@ jobs:
         - ${{ github.workspace }}:${{ github.workspace }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # https://github.com/actions/runner/issues/2033
       - name: Set safe directory

--- a/.github/workflows/test-pip-package.yml
+++ b/.github/workflows/test-pip-package.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -41,7 +41,7 @@ jobs:
         run: python -m build --sdist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sdist
           path: python/dist/zeroc_ice-*.tar.gz
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -68,7 +68,7 @@ jobs:
         uses: ./.github/actions/setup-python
 
       - name: Download sdist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdist
           path: sdist

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -44,7 +44,7 @@ jobs:
               ;;
           esac
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download artifacts
         env:

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run whitespace validation
         uses: zeroc-ice/github-actions/@main


### PR DESCRIPTION
Hardens the GitHub Actions supply chain and simplifies the Dependabot config.

- Pins every third-party action (in workflows *and* composite actions) to a full commit SHA with the version in a trailing comment — a moved tag can no longer change what CI runs, and Dependabot still bumps the SHA and comment together.
- Points the `github-actions` ecosystem at both `/` (workflows) and `/.github/actions/*` (composite actions).
- Extends Dependabot to the release branches via `target-branch`: 3.8 and 3.7 get **GitHub Actions updates only** — their language deps stay in sync with `main` by cherry-pick.
- Runs everything monthly with a flat 7-day cooldown, and drops `open-pull-requests-limit`.

Dependabot reads this config only from the default branch, and security updates always target the default branch. `zeroc-ice/github-actions@main` is intentionally left tracking `main`.
