### PR TITLE
Fix Schannel data loss when a renegotiation coincides with application data

### DIFF
--- a/changelog.d/cpp/schannel-renegotiate-data-loss.md
+++ b/changelog.d/cpp/schannel-renegotiate-data-loss.md
@@ -1,3 +1,3 @@
 - Fixed silent application-data loss in the Schannel-based IceSSL transport (Windows) when a TLS renegotiation (such as
   a TLS 1.3 KeyUpdate or NewSessionTicket) is received in the same read as already-decrypted application data. The
-  plaintext extracted before the renegotiation request was dropped, corrupting the Ice protocol stream.
+  plaintext extracted before the renegotiation request was dropped, breaking the affected connection.

--- a/changelog.d/cpp/schannel-renegotiate-data-loss.md
+++ b/changelog.d/cpp/schannel-renegotiate-data-loss.md
@@ -1,0 +1,3 @@
+- Fixed silent application-data loss in the Schannel-based IceSSL transport (Windows) when a TLS renegotiation (such as
+  a TLS 1.3 KeyUpdate or NewSessionTicket) is received in the same read as already-decrypted application data. The
+  plaintext extracted before the renegotiation request was dropped, corrupting the Ice protocol stream.

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -605,7 +605,11 @@ Schannel::TransceiverI::decryptMessage(IceInternal::Buffer& buffer)
                 memcpy(_extraBuffer.i, extraBuffer->pvBuffer, extraBuffer->cbBuffer);
                 _extraBuffer.i += extraBuffer->cbBuffer;
             }
-            return 0;
+            // Return the application data already copied into the caller's buffer during this call (it may be non-zero
+            // because earlier records in the same batch were decrypted before this renegotiation request). The caller
+            // must advance buf.i by this amount before performing the re-handshake, otherwise the next decryptMessage
+            // overwrites these bytes and the plaintext is silently lost.
+            return i - buffer.i;
         }
         else if (err == SEC_I_CONTEXT_EXPIRED)
         {
@@ -829,6 +833,9 @@ Schannel::TransceiverI::read(IceInternal::Buffer& buf)
         }
 
         size_t decrypted = decryptMessage(buf);
+        // Account for the bytes decryptMessage copied into buf right away, so a renegotiation in the middle of the
+        // batch does not drop the plaintext already extracted before it.
+        buf.i += decrypted;
         if (_sslConnectionRenegotiating)
         {
             // The peer has requested a renegotiation.
@@ -854,8 +861,6 @@ Schannel::TransceiverI::read(IceInternal::Buffer& buf)
             }
             continue;
         }
-
-        buf.i += decrypted;
     }
     _delegate->getNativeInfo()->ready(
         IceInternal::SocketOperationRead,
@@ -925,10 +930,14 @@ Schannel::TransceiverI::finishRead(IceInternal::Buffer& buf)
     _delegate->finishRead(_readBuffer);
     if (_state == StateHandshakeComplete)
     {
-        size_t decrypted;
-        while (true)
+        std::byte* const start = buf.i;
+        // Decrypt the buffered data into buf, advancing buf.i as we go so that a renegotiation in the middle of the
+        // batch does not drop or overwrite the plaintext already extracted. The loop guard matches decryptMessage's
+        // precondition: there is buffered (_readBuffer) or unprocessed data left to decrypt.
+        while (buf.i != buf.b.end() && (_readBuffer.i != _readBuffer.b.begin() || !_readUnprocessed.b.empty()))
         {
-            decrypted = decryptMessage(buf);
+            size_t decrypted = decryptMessage(buf);
+            buf.i += decrypted;
             if (_sslConnectionRenegotiating)
             {
                 // The peer has requested a renegotiation.
@@ -938,31 +947,23 @@ Schannel::TransceiverI::finishRead(IceInternal::Buffer& buf)
                     _extraBuffer.b.begin()};
                 IceInternal::SocketOperation op = sslHandshake(&extraBuffer);
                 _extraBuffer.b.clear();
-                if (op == IceInternal::SocketOperationNone)
+                if (op != IceInternal::SocketOperationNone)
                 {
-                    _sslConnectionRenegotiating = false;
-                    if (buf.i != buf.b.begin())
-                    {
-                        continue;
-                    }
-                    break;
+                    throw ConnectionLostException(__FILE__, __LINE__);
                 }
-                throw ConnectionLostException(__FILE__, __LINE__);
+                _sslConnectionRenegotiating = false;
+                continue;
             }
-            break;
+            if (decrypted == 0)
+            {
+                // Not enough buffered data to decrypt a complete record; wait for the next read.
+                break;
+            }
         }
 
-        if (decrypted > 0)
-        {
-            buf.i += decrypted;
-            _delegate->getNativeInfo()->ready(
-                IceInternal::SocketOperationRead,
-                !_readUnprocessed.b.empty() || _readBuffer.i != _readBuffer.b.begin());
-        }
-        else
-        {
-            _delegate->getNativeInfo()->ready(IceInternal::SocketOperationRead, false);
-        }
+        _delegate->getNativeInfo()->ready(
+            IceInternal::SocketOperationRead,
+            buf.i != start && (!_readUnprocessed.b.empty() || _readBuffer.i != _readBuffer.b.begin()));
     }
 }
 

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -605,6 +605,10 @@ Schannel::TransceiverI::decryptMessage(IceInternal::Buffer& buffer)
                 memcpy(_extraBuffer.i, extraBuffer->pvBuffer, extraBuffer->cbBuffer);
                 _extraBuffer.i += extraBuffer->cbBuffer;
             }
+            // Unlike the SEC_E_OK path below, we deliberately leave _readBuffer untouched here: sslHandshake resumes
+            // the handshake from the data still buffered in _readBuffer and moves the trailing post-renegotiation
+            // records back to its front, which is how the application data following the renegotiation is recovered.
+            // Resetting _readBuffer.i here would underflow that memmove.
             // Return the application data already copied into the caller's buffer during this call (it may be non-zero
             // because earlier records in the same batch were decrypted before this renegotiation request). The caller
             // must advance buf.i by this amount before performing the re-handshake, otherwise the next decryptMessage


### PR DESCRIPTION
Fixes the high-severity audit finding zeroc-ice/ice-audit#58.

## Problem

On Windows (Schannel), `Schannel::TransceiverI::decryptMessage` copies decrypted application data into the caller's buffer as it loops over TLS records, advancing a local cursor `i` (the caller's `buf.i` is advanced by the *caller*). On `SEC_I_RENEGOTIATE` it returned `0` instead of `i - buffer.i` — the number of bytes it had already copied during that call (from draining `_readUnprocessed` and from earlier records in the same batch).

Both callers (`read()` and `finishRead()`) then performed the renegotiation handshake and `continue`d **without** advancing `buf.i` for those bytes, so the next `decryptMessage` wrote at the same `buf.i` and overwrote the already-extracted plaintext.

### Impact

A client connection where Schannel surfaces a TLS 1.3 `KeyUpdate` / `NewSessionTicket` (reported as `SEC_I_RENEGOTIATE`) in the same read as already-decrypted application data silently loses those application bytes — Ice protocol-stream corruption, typically surfacing later as an unmarshaling or protocol error that is hard to attribute back to the renegotiation. This is reachable by a conformant peer.

## Fix

- `decryptMessage`: return `i - buffer.i` on `SEC_I_RENEGOTIATE` instead of `0`.
- `read()`: advance `buf.i += decrypted` immediately after `decryptMessage`, so the bytes copied before the renegotiation survive the `continue`.
- `finishRead()`: advance `buf.i` per `decryptMessage` inside the loop (it previously advanced once, after the loop), and guard the loop with `decryptMessage`'s data precondition. The readiness signal now reflects total progress across the call.

After the fix, the plaintext extracted before the renegotiation is preserved and the post-handshake application data follows it contiguously and in order; `buf.i` is advanced by exactly the number of plaintext bytes delivered.

## Verification

- Compiles and links cleanly on `main` (Windows, `ice.dll`).
- Reviewed by tracing the state machine for both `read()` and `finishRead()`, covering the app-records-then-renegotiation and renegotiation-first cases. Confirmed no data loss/overwrite, no new asserts or infinite loops, and that `ready()` matches the previous behavior on the non-renegotiation path. The new `finishRead` loop guard is exactly `decryptMessage`'s data precondition, so it is strictly safer than the previous unconditional `while (true)`.

## Testing notes

A targeted regression test is hard to construct deterministically — it requires injecting a renegotiation record mid-batch behind already-decrypted application data, which depends on Schannel's record framing. The existing SSL test suite exercises the non-renegotiation paths.
