### PR TITLE
Fix use-after-free unmarshaling dictionary with class value (PHP)

### DIFF
--- a/changelog.d/php/dict-class-value-use-after-free.md
+++ b/changelog.d/php/dict-class-value-use-after-free.md
@@ -1,0 +1,3 @@
+- Fixed a crash in Ice for PHP when unmarshaling a non-empty dictionary whose value type is a class (for example
+  `dictionary<string, SomeClass>`). The dictionary key could be freed before the deferred class value was inserted,
+  causing a use-after-free.

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -2244,9 +2244,12 @@ IcePHP::DictionaryInfo::KeyCallback::unmarshaled(zval* zv, zval*, void*)
     ZVAL_COPY(&key, zv);
 }
 
-IcePHP::DictionaryInfo::ValueCallback::ValueCallback(zval* k) { ZVAL_COPY_VALUE(&key, k); }
+// Hold a real reference to the key: for a class value type, unmarshaled() runs later (during pending-value
+// patching), after the loop has destroyed the KeyCallback that owns the key. ZVAL_COPY addrefs a string key (and is
+// inert for long/bool keys), and the destructor releases it.
+IcePHP::DictionaryInfo::ValueCallback::ValueCallback(zval* k) { ZVAL_COPY(&key, k); }
 
-IcePHP::DictionaryInfo::ValueCallback::~ValueCallback() = default;
+IcePHP::DictionaryInfo::ValueCallback::~ValueCallback() { zval_ptr_dtor(&key); }
 
 void
 IcePHP::DictionaryInfo::ValueCallback::unmarshaled(zval* zv, zval* target, void*)


### PR DESCRIPTION
## Summary

When IcePHP unmarshals a dictionary, each loop iteration creates a loop-local `KeyCallback` that **owns** the key zval (and frees it in `~KeyCallback` via `zval_ptr_dtor`), plus a `ValueCallback` that only **borrowed** the key:

```cpp
ValueCallback::ValueCallback(zval* k) { ZVAL_COPY_VALUE(&key, k); }   // raw copy, no addref
ValueCallback::~ValueCallback() = default;                            // doesn't release
```

That is safe only when the value unmarshals synchronously within the iteration. When the dictionary **value type is a Slice class**, `ClassInfo::unmarshal` defers: it registers a `ReadObjectCallback` (kept alive by `StreamUtil`), and `ValueCallback::unmarshaled` fires later during pending-value patching (`readPendingValues`/`endEncapsulation`) — after the loop has destroyed every `KeyCallback` and freed every key. For a string key, `add_assoc_zval_ex(target, Z_STRVAL(key), Z_STRLEN(key), zv)` then reads freed memory.

So unmarshaling any non-empty `dictionary<string, SomeClass>` (return value, out-parameter, or data member) reads freed string storage during patching — a crash or heap corruption. The encoded data comes from the peer.

## Fix

Make `ValueCallback` own a real reference to the key:

```cpp
ValueCallback::ValueCallback(zval* k) { ZVAL_COPY(&key, k); }     // addrefs a string key
ValueCallback::~ValueCallback() { zval_ptr_dtor(&key); }          // releases it
```

`ZVAL_COPY` addrefs a string key and is inert for long/bool keys, so the copy is harmless for every valid key type. This is the first option from the audit's recommendation; IcePy uses the other (it pre-inserts the key into the dictionary with a placeholder so the dictionary holds the reference).

## Verification

The existing `test/Ice/objects` test already exercises this path: `opValueMap` round-trips a `dictionary<string, Value>` (`"l" => new Test\L()`) as an out-parameter and return value, and the client reads the unmarshaled entries. Pre-fix this is a use-after-free (often latent — freed storage frequently still holds the old bytes — but it fails under ASan). Extension builds and links cleanly.

## Other language mappings

PHP-specific. The defect is in IcePHP's `ValueCallback` borrowing the key zval across the deferred class-value patch. IcePy holds a key reference (pre-inserts the key with a `Py_None` placeholder). C++, C#, and Java don't use this per-entry deferred-callback pattern for dictionary keys.

Fixes zeroc-ice/ice-audit#92

🤖 Generated with [Claude Code](https://claude.com/claude-code)