### PR TITLE
Fix latent UB in C++ WebSocket unmask offset computation

### DIFF
--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -1365,7 +1365,7 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
                     }
                     _readState = ReadStatePayload;
                     assert(buf.i != buf.b.end());
-                    _readFrameStart = buf.i;
+                    _readFrameOffset = 0;
                     break;
                 }
                 case OP_CLOSE: // Connection close
@@ -1529,13 +1529,16 @@ IceInternal::WSTransceiver::postRead(Buffer& buf)
     if (_incoming)
     {
         //
-        // Unmask the data we just read.
+        // Unmask the data we just read. _readFrameOffset is the mask index (payload bytes consumed so far in
+        // this frame). We keep it as an integer rather than an iterator into buf because ConnectionI reallocates
+        // the read buffer between reads of the same frame, which would invalidate such an iterator.
         //
         IceInternal::Buffer::Container::iterator p = _readStart;
-        for (auto n = static_cast<size_t>(_readStart - _readFrameStart); p < buf.i; ++p, ++n)
+        for (size_t n = _readFrameOffset; p < buf.i; ++p, ++n)
         {
             *p ^= _readMask[n % 4];
         }
+        _readFrameOffset += static_cast<size_t>(buf.i - _readStart);
     }
 
     _readPayloadLength -= static_cast<size_t>(buf.i - _readStart);

--- a/cpp/src/Ice/WSTransceiver.h
+++ b/cpp/src/Ice/WSTransceiver.h
@@ -117,7 +117,7 @@ namespace IceInternal
         size_t _readHeaderLength;
         size_t _readPayloadLength;
         Buffer::Container::iterator _readStart;
-        size_t _readFrameOffset;
+        size_t _readFrameOffset{0};
         std::byte _readMask[4];
 
         enum WriteState

--- a/cpp/src/Ice/WSTransceiver.h
+++ b/cpp/src/Ice/WSTransceiver.h
@@ -117,7 +117,7 @@ namespace IceInternal
         size_t _readHeaderLength;
         size_t _readPayloadLength;
         Buffer::Container::iterator _readStart;
-        Buffer::Container::iterator _readFrameStart;
+        size_t _readFrameOffset;
         std::byte _readMask[4];
 
         enum WriteState


### PR DESCRIPTION
The C++ WebSocket transceiver computed the per-frame unmask offset by subtracting two iterators into the read buffer:

```cpp
for (auto n = static_cast<size_t>(_readStart - _readFrameStart); p < buf.i; ++p, ++n)
    *p ^= _readMask[n % 4];
```

`_readFrameStart` is captured at the frame's payload start, while `ConnectionI` reads the 14-byte Ice message header. `ConnectionI` then `resize`s `_readStream` to the full message size — a `::realloc` in `Buffer.cpp` — before reading the body, freeing the old allocation. For the first frame of any message larger than the read buffer's capacity (~240 bytes), `postRead` then subtracts pointers into two different allocations, one of them freed.

This is **latent undefined behavior**. On mainstream allocators it still produced the correct mask index — only `n % 4` is used, and since `malloc`/`realloc` align to ≥ 4 bytes the spurious `(newBuf - oldBuf)` term (and any `size_t` wraparound) vanishes mod 4 — so no incorrect bytes were ever observed in practice. But subtracting pointers across distinct allocations (and reading an iterator into a freed block) is UB by the standard, and breaks under pointer-provenance tooling (`-fsanitize=pointer-subtract`) and provenance-strict targets such as CHERI.

The fix tracks the mask offset as an integer (`_readFrameOffset`, the number of payload bytes consumed so far in the frame) rather than an iterator into a reallocatable buffer, mirroring the C# port. No cross-allocation pointer subtraction remains. Continuation-frame behavior is unchanged: the offset resets to 0 at each frame start, exactly as `_readFrameStart` did.

Tested with `Ice/operations` over the `ws` protocol (client/server, AMD, collocated) — all pass.

No CHANGELOG entry: no observable behavior change on supported platforms; this removes latent UB only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)