### PR TITLE
Fix DataStorm DiscardPolicy::Priority crash for filtered/any-key readers

### DIFF
--- a/changelog.d/datastorm/5782-datastorm-priority-discard-anykey-crash.md
+++ b/changelog.d/datastorm/5782-datastorm-priority-discard-anykey-crash.md
@@ -1,0 +1,2 @@
+- Fixed a crash in DataStorm where a filtered or any-key reader configured with `DiscardPolicy::Priority` crashed
+  when it received samples from an any-key writer.

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -734,25 +734,6 @@ DataReaderI::getNextUnread()
     return sample;
 }
 
-bool
-DataReaderI::hasLowerPriorityThanConnected(int priority, const shared_ptr<Key>& key) const
-{
-    // A sample with this key can come from a connected publisher registered under the key itself (a keyed peer) or
-    // under the null key (a filter or any-key peer, which delivers every key). Discard the sample when its priority is
-    // below the highest priority among all of them. Each list is sorted by ascending priority in addConnectedKey, so
-    // back() is the highest priority; don't discard when there are no connected publishers to compare against.
-    int threshold = priority;
-    for (const auto& k : {key, shared_ptr<Key>{}})
-    {
-        auto p = _connectedKeys.find(k);
-        if (p != _connectedKeys.end() && !p->second.empty())
-        {
-            threshold = std::max(threshold, p->second.back()->priority);
-        }
-    }
-    return priority < threshold;
-}
-
 void
 DataReaderI::initSamples(
     const vector<shared_ptr<Sample>>& samples,
@@ -1033,6 +1014,25 @@ DataReaderI::addConnectedKey(const shared_ptr<Key>& key, const shared_ptr<Subscr
     {
         return false;
     }
+}
+
+bool
+DataReaderI::hasLowerPriorityThanConnected(int priority, const shared_ptr<Key>& key) const
+{
+    // The connected publishers that can deliver this key are registered under the key itself (a keyed peer) and under
+    // the null key (a filter or any-key peer, which delivers every key). The threshold is the highest priority across
+    // both; each list is sorted ascending in addConnectedKey, so back() is the highest. With no connected publishers
+    // the threshold stays at the sample's own priority, so the function returns false.
+    int threshold = priority;
+    for (const auto& k : {key, shared_ptr<Key>{}})
+    {
+        auto p = _connectedKeys.find(k);
+        if (p != _connectedKeys.end() && !p->second.empty())
+        {
+            threshold = std::max(threshold, p->second.back()->priority);
+        }
+    }
+    return priority < threshold;
 }
 
 DataWriterI::DataWriterI(TopicWriterI* topic, string name, int64_t id, const DataStorm::WriterConfig& config)

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -734,6 +734,23 @@ DataReaderI::getNextUnread()
     return sample;
 }
 
+bool
+DataReaderI::hasLowerPriorityThanConnected(int priority, const shared_ptr<Key>& key) const
+{
+    // Find the connected publishers that determine the priority threshold for this sample. They're registered under
+    // the sample's key for a keyed reader, or under the null key for a filter or any-key reader (whose samples carry a
+    // real key); fall back to the null key when there's no entry for the sample's key.
+    auto p = _connectedKeys.find(key);
+    if (p == _connectedKeys.end() || p->second.empty())
+    {
+        p = _connectedKeys.find(nullptr);
+    }
+
+    // The subscriber list is sorted by ascending priority in addConnectedKey, so back() is the highest priority. Don't
+    // discard when there are no connected publishers to compare against.
+    return p != _connectedKeys.end() && !p->second.empty() && priority < p->second.back()->priority;
+}
+
 void
 DataReaderI::initSamples(
     const vector<shared_ptr<Sample>>& samples,
@@ -765,7 +782,7 @@ DataReaderI::initSamples(
         //   publishers for the same key. The subscriber list is sorted by priority in addConnectedKey.
         if ((_discardPolicy == DataStorm::DiscardPolicy::SendTime && sample->timestamp <= _lastSendTime) ||
             (_discardPolicy == DataStorm::DiscardPolicy::Priority &&
-             priority < _connectedKeys[sample->key].back()->priority))
+             hasLowerPriorityThanConnected(priority, sample->key)))
         {
             continue;
         }
@@ -908,8 +925,7 @@ DataReaderI::queue(
     // - Priority: discard samples from publisher with lower priority than the highest priority among the connected
     //   publishers for the same key. The subscriber list is sorted by priority in addConnectedKey.
     if ((_discardPolicy == DataStorm::DiscardPolicy::SendTime && sample->timestamp <= _lastSendTime) ||
-        (_discardPolicy == DataStorm::DiscardPolicy::Priority &&
-         priority < _connectedKeys[sample->key].back()->priority))
+        (_discardPolicy == DataStorm::DiscardPolicy::Priority && hasLowerPriorityThanConnected(priority, sample->key)))
     {
         if (_traceLevels->data > 2)
         {

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -737,18 +737,20 @@ DataReaderI::getNextUnread()
 bool
 DataReaderI::hasLowerPriorityThanConnected(int priority, const shared_ptr<Key>& key) const
 {
-    // Find the connected publishers that determine the priority threshold for this sample. They're registered under
-    // the sample's key for a keyed reader, or under the null key for a filter or any-key reader (whose samples carry a
-    // real key); fall back to the null key when there's no entry for the sample's key.
-    auto p = _connectedKeys.find(key);
-    if (p == _connectedKeys.end() || p->second.empty())
+    // A sample with this key can come from a connected publisher registered under the key itself (a keyed peer) or
+    // under the null key (a filter or any-key peer, which delivers every key). Discard the sample when its priority is
+    // below the highest priority among all of them. Each list is sorted by ascending priority in addConnectedKey, so
+    // back() is the highest priority; don't discard when there are no connected publishers to compare against.
+    int threshold = priority;
+    for (const auto& k : {key, shared_ptr<Key>{}})
     {
-        p = _connectedKeys.find(nullptr);
+        auto p = _connectedKeys.find(k);
+        if (p != _connectedKeys.end() && !p->second.empty())
+        {
+            threshold = std::max(threshold, p->second.back()->priority);
+        }
     }
-
-    // The subscriber list is sorted by ascending priority in addConnectedKey, so back() is the highest priority. Don't
-    // discard when there are no connected publishers to compare against.
-    return p != _connectedKeys.end() && !p->second.empty() && priority < p->second.back()->priority;
+    return priority < threshold;
 }
 
 void

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -374,6 +374,10 @@ namespace DataStormI
         [[nodiscard]] virtual bool matchKey(const std::shared_ptr<Key>&) const = 0;
         [[nodiscard]] bool addConnectedKey(const std::shared_ptr<Key>&, const std::shared_ptr<Subscriber>&) override;
 
+        // Returns true if a sample with the given priority and key should be discarded under DiscardPolicy::Priority,
+        // i.e. its priority is lower than the highest-priority connected publisher governing that key.
+        [[nodiscard]] bool hasLowerPriorityThanConnected(int priority, const std::shared_ptr<Key>& key) const;
+
         TopicReaderI* _parent;
 
         std::deque<std::shared_ptr<Sample>> _samples;

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -374,8 +374,8 @@ namespace DataStormI
         [[nodiscard]] virtual bool matchKey(const std::shared_ptr<Key>&) const = 0;
         [[nodiscard]] bool addConnectedKey(const std::shared_ptr<Key>&, const std::shared_ptr<Subscriber>&) override;
 
-        // Returns true if a sample with the given priority and key should be discarded under DiscardPolicy::Priority,
-        // i.e. its priority is lower than the highest-priority connected publisher governing that key.
+        // Returns true if the given sample priority is lower than the highest priority among the connected publishers
+        // that can deliver the given key (a keyed peer under the key, or a filter/any-key peer under the null key).
         [[nodiscard]] bool hasLowerPriorityThanConnected(int priority, const std::shared_ptr<Key>& key) const;
 
         TopicReaderI* _parent;


### PR DESCRIPTION
A DataStorm reader configured with `DiscardPolicy::Priority` compared a sample's priority against `_connectedKeys[sample->key].back()->priority`. `_connectedKeys` maps a key to the connected publishers' subscriber list (sorted by priority).

A filtered or any-key reader attached to an any-key writer is registered under the **null** key, but its samples carry a real marshaled key. So `_connectedKeys[sample->key]` looked up the real key, found no entry, and `operator[]` default-constructed an **empty** vector — making `.back()` undefined behavior (typically a crash). This is a supported reader configuration, so no malformed input is required; it affects both `queue` (live samples) and `initSamples`.

The fix resolves the priority threshold via a small helper (`hasLowerPriorityThanConnected`) that:
- never calls `.back()` on an empty list (uses `find`, not `operator[]`, and checks `empty()`), and
- compares the sample's priority against the highest-priority connected publisher across **both** the sample's key bucket and the null-key bucket — an any-key/filter peer (null key) delivers every key, so it is a valid publisher for the sample's key. The sample is discarded only when some connected publisher has a strictly higher priority.

Behavior:
- **Keyed readers** have only their own-key bucket (no null entry), so the decision is unchanged.
- **Filter/any-key readers** no longer crash when the sample's key has no own bucket, and when such a reader is connected to both a keyed writer and an any-key writer for the same key, the threshold now correctly accounts for both.

No test: reproducing this needs a filtered/any-key reader with `DiscardPolicy::Priority` receiving samples from an any-key writer, which requires a coordinated multi-process reader/writer scenario in the DataStorm test harness — disproportionate for a guarded lookup. The change is verified by compilation and review.