### PR TITLE
Allow at most one syslog logger per process (C++)

### DIFF
--- a/changelog.d/cpp/syslog-single-communicator.md
+++ b/changelog.d/cpp/syslog-single-communicator.md
@@ -1,0 +1,3 @@
+- Only one Ice syslog logger can be active at a time in a process. Creating a second one (for example, a second
+  communicator with `Ice.UseSyslog=1`) while the first is still active now throws `InitializationException` instead of
+  corrupting the process-global syslog state.

--- a/cpp/src/Ice/SysLoggerI.cpp
+++ b/cpp/src/Ice/SysLoggerI.cpp
@@ -10,6 +10,12 @@ using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
+// syslog's openlog/closelog and its ident are process-global, and openlog retains the ident pointer rather than
+// copying it. We therefore allow at most one SysLoggerI alive at a time, so the ident never dangles and closelog never
+// tears down a connection another logger is still using. The constructor claims this flag; the destructor releases it.
+std::mutex Ice::SysLoggerI::_mutex;
+bool Ice::SysLoggerI::_active = false;
+
 Ice::SysLoggerI::SysLoggerI(string prefix, string_view facilityString) : _facility(0), _prefix(std::move(prefix))
 {
     if (facilityString == "LOG_KERN")
@@ -104,17 +110,26 @@ Ice::SysLoggerI::SysLoggerI(string prefix, string_view facilityString) : _facili
             "Invalid value for Ice.SyslogFacility: " + string{facilityString});
     }
 
+    claimSyslog(__FILE__, __LINE__);
+
     int logopt = LOG_PID | LOG_CONS;
     openlog(_prefix.c_str(), logopt, _facility);
 }
 
 Ice::SysLoggerI::SysLoggerI(string prefix, int facility) : _facility(facility), _prefix(std::move(prefix))
 {
+    claimSyslog(__FILE__, __LINE__);
+
     int logopt = LOG_PID | LOG_CONS;
     openlog(_prefix.c_str(), logopt, facility);
 }
 
-Ice::SysLoggerI::~SysLoggerI() { closelog(); }
+Ice::SysLoggerI::~SysLoggerI()
+{
+    lock_guard lock(_mutex);
+    closelog();
+    _active = false;
+}
 
 void
 Ice::SysLoggerI::print(const string& message)
@@ -152,9 +167,21 @@ Ice::SysLoggerI::getPrefix()
 }
 
 Ice::LoggerPtr
-Ice::SysLoggerI::cloneWithPrefix(string prefix)
+Ice::SysLoggerI::cloneWithPrefix(string)
 {
-    return make_shared<SysLoggerI>(std::move(prefix), _facility);
+    // syslog is process-global, so a second SysLoggerI would fight over the global openlog ident and connection.
+    throw FeatureNotSupportedException(__FILE__, __LINE__, "the Ice syslog logger does not support cloneWithPrefix");
+}
+
+void
+Ice::SysLoggerI::claimSyslog(const char* file, int line)
+{
+    lock_guard lock(_mutex);
+    if (_active)
+    {
+        throw InitializationException(file, line, "another Ice syslog logger is already active in this process");
+    }
+    _active = true;
 }
 
 #endif

--- a/cpp/src/Ice/SysLoggerI.h
+++ b/cpp/src/Ice/SysLoggerI.h
@@ -25,9 +25,16 @@ namespace Ice
         LoggerPtr cloneWithPrefix(std::string) final;
 
     private:
+        // Claims the process-wide syslog logger, throwing if another SysLoggerI is already active.
+        static void claimSyslog(const char* file, int line);
+
         int _facility;
         const std::string _prefix;
-        std::mutex _mutex;
+
+        // openlog/closelog and the syslog ident are process-global, so at most one SysLoggerI may be active at a time.
+        // _mutex (shared by all instances) guards _active and serializes the syslog calls.
+        static std::mutex _mutex;
+        static bool _active;
     };
 }
 


### PR DESCRIPTION
## Summary

`SysLoggerI` calls the process-global `openlog`/`closelog` per instance and passes its own `_prefix.c_str()` as the ident. POSIX retains the ident pointer rather than copying it. With more than one `SysLoggerI` alive — two communicators in the same process, each with `Ice.UseSyslog=1` — the second `openlog` replaces the global ident with a pointer into the second instance's `_prefix`, and destroying that instance both runs `closelog()` (closing the connection shared by survivors) and leaves the global ident dangling. The next `syslog()` from a surviving logger then dereferences freed memory (use-after-free).

`cloneWithPrefix` would produce the same situation, but it is never reached at runtime in practice.

## Fix

Enforce a single active `SysLoggerI` per process:

- The constructor claims a static flag via `claimSyslog`, throwing `InitializationException` if a `SysLoggerI` is already active.
- The destructor `closelog()`s and clears the flag under the same static `_mutex` that serializes the `syslog()` calls, so teardown can't race a concurrent construction or log call.
- `cloneWithPrefix` now throws `FeatureNotSupportedException` — syslog cannot support a per-instance ident.

This means `Ice.UseSyslog` now supports one communicator per process; a second one configured with `Ice.UseSyslog=1` fails fast with `InitializationException` instead of corrupting the shared syslog state. A changelog entry documents this, and a follow-up doc issue will clarify the `Ice.UseSyslog` property page.

Fixes zeroc-ice/ice-audit#75

🤖 Generated with [Claude Code](https://claude.com/claude-code)