### PR TITLE
Validate ThreadPriority properties (C#, Java)

### DIFF
--- a/changelog.d/csharp/thread-priority-property-validation.md
+++ b/changelog.d/csharp/thread-priority-property-validation.md
@@ -1,0 +1,4 @@
+- A `ThreadPriority` property set to an unrecognized value now throws `PropertyException` instead of being
+  silently ignored and falling back to the normal priority. This applies to `Ice.ThreadPriority` and to any
+  thread pool's `ThreadPriority` property, such as `Ice.ThreadPool.Server.ThreadPriority` or an object adapter's
+  `<adapter>.ThreadPool.ThreadPriority`.

--- a/changelog.d/java/thread-priority-property-validation.md
+++ b/changelog.d/java/thread-priority-property-validation.md
@@ -1,0 +1,8 @@
+- A `ThreadPriority` property set to an unrecognized value now throws `PropertyException` instead of being
+  silently ignored and falling back to the normal priority. This applies to `Ice.ThreadPriority` and to any
+  thread pool's `ThreadPriority` property, such as `Ice.ThreadPool.Server.ThreadPriority` or an object adapter's
+  `<adapter>.ThreadPool.ThreadPriority`. Integer values outside the allowed range (1-10) are also rejected.
+- A thread pool's `ThreadPriority` property (such as `Ice.ThreadPool.Server.ThreadPriority` or an object
+  adapter's `<adapter>.ThreadPool.ThreadPriority`) now also accepts the priority constant names `MIN_PRIORITY`,
+  `NORM_PRIORITY`, and `MAX_PRIORITY`, like `Ice.ThreadPriority` already did. Previously these properties accepted
+  only integer values.

--- a/csharp/src/Ice/Internal/EndpointHostResolver.cs
+++ b/csharp/src/Ice/Internal/EndpointHostResolver.cs
@@ -14,8 +14,7 @@ public class EndpointHostResolver
         _preferIPv6 = instance.preferIPv6();
         _thread = new HelperThread(this);
         updateObserver();
-        _thread.Start(Util.stringToThreadPriority(
-                instance.initializationData().properties.getIceProperty("Ice.ThreadPriority")));
+        _thread.Start(Util.getThreadPriorityProperty(instance.initializationData().properties, "Ice"));
     }
 
     public void resolve(string host, int port, IPEndpointI endpoint, EndpointI_connectors callback)

--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -955,8 +955,7 @@ public sealed class Instance
         //
         try
         {
-            _timer = new Timer(this, Util.stringToThreadPriority(
-                                            initializationData().properties.getIceProperty("Ice.ThreadPriority")));
+            _timer = new Timer(this, Util.getThreadPriorityProperty(initializationData().properties, "Ice"));
         }
         catch (System.Exception ex)
         {

--- a/csharp/src/Ice/Internal/ThreadPool.cs
+++ b/csharp/src/Ice/Internal/ThreadPool.cs
@@ -171,8 +171,8 @@ public sealed class ThreadPool : System.Threading.Tasks.TaskScheduler
         _stackSize = stackSize;
 
         _priority = properties.getProperty(_prefix + ".ThreadPriority").Length > 0 ?
-            Util.stringToThreadPriority(properties.getProperty(_prefix + ".ThreadPriority")) :
-            Util.stringToThreadPriority(properties.getIceProperty("Ice.ThreadPriority"));
+            Util.getThreadPriorityProperty(properties, _prefix) :
+            Util.getThreadPriorityProperty(properties, "Ice");
 
         if (_instance.traceLevels().threadPool >= 1)
         {

--- a/csharp/src/Ice/Internal/Util.cs
+++ b/csharp/src/Ice/Internal/Util.cs
@@ -6,36 +6,24 @@ public sealed class Util
 {
     public static Instance getInstance(Ice.Communicator communicator) => communicator.instance;
 
-    public static ThreadPriority stringToThreadPriority(string s)
+    public static ThreadPriority getThreadPriorityProperty(Ice.Properties properties, string prefix)
     {
+        string propertyName = prefix + ".ThreadPriority";
+        string s = properties.getProperty(propertyName);
         if (string.IsNullOrEmpty(s))
         {
             return ThreadPriority.Normal;
         }
-        if (s.StartsWith("ThreadPriority.", StringComparison.Ordinal))
+        string value = s.StartsWith("ThreadPriority.", StringComparison.Ordinal) ?
+            s["ThreadPriority.".Length..] : s;
+        return value switch
         {
-            s = s["ThreadPriority.".Length..];
-        }
-        if (s == "Lowest")
-        {
-            return ThreadPriority.Lowest;
-        }
-        else if (s == "BelowNormal")
-        {
-            return ThreadPriority.BelowNormal;
-        }
-        else if (s == "Normal")
-        {
-            return ThreadPriority.Normal;
-        }
-        else if (s == "AboveNormal")
-        {
-            return ThreadPriority.AboveNormal;
-        }
-        else if (s == "Highest")
-        {
-            return ThreadPriority.Highest;
-        }
-        return ThreadPriority.Normal;
+            "Lowest" => ThreadPriority.Lowest,
+            "BelowNormal" => ThreadPriority.BelowNormal,
+            "Normal" => ThreadPriority.Normal,
+            "AboveNormal" => ThreadPriority.AboveNormal,
+            "Highest" => ThreadPriority.Highest,
+            _ => throw new PropertyException($"property '{propertyName}' has an invalid value: '{s}'"),
+        };
     }
 }

--- a/csharp/test/Ice/threadPoolPriority/Client.cs
+++ b/csharp/test/Ice/threadPoolPriority/Client.cs
@@ -10,7 +10,7 @@ public class Client : global::Test.TestHelper
         TextWriter output = getWriter();
 
         output.Write("testing thread priority property parsing... ");
-        Properties properties = new Properties();
+        var properties = new Properties();
         properties.setProperty("Ice.ThreadPriority", "ThreadPriority.AboveNormal");
         test(Ice.Internal.Util.getThreadPriorityProperty(properties, "Ice") ==
             System.Threading.ThreadPriority.AboveNormal);

--- a/csharp/test/Ice/threadPoolPriority/Client.cs
+++ b/csharp/test/Ice/threadPoolPriority/Client.cs
@@ -9,12 +9,26 @@ public class Client : global::Test.TestHelper
         using Communicator communicator = initialize(ref args);
         TextWriter output = getWriter();
 
-        output.Write("testing stringToThreadPriority parsing... ");
-        test(Ice.Internal.Util.stringToThreadPriority("ThreadPriority.AboveNormal") ==
+        output.Write("testing thread priority property parsing... ");
+        Properties properties = new Properties();
+        properties.setProperty("Ice.ThreadPriority", "ThreadPriority.AboveNormal");
+        test(Ice.Internal.Util.getThreadPriorityProperty(properties, "Ice") ==
             System.Threading.ThreadPriority.AboveNormal);
-        test(Ice.Internal.Util.stringToThreadPriority("AboveNormal") ==
+        properties.setProperty("Ice.ThreadPriority", "AboveNormal");
+        test(Ice.Internal.Util.getThreadPriorityProperty(properties, "Ice") ==
             System.Threading.ThreadPriority.AboveNormal);
-        test(Ice.Internal.Util.stringToThreadPriority("") == System.Threading.ThreadPriority.Normal);
+        properties.setProperty("Ice.ThreadPriority", "");
+        test(Ice.Internal.Util.getThreadPriorityProperty(properties, "Ice") ==
+            System.Threading.ThreadPriority.Normal);
+        properties.setProperty("Ice.ThreadPriority", "BogusPriority");
+        try
+        {
+            Ice.Internal.Util.getThreadPriorityProperty(properties, "Ice");
+            test(false);
+        }
+        catch (PropertyException)
+        {
+        }
         output.WriteLine("ok");
 
         output.Write("testing server priority... ");

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ThreadPool.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ThreadPool.java
@@ -131,14 +131,10 @@ final class ThreadPool implements Executor {
         }
         _stackSize = stackSize;
 
-        boolean hasPriority = properties.getProperty(_prefix + ".ThreadPriority").length() > 0;
-        int priority = properties.getPropertyAsInt(_prefix + ".ThreadPriority");
-        if (!hasPriority) {
-            hasPriority = properties.getIceProperty("Ice.ThreadPriority").length() > 0;
-            priority = properties.getIcePropertyAsInt("Ice.ThreadPriority");
-        }
-        _hasPriority = hasPriority;
-        _priority = priority;
+        _priority =
+            properties.getProperty(_prefix + ".ThreadPriority").length() > 0
+                ? Util.getThreadPriorityProperty(properties, _prefix)
+                : Util.getThreadPriorityProperty(properties, "Ice");
 
         _workQueue = new ThreadPoolWorkQueue(_instance, this, _selector);
         _nextHandler = _handlers.iterator();
@@ -152,7 +148,7 @@ final class ThreadPool implements Executor {
         try {
             for (int i = 0; i < _size; i++) {
                 EventHandlerThread thread = new EventHandlerThread(_threadPrefix + "-" + _threadIndex++);
-                thread.start(_hasPriority ? _priority : Thread.NORM_PRIORITY);
+                thread.start();
                 _threads.add(thread);
             }
         } catch (RuntimeException ex) {
@@ -413,11 +409,7 @@ final class ThreadPool implements Executor {
                     try {
                         EventHandlerThread thread = new EventHandlerThread(_threadPrefix + "-" + _threadIndex++);
                         _threads.add(thread);
-                        if (_hasPriority) {
-                            thread.start(_priority);
-                        } else {
-                            thread.start(Thread.NORM_PRIORITY);
-                        }
+                        thread.start();
                     } catch (RuntimeException ex) {
                         String s = "cannot create thread for `" + _prefix + "':\n" + Ex.toString(ex);
                         _instance.initializationData().logger.error(s);
@@ -524,9 +516,9 @@ final class ThreadPool implements Executor {
             _thread.join();
         }
 
-        public void start(int priority) {
+        public void start() {
             _thread = new Thread(null, this, _name, _stackSize);
-            _thread.setPriority(priority);
+            _thread.setPriority(_priority);
             _thread.start();
         }
 
@@ -576,7 +568,6 @@ final class ThreadPool implements Executor {
     private final int _sizeWarn; // If _inUse reaches _sizeWarn, a "low on threads" warning will be printed.
     private final boolean _serialize; // True if requests need to be serialized over the connection.
     private final int _priority;
-    private final boolean _hasPriority;
     private final long _serverIdleTime;
     private final long _threadIdleTime;
     private final int _stackSize;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -403,10 +403,7 @@ public final class Util {
             public Thread newThread(Runnable r) {
                 Thread t = new Thread(r);
                 t.setName(name);
-
-                if (properties.getIceProperty("Ice.ThreadPriority").length() > 0) {
-                    t.setPriority(Util.getThreadPriorityProperty(properties, "Ice"));
-                }
+                t.setPriority(Util.getThreadPriorityProperty(properties, "Ice"));
                 return t;
             }
         };
@@ -521,20 +518,35 @@ public final class Util {
         return null;
     }
 
-    private static int getThreadPriorityProperty(Properties properties, String prefix) {
+    static int getThreadPriorityProperty(Properties properties, String prefix) {
         String pri = properties.getProperty(prefix + ".ThreadPriority");
-        if ("MIN_PRIORITY".equals(pri) || "java.lang.Thread.MIN_PRIORITY".equals(pri)) {
-            return Thread.MIN_PRIORITY;
-        } else if ("NORM_PRIORITY".equals(pri) || "java.lang.Thread.NORM_PRIORITY".equals(pri)) {
+        if (pri.isEmpty()) {
             return Thread.NORM_PRIORITY;
-        } else if ("MAX_PRIORITY".equals(pri) || "java.lang.Thread.MAX_PRIORITY".equals(pri)) {
-            return Thread.MAX_PRIORITY;
+        }
+        switch (pri) {
+            case "MIN_PRIORITY", "java.lang.Thread.MIN_PRIORITY" -> {
+                return Thread.MIN_PRIORITY;
+            }
+            case "NORM_PRIORITY", "java.lang.Thread.NORM_PRIORITY" -> {
+                return Thread.NORM_PRIORITY;
+            }
+            case "MAX_PRIORITY", "java.lang.Thread.MAX_PRIORITY" -> {
+                return Thread.MAX_PRIORITY;
+            }
         }
 
+        int priority;
         try {
-            return Integer.parseInt(pri);
-        } catch (NumberFormatException ex) {}
-        return Thread.NORM_PRIORITY;
+            priority = Integer.parseInt(pri);
+        } catch (NumberFormatException ex) {
+            throw new PropertyException(
+                "property '" + prefix + ".ThreadPriority' has an invalid value: '" + pri + "'");
+        }
+        if (priority < Thread.MIN_PRIORITY || priority > Thread.MAX_PRIORITY) {
+            throw new PropertyException(
+                "property '" + prefix + ".ThreadPriority' has an invalid value: '" + pri + "'");
+        }
+        return priority;
     }
 
     /**

--- a/java/test/src/main/java/test/Ice/threadPoolPriority/Client.java
+++ b/java/test/src/main/java/test/Ice/threadPoolPriority/Client.java
@@ -4,6 +4,8 @@ package test.Ice.threadPoolPriority;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ObjectPrx;
+import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.PropertyException;
 
 import test.Ice.threadPoolPriority.Test.PriorityPrx;
 import test.TestHelper;
@@ -24,5 +26,16 @@ public class Client extends TestHelper {
             out.println("ok");
             priority.shutdown();
         }
+
+        out.print("testing invalid thread priority... ");
+        out.flush();
+        Properties properties = new Properties();
+        properties.setProperty("Ice.ThreadPool.Client.ThreadPriority", "11");
+        try (Communicator communicator = initialize(properties)) {
+            test(false);
+        } catch (PropertyException ex) {
+            // expected: 11 is outside the allowed range [1, 10]
+        }
+        out.println("ok");
     }
 }

--- a/java/test/src/main/java/test/Ice/threadPoolPriority/Client.java
+++ b/java/test/src/main/java/test/Ice/threadPoolPriority/Client.java
@@ -30,11 +30,11 @@ public class Client extends TestHelper {
         out.print("testing invalid thread priority... ");
         out.flush();
         Properties properties = new Properties();
-        properties.setProperty("Ice.ThreadPool.Client.ThreadPriority", "11");
+        properties.setProperty("Ice.ThreadPool.Client.ThreadPriority", Integer.toString(Thread.MAX_PRIORITY + 1));
         try (Communicator communicator = initialize(properties)) {
             test(false);
         } catch (PropertyException ex) {
-            // expected: 11 is outside the allowed range [1, 10]
+            // expected: outside the allowed range
         }
         out.println("ok");
     }


### PR DESCRIPTION
A `ThreadPriority` property set to an unrecognized value was silently ignored and fell back to the normal priority. This PR rejects such values with a `PropertyException` instead, in both C# and Java.

### Java
- Unified the thread pool priority path with the existing `Ice.ThreadPriority` path: both now go through `Util.getThreadPriorityProperty` rather than the thread pool parsing the value as a plain integer via `getPropertyAsInt`.
- As a result, **all** thread priority properties (`Ice.ThreadPriority`, `Ice.ThreadPool.{Client,Server}.ThreadPriority`, and an object adapter's `<adapter>.ThreadPool.ThreadPriority`) share one validated code path:
  - unrecognized values throw `PropertyException`;
  - integer values are validated against the allowed range (1-10);
  - thread pool priorities now also accept the `MIN_PRIORITY`/`NORM_PRIORITY`/`MAX_PRIORITY` constant names, which previously only `Ice.ThreadPriority` accepted.
- Dropped the now-redundant `_hasPriority` flag (the helper always yields a valid priority, defaulting to `NORM_PRIORITY`), so the thread pool and the timer/endpoint-resolver threads now always set their priority explicitly — matching C#.

### C#
- Reworked `Util.stringToThreadPriority` into `getThreadPriorityProperty(Ice.Properties, string prefix)`, which reads the property value itself instead of having each caller fetch it, mirroring the Java helper. Unrecognized values now throw `PropertyException`.

### Behavioral note
The Java timer/endpoint-resolver and thread-pool threads now always call `setPriority` (to `NORM_PRIORITY` when unconfigured) instead of inheriting the creating thread's priority. In practice this is the same value (5) and matches long-standing C# behavior.

### Tests
Updated the C# and Java `threadPoolPriority` tests to cover the new validation (invalid string in C#, out-of-range integer in Java). Both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)