### PR TITLE
Pin the 3.7 branch's GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/build-slice-compiler/action.yml
+++ b/.github/actions/build-slice-compiler/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Sign Compiler Artifact
       if: runner.os == 'Windows' && inputs.authenticode_sign == 'true'
-      uses: azure/trusted-signing-action@v2
+      uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
       with:
         azure-tenant-id: ${{ env.AZURE_TENANT_ID }}
         azure-client-id: ${{ env.AZURE_CLIENT_ID }}

--- a/.github/actions/install-windows-debug-tools/action.yml
+++ b/.github/actions/install-windows-debug-tools/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Upload SDK install log
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: sdk-install-log
         path: ${{ runner.temp }}/sdk.log

--- a/.github/actions/setup-cpp/action.yml
+++ b/.github/actions/setup-cpp/action.yml
@@ -34,7 +34,7 @@ runs:
       if: runner.os == 'Linux'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v3
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
       with:
         msbuild-architecture: x64
       if: runner.os == 'Windows'

--- a/.github/actions/setup-dotnet/action.yml
+++ b/.github/actions/setup-dotnet/action.yml
@@ -10,12 +10,12 @@ runs:
   using: "composite"
   steps:
     - name: Setup .NET 8
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: 8.0.x
 
     - name: Setup .NET 10
       if: inputs.include_net10 == 'true'
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: 10.0.x

--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -3,7 +3,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Oracle Java 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
         distribution: "oracle"
         java-version: "17"

--- a/.github/actions/setup-matlab/action.yml
+++ b/.github/actions/setup-matlab/action.yml
@@ -8,7 +8,7 @@ runs:
     #
     - name: Setup MATLAB
       id: setup-matlab
-      uses: matlab-actions/setup-matlab@v3
+      uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v3.0.1
       with:
         release: "R2025b"
 

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,6 +4,6 @@ description: "Sets up Node.js environment"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "22"

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -4,6 +4,6 @@ description: "Setup Ruby environment"
 runs:
   using: "composite"
   steps:
-    - uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         ruby-version: "3.4"

--- a/.github/workflows/build-brew-packages.yml
+++ b/.github/workflows/build-brew-packages.yml
@@ -35,7 +35,7 @@ jobs:
     if: ${{ inputs.quality == 'nightly' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -45,7 +45,7 @@ jobs:
           ./packaging/brew/update-nightly-tap.sh "${{ inputs.channel }}" "${{ inputs.quality }}" "${{ inputs.ice_version }}"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: homebrew-bottle
           path: |

--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: ice
 
@@ -84,10 +84,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -141,15 +141,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: ice
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice

--- a/.github/workflows/build-cpp-nuget-packages.yml
+++ b/.github/workflows/build-cpp-nuget-packages.yml
@@ -27,7 +27,7 @@ jobs:
         platform-toolset: [v143, v142]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -55,7 +55,7 @@ jobs:
         working-directory: cpp/msbuild
 
       - name: Upload NuGet Packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-cpp-${{ matrix.platform-toolset }}-nuget-packages
           path: |

--- a/.github/workflows/build-cpp-windows-binaries.yml
+++ b/.github/workflows/build-cpp-windows-binaries.yml
@@ -33,7 +33,7 @@ jobs:
         platform-toolset: [v143, v142]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -60,7 +60,7 @@ jobs:
 
       - name: Sign C++ Binaries with Trusted Signing
         if: ${{ inputs.authenticode_sign }}
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -75,7 +75,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Upload C++ Build
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-cpp-${{matrix.platform-toolset}}-${{ matrix.platform }}-${{ matrix.configuration }}-build
           path: |

--- a/.github/workflows/build-deb-ice-repo-packages.yml
+++ b/.github/workflows/build-deb-ice-repo-packages.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: ice
 
@@ -28,10 +28,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -65,7 +65,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deb-packages-${{ matrix.distribution }}
           path: |

--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -31,7 +31,7 @@ jobs:
       DEB_BUILD_OPTIONS: "nocheck parallel=4"
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: ice
 
@@ -41,10 +41,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -69,7 +69,7 @@ jobs:
         shell: bash
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deb-packages-${{ matrix.distribution }}-${{ matrix.arch }}
           path: |

--- a/.github/workflows/build-dotnet-packages.yml
+++ b/.github/workflows/build-dotnet-packages.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -60,7 +60,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
       - name: Upload Compiler Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: slice2cs-${{ matrix.target }}
           path: ${{ matrix.artifact-path }}
@@ -73,10 +73,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download All slice2cs Compiler Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: slice2cs-*
@@ -158,7 +158,7 @@ jobs:
 
       - name: Sign .NET Assemblies with Trusted Signing
         if: ${{ inputs.authenticode_sign }}
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -177,7 +177,7 @@ jobs:
           ${{ inputs.ice_version && format('/p:PackageVersion={0}', inputs.ice_version) || '' }}
 
       - name: Upload NuGet Packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dotnet-nuget-packages
           path: |

--- a/.github/workflows/build-gem-packages.yml
+++ b/.github/workflows/build-gem-packages.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -39,7 +39,7 @@ jobs:
         run: rake
 
       - name: Upload Gem Packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gem-packages
           path: ruby/zeroc-ice-*.gem

--- a/.github/workflows/build-icegridgui-jar.yml
+++ b/.github/workflows/build-icegridgui-jar.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -33,7 +33,7 @@ jobs:
         working-directory: java
 
       - name: Upload IceGrid GUI JAR
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: icegridgui-jar
           path: |

--- a/.github/workflows/build-matlab-packages.yml
+++ b/.github/workflows/build-matlab-packages.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -74,7 +74,7 @@ jobs:
           Add-Content -Path "${{ github.workspace }}\catalog.txt" -Value "cpp\bin\x64\Release\slice2matlab.exe"
 
       - name: Sign C++ Binaries
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         if: runner.os == 'Windows' && inputs.authenticode_sign
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -93,7 +93,7 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: matlab-packages-${{ matrix.os }}
           path: matlab/toolbox/*.mltbx

--- a/.github/workflows/build-maven-packages.yml
+++ b/.github/workflows/build-maven-packages.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -43,7 +43,7 @@ jobs:
         working-directory: java-compat
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: java-packages
           path: |

--- a/.github/workflows/build-npm-packages.yml
+++ b/.github/workflows/build-npm-packages.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -60,7 +60,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
       - name: Upload Compiler Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: slice2js-${{ matrix.target }}
           path: ${{ matrix.artifact-path }}
@@ -73,12 +73,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: ice
 
       - name: Download All slice2js Compiler Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: slice2js-*
@@ -133,7 +133,7 @@ jobs:
         working-directory: ice/js
 
       - name: Upload NPM Packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: js-npm-packages
           path: |

--- a/.github/workflows/build-pip-packages.yml
+++ b/.github/workflows/build-pip-packages.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -48,7 +48,7 @@ jobs:
         run: python3 -m build
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pip-packages-${{ matrix.os }}-${{ matrix.python-version }}
           path: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Configure build
         id: configure

--- a/.github/workflows/build-rpm-ice-repo-packages.yml
+++ b/.github/workflows/build-rpm-ice-repo-packages.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: ice
 
@@ -28,10 +28,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -72,7 +72,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rpm-packages-${{ matrix.distribution }}
           path: |

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: ice
 
@@ -33,10 +33,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -61,7 +61,7 @@ jobs:
             /workspace/ice/packaging/rpm/sign-package.sh
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rpm-packages-${{ matrix.distribution }}-${{ matrix.arch }}
           path: |

--- a/.github/workflows/build-swift-packages.yml
+++ b/.github/workflows/build-swift-packages.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -31,7 +31,7 @@ jobs:
         run: tar -czvf spm-sources-${{ inputs.ice_version }}.tar.gz -C packaging/swift spm
 
       - name: Upload SPM sources artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spm-sources
           path: spm-sources-${{ inputs.ice_version }}.tar.gz

--- a/.github/workflows/build-symbols-sources-store.yml
+++ b/.github/workflows/build-symbols-sources-store.yml
@@ -40,7 +40,7 @@ jobs:
         platform-toolset: [v143, v142]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set ICE_VERSION
         shell: bash
@@ -94,7 +94,7 @@ jobs:
             /f "${{ github.workspace }}/symbols-sources/pdbs/$env:ICE_VERSION/"
 
       - name: Upload Symbols and Sources
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-${{ matrix.platform-toolset }}-symbols-sources
           path: ${{ github.workspace }}/symbols-sources/

--- a/.github/workflows/build-windows-msi.yml
+++ b/.github/workflows/build-windows-msi.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -115,7 +115,7 @@ jobs:
 
       - name: Sign MSI installer with Trusted Signing
         if: ${{ inputs.authenticode_sign }}
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -130,7 +130,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Upload MSI
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-msi
           path: |

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Load version info
         run: |
@@ -150,10 +150,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: zeroc-ice
@@ -180,7 +180,7 @@ jobs:
             "
 
       - name: Upload test logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ matrix.config }}-${{ matrix.distribution }}-${{ matrix.arch }}
           path: cpp/**/*.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -142,7 +142,7 @@ jobs:
         if: matrix.cross_test_flags != ''
 
       - name: Upload test logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ matrix.config }}-${{ matrix.os }}
           path: ${{ '.' }}/**/*.log
@@ -150,7 +150,7 @@ jobs:
         if: always()
 
       - name: Upload macOS crash diagnostics
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: crash-diagnostics-${{ matrix.config }}-${{ matrix.os }}
           path: ~/Library/Logs/DiagnosticReports/*.ips

--- a/.github/workflows/dispatch-nightly-release.yml
+++ b/.github/workflows/dispatch-nightly-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Dispatch nightly build for main (2:00 UTC)
         if: github.event.schedule == '0 2 * * *'

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >-
             --config .lychee.toml

--- a/.github/workflows/prune-nightly-artifacts.yml
+++ b/.github/workflows/prune-nightly-artifacts.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Prune nightly artifacts
         env:

--- a/.github/workflows/publish-brew-packages.yml
+++ b/.github/workflows/publish-brew-packages.yml
@@ -36,7 +36,7 @@ jobs:
       QUALITY: ${{ inputs.quality }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download Homebrew Bottle XCFramework artifacts
         env:

--- a/.github/workflows/publish-deb-packages.yml
+++ b/.github/workflows/publish-deb-packages.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: ice
 

--- a/.github/workflows/publish-maven-packages.yml
+++ b/.github/workflows/publish-maven-packages.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download Java artifacts
         env:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -59,7 +59,7 @@ jobs:
           QUALITY: ${{ inputs.quality }}
           NEXUS_NIGHTLY_NPM_AUTH_TOKEN: ${{ secrets.NEXUS_NIGHTLY_NPM_AUTH_TOKEN }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: ${{ inputs.quality == 'stable' }}
         with:
           node-version: '24'

--- a/.github/workflows/publish-swift-packages.yml
+++ b/.github/workflows/publish-swift-packages.yml
@@ -34,7 +34,7 @@ jobs:
     if: ${{ inputs.quality == 'nightly' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download SPM sources artifact
         env:

--- a/.github/workflows/publish-symbols-sources.yml
+++ b/.github/workflows/publish-symbols-sources.yml
@@ -65,7 +65,7 @@ jobs:
       S3_BUCKET: zeroc-sourcesandsymbols
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Windows Debug Tools
         uses: ./.github/actions/install-windows-debug-tools


### PR DESCRIPTION
Pins the 3.7 branch's GitHub Actions to full commit SHAs, matching `main` and 3.8.

- Every third-party action (in workflows *and* composite actions) pinned to a full commit SHA with the version in a trailing comment.
- Once the companion `target-branch: "3.7"` config on `main` merges, Dependabot keeps these SHAs and comments current.
