### PR TITLE
Validate IceDiscovery.LatencyMultiplier (>= 1) (C++, C#, Java)

### DIFF
--- a/cpp/src/IceDiscovery/LookupI.cpp
+++ b/cpp/src/IceDiscovery/LookupI.cpp
@@ -193,6 +193,13 @@ LookupI::LookupI(LocatorRegistryIPtr registry, const LookupPrx& lookup, const Ic
       _domainId(properties->getIceProperty("IceDiscovery.DomainId")),
       _timer(IceInternal::getInstanceTimer(lookup->ice_getCommunicator()))
 {
+    if (_latencyMultiplier < 1)
+    {
+        throw PropertyException{
+            __FILE__,
+            __LINE__,
+            "property 'IceDiscovery.LatencyMultiplier' must be greater than or equal to 1"};
+    }
 }
 
 void

--- a/csharp/src/IceDiscovery/LookupI.cs
+++ b/csharp/src/IceDiscovery/LookupI.cs
@@ -106,11 +106,10 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
             _proxies.Add(proxy);
             if (_latency == 0)
             {
-                _latency = (long)((DateTime.Now.Ticks - _start) * lookup_.latencyMultiplier() / 10000.0);
-                if (_latency == 0)
-                {
-                    _latency = 1; // 1ms
-                }
+                // The aggregation window is the measured response time, scaled by IceDiscovery.LatencyMultiplier,
+                // with a 1ms floor so we never schedule a degenerate zero-length window.
+                double responseTimeMs = TimeSpan.FromTicks(DateTime.Now.Ticks - _start).TotalMilliseconds;
+                _latency = Math.Max(1, (long)(responseTimeMs * lookup_.latencyMultiplier()));
                 lookup_.timer().cancel(this);
                 lookup_.timer().schedule(this, _latency);
             }
@@ -230,6 +229,11 @@ internal class LookupI : LookupDisp_
         _timeout = properties.getIcePropertyAsInt("IceDiscovery.Timeout");
         _retryCount = properties.getIcePropertyAsInt("IceDiscovery.RetryCount");
         _latencyMultiplier = properties.getIcePropertyAsInt("IceDiscovery.LatencyMultiplier");
+        if (_latencyMultiplier < 1)
+        {
+            throw new Ice.PropertyException(
+                "property 'IceDiscovery.LatencyMultiplier' must be greater than or equal to 1");
+        }
         _domainId = properties.getIceProperty("IceDiscovery.DomainId");
         _timer = Ice.Internal.Util.getInstance(lookup.ice_getCommunicator()).timer();
 

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
@@ -10,6 +10,7 @@ import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.LocalException;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.PropertyException;
 import com.zeroc.Ice.UDPEndpointInfo;
 
 import java.util.ArrayList;
@@ -134,8 +135,8 @@ class LookupI implements Lookup {
                 if (_latency == 0) {
                     // The aggregation window is the measured response time, scaled by IceDiscovery.LatencyMultiplier,
                     // with a 1ms floor so we never schedule a degenerate zero-length window.
-                    long responseTimeMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - _start);
-                    _latency = Math.max(1, responseTimeMillis * _latencyMultiplier);
+                    long responseTimeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - _start);
+                    _latency = Math.max(1, responseTimeMs * _latencyMultiplier);
                     cancelTimer();
                     scheduleTimer(_latency);
                 }
@@ -239,6 +240,10 @@ class LookupI implements Lookup {
         _timeout = properties.getIcePropertyAsInt("IceDiscovery.Timeout");
         _retryCount = properties.getIcePropertyAsInt("IceDiscovery.RetryCount");
         _latencyMultiplier = properties.getIcePropertyAsInt("IceDiscovery.LatencyMultiplier");
+        if (_latencyMultiplier < 1) {
+            throw new PropertyException(
+                "property 'IceDiscovery.LatencyMultiplier' must be greater than or equal to 1");
+        }
         _domainId = properties.getIceProperty("IceDiscovery.DomainId");
         _timer = lookup.ice_getCommunicator().getInstance().timer();
 


### PR DESCRIPTION
Fixes #5730.

`IceDiscovery.LatencyMultiplier` was read directly from the configuration with no validation in any mapping, so a user could set it to `0` or a negative value — producing a zero-length or negative replica-group aggregation window.

This PR rejects values `< 1` at `LookupI` construction with a `PropertyException`, consistently across C++, C#, and Java:

> property 'IceDiscovery.LatencyMultiplier' must be greater than or equal to 1

While here, the C# latency computation in `AdapterRequest.response()` is refactored to mirror the Java version for readability — the bare `/ 10000.0` is replaced with an explicit `TimeSpan.FromTicks(...).TotalMilliseconds` conversion and the separate `if (_latency == 0) _latency = 1;` floor is folded into `Math.Max(1, ...)`. The math is unchanged (still `floor(elapsed_ms × multiplier)`, matching C++). The `responseTimeMillis` local is also renamed to `responseTimeMs` in C# and Java.

No CHANGELOG entry: this is a validation tightening (silent-accept → reject) for a nonsensical configuration value, not a user-visible behavioral fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)