### PR TITLE
Fix Java Network.compareAddress to compare the IPv6 scope id (#5696)

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
@@ -512,13 +512,25 @@ public final class Network {
             return v;
         }
 
-        byte[] larr = addr1.getAddress().getAddress();
-        byte[] rarr = addr2.getAddress().getAddress();
-        v = larr.length - rarr.length;
+        InetAddress inetAddress1 = addr1.getAddress();
+        InetAddress inetAddress2 = addr2.getAddress();
+        byte[] addressBytes1 = inetAddress1.getAddress();
+        byte[] addressBytes2 = inetAddress2.getAddress();
+        v = addressBytes1.length - addressBytes2.length;
         if (v != 0) {
             return v;
         }
-        return Arrays.compare(larr, rarr);
+        v = Arrays.compare(addressBytes1, addressBytes2);
+        if (v != 0) {
+            return v;
+        }
+
+        // Distinguish scoped link-local addresses such as fe80::1%eth0 and fe80::1%eth1.
+        if (inetAddress1 instanceof Inet6Address inet6Address1
+                && inetAddress2 instanceof Inet6Address inet6Address2) {
+            return Integer.compare(inet6Address1.getScopeId(), inet6Address2.getScopeId());
+        }
+        return 0;
     }
 
     public static List<InetSocketAddress> getAddresses(

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
@@ -527,7 +527,7 @@ public final class Network {
 
         // Distinguish scoped link-local addresses such as fe80::1%eth0 and fe80::1%eth1.
         if (inetAddress1 instanceof Inet6Address inet6Address1
-                && inetAddress2 instanceof Inet6Address inet6Address2) {
+            && inetAddress2 instanceof Inet6Address inet6Address2) {
             return Integer.compare(inet6Address1.getScopeId(), inet6Address2.getScopeId());
         }
         return 0;


### PR DESCRIPTION
`Network.compareAddress` compared only the raw 16 address bytes returned by `InetAddress.getAddress()`, which **omits the IPv6 scope id**. As a result two IPv6 link-local addresses that differ only by their zone (e.g. `fe80::1%eth0` vs `fe80::1%eth1`) compared as equal under `compareAddress`, even though `InetAddress.equals` (used for connection reuse) treats them as distinct — a `compareTo`/`equals` contract inconsistency in `IPEndpointI.compareTo`.

This now also compares `Inet6Address.getScopeId()` when both operands are IPv6, mirroring the C++ `sin6_scope_id` fix in #5679 (same comment).

Fixes #5696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)