### PR TITLE
Fix NPE in C# MetricsMap.getMatching when metrics construction fails (#5652)

### DIFF
--- a/csharp/src/Ice/Internal/MetricsAdminI.cs
+++ b/csharp/src/Ice/Internal/MetricsAdminI.cs
@@ -423,6 +423,7 @@ public class MetricsMap<T> : IMetricsMap where T : IceMX.Metrics, new()
                 catch (System.Exception)
                 {
                     Debug.Assert(false);
+                    return null;
                 }
             }
             e.attach(helper);


### PR DESCRIPTION
The Java fix in #5630 (for #5510) applies to the C# `MetricsMap<T>.getMatching` as well. If `new T()` throws, the `catch` ran `Debug.Assert(false)` — a no-op in release builds — leaving `e` null and falling through to `e.attach(helper)`, which raises a `NullReferenceException` out of the observer path.

This returns `null` in the `catch`, mirroring the Java fix. `getMatching` already returns `null` on its other branches (destroyed map, no match), so callers handle a null entry.

Latent: `MetricsMap<T>` is constrained `where T : IceMX.Metrics, new()`, so `new T()` only throws if the metrics class's own constructor throws, which the built-in metrics classes don't. (C++ is unaffected — it uses `std::make_shared<T>()`.)

Fixes #5652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)