### PR TITLE
Fix Windows build with the Visual Studio 2026 (v180) toolset

### DIFF
--- a/cpp/msbuild/ice.cpp.props
+++ b/cpp/msbuild/ice.cpp.props
@@ -179,7 +179,7 @@
   -->
   <ItemDefinitionGroup Condition="'$(IceBuildingSrc)' == 'yes'">
     <Link>
-      <GenerateDebugInformation>Yes</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
 

--- a/cpp/msbuild/ice.test.props
+++ b/cpp/msbuild/ice.test.props
@@ -20,7 +20,7 @@
   -->
   <ItemDefinitionGroup>
     <Link>
-      <GenerateDebugInformation>Yes</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
## What

The `windows-2025` GitHub runner image was updated to **Visual Studio 2026** (MSVC 14.51, toolset **v180**). Its `Microsoft.Build.CPPTasks.Link` task no longer accepts the legacy `<GenerateDebugInformation>` value `Yes`, which broke the nightly **Build MATLAB Packages** job:

```
Microsoft.CppCommon.targets(1196,5): error : Element <GenerateDebugInformation> has an invalid value of "Yes".
error MSB6011: Invalid parameters passed to the Microsoft.Build.CPPTasks.Link task.
```

(Failure seen in the 3.7 nightly run [28351012886](https://github.com/zeroc-ice/ice/actions/runs/28351012886) — the `slice2matlab` link step. The `ubuntu-24.04` job in the same matrix only shows "The operation was canceled" because `fail-fast` killed it after the Windows job failed.)

## Why

`ice.cpp.props` / `ice.test.props` set `Yes` as the **default** `GenerateDebugInformation` and only override it for the `v140`/`v141`/`v142`/`v143` toolsets. v180 matches none of those, so it falls through to the now-invalid `Yes`. The C++ Windows binary jobs are unaffected because they run on `windows-2022` and pin `v142`/`v143`; the MATLAB job runs on `windows-2025` and pins no toolset.

`main`/`3.8` already uses `DebugFull` and is not affected; this was never backported to 3.7.

## Fix

Change the default fallback value to a modern value valid on all current/future toolsets (the per-toolset overrides for v140–v143 are unchanged):

- `cpp/msbuild/ice.cpp.props`: default `Yes` → `DebugFull` (matches the v141–v143 override)
- `cpp/msbuild/ice.test.props`: default `Yes` → `DebugFastLink` (matches the v140–v143 test override)

The default `ItemDefinitionGroup` has no toolset condition, so it always applies regardless of what `DefaultPlatformToolset` v180 reports.

## Note

The build died at the first link, so this addresses the one v180 incompatibility visible in the log. A green nightly re-run is the way to confirm nothing else in the v180 toolset trips.