### PR TITLE
Add DataStorm test for relay-to-relay forwarding across a connection drop

### DIFF
--- a/cpp/msbuild/ice.test.slnx
+++ b/cpp/msbuild/ice.test.slnx
@@ -44,6 +44,11 @@
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
     </Project>
   </Folder>
+  <Folder Name="/DataStorm/relayHopDrop/">
+    <Project Path="../test/DataStorm/relayHopDrop/msbuild/writer/writer.vcxproj">
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
+    </Project>
+  </Folder>
   <Folder Name="/DataStorm/relayReconnect/">
     <Project Path="../test/DataStorm/relayReconnect/msbuild/reader/reader.vcxproj">
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />

--- a/cpp/test/DataStorm/relayHopDrop/Makefile.mk
+++ b/cpp/test/DataStorm/relayHopDrop/Makefile.mk
@@ -1,0 +1,8 @@
+# Copyright (c) ZeroC, Inc.
+
+$(project)_programs        = writer
+$(project)_dependencies    = DataStorm Ice TestCommon
+
+$(project)_writer_sources  = Writer.cpp
+
+tests += $(project)

--- a/cpp/test/DataStorm/relayHopDrop/Writer.cpp
+++ b/cpp/test/DataStorm/relayHopDrop/Writer.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "Ice/Ice.h"
+#include "TestHelper.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace DataStorm;
+using namespace std;
+
+namespace
+{
+    // H3: a bounded read. DataStorm's getNextUnread blocks forever, so a lost-sample regression turns into a silent
+    // CI hang. This polls hasUnread with a deadline and, on expiry, fails with context instead of hanging.
+    template<typename ReaderT>
+    int boundedNextUnread(ReaderT& reader, int expected, chrono::seconds timeout = chrono::seconds(30))
+    {
+        auto deadline = chrono::steady_clock::now() + timeout;
+        while (!reader.hasUnread())
+        {
+            if (chrono::steady_clock::now() >= deadline)
+            {
+                cerr << "timed out waiting for a sample (expected value " << expected
+                     << "): a sample was lost across a relay-hop drop" << endl;
+                test(false);
+            }
+            this_thread::sleep_for(chrono::milliseconds(5));
+        }
+        return reader.getNextUnread().getValue();
+    }
+
+    Ice::CommunicatorPtr
+    makeNode(const Ice::PropertiesPtr& base, const string& name, const string& endpoint, const string& connectTo)
+    {
+        Ice::InitializationData init;
+        init.properties = base->clone();
+        init.properties->setProperty("DataStorm.Node.Name", name);
+        init.properties->setProperty("Ice.ProgramName", name);
+        init.properties->setProperty("DataStorm.Node.Multicast.Enabled", "0");
+        init.properties->setProperty("DataStorm.Node.Server.Enabled", endpoint.empty() ? "0" : "1");
+        init.properties->setProperty("DataStorm.Node.Server.Endpoints", endpoint);
+        init.properties->setProperty("DataStorm.Node.ConnectTo", connectTo);
+        init.properties->setProperty("Ice.Warn.Connections", "0");
+        return Ice::initialize(init);
+    }
+}
+
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Writer::run(int argc, char* argv[])
+{
+    Ice::PropertiesPtr base = createTestProperties(argc, argv);
+    const string ep1 = getTestEndpoint(base, 0);
+    const string ep2 = getTestEndpoint(base, 1);
+
+    cout << "testing 2-hop forwarding across relay-to-relay drops while the writer is active... " << flush;
+
+    // Chain: writer -> relay1 -> relay2 -> reader. The writer and relay2 both dial relay1 (ep1); the reader dials
+    // relay2 (ep2). The hop we repeatedly drop is relay2's connection to relay1 -- a non-app, relay-to-relay
+    // connection that no existing test closes.
+    Ice::CommunicatorPtr relay1Comm = makeNode(base, "relay1", ep1, "");
+    Ice::CommunicatorPtr relay2Comm = makeNode(base, "relay2", ep2, ep1);
+    Ice::CommunicatorPtr writerComm = makeNode(base, "writer", "", ep1);
+    Ice::CommunicatorPtr readerComm = makeNode(base, "reader", "", ep2);
+
+    const int sampleCount = 500;
+    try
+    {
+        Node relay1{relay1Comm};
+        Node relay2{relay2Comm};
+        Node writerNode{writerComm};
+        Node readerNode{readerComm};
+
+        WriterConfig writerConfig;
+        writerConfig.clearHistory = ClearHistoryPolicy::Never;
+        ReaderConfig readerConfig;
+        readerConfig.clearHistory = ClearHistoryPolicy::Never;
+
+        Topic<string, int> writerTopic{writerNode, "topic"};
+        Topic<string, int> readerTopic{readerNode, "topic"};
+        auto writer = makeSingleKeyWriter(writerTopic, "key", "", writerConfig);
+        auto reader = makeSingleKeyReader(readerTopic, "key", "", readerConfig);
+
+        // The reader is attached through both relays once this returns.
+        writer.waitForReaders();
+
+        // Publish a known sequence at a steady pace on a background thread, so the writer is still forwarding samples
+        // through the relays while the main thread drops the relay-to-relay hop.
+        atomic<bool> writerFailed{false};
+        thread writerThread(
+            [&]
+            {
+                try
+                {
+                    for (int i = 0; i < sampleCount; ++i)
+                    {
+                        writer.update(i);
+                        this_thread::sleep_for(chrono::milliseconds(2));
+                    }
+                }
+                catch (...)
+                {
+                    writerFailed = true;
+                }
+            });
+
+        // Read the whole sequence, dropping the relay-to-relay hop every 50 samples while the writer keeps
+        // publishing. Each sample must arrive exactly once and in order: a sample lost or duplicated by a relay-hop
+        // drop while it was mid-forward would surface here as a gap (bounded-read timeout), a duplicate, or a rewind.
+        for (int i = 0; i < sampleCount; ++i)
+        {
+            int v = boundedNextUnread(reader, i);
+            if (v != i)
+            {
+                cerr << "duplicate, gap, or rewound sample across a relay-hop drop: " << v << " expected " << i << endl;
+                test(false);
+            }
+
+            if (i > 0 && (i % 50) == 0)
+            {
+                // Ice caches one connection per endpoint, so a proxy to relay1's Lookup endpoint returns the
+                // connection relay2 currently uses for the relay session; closing it drops the middle hop without
+                // touching the writer or reader connections. relay2 reconnects immediately, so we re-fetch each time.
+                if (auto hop = relay2Comm->stringToProxy("DataStorm/Lookup:" + ep1)->ice_getConnection())
+                {
+                    hop->close().get();
+                }
+            }
+        }
+
+        writerThread.join();
+        test(!writerFailed);
+    }
+    catch (...)
+    {
+        readerComm->destroy();
+        writerComm->destroy();
+        relay2Comm->destroy();
+        relay1Comm->destroy();
+        throw;
+    }
+    readerComm->destroy();
+    writerComm->destroy();
+    relay2Comm->destroy();
+    relay1Comm->destroy();
+
+    cout << "ok" << endl;
+}
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/relayHopDrop/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/relayHopDrop/msbuild/writer/writer.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{CF54433D-4DA0-41E2-9F38-8E5629C94CB4}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/relayHopDrop/msbuild/writer/writer.vcxproj.filters
+++ b/cpp/test/DataStorm/relayHopDrop/msbuild/writer/writer.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/relayHopDrop/test.py
+++ b/cpp/test/DataStorm/relayHopDrop/test.py
@@ -1,0 +1,17 @@
+# Copyright (c) ZeroC, Inc.
+
+#
+# Coverage test for DataStorm relay-to-relay forwarding integrity across a connection drop.
+#
+# A writer reaches a reader through two chained relay nodes (writer -> relay1 -> relay2 -> reader). No existing
+# test ever closes a non-app (relay-to-relay) connection -- the reliability suite only closes app-side
+# connections. This single-process test repeatedly drops the relay1<->relay2 hop while the writer is actively
+# publishing, and asserts every sample still arrives at the reader exactly once and in order: the relay forwards
+# samples losslessly across the hop drops (the relay heals transparently, so the end-to-end session is not even
+# disrupted). A regression that dropped or duplicated an in-flight sample on a closed relay hop would fail here.
+#
+
+from DataStormUtil import Writer
+from Util import ClientTestCase, TestSuite
+
+TestSuite(__file__, [ClientTestCase(client=Writer())])


### PR DESCRIPTION
A coverage test from the DataStorm session-reconnection audit. No production code change.

## Gap

DataStorm relays are byte forwarders — a sample id is stable end-to-end across a multi-relay chain. But the `reliability` suite only ever closes **app-side** connections; **no test closes a non-app (relay-to-relay) connection**, so the forwarding path was never exercised under a mid-chain connection drop.

## Test

`DataStorm/relayHopDrop` builds a `writer → relay1 → relay2 → reader` chain in a single process and, while a background thread publishes a paced `0..499` sequence, repeatedly drops the `relay1↔relay2` hop (via the connection Ice caches for relay2's session to relay1). The reader asserts every sample arrives **exactly once and in order**.

Traced confirmation that it's meaningful: ~10 hop drops occur **during active forwarding** (data in flight), and the relay heals transparently each time — the end-to-end reader session is never even disrupted, and no sample is lost or duplicated. A regression that dropped or duplicated an in-flight sample on a closed relay hop would fail here.

### Note on scope

This started as a "2-hop resync" test, but tracing showed a relay-to-relay drop does **not** force the reader to resync: DataStorm's relay heals transparently (the relay reconnects on its first, immediate retry and re-forwards), so the end-to-end session stays connected. The test therefore verifies relay **forwarding integrity** across hop drops rather than a session resync — which is the relevant "byte-forwarder" property the audit flagged as untested.

## H3 helper

Adds a small bounded-read helper (the audit's "H3"): `getNextUnread` wrapped in a deadline that fails with context instead of blocking forever, so a lost-sample regression surfaces as a diagnostic failure rather than a silent CI timeout. Stable across repeated runs.