### PR TITLE
Size bzip2 AvailIn from the buffer limit, not the array capacity (C#)

### DIFF
--- a/csharp/src/Ice/Internal/BZip2.cs
+++ b/csharp/src/Ice/Internal/BZip2.cs
@@ -225,7 +225,9 @@ public static class BZip2
             }
 
             bzStream.NextIn = compressedHandle.AddrOfPinnedObject() + headerSize + 4;
-            bzStream.AvailIn = (uint)(compressed.Length - headerSize - 4);
+            // Size the input from the buffer's logical limit, not the backing array capacity (which can be larger),
+            // so bzip2 doesn't consume padding past the message. getInt above guarantees limit >= headerSize + 4.
+            bzStream.AvailIn = (uint)(buf.b.limit() - headerSize - 4);
             rc = (BzStatus)BZ2_bzDecompress(ref bzStream);
             if (rc != BzStatus.StreamEnd)
             {


### PR DESCRIPTION
## Summary

`BZip2.decompress` set the decoder's `AvailIn` from `compressed.Length` — the backing-array capacity returned by `rawBytes()` — instead of the buffer's logical limit:

```csharp
bzStream.AvailIn = (uint)(compressed.Length - headerSize - 4);   // capacity, not limit
```

The C# `Buffer` over-allocates its backing array, so `rawBytes().Length` is routinely larger than the actual message:

- `Buffer.reserve` grows capacity to `max(n, 2 * _capacity)` and then `max(240, _capacity)` — i.e. a 240-byte minimum and 2x growth.
- Capacity is retained (and only lazily shrunk) across messages on the same connection.
- On the read path, `InputStream.resize(size)` → `Buffer.resize(size, reading: true)` → `b.limit(size)` sets the *limit* to the exact message size.

So for any compressed message smaller than the allocated capacity — e.g. anything under 240 bytes, which covers most small/control messages — `compressed.Length > buf.b.limit()`, and the decoder was handed padding/uninitialized bytes of the backing array beyond the logical frame as if they were input. This is in-bounds (not an out-of-bounds read), but it is not message data.

## Fix

```csharp
// Size the input from the buffer's logical limit, not the backing array capacity (which can be larger),
// so bzip2 doesn't consume padding past the message. getInt above guarantees limit >= headerSize + 4.
bzStream.AvailIn = (uint)(buf.b.limit() - headerSize - 4);
```

`decompress` calls `buf.b.getInt()` after `position(headerSize)`, which validates four logical bytes against the limit, so `limit() >= headerSize + 4` and the subtraction can't underflow. (The originally-reported negative-subtraction/`uint` underflow was already found unreachable for the same reason.)

## Impact / severity

Low. For **valid** frames there is no behavior change: bzip2 returns `BZ_STREAM_END` at the logical end of the stream and ignores the trailing `AvailIn`, so well-formed messages always decoded correctly. The bug only affects **malformed** frames whose logical payload is shorter than the backing array: instead of failing cleanly at the frame boundary, the decoder could read the backing-storage padding as input, producing garbage decompression results or misleading protocol errors. No out-of-bounds memory access.

## Other language mappings

C++-only and Java are **not** affected:

- C++ `doUncompress` uses `compressed.b.size()` — `std::vector::size()` is the logical size (the buffer is resized exactly), not a capacity.
- Java `uncompress` uses `buf.size()` — the logical `_size`, not the backing array length.

Only the C# path used the backing-array length (`rawBytes().Length`) instead of the logical limit.

Fixes zeroc-ice/ice-audit#88

🤖 Generated with [Claude Code](https://claude.com/claude-code)