### PR TITLE
Fix Escaping of Deprecation Reasons in Generated Code

### DIFF
--- a/cpp/src/Slice/StringLiteralUtil.cpp
+++ b/cpp/src/Slice/StringLiteralUtil.cpp
@@ -384,8 +384,6 @@ Slice::toStringLiteral(
     }
     else
     {
-        assert(escapeMode == Octal);
-
         for (size_t i = 0; i < value.size(); ++i)
         {
             char c = value[i];

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -75,7 +75,8 @@ namespace
         {
             if (auto reason = p1->getDeprecationReason())
             {
-                deprecatedAttribute = "[[deprecated(\"" + *reason + "\")]] ";
+                const string escapedReason = toStringLiteral(*reason, "\a\b\f\n\r\t\v", "?", UCN, 0);
+                deprecatedAttribute = "[[deprecated(\"" + escapedReason + "\")]] ";
             }
             else
             {

--- a/cpp/src/slice2cs/CsVisitor.cpp
+++ b/cpp/src/slice2cs/CsVisitor.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) ZeroC, Inc.
 
 #include "CsVisitor.h"
-#include "CsUtil.h"
 #include "../Slice/Util.h"
+#include "CsUtil.h"
 
 #include <cassert>
 

--- a/cpp/src/slice2cs/CsVisitor.cpp
+++ b/cpp/src/slice2cs/CsVisitor.cpp
@@ -2,6 +2,7 @@
 
 #include "CsVisitor.h"
 #include "CsUtil.h"
+#include "../Slice/Util.h"
 
 #include <cassert>
 
@@ -60,7 +61,8 @@ Slice::CsVisitor::emitObsoleteAttribute(const ContainedPtr& p)
     {
         if (auto reason = p->getDeprecationReason())
         {
-            _out << nl << "[global::System.Obsolete(\"" << *reason << "\")]";
+            const string escapedReason = toStringLiteral(*reason, "\a\b\f\n\r\t\v\0", "", UCN, 0);
+            _out << nl << "[global::System.Obsolete(\"" << escapedReason << "\")]";
         }
         else
         {

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1930,8 +1930,9 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         if (operation->isDeprecated())
         {
             // Get the deprecation reason if present, or default to an empty string.
-            string reason = operation->getDeprecationReason().value_or("");
-            out << nl << className << "._op_" << sliceName << ".deprecate(\"" << reason << "\")";
+            const string reason = operation->getDeprecationReason().value_or("");
+            const string escapedReason = toStringLiteral(reason, "\a\b\f\n\r\t\v", "", UCN, 0);
+            out << nl << className << "._op_" << sliceName << ".deprecate(\"" << escapedReason << "\")";
         }
     }
 

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -466,8 +466,9 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         if (op->isDeprecated())
         {
             // Get the deprecation reason if present, or default to an empty string.
-            string reason = op->getDeprecationReason().value_or("");
-            _out << nl << proxyName << "_mixin::OP_" << opName << ".deprecate(\"" << reason << "\")";
+            const string reason = op->getDeprecationReason().value_or("");
+            const string escapedReason = toStringLiteral(reason, "\a\b\f\n\r\t\v\x20\x1b", "", EC6UCN, 0);
+            _out << nl << proxyName << "_mixin::OP_" << opName << ".deprecate(\"" << escapedReason << "\")";
         }
     }
 


### PR DESCRIPTION
This PR fixes points 5 and 6 of #5491.

For C++, C#, Ruby, and Python, we do no escaping of the reason provided to `["deprecated(bad stuff)"]` metadata.
This meant if a user had something like a `"` in their reason (for whatever reason), we'd emit uncompilable code.
Now, as-of this PR, we run these strings through `toStringLiteral` like we do for other string literals we emit in the languages. Among other things, it will properly escape any internal `"` characters.

The other 5 languages are already fine, or just don't emit this reason at all in the generated code.

----

I didn't write a CHANGELOG entry because I just don't think this actually affects someone.
This isn't triggered by a `"` in a doc-comment, this is triggered by writing a quote in your already-quoted metadata:
If you think this warrants a CHANGELOG fix, feel free to say so and I will add one for the 4 affected languages.