### PR TITLE
Add OOM null checks on IcePy dispatch/decode paths

### DIFF
--- a/python/modules/IcePy/Current.cpp
+++ b/python/modules/IcePy/Current.cpp
@@ -15,6 +15,10 @@ IcePy::createCurrent(const Ice::Current& current)
     PyObject* currentType{lookupType("Ice.Current")};
 
     PyObjectHandle args{PyTuple_New(9)};
+    if (!args.get())
+    {
+        return nullptr;
+    }
 
     PyObject* adapter{wrapObjectAdapter(current.adapter)};
     if (!adapter)
@@ -78,6 +82,10 @@ IcePy::createCurrent(const Ice::Current& current)
     PyTuple_SetItem(args.get(), 5, getAttr(operationModeType, enumerator, false));
 
     PyObjectHandle ctx{PyDict_New()};
+    if (!ctx.get())
+    {
+        return nullptr;
+    }
     if (!contextToDictionary(current.ctx, ctx.get()))
     {
         return nullptr;

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -2031,6 +2031,10 @@ IcePy::TypedUpcall::dispatch(PyObject* servant, pair<const byte*, const byte*> i
     // Create an object to represent Ice::Current. We need to append this to the argument tuple.
     //
     PyObjectHandle curr{createCurrent(current)};
+    if (!curr.get())
+    {
+        throwPythonException();
+    }
     PyTuple_SET_ITEM(
         args.get(),
         PyTuple_GET_SIZE(args.get()) - 1,
@@ -2167,6 +2171,10 @@ IcePy::BlobjectUpcall::dispatch(PyObject* servant, pair<const byte*, const byte*
     // this to the argument tuple.
     //
     PyObjectHandle curr{createCurrent(current)};
+    if (!curr.get())
+    {
+        throwPythonException();
+    }
     PyTuple_SET_ITEM(args.get(), start, curr.release()); // PyTuple_SET_ITEM steals a reference.
 
     dispatchImpl(servant, "ice_invoke", args.get(), current);

--- a/python/modules/IcePy/PropertiesAdmin.cpp
+++ b/python/modules/IcePy/PropertiesAdmin.cpp
@@ -81,20 +81,27 @@ nativePropertiesAdminAddUpdateCB(NativePropertiesAdminObject* self, PyObject* ar
                     AdoptThread adoptThread; // Ensure the current thread is able to call into Python.
 
                     PyObjectHandle result{PyDict_New()};
-                    if (result.get())
+                    if (!result.get())
                     {
-                        for (const auto& [key, value] : dict)
+                        return;
+                    }
+
+                    for (const auto& [key, value] : dict)
+                    {
+                        PyObjectHandle pyKey{createString(key)};
+                        PyObjectHandle pyValue{createString(value)};
+                        if (!pyKey.get() || !pyValue.get() ||
+                            PyDict_SetItem(result.get(), pyKey.get(), pyValue.get()) < 0)
                         {
-                            PyObjectHandle pyKey{createString(key)};
-                            PyObjectHandle pyValue{createString(value)};
-                            if (!pyValue.get() || PyDict_SetItem(result.get(), pyKey.get(), pyValue.get()) < 0)
-                            {
-                                return;
-                            }
+                            return;
                         }
                     }
 
                     PyObjectHandle callbackArgs{PyTuple_New(1)};
+                    if (!callbackArgs.get())
+                    {
+                        return;
+                    }
                     PyTuple_SetItem(callbackArgs.get(), 0, result.release());
 
                     PyObjectHandle obj{PyObject_Call(callback, callbackArgs.get(), nullptr)};

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -766,6 +766,11 @@ IcePy::PrimitiveInfo::unmarshal(
             uint8_t val;
             is->read(val);
             PyObjectHandle p{PyLong_FromLong(val)};
+            if (!p.get())
+            {
+                assert(PyErr_Occurred());
+                throw AbortMarshaling();
+            }
             cb->unmarshaled(p.get(), target, closure);
             break;
         }
@@ -774,6 +779,11 @@ IcePy::PrimitiveInfo::unmarshal(
             int16_t val;
             is->read(val);
             PyObjectHandle p{PyLong_FromLong(val)};
+            if (!p.get())
+            {
+                assert(PyErr_Occurred());
+                throw AbortMarshaling();
+            }
             cb->unmarshaled(p.get(), target, closure);
             break;
         }
@@ -782,6 +792,11 @@ IcePy::PrimitiveInfo::unmarshal(
             int32_t val;
             is->read(val);
             PyObjectHandle p{PyLong_FromLong(val)};
+            if (!p.get())
+            {
+                assert(PyErr_Occurred());
+                throw AbortMarshaling();
+            }
             cb->unmarshaled(p.get(), target, closure);
             break;
         }
@@ -790,6 +805,11 @@ IcePy::PrimitiveInfo::unmarshal(
             int64_t val;
             is->read(val);
             PyObjectHandle p{PyLong_FromLongLong(val)};
+            if (!p.get())
+            {
+                assert(PyErr_Occurred());
+                throw AbortMarshaling();
+            }
             cb->unmarshaled(p.get(), target, closure);
             break;
         }
@@ -798,6 +818,11 @@ IcePy::PrimitiveInfo::unmarshal(
             float val;
             is->read(val);
             PyObjectHandle p{PyFloat_FromDouble(val)};
+            if (!p.get())
+            {
+                assert(PyErr_Occurred());
+                throw AbortMarshaling();
+            }
             cb->unmarshaled(p.get(), target, closure);
             break;
         }
@@ -806,6 +831,11 @@ IcePy::PrimitiveInfo::unmarshal(
             double val;
             is->read(val);
             PyObjectHandle p{PyFloat_FromDouble(val)};
+            if (!p.get())
+            {
+                assert(PyErr_Occurred());
+                throw AbortMarshaling();
+            }
             cb->unmarshaled(p.get(), target, closure);
             break;
         }
@@ -814,6 +844,11 @@ IcePy::PrimitiveInfo::unmarshal(
             string val;
             is->read(val, false); // Bypass string conversion.
             PyObjectHandle p{createString(val)};
+            if (!p.get())
+            {
+                assert(PyErr_Occurred());
+                throw AbortMarshaling();
+            }
             cb->unmarshaled(p.get(), target, closure);
             break;
         }
@@ -1855,6 +1890,11 @@ IcePy::SequenceInfo::createSequenceFromMemory(
     AdoptThread adoptThread; // Ensure the current thread is able to call into Python.
 
     PyObjectHandle args{PyTuple_New(2)};
+    if (!args.get())
+    {
+        assert(PyErr_Occurred());
+        throw AbortMarshaling();
+    }
     PyTuple_SET_ITEM(args.get(), 0, memoryView.get() ? memoryView.release() : Py_None);
     PyTuple_SET_ITEM(args.get(), 1, builtinType.release());
     PyObjectHandle result{PyObject_Call(sm->factory, args.get(), nullptr)};
@@ -2744,6 +2784,11 @@ IcePy::ProxyInfo::unmarshal(
     }
 
     PyObjectHandle p{createProxy(proxy.value(), proxy->ice_getCommunicator(), pythonType)};
+    if (!p.get())
+    {
+        assert(PyErr_Occurred());
+        throw AbortMarshaling();
+    }
     cb->unmarshaled(p.get(), target, closure);
 }
 


### PR DESCRIPTION
Several CPython allocations on IcePy decode/dispatch paths were used without a null check. Under memory pressure a failed allocation (`NULL` with a pending `MemoryError`) became a null dereference or, worse, silently wrong object state — and these paths run while processing incoming traffic.

Each fix null-checks the allocation and aborts cleanly, leaving the pending exception set, mirroring the neighboring already-checked allocations in the same files.

### `Types.cpp`
- `PrimitiveInfo::unmarshal` — each primitive case (`PyLong_FromLong` / `PyLong_FromLongLong` / `PyFloat_FromDouble` / `createString`) passed its result to `cb->unmarshaled(p.get(), ...)` without a null check. A `NULL` to `DataMember::unmarshaled` becomes `PyObject_SetAttrString(target, name, nullptr)`, which CPython interprets as *delete the attribute* — masking the OOM as wrong object state. Now checked, mirroring `StructInfo::unmarshal`.
- `ProxyInfo::unmarshal` and `SequenceInfo::createSequenceFromMemory` had the same unguarded pattern (`createProxy` / `PyTuple_New(2)`).

### `Current.cpp`
- `createCurrent` did not null-check `PyTuple_New(9)` or the context `PyDict_New()` before using them; both run on every incoming dispatch. Now return `nullptr`, consistent with the function's other allocation checks.

### `Operation.cpp`
- `TypedUpcall::dispatch` and `BlobjectUpcall::dispatch` stole `createCurrent`'s result into the argument tuple without checking it for `NULL`. Now checked (`throwPythonException`), so an allocation failure in `createCurrent` aborts the dispatch instead of placing `NULL` into the tuple.

### `PropertiesAdmin.cpp`
- The property-update callback skipped its populate block on `PyDict_New` failure and then placed the `NULL` `result` into the call tuple; the per-entry key and the call tuple itself were also unchecked. Now bails on `PyDict_New` failure and null-checks the key and the tuple. `result` is released into the tuple only after the tuple is confirmed non-null.

These are OOM-only triggers (no behavior change on the success path); verified from the CPython C-API control flow.