### PR TITLE
Call 'mdb_env_close' for Every `throw` case in `IceDB::Env` Constructor

### DIFF
--- a/cpp/src/IceDB/IceDB.cpp
+++ b/cpp/src/IceDB/IceDB.cpp
@@ -129,6 +129,7 @@ Env::Env(const string& path, MDB_dbi maxDbs, size_t mapSize, unsigned int maxRea
     auto envMaxKeySize = static_cast<size_t>(mdb_env_get_maxkeysize(_menv));
     if (maxKeySize > envMaxKeySize)
     {
+        mdb_env_close(_menv);
         throw BadEnvException(__FILE__, __LINE__, envMaxKeySize);
     }
 }


### PR DESCRIPTION
This PR fixes point 4 of issue #5491.

The [docs for `mdb_env_create`](http://www.lmdb.tech/doc/group__mdb.html#gaad6be3d8dcd4ea01f8df436f41d158d4) state that it's required to call `mdb_env_close` to close a created environment. And in every other path where we `throw` we were, except for this one.

In reality, this is basically impossible to hit, you would need a custom build of LMDB with a higher `maxkeysize`.
So this is more of a correctness-fix, not a bug-fix. Since no one has ever hit this, I didn't add a CHANGELOG entry.