### PR TITLE
Don't statically link the Slice compilers on hppa (PA-RISC)

### DIFF
--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -139,7 +139,8 @@ static_ldflags  = -pie
 
 # Link the Slice compilers without any shared libraries.
 # On Amazon Linux 2023, disable static linking since libmcpp-devel provides only the shared library.
-ifeq ($(filter amzn,$(linux_id)),)
+# On hppa (PA-RISC), disable static linking because static PIE executables crash at startup.
+ifeq ($(filter amzn,$(linux_id))$(filter parisc%,$(shell uname -m)),)
 fully_static_ldflags = -static
 endif
 


### PR DESCRIPTION
On hppa (PA-RISC), static PIE executables crash at startup, so `slice2py` segfaults on its very first invocation during the Debian package build:

```
../../cpp/bin/slice2py ... ../../slice/Ice/BuiltinSequences.ice
Segmentation fault
```

The Slice compilers are linked with `-static -pie`. hppa's toolchain doesn't reliably support static PIE (function-descriptor/PLABEL relocations, GP register setup, branch-distance stubs).

This change skips `-static` on hppa (detected via `uname -m` matching `parisc%`), reusing the same empty-filter idiom already used to disable static linking on Amazon Linux. `libSlice.a` and `libIceUtil.a` are still linked statically since they're `.a` archives pulled in directly; only glibc/libstdc++ become dynamic. `-pie` is retained, which the other compilers already tolerate.

Fixes #5331

🤖 Generated with [Claude Code](https://claude.com/claude-code)