### PR TITLE
Handle null from non-blocking accept() in Network.doAccept (Java)

### DIFF
--- a/changelog.d/java/doaccept-null-npe.md
+++ b/changelog.d/java/doaccept-null-npe.md
@@ -1,0 +1,3 @@
+- Fixed Ice for Java to no longer log a spurious `NullPointerException` (at error level, with a stack trace) when a
+  client resets a pending connection during `accept()`. The accept-path race is now handled like any other accept
+  failure: silent by default, or a one-line warning when `Ice.Warn.Connections` is set.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
@@ -264,14 +264,18 @@ public final class Network {
     }
 
     public static SocketChannel doAccept(ServerSocketChannel socketChannel) {
-        SocketChannel fd = null;
-        while (true) {
-            try {
-                fd = socketChannel.accept();
-                break;
-            } catch (IOException ex) {
-                throw new SocketException(ex);
-            }
+        SocketChannel fd;
+        try {
+            fd = socketChannel.accept();
+        } catch (IOException ex) {
+            throw new SocketException(ex);
+        }
+
+        // The acceptor's channel is non-blocking, so accept() returns null when no connection is actually pending
+        // (e.g. a spurious selector wakeup, or the pending connection was reset before accept()). Surface this as a
+        // SocketException so it's handled like any other accept failure, instead of dereferencing null.
+        if (fd == null) {
+            throw new SocketException();
         }
 
         try {


### PR DESCRIPTION
## Summary

`Network.doAccept` calls `accept()` on a `ServerSocketChannel` that `TcpAcceptor` configures as non-blocking (`Network.setBlock(_fd, false)`). A non-blocking `accept()` returns `null` when no connection is actually pending, but `doAccept` broke out of its loop on any non-exceptional result and then dereferenced the result via `fd.socket()`:

```java
while (true) {
    try {
        fd = socketChannel.accept();
        break;                       // breaks even when accept() returns null
    } catch (IOException ex) {
        throw new SocketException(ex);
    }
}
Socket socket = fd.socket();         // NPE when fd == null
```

The accept path is selector-driven: `IncomingConnectionFactory.message` calls `_acceptor.accept()` only after the selector reports `OP_ACCEPT` readiness. But the socket is non-blocking, so `accept()` can still return `null` in the gap between the readiness notification and the call — a spurious selector wakeup, or the pending connection being reset (RST) by the peer in that window (which a remote peer could race). The resulting `NullPointerException` is not a `LocalException`, so it escapes the `catch (LocalException)` accept-failure handling in `IncomingConnectionFactory.message` and lands in the thread pool's unexpected-exception handler.

## Fix

Throw `SocketException` when `accept()` returns `null`, so it is handled like any other accept failure (caught by `message`'s `catch (LocalException)`, which logs if `Ice.Warn.Connections` is set and returns). Also drop the `while(true)`/`break`, which never looped (the `break` was unconditional and the `catch` rethrows).

`SocketException` with no cause is an established pattern (`UdpTransceiver.write` already throws `new SocketException()` when no datagram peer has been seen), and nothing in the tree assumes a `SocketException` carries an inner exception.

## Other language mappings

Java-specific:

- C++ `doAccept` checks the raw `accept()` result and throws `SocketException` on an anomaly (a spurious `EWOULDBLOCK` is not in `acceptInterrupted()`'s retry set), so there is no null dereference.
- C# uses the asynchronous `BeginAccept`/`EndAccept` model: `accept()` returns a stored handle or throws the stored error — there is no null-from-non-blocking case.

This brings Java in line with both: an accept anomaly surfaces as a `SocketException` rather than a raw `NullPointerException`.

Fixes zeroc-ice/ice-audit#89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
