### PR TITLE
Fix IcePy properties-admin update callback to not throw into the Ice runtime

### DIFF
--- a/python/modules/IcePy/PropertiesAdmin.cpp
+++ b/python/modules/IcePy/PropertiesAdmin.cpp
@@ -107,8 +107,7 @@ nativePropertiesAdminAddUpdateCB(NativePropertiesAdminObject* self, PyObject* ar
                     if (!obj.get())
                     {
                         assert(PyErr_Occurred());
-                        // The update callback raised. Propagate the exception out of setProperties (aborting the
-                        // dispatch and skipping any remaining callbacks), matching the C++, C#, and Java mappings.
+                        // The update callback raised.
                         throwPythonException();
                     }
                 });

--- a/python/modules/IcePy/PropertiesAdmin.cpp
+++ b/python/modules/IcePy/PropertiesAdmin.cpp
@@ -3,7 +3,6 @@
 #include "PropertiesAdmin.h"
 #include "Ice/DisableWarnings.h"
 #include "Thread.h"
-#include "Types.h"
 #include "Util.h"
 
 #include <algorithm>
@@ -83,7 +82,7 @@ nativePropertiesAdminAddUpdateCB(NativePropertiesAdminObject* self, PyObject* ar
                     PyObjectHandle result{PyDict_New()};
                     if (!result.get())
                     {
-                        return;
+                        throwPythonException();
                     }
 
                     for (const auto& [key, value] : dict)
@@ -93,14 +92,14 @@ nativePropertiesAdminAddUpdateCB(NativePropertiesAdminObject* self, PyObject* ar
                         if (!pyKey.get() || !pyValue.get() ||
                             PyDict_SetItem(result.get(), pyKey.get(), pyValue.get()) < 0)
                         {
-                            return;
+                            throwPythonException();
                         }
                     }
 
                     PyObjectHandle callbackArgs{PyTuple_New(1)};
                     if (!callbackArgs.get())
                     {
-                        return;
+                        throwPythonException();
                     }
                     PyTuple_SetItem(callbackArgs.get(), 0, result.release());
 
@@ -108,7 +107,9 @@ nativePropertiesAdminAddUpdateCB(NativePropertiesAdminObject* self, PyObject* ar
                     if (!obj.get())
                     {
                         assert(PyErr_Occurred());
-                        throw AbortMarshaling();
+                        // The update callback raised. Propagate the exception out of setProperties (aborting the
+                        // dispatch and skipping any remaining callbacks), matching the C++, C#, and Java mappings.
+                        throwPythonException();
                     }
                 });
 


### PR DESCRIPTION
The property-update callback registered with `NativePropertiesAdmin.addUpdateCallback` is invoked by the Ice runtime from `NativePropertiesAdmin::setProperties`. Previously, when the user's Python callback raised, the IcePy callback threw `AbortMarshaling` — the extension's internal marshaling-unwind sentinel, which has no handler on this path: it escaped into the connection dispatch's generic `catch (...)` and left a pending Python exception set.

This makes every failure path in the callback call `throwPythonException()`, which captures and clears the pending Python error and converts it to a C++ exception that unwinds out of `setProperties` — the same behavior as a throwing update callback in the C++, C#, and Java mappings (which propagate, aborting the dispatch and skipping the remaining callbacks). The OOM `return;` paths added in #5776, which also left a pending Python error set while invoked from the runtime, now propagate the same way.

Also drops the now-unused `Types.h` include.

No changelog: externally visible behavior is unchanged (callers already received an `UnknownException`); the fix is internal — stop throwing the internal sentinel, and stop leaking a pending Python error.

Closes #5777