### PR TITLE
Propagate a located servant's dispatch error in Java ServantManager

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ServantManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ServantManager.java
@@ -4,6 +4,7 @@ package com.zeroc.Ice;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
 /** A dispatcher that manages servants and servant locators for an object adapter. */
@@ -70,15 +71,17 @@ final class ServantManager implements Object {
                         ex = finishedEx;
                     }
                     if (ex != null) {
-                        // We only marshal errors and runtime exceptions
-                        // (including CompletionException) at a higher level.
+                        // Propagate the dispatch error like the plain-servant path so error-inspecting
+                        // middleware observes it (instead of converting it to a response here). Errors and
+                        // runtime exceptions propagate directly; the remaining (checked) user exception is
+                        // wrapped so it can flow through the completion stage.
                         if (ex instanceof Error errorEx) {
                             throw errorEx;
                         }
                         if (ex instanceof RuntimeException runtimeEx) {
                             throw runtimeEx;
                         }
-                        return current.createOutgoingResponse(ex);
+                        throw new CompletionException(ex);
                     } else {
                         return r;
                     }

--- a/java/test/src/main/java/test/Ice/middleware/AllTests.java
+++ b/java/test/src/main/java/test/Ice/middleware/AllTests.java
@@ -7,13 +7,16 @@ import com.zeroc.Ice.Current;
 import com.zeroc.Ice.ErrorObserverMiddleware;
 import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.IncomingRequest;
+import com.zeroc.Ice.LocalException;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.OutgoingResponse;
+import com.zeroc.Ice.ServantLocator;
 import com.zeroc.Ice.UnknownException;
 import com.zeroc.Ice.UserException;
 
+import test.Ice.middleware.Test.MyException;
 import test.Ice.middleware.Test.MyObject;
 import test.Ice.middleware.Test.MyObjectPrx;
 import test.TestHelper;
@@ -82,6 +85,53 @@ public class AllTests {
         Error error;
     }
 
+    // A custom dispatcher whose dispatch always completes exceptionally with a (bare) user exception.
+    private static class ThrowingServant implements Object {
+        @Override
+        public CompletionStage<OutgoingResponse> dispatch(IncomingRequest request) {
+            return CompletableFuture.failedFuture(new MyException());
+        }
+    }
+
+    private static class ThrowingServantLocator implements ServantLocator {
+        @Override
+        public ServantLocator.LocateResult locate(Current curr) {
+            return new ServantLocator.LocateResult(new ThrowingServant(), null);
+        }
+
+        @Override
+        public void finished(Current curr, Object servant, java.lang.Object cookie) {}
+
+        @Override
+        public void deactivate(String category) {}
+    }
+
+    private static class ThrowObserver {
+        boolean observed;
+    }
+
+    private static class ThrowObservingMiddleware implements Object {
+        private final Object _next;
+        private final ThrowObserver _observer;
+
+        ThrowObservingMiddleware(Object next, ThrowObserver observer) {
+            _next = next;
+            _observer = observer;
+        }
+
+        @Override
+        public CompletionStage<OutgoingResponse> dispatch(IncomingRequest request)
+            throws UserException {
+            return _next.dispatch(request)
+                .whenComplete(
+                    (response, ex) -> {
+                        if (ex != null) {
+                            _observer.observed = true;
+                        }
+                    });
+        }
+    }
+
     public static void allTests(TestHelper helper) {
         Communicator communicator = helper.communicator();
         PrintWriter output = helper.getWriter();
@@ -94,6 +144,8 @@ public class AllTests {
         // With error
         testErrorObserverMiddleware(communicator, output, true, false);
         testErrorObserverMiddleware(communicator, output, true, true);
+
+        testMiddlewareObservesLocatorDispatchError(communicator, output);
     }
 
     private static void testMiddlewareExecutionOrder(
@@ -162,6 +214,39 @@ public class AllTests {
         } else {
             test(errorHolder.error == null);
         }
+
+        output.println("ok");
+        oa.destroy();
+    }
+
+    private static void testMiddlewareObservesLocatorDispatchError(
+            Communicator communicator, PrintWriter output) {
+        output.write("testing middleware observes a servant-locator dispatch error... ");
+        output.flush();
+
+        // Arrange
+        var observer = new ThrowObserver();
+        ObjectAdapter oa =
+            communicator.createObjectAdapterWithEndpoints("MiddlewareLocatorOA", "tcp -h 127.0.0.1 -p 0");
+        oa.addServantLocator(new ThrowingServantLocator(), "");
+        oa.use(next -> new ThrowObservingMiddleware(next, observer));
+        oa.activate();
+
+        var p = MyObjectPrx.uncheckedCast(oa.createProxy(new Identity("test", "")));
+
+        // Act
+        boolean threw = false;
+        try {
+            p.getName();
+        } catch (LocalException e) {
+            threw = true;
+        }
+
+        // Assert: the located servant always fails, so the client sees a dispatch error and the middleware
+        // observed the dispatch completing exceptionally, rather than it being converted to a response inside
+        // ServantManager.
+        test(threw);
+        test(observer.observed);
 
         output.println("ok");
         oa.destroy();

--- a/java/test/src/main/java/test/Ice/middleware/Test.ice
+++ b/java/test/src/main/java/test/Ice/middleware/Test.ice
@@ -5,6 +5,8 @@
 ["java:identifier:test.Ice.middleware.Test"]
 module Test
 {
+    exception MyException {}
+
     interface MyObject
     {
         ["amd"] string getName();


### PR DESCRIPTION
Fixes #5712. Java (com.zeroc) follow-up to the Swift fix #5706 (for #5555).

## Problem

In `ServantManager.dispatch`'s servant-locator path, the async completion handler converted a `UserException` that completed a located servant's dispatch into a response **in-place**:

```java
if (ex instanceof Error errorEx) { throw errorEx; }
if (ex instanceof RuntimeException runtimeEx) { throw runtimeEx; }
return current.createOutgoingResponse(ex);   // UserException converted here
```

Because `ServantManager` is the innermost dispatcher, error-inspecting middleware never observed the throw — unlike the **plain-servant path** (line 25, which returns `servant.dispatch(request)` as-is) and the C#/JS runtimes. `Error`/`RuntimeException` and synchronous throws already propagated, so the divergence was limited to async `UserException` completions.

## Fix

Propagate the user exception instead of converting it:

```java
throw new CompletionException(ex);
```

The lambda can't throw a checked `UserException`, so it's wrapped in `CompletionException`. The higher-level consumer (`ConnectionI`, `response.whenComplete(... createOutgoingResponse(exception) ...)`) marshals the propagated exception, and `Current.createOutgoingResponse(Throwable)` **unwraps** `CompletionException` before marshalling — so the client receives the **same wire response** as before, while middleware between the connection and `ServantManager` now observes the dispatch error. This matches the plain-servant path.

## Test

New `test/Ice/middleware` case: a request is routed through a servant locator whose located servant fails its dispatch with a user exception (a custom dispatcher returning `CompletableFuture.failedFuture(...)` — a generated AMD servant would wrap the exception in `CompletionException`, which already propagates), with an error-observing middleware installed. It asserts the client sees the dispatch error **and** the middleware observed the throw.

Confirmed red→green: without the fix, the client still errors but the middleware no longer observes the throw (`ServantManager` converts the exception to a response). `:ice` + `:test` compile; checkstyle and OpenRewrite are clean.