### PR TITLE
Fix double close of UDP socket on bind failure (C++)

### DIFF
--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -1255,35 +1255,50 @@ IceInternal::getRecvBufferSize(SOCKET fd)
 void
 IceInternal::setMcastGroup(SOCKET fd, const Address& group, const string& intf)
 {
-    vector<string> interfaces = getInterfacesForMulticast(intf, getProtocolSupport(group));
-    set<int> indexes;
-    for (const auto& interface : interfaces)
+    try
     {
-        int rc = 0;
-        if (group.saStorage.ss_family == AF_INET)
+        vector<string> interfaces = getInterfacesForMulticast(intf, getProtocolSupport(group));
+        set<int> indexes;
+        for (const auto& interface : interfaces)
         {
-            struct ip_mreq mreq;
-            mreq.imr_multiaddr = group.saIn.sin_addr;
-            mreq.imr_interface = getInterfaceAddress(interface);
-            rc = setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, reinterpret_cast<char*>(&mreq), int(sizeof(mreq)));
-        }
-        else
-        {
-            int index = getInterfaceIndex(interface);
-            if (indexes.find(index) == indexes.end()) // Don't join twice the same interface (if it has multiple IPs)
+            int rc = 0;
+            if (group.saStorage.ss_family == AF_INET)
             {
-                indexes.insert(index);
-                struct ipv6_mreq mreq;
-                mreq.ipv6mr_multiaddr = group.saIn6.sin6_addr;
-                mreq.ipv6mr_interface = static_cast<unsigned int>(index);
-                rc = setsockopt(fd, IPPROTO_IPV6, IPV6_JOIN_GROUP, reinterpret_cast<char*>(&mreq), int(sizeof(mreq)));
+                struct ip_mreq mreq;
+                mreq.imr_multiaddr = group.saIn.sin_addr;
+                mreq.imr_interface = getInterfaceAddress(interface);
+                rc = setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, reinterpret_cast<char*>(&mreq), int(sizeof(mreq)));
+            }
+            else
+            {
+                int index = getInterfaceIndex(interface);
+                // Don't join twice the same interface (if it has multiple IPs).
+                if (indexes.find(index) == indexes.end())
+                {
+                    indexes.insert(index);
+                    struct ipv6_mreq mreq;
+                    mreq.ipv6mr_multiaddr = group.saIn6.sin6_addr;
+                    mreq.ipv6mr_interface = static_cast<unsigned int>(index);
+                    rc = setsockopt(
+                        fd,
+                        IPPROTO_IPV6,
+                        IPV6_JOIN_GROUP,
+                        reinterpret_cast<char*>(&mreq),
+                        int(sizeof(mreq)));
+                }
+            }
+            if (rc == SOCKET_ERROR)
+            {
+                throw SocketException(__FILE__, __LINE__, getSocketErrno());
             }
         }
-        if (rc == SOCKET_ERROR)
-        {
-            closeSocketNoThrow(fd);
-            throw SocketException(__FILE__, __LINE__, getSocketErrno());
-        }
+    }
+    catch (...)
+    {
+        // Close the socket on any failure (interface resolution or the multicast join) so this helper always
+        // leaves the socket closed when it throws, like doBind and setReuseAddress.
+        closeSocketNoThrow(fd);
+        throw;
     }
 }
 

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -69,36 +69,50 @@ IceInternal::UdpTransceiver::closing(bool, exception_ptr)
 void
 IceInternal::UdpTransceiver::close()
 {
-    assert(_fd != INVALID_SOCKET);
-    SOCKET fd = _fd;
-    _fd = INVALID_SOCKET;
-    closeSocket(fd);
+    // _fd can be INVALID_SOCKET when bind failed: the bind/setup helper that threw already closed the socket and
+    // reset _fd.
+    if (_fd != INVALID_SOCKET)
+    {
+        SOCKET fd = _fd;
+        _fd = INVALID_SOCKET;
+        closeSocket(fd);
+    }
 }
 
 EndpointIPtr
 IceInternal::UdpTransceiver::bind()
 {
-    if (isMulticast(_addr))
+    try
     {
-        // Set SO_REUSEADDR socket option to allow multiple sockets to bind to the same multicast address.
-        setReuseAddress(_fd, true);
-        _mcastAddr = _addr;
+        if (isMulticast(_addr))
+        {
+            // Set SO_REUSEADDR socket option to allow multiple sockets to bind to the same multicast address.
+            setReuseAddress(_fd, true);
+            _mcastAddr = _addr;
 
 #ifdef _WIN32
-        // Windows does not allow binding to the mcast address itself so we bind to INADDR_ANY instead.
-        const_cast<Address&>(_addr) = getAddressForServer("", _port, getProtocolSupport(_addr), false, false);
+            // Windows does not allow binding to the mcast address itself so we bind to INADDR_ANY instead.
+            const_cast<Address&>(_addr) = getAddressForServer("", _port, getProtocolSupport(_addr), false, false);
 #endif
 
-        const_cast<Address&>(_addr) = doBind(_fd, _addr, _mcastInterface);
-        if (getPort(_mcastAddr) == 0)
-        {
-            setPort(_mcastAddr, getPort(_addr));
+            const_cast<Address&>(_addr) = doBind(_fd, _addr, _mcastInterface);
+            if (getPort(_mcastAddr) == 0)
+            {
+                setPort(_mcastAddr, getPort(_addr));
+            }
+            setMcastGroup(_fd, _mcastAddr, _mcastInterface);
         }
-        setMcastGroup(_fd, _mcastAddr, _mcastInterface);
+        else
+        {
+            const_cast<Address&>(_addr) = doBind(_fd, _addr);
+        }
     }
-    else
+    catch (...)
     {
-        const_cast<Address&>(_addr) = doBind(_fd, _addr);
+        // setReuseAddress/doBind/setMcastGroup close the socket before throwing, so reset _fd to avoid a double
+        // close when close() runs during cleanup. Mirrors TcpAcceptor::listen.
+        _fd = INVALID_SOCKET;
+        throw;
     }
 
     _bound = true;

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -69,13 +69,12 @@ IceInternal::UdpTransceiver::closing(bool, exception_ptr)
 void
 IceInternal::UdpTransceiver::close()
 {
-    // _fd can be INVALID_SOCKET when bind failed: the bind/setup helper that threw already closed the socket and
-    // reset _fd.
+    // _fd can be INVALID_SOCKET when bind failed: the bind/setup helper that threw already closed the socket, and
+    // bind()'s catch reset _fd.
     if (_fd != INVALID_SOCKET)
     {
-        SOCKET fd = _fd;
+        closeSocketNoThrow(_fd);
         _fd = INVALID_SOCKET;
-        closeSocket(fd);
     }
 }
 


### PR DESCRIPTION
## Summary

When `UdpTransceiver::bind()` fails, the bind/setup helpers (`doBind`, `setReuseAddress`, `setMcastGroup`) call `closeSocketNoThrow(fd)` before throwing, but `bind()` left `_fd` pointing at the now-closed descriptor. The cleanup path in `IncomingConnectionFactory::initialize()` then called `_transceiver->close()`, which closed that descriptor value a second time. Under concurrent socket activity the fd number could already have been reused by another thread, so the second close could shut down an unrelated descriptor.

This is an internal correctness fix: the trigger is a UDP object adapter that fails to bind (port already in use, or a failed multicast-group join), which surfaces as an exception from adapter activation. No user-visible behavior change, hence no changelog entry.

## Fix

- `UdpTransceiver::bind()` — wrap the bind/setup calls and reset `_fd = INVALID_SOCKET` if a helper throws, mirroring `TcpAcceptor::listen()`.
- `UdpTransceiver::close()` — no-op when `_fd == INVALID_SOCKET` (was an assert), matching the acceptors' `close()`.
- `setMcastGroup()` — close the socket on **all** of its throw paths (interface resolution as well as the `IP_ADD_MEMBERSHIP`/`IPV6_JOIN_GROUP` join), so its failure contract matches `doBind`/`setReuseAddress` and the `catch` in `bind()` never leaves an open fd behind.

The related `setBufSize` close-on-throw paths are tracked separately by #5688 and intentionally not touched here.

Fixes zeroc-ice/ice-audit#70

🤖 Generated with [Claude Code](https://claude.com/claude-code)