### PR TITLE
Pin Windows builds to the v143 platform toolset

### DIFF
--- a/.github/actions/setup-cpp/action.yml
+++ b/.github/actions/setup-cpp/action.yml
@@ -38,3 +38,13 @@ runs:
       with:
         msbuild-architecture: x64
       if: runner.os == 'Windows'
+
+    # Ice 3.7 supports the Visual Studio 2019/2022 (v141/v142/v143) toolsets. Newer runner images (e.g. the VS2026 /
+    # v145 image) would otherwise build with a platform toolset Ice 3.7 does not support, which fails. Pin to v143
+    # through the environment so every Windows build uses a supported toolset. Workflows that build a specific toolset
+    # (the C++ binary and NuGet package builds) pass /p:DefaultPlatformToolset=... explicitly, and that command-line
+    # property overrides this environment default.
+    - name: Pin MSVC platform toolset to v143
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: Add-Content -Path $env:GITHUB_ENV -Value "DefaultPlatformToolset=v143"


### PR DESCRIPTION
## Problem

GitHub moved the `windows-2025` runner image to Visual Studio 2026, whose default platform toolset is **v145**. Ice 3.7 supports the VS2019/2022 toolsets (v141/v142/v143), so the Windows builds that don't pin a toolset now fail when MSBuild defaults to v145 — for example:

```
error : Element <GenerateDebugInformation> has an invalid value of "Yes". [slice2matlab.vcxproj]
```

Two workflows build Ice C++ on the VS2026 runner without pinning a toolset, and both broke:

- `ci.yml`
- `build-matlab-packages.yml` (the Windows MATLAB toolbox)

The release C++ binary (`build-cpp-windows-binaries.yml`) and NuGet (`build-cpp-nuget-packages.yml`) builds are unaffected — they run on `windows-2022` and already pin `/p:DefaultPlatformToolset=v143`/`v142`.

## Fix

Pin `DefaultPlatformToolset=v143` via the environment in the shared `setup-cpp` action (Windows only). Every Ice C++ Windows build goes through `setup-cpp`, so this fixes both unpinned workflows in one place and keeps the 3.7 release on consistent v143 binaries.

MSBuild reads `DefaultPlatformToolset` from the environment, and `Microsoft.Cpp.Default.props` only assigns it when empty, so the environment value survives. A command-line `/p:DefaultPlatformToolset=…` is a global property that overrides the environment, so the builds that pin a specific toolset (v142/v143) keep building that toolset.

## Notes

- VS2026 ships the v143 toolset side-by-side (the `v170` VCTargets + the 14.4x compiler), so building with v143 works on the VS2026 image.
- If a future `windows-2025` image ever drops v143, the fallback is to move those two jobs to `runs-on: windows-2022` (what the release builds already use).
