### PR TITLE
Validate operation mode in incoming requests

### DIFF
--- a/changelog.d/general/incoming-request-invalid-operation-mode.md
+++ b/changelog.d/general/incoming-request-invalid-operation-mode.md
@@ -1,2 +1,0 @@
-- The Ice server runtime now validates the operation mode of an incoming request and rejects a request with an invalid
-  operation mode with a `MarshalException`.

--- a/changelog.d/general/incoming-request-invalid-operation-mode.md
+++ b/changelog.d/general/incoming-request-invalid-operation-mode.md
@@ -1,0 +1,2 @@
+- The Ice server runtime now validates the operation mode of an incoming request and rejects a request with an invalid
+  operation mode with a `MarshalException`.

--- a/cpp/src/Ice/IncomingRequest.cpp
+++ b/cpp/src/Ice/IncomingRequest.cpp
@@ -38,13 +38,7 @@ IncomingRequest::IncomingRequest(
 
     inputStream.read(_current.operation, false);
 
-    uint8_t mode;
-    inputStream.read(mode);
-    if (mode > static_cast<uint8_t>(OperationMode::Idempotent))
-    {
-        throw MarshalException{__FILE__, __LINE__, "received invalid operation mode"};
-    }
-    _current.mode = static_cast<OperationMode>(mode);
+    inputStream.read(_current.mode);
 
     int32_t sz = inputStream.readSize();
     while (sz--)

--- a/cpp/src/Ice/IncomingRequest.cpp
+++ b/cpp/src/Ice/IncomingRequest.cpp
@@ -40,6 +40,10 @@ IncomingRequest::IncomingRequest(
 
     uint8_t mode;
     inputStream.read(mode);
+    if (mode > static_cast<uint8_t>(OperationMode::Idempotent))
+    {
+        throw MarshalException{__FILE__, __LINE__, "received invalid operation mode"};
+    }
     _current.mode = static_cast<OperationMode>(mode);
 
     int32_t sz = inputStream.readSize();

--- a/csharp/src/Ice/IncomingRequest.cs
+++ b/csharp/src/Ice/IncomingRequest.cs
@@ -54,7 +54,12 @@ public sealed class IncomingRequest
             facet = facetPath[0];
         }
         string operation = inputStream.readString();
-        var mode = (OperationMode)inputStream.readByte();
+        byte modeByte = inputStream.readByte();
+        if (modeByte > (byte)OperationMode.Idempotent)
+        {
+            throw new MarshalException($"Received invalid operation mode {modeByte}.");
+        }
+        var mode = (OperationMode)modeByte;
         var ctx = new Dictionary<string, string>();
         int sz = inputStream.readSize();
         while (sz-- > 0)

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingRequest.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingRequest.java
@@ -46,7 +46,11 @@ public final class IncomingRequest {
             facet = facetPath[0];
         }
         String operation = inputStream.readString();
-        OperationMode mode = OperationMode.valueOf(inputStream.readByte());
+        byte modeByte = inputStream.readByte();
+        OperationMode mode = OperationMode.valueOf(modeByte);
+        if (mode == null) {
+            throw new MarshalException("Received invalid operation mode " + (modeByte & 0xff) + ".");
+        }
         Map<String, String> ctx = new HashMap<>();
         int sz = inputStream.readSize();
         while (sz-- > 0) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingRequest.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingRequest.java
@@ -46,11 +46,7 @@ public final class IncomingRequest {
             facet = facetPath[0];
         }
         String operation = inputStream.readString();
-        byte modeByte = inputStream.readByte();
-        OperationMode mode = OperationMode.valueOf(modeByte);
-        if (mode == null) {
-            throw new MarshalException("Received invalid operation mode " + (modeByte & 0xff) + ".");
-        }
+        OperationMode mode = OperationMode.ice_read(inputStream);
         Map<String, String> ctx = new HashMap<>();
         int sz = inputStream.readSize();
         while (sz-- > 0) {

--- a/js/packages/ice/src/Ice/IncomingRequest.js
+++ b/js/packages/ice/src/Ice/IncomingRequest.js
@@ -42,11 +42,7 @@ export class IncomingRequest {
             facet = facetPath[0];
         }
         const operation = inputStream.readString();
-        const modeByte = inputStream.readByte();
-        const mode = OperationMode.valueOf(modeByte);
-        if (mode === undefined) {
-            throw new MarshalException(`Received invalid operation mode ${modeByte}.`);
-        }
+        const mode = OperationMode._read(inputStream);
         const ctx = new Context();
         let sz = inputStream.readSize();
         while (sz-- > 0) {

--- a/js/packages/ice/src/Ice/IncomingRequest.js
+++ b/js/packages/ice/src/Ice/IncomingRequest.js
@@ -42,7 +42,11 @@ export class IncomingRequest {
             facet = facetPath[0];
         }
         const operation = inputStream.readString();
-        const mode = OperationMode.valueOf(inputStream.readByte());
+        const modeByte = inputStream.readByte();
+        const mode = OperationMode.valueOf(modeByte);
+        if (mode === undefined) {
+            throw new MarshalException(`Received invalid operation mode ${modeByte}.`);
+        }
         const ctx = new Context();
         let sz = inputStream.readSize();
         while (sz-- > 0) {


### PR DESCRIPTION
The operation mode is a one-byte field in the Ice request header, with only three valid values: `Normal` (0), `Nonmutating` (1, deprecated), and `Idempotent` (2). The server runtime previously accepted any byte value without validation:

- C++ and C# cast the byte straight to the `OperationMode` enum, producing an out-of-range enum value.
- Java and JS mapped an unknown byte to `null`/`undefined`.

This change validates the operation mode where the request header is unmarshaled and rejects an out-of-range value with a `MarshalException`, mirroring the existing facet-path validation in the same code. The C++ change also covers the Python, PHP, Ruby, MATLAB, and Swift mappings, which dispatch through the C++ core.

Valid values are unchanged — the deprecated `Nonmutating` (1) is still accepted; only values `>= 3` are rejected.

No test: triggering this requires a peer that writes a malformed request header, since an out-of-range mode byte cannot be produced through the public API (it would need raw-protocol fault injection).