### PR TITLE
Reformat JS to match prettier 3.9

### DIFF
--- a/js/packages/ice/src/Ice/ConnectionI.js
+++ b/js/packages/ice/src/Ice/ConnectionI.js
@@ -642,12 +642,10 @@ export class ConnectionI {
         } else if (traceLevels.network >= 1) {
             let s = `closed ${this._endpoint.protocol()} connection\n${this}`;
             // Trace the cause of most connection closures
-            if (
-                !(
-                    this._exception instanceof CommunicatorDestroyedException ||
-                    this._exception instanceof ObjectAdapterDestroyedException
-                )
-            ) {
+            if (!(
+                this._exception instanceof CommunicatorDestroyedException ||
+                this._exception instanceof ObjectAdapterDestroyedException
+            )) {
                 s += `\n${this._exception}`;
             }
             this._logger.trace(traceLevels.networkCat, s);
@@ -808,15 +806,13 @@ export class ConnectionI {
                 // We don't warn if we are not validated.
                 if (this._warn && this._validated) {
                     // Don't warn about certain expected exceptions.
-                    if (
-                        !(
-                            this._exception instanceof CloseConnectionException ||
-                            this._exception instanceof ConnectionClosedException ||
-                            this._exception instanceof CommunicatorDestroyedException ||
-                            this._exception instanceof ObjectAdapterDestroyedException ||
-                            (this._exception instanceof ConnectionLostException && this._state === StateClosing)
-                        )
-                    ) {
+                    if (!(
+                        this._exception instanceof CloseConnectionException ||
+                        this._exception instanceof ConnectionClosedException ||
+                        this._exception instanceof CommunicatorDestroyedException ||
+                        this._exception instanceof ObjectAdapterDestroyedException ||
+                        (this._exception instanceof ConnectionLostException && this._state === StateClosing)
+                    )) {
                         this.warning("connection exception", this._exception);
                     }
                 }

--- a/js/packages/ice/src/Ice/EndpointI.js
+++ b/js/packages/ice/src/Ice/EndpointI.js
@@ -29,7 +29,7 @@ export class EndpointI {
 
         let knownOptions = new Set();
 
-        for (let i = 0; i < args.length; ) {
+        for (let i = 0; i < args.length;) {
             const option = args[i++];
             if (option.length < 2 || option.charAt(0) != "-") {
                 unknown.push(option);


### PR DESCRIPTION
The `prettier` CI job runs `npx prettier --check` on `node-version: latest`, so it picks up the newest release satisfying the `^3.8.3` range in `js/package.json` — currently 3.9.3. Prettier 3.9 changed how it wraps a negated parenthesized condition (collapsing `if ( !( ... ) )` onto the `if (!(` line) and how it formats an empty for-loop update clause, which left `ConnectionI.js` and `EndpointI.js` failing the check.