### PR TITLE
Fix dangling _detachedPos iterator on metrics queue eviction (C++)

### DIFF
--- a/cpp/src/Ice/MetricsAdminI.h
+++ b/cpp/src/Ice/MetricsAdminI.h
@@ -443,7 +443,12 @@ namespace IceInternal
             // If there's still no room, remove the oldest entry (at the front).
             if (static_cast<int>(_detachedQueue.size()) == _retain)
             {
-                _objects.erase(_detachedQueue.front()->_object->id);
+                EntryTPtr front = _detachedQueue.front();
+                // Reset the evicted entry's position so a surviving EntryTPtr doesn't keep an iterator into the erased
+                // list node.
+                front->_detachedPos = _detachedQueue.end();
+
+                _objects.erase(front->_object->id);
                 _detachedQueue.pop_front();
             }
 


### PR DESCRIPTION
## Summary

In `MetricsMapT::detached`, when the detached queue is full the oldest entry is evicted from the front (`_objects.erase(...)` + `_detachedQueue.pop_front()`), but — unlike the compress loop just above, which sets `(*p)->_detachedPos = _detachedQueue.end()` before erasing — the eviction path never reset the evicted entry's `_detachedPos`. `ObserverT::detach()` deliberately keeps `_object` populated after detaching, so a lingering observer can still hold an `EntryTPtr` to the evicted entry. That entry then survives with `_detachedPos` pointing at the erased list node, and a later re-attach/detach cycle compares/splices the dangling iterator (undefined behavior), or `getMatching` trips an assert.

## Fix

Reset the evicted entry's `_detachedPos` to `_detachedQueue.end()` before `pop_front()`, matching the compress loop, so a surviving `EntryTPtr` never holds a dangling list iterator.

## Other language mappings

Verified this bug does **not** exist in C# or Java: their metrics maps don't cache a per-entry list position. `detached()` re-scans the `LinkedList` each call and removes `entry == p || !isDetached()`, so there's no cached iterator/node to dangle. The defect is specific to the C++ map, which caches a `std::list` iterator (`_detachedPos`) for O(1) splicing.

Fixes zeroc-ice/ice-audit#76

🤖 Generated with [Claude Code](https://claude.com/claude-code)