### PR TITLE
Add DataStorm test for reconnect with the writer actively publishing

### DIFF
--- a/cpp/msbuild/ice.test.slnx
+++ b/cpp/msbuild/ice.test.slnx
@@ -76,6 +76,14 @@
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
     </Project>
   </Folder>
+  <Folder Name="/DataStorm/writerActiveReconnect/">
+    <Project Path="../test/DataStorm/writerActiveReconnect/msbuild/reader/reader.vcxproj">
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
+    </Project>
+    <Project Path="../test/DataStorm/writerActiveReconnect/msbuild/writer/writer.vcxproj">
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
+    </Project>
+  </Folder>
   <Folder Name="/Glacier2/" />
   <Folder Name="/Glacier2/attack/">
     <Project Path="../test/Glacier2/attack/msbuild/client/client.vcxproj">

--- a/cpp/test/DataStorm/writerActiveReconnect/Makefile.mk
+++ b/cpp/test/DataStorm/writerActiveReconnect/Makefile.mk
@@ -1,0 +1,9 @@
+# Copyright (c) ZeroC, Inc.
+
+$(project)_programs        = reader writer
+$(project)_dependencies    = DataStorm Ice TestCommon
+
+$(project)_reader_sources  = Reader.cpp
+$(project)_writer_sources  = Writer.cpp
+
+tests += $(project)

--- a/cpp/test/DataStorm/writerActiveReconnect/Reader.cpp
+++ b/cpp/test/DataStorm/writerActiveReconnect/Reader.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+
+#include <chrono>
+#include <thread>
+
+using namespace DataStorm;
+using namespace std;
+
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Reader::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    ReaderConfig config;
+    config.clearHistory = ClearHistoryPolicy::Never;
+
+    {
+        Topic<string, int> topic(node, "writerActive");
+        auto reader = makeSingleKeyReader(topic, "element", "", config);
+
+        // The writer publishes 0..999 at a steady pace. We read the whole sequence and force a session reconnect
+        // every 50 samples -- while the writer is still publishing -- so each reconnect overlaps live `s()` sample
+        // forwards with the resync. Every sample must arrive exactly once and in order: a regression in the
+        // writer-active resync window would surface here as a duplicate, a gap, or an out-of-order value.
+        for (int i = 0; i < 1000; ++i)
+        {
+            auto sample = reader.getNextUnread();
+            if (sample.getValue() != i)
+            {
+                cerr << "unexpected sample: " << sample.getValue() << " expected: " << i << endl;
+                test(false);
+            }
+
+            if (i > 0 && (i % 50) == 0)
+            {
+                auto connection = node.getSessionConnection(sample.getSession());
+                while (!connection)
+                {
+                    this_thread::sleep_for(chrono::milliseconds(10));
+                    connection = node.getSessionConnection(sample.getSession());
+                }
+                connection->close().get();
+            }
+        }
+
+        // Signal the writer that the full sequence was received exactly once.
+        auto barrier = makeSingleKeyWriter(topic, "barrier");
+        barrier.waitForReaders();
+        barrier.update(0);
+        barrier.waitForNoReaders();
+    }
+}
+
+DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/writerActiveReconnect/Writer.cpp
+++ b/cpp/test/DataStorm/writerActiveReconnect/Writer.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+
+#include <chrono>
+#include <thread>
+
+using namespace DataStorm;
+using namespace std;
+
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Writer::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    WriterConfig config;
+    config.clearHistory = ClearHistoryPolicy::Never;
+
+    cout << "testing reader reconnect while the writer is actively publishing... " << flush;
+    {
+        Topic<string, int> topic(node, "writerActive");
+        auto writer = makeSingleKeyWriter(topic, "element", "", config);
+        writer.waitForReaders();
+
+        // Publish a known sequence at a steady pace. Unlike the reliability test (which publishes the whole batch
+        // up front and then stays idle while the reader reconnects), the pacing keeps the writer publishing *live*
+        // while the reader forces its reconnections, so live `s()` sample forwards race the session resync.
+        for (int i = 0; i < 1000; ++i)
+        {
+            writer.update(i);
+            this_thread::sleep_for(chrono::milliseconds(1));
+        }
+
+        // Wait for the reader to confirm it received the whole sequence exactly once and in order.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(topic, "barrier").getNextUnread();
+    }
+    cout << "ok" << endl;
+}
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/writerActiveReconnect/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/writerActiveReconnect/msbuild/reader/reader.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{4FC4AF79-D989-4643-867E-71AC694EB082}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/writerActiveReconnect/msbuild/reader/reader.vcxproj.filters
+++ b/cpp/test/DataStorm/writerActiveReconnect/msbuild/reader/reader.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/writerActiveReconnect/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/writerActiveReconnect/msbuild/writer/writer.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7DBDFEF5-8CA8-432D-81A0-FD6886E073A7}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/writerActiveReconnect/msbuild/writer/writer.vcxproj.filters
+++ b/cpp/test/DataStorm/writerActiveReconnect/msbuild/writer/writer.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/writerActiveReconnect/test.py
+++ b/cpp/test/DataStorm/writerActiveReconnect/test.py
@@ -1,0 +1,46 @@
+# Copyright (c) ZeroC, Inc.
+
+#
+# Coverage test for DataStorm session reconnection with the writer ACTIVE during the reconnect.
+#
+# The existing reliability test forces reconnects only after the writer has published its whole batch and gone
+# idle, so the reader always resyncs from retained history. Here the writer publishes a known sequence at a steady
+# pace while the reader repeatedly closes the session connection, so live `s()` sample forwards overlap the resync.
+# The reader asserts it receives every sample exactly once and in order across all the reconnects.
+#
+
+from DataStormUtil import Reader, Writer
+from Util import ClientServerTestCase, TestSuite
+
+traceProps = {
+    "DataStorm.Trace.Topic": 1,
+    "DataStorm.Trace.Session": 3,
+    "DataStorm.Trace.Data": 2,
+}
+
+# Reader connects (client) to the writer, which owns the public endpoint (server).
+readerProps = {
+    "DataStorm.Node.Multicast.Enabled": 0,
+    "DataStorm.Node.Server.Enabled": 0,
+    "DataStorm.Node.ConnectTo": "tcp -p {port1}",
+    "DataStorm.Node.Name": "reader-app",
+}
+
+writerProps = {
+    "DataStorm.Node.Multicast.Enabled": 0,
+    "DataStorm.Node.Server.Endpoints": "tcp -p {port1}",
+    "DataStorm.Node.ConnectTo": "",
+    "DataStorm.Node.Name": "writer-app",
+}
+
+TestSuite(
+    __file__,
+    [
+        ClientServerTestCase(
+            name="reader reconnect while writer is actively publishing",
+            client=Reader(props=readerProps),
+            server=Writer(props=writerProps),
+            traceProps=traceProps,
+        )
+    ],
+)


### PR DESCRIPTION
A coverage test from the DataStorm session-reconnection audit. No production code change.

## Gap

On a session reconnect, DataStorm resumes exactly-once sample delivery to a subscriber. `SubscriberSessionI::s` does this **without an `id > lastId` guard** — it relies on the `initialized == false` gate plus the topic lock to keep stale/duplicate samples out of `s()` while a session resyncs.

The existing `reliability` test only forces reconnects **after the writer has published its whole batch and gone idle**, so the reader always resyncs from retained history. The window where a *live* `s()` sample forward overlaps the resync — i.e. the writer is still publishing while the session re-establishes — is never exercised.

## Test

`DataStorm/writerActiveReconnect`: the writer publishes a known `0..999` sequence at a steady pace; the reader reads the whole sequence and closes its session connection every 50 samples. Because the closes land at `i <= 950` while the writer runs to `999`, the writer is **guaranteed to still be live-publishing during each of the ~20 reconnects**. The reader asserts every sample arrives **exactly once and in order** — a regression in the writer-active resync window would surface as a duplicate, a gap, or an out-of-order value.

Confirmed via session trace that ~20 resume cycles occur mid-stream (the session is resumed, not recreated, and re-initializes from the writer each time), so the test genuinely exercises the previously-uncovered path rather than passing vacuously. Stable across repeated runs.

The path is correct today, so this is a regression guard. It closes a coverage hole called out in the audit (§6 item 4 / the untested "`s()` exactly-once across writer-active reconnect" path).