### PR TITLE
Reword WebSocket ping/pong changelog to the server-only impact

### DIFF
--- a/changelog.d/cpp/ws-control-frame-masking.md
+++ b/changelog.d/cpp/ws-control-frame-masking.md
@@ -1,4 +1,4 @@
-- Fixed a WebSocket bug where Ice, acting as a server, echoed a received ping's payload in the pong
-  without unmasking it (and, as a client, sent the pong payload unmasked). A non-Ice WebSocket peer
-  that sends payload-bearing pings and validates the echoed pong could therefore drop the connection
-  (RFC 6455 §5.5.3). The common cases — browser/JS clients and empty keepalive pings — were unaffected.
+- Fixed a WebSocket bug where an Ice server echoed a received ping's payload in the pong without
+  unmasking it, so a non-Ice WebSocket peer that sends payload-bearing pings and validates the echoed
+  pong (e.g. an L7 load balancer or gateway health check) could drop the connection (RFC 6455 §5.5.3).
+  The common cases — browser/JS clients and empty keepalive pings — were unaffected.

--- a/changelog.d/csharp/ws-control-frame-masking.md
+++ b/changelog.d/csharp/ws-control-frame-masking.md
@@ -1,4 +1,4 @@
-- Fixed a WebSocket bug where Ice, acting as a server, echoed a received ping's payload in the pong
-  without unmasking it (and, as a client, sent the pong payload unmasked). A non-Ice WebSocket peer
-  that sends payload-bearing pings and validates the echoed pong could therefore drop the connection
-  (RFC 6455 §5.5.3). The common cases — browser/JS clients and empty keepalive pings — were unaffected.
+- Fixed a WebSocket bug where an Ice server echoed a received ping's payload in the pong without
+  unmasking it, so a non-Ice WebSocket peer that sends payload-bearing pings and validates the echoed
+  pong (e.g. an L7 load balancer or gateway health check) could drop the connection (RFC 6455 §5.5.3).
+  The common cases — browser/JS clients and empty keepalive pings — were unaffected.

--- a/changelog.d/java/ws-control-frame-masking.md
+++ b/changelog.d/java/ws-control-frame-masking.md
@@ -1,4 +1,4 @@
-- Fixed a WebSocket bug where Ice, acting as a server, echoed a received ping's payload in the pong
-  without unmasking it (and, as a client, sent the pong payload unmasked). A non-Ice WebSocket peer
-  that sends payload-bearing pings and validates the echoed pong could therefore drop the connection
-  (RFC 6455 §5.5.3). The common cases — browser/JS clients and empty keepalive pings — were unaffected.
+- Fixed a WebSocket bug where an Ice server echoed a received ping's payload in the pong without
+  unmasking it, so a non-Ice WebSocket peer that sends payload-bearing pings and validates the echoed
+  pong (e.g. an L7 load balancer or gateway health check) could drop the connection (RFC 6455 §5.5.3).
+  The common cases — browser/JS clients and empty keepalive pings — were unaffected.


### PR DESCRIPTION
Follow-up to #5678 (already merged), applying Bernard's post-merge review suggestion to the three `ws-control-frame-masking` changelog fragments (C++, C#, Java).

## Change

Changelog-only. Drops the "and, as a client, sent the pong payload unmasked" clause and adds a concrete real-world trigger:

```diff
-- Fixed a WebSocket bug where Ice, acting as a server, echoed a received ping's payload in the pong
-  without unmasking it (and, as a client, sent the pong payload unmasked). A non-Ice WebSocket peer
-  that sends payload-bearing pings and validates the echoed pong could therefore drop the connection
-  (RFC 6455 §5.5.3). The common cases — browser/JS clients and empty keepalive pings — were unaffected.
+- Fixed a WebSocket bug where an Ice server echoed a received ping's payload in the pong without
+  unmasking it, so a non-Ice WebSocket peer that sends payload-bearing pings and validates the echoed
+  pong (e.g. an L7 load balancer or gateway health check) could drop the connection (RFC 6455 §5.5.3).
+  The common cases — browser/JS clients and empty keepalive pings — were unaffected.
```

## Why

The client-side masking fix is correct and stays in the code for RFC conformance, but it isn't reachable in a pure-Ice deployment — an Ice server never originates a ping, so an Ice client never has a payload-bearing ping to echo. The only real-world trigger is the server-side case, which is now the sole subject of the entry.

Applied identically to all three fragments (the text matches Bernard's `suggestion` blocks verbatim). No code changes.