### PR TITLE
Exclude dotnet.microsoft.com from the link checker

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -33,6 +33,8 @@ exclude = [
     "^https?://gitter\\.im",
     # npm returns 403 to bots
     "^https?://www\\.npmjs\\.com",
+    # dotnet.microsoft.com returns 403 to bots
+    "^https?://dotnet\\.microsoft\\.com",
     # Symbol server
     "^https?://symbols\\.zeroc\\.com",
 ]


### PR DESCRIPTION
## What

The **Check Links** CI job fails because `dotnet.microsoft.com` returns `403 Forbidden` to the lychee link checker's bot user agent:

```
[403] https://dotnet.microsoft.com/en-us/download/dotnet | Rejected status code: 403 Forbidden (configurable with "accept" option)
```

The link is valid in a browser; the site just blocks bots. Of 303 links checked, these were the only 3 errors (all the same URL), in:

- `cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/BUILDING.md`
- `csharp/BUILDING.md`
- `csharp/src/ZeroC.Ice.Slice.Tools/BUILDING.md`

See run [28378700509](https://github.com/zeroc-ice/ice/actions/runs/28378700509).

## Fix

Add `dotnet.microsoft.com` to the `exclude` list in `.lychee.toml`, alongside the existing exclusions for npmjs.com and other sites that reject bots.