### PR TITLE
Group Dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,10 +23,8 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      js-minor-and-patch:
-        update-types: ["minor", "patch"]
-      js-major:
-        update-types: ["major"]
+      js:
+        patterns: ["*"]
 
   - package-ecosystem: "pip"
     directory: "/python"
@@ -35,10 +33,8 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      python-minor-and-patch:
-        update-types: ["minor", "patch"]
-      python-major:
-        update-types: ["major"]
+      python:
+        patterns: ["*"]
 
   - package-ecosystem: "pip"
     directory: "/python/docs"
@@ -57,10 +53,8 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      swift-minor-and-patch:
-        update-types: ["minor", "patch"]
-      swift-major:
-        update-types: ["major"]
+      swift:
+        patterns: ["*"]
 
   # 3.8 only receives GitHub Actions updates here; its language deps are kept in
   # sync with main by cherry-pick. (Config is read from the default branch only,


### PR DESCRIPTION
Consolidates each Dependabot ecosystem into a single catch-all group so updates arrive as one PR per ecosystem instead of one per dependency.

- Replaces the per-ecosystem `*-minor-and-patch` / `*-major` split (keyed only on `update-types`) with a single `patterns: ["*"]` group per ecosystem — matching how the `github-actions` block already groups.
- Pre-empts the one-PR-per-dependency flood seen on ice-demos: `python/pyproject.toml` declares its dev tools in a PEP 735 `[dependency-groups]` block, which the `update-types`-keyed groups don't reliably capture.
- `github-actions` grouping is unchanged.

Matching by name is simpler and easier to maintain and review than the old `update-types` split: one group per ecosystem means one PR per ecosystem to review instead of two, there's no semver-type filter for updates to slip through (which is exactly how the ruff/pyright requirement bumps became separate PRs), and every block now follows the same one-line shape as `github-actions`.
