### PR TITLE
Remove vestigial synchronized from Java UdpTransceiver.setBufferSize / checkSendSize

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
@@ -249,7 +249,7 @@ final class UdpTransceiver implements Transceiver {
     }
 
     @Override
-    public synchronized void checkSendSize(Buffer buf) {
+    public void checkSendSize(Buffer buf) {
         // The maximum packetSize is either the maximum allowable UDP packet size, or the UDP send
         // buffer size (which ever is smaller).
         final int packetSize = java.lang.Math.min(_maxPacketSize, _sndSize - _udpOverhead);
@@ -260,7 +260,7 @@ final class UdpTransceiver implements Transceiver {
     }
 
     @Override
-    public synchronized void setBufferSize(int rcvSize, int sndSize) {
+    public void setBufferSize(int rcvSize, int sndSize) {
         assert (_fd != null);
 
         // The default size is the size currently configured on the socket. We don't set the buffer size when the


### PR DESCRIPTION
Drops `synchronized` from `UdpTransceiver.setBufferSize` and `checkSendSize` in the Java mapping. Both callers already hold `ConnectionI`'s lock, so the transceiver-level locking is redundant (and locks the wrong monitor). This aligns Java with C++/C#, which do no transceiver-level locking. No behavioral change.

Fixes #5775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)