### PR TITLE
Fix slice2java optional sequence with overriding java:type metadata

### DIFF
--- a/changelog.d/java/slice2java-optional-seq-java-type.md
+++ b/changelog.d/java/slice2java-optional-seq-java-type.md
@@ -1,0 +1,3 @@
+- Fixed a `slice2java` bug with optional sequences. When a parameter, return value, or field applied `java:type`
+  metadata that overrode the sequence's default mapping, `slice2java` generated no marshaling code. As a result,
+  the generated Java did not compile (parameters and return values) or silently dropped the value on the wire (fields).

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -267,8 +267,10 @@ Slice::JavaVisitor::writeMarshalUnmarshalCode(
                     {
                         out << nl << param << " = " << helper << ".read" << spar << stream << tag << epar << ";";
                     }
+                    return;
                 }
-                return;
+                // Otherwise the helper is incompatible with the local 'java:type' metadata; fall through to the in-line
+                // code below.
             }
 
             if (marshal)

--- a/java/test/src/main/java/test/Ice/customSequence/AllTests.java
+++ b/java/test/src/main/java/test/Ice/customSequence/AllTests.java
@@ -226,6 +226,20 @@ public class AllTests {
         }
 
         {
+            List<A> list = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                list.add(new A(i));
+            }
+            TestIntf.OpOptASeqLocalTypeResult r = t.opOptASeqLocalType(java.util.Optional.of(list));
+            test(r.returnValue.isPresent() && r.outSeq.isPresent());
+            test(r.returnValue.get().equals(list));
+            test(r.outSeq.get().equals(list));
+
+            r = t.opOptASeqLocalType(java.util.Optional.empty());
+            test(!r.returnValue.isPresent() && !r.outSeq.isPresent());
+        }
+
+        {
             final byte[] fullSeq = new byte[]{0, 1, 2, 3, 4, 5, 6, 7};
             final byte[] usedSeq = new byte[]{2, 3, 4, 5};
 

--- a/java/test/src/main/java/test/Ice/customSequence/Test.ice
+++ b/java/test/src/main/java/test/Ice/customSequence/Test.ice
@@ -85,6 +85,13 @@ module Test
         optional(1) DSeq opOptDSeq(optional(2) DSeq inSeq, out optional(3) DSeq outSeq);
         optional(1) StringSeqSeq opOptStringSeqSeq(optional(2) StringSeqSeq inSeq, out optional(3) StringSeqSeq outSeq);
 
+        // An optional sequence parameter with local 'java:type' metadata that overrides the sequence's default
+        // mapping (a native array). The generated marshaling code can't use the sequence helper and must fall back to
+        // in-line marshaling.
+        ["java:type:java.util.ArrayList<A>"] optional(1) ASeq opOptASeqLocalType(
+            ["java:type:java.util.ArrayList<A>"] optional(2) ASeq inSeq,
+            ["java:type:java.util.ArrayList<A>"] out optional(3) ASeq outSeq);
+
         optional(1) ByteBuffer opOptByteBufferSeq(optional(2) ByteBuffer inSeq, out optional(3) ByteBuffer outSeq);
         optional(1) ShortBuffer opOptShortBufferSeq(optional(2) ShortBuffer inSeq, out optional(3) ShortBuffer outSeq);
         optional(1) IntBuffer opOptIntBufferSeq(optional(2) IntBuffer inSeq, out optional(3) IntBuffer outSeq);

--- a/java/test/src/main/java/test/Ice/customSequence/TestI.java
+++ b/java/test/src/main/java/test/Ice/customSequence/TestI.java
@@ -268,6 +268,12 @@ public final class TestI implements TestIntf {
     }
 
     @Override
+    public TestIntf.OpOptASeqLocalTypeResult opOptASeqLocalType(
+            Optional<List<A>> inSeq, Current current) {
+        return new TestIntf.OpOptASeqLocalTypeResult(inSeq, inSeq);
+    }
+
+    @Override
     public TestIntf.OpOptByteBufferSeqResult opOptByteBufferSeq(
             Optional<ByteBuffer> inSeq, Current current) {
         return new TestIntf.OpOptByteBufferSeqResult(inSeq, inSeq);


### PR DESCRIPTION
## Summary

Fixes the `slice2java` bug reported in zeroc-ice/ice-audit#64.

In the optional-sequence branch of `writeMarshalUnmarshalCode`, the `return` after the sequence-helper call was unconditional — even when the helper-compatibility check failed and the branch emitted nothing. When a parameter, return value, or field applies `java:type` metadata that overrides the sequence's default mapping, the helper is incompatible, so the branch emitted no marshaling code and then returned, bypassing the in-line fallback below that was written to handle exactly this case.

Result: the generated Java did not compile (parameters and return values: `variable might not have been initialized`) or silently dropped the tagged value on the wire (fields).

The fix moves the `return` inside the branch that actually emits the helper call, so control falls through to the in-line fallback when the helper is incompatible.

## Test

Added an optional sequence parameter with a local `java:type` override (differing from the sequence's default mapping) to the `customSequence` Java test, plus a roundtrip in `AllTests` that also guards against the silent data-loss path.

- Without the fix, the test module fails to compile with the exact error from the audit issue (`variable iceP_inSeq might not have been initialized`).
- With the fix, in-line marshaling is generated and the test passes (client/server and collocated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)