### PR TITLE
Fix OpenSSL-based IceSSL build against OpenSSL 4.0

### DIFF
--- a/changelog.d/cpp/openssl-4.0-asn1-opaque.md
+++ b/changelog.d/cpp/openssl-4.0-asn1-opaque.md
@@ -1,0 +1,3 @@
+- Fixed a build failure of the OpenSSL-based IceSSL transport against OpenSSL 4.0, which makes `ASN1_STRING`
+  opaque. Subject Alternative Name parsing now uses the `ASN1_STRING_get0_data`, `ASN1_STRING_length`, and
+  `ASN1_STRING_type` accessors instead of direct struct member access.

--- a/cpp/src/Ice/SSL/SSLUtil.cpp
+++ b/cpp/src/Ice/SSL/SSLUtil.cpp
@@ -496,6 +496,19 @@ namespace
         return result;
     }
 
+    string convertIA5StringToString(ASN1_IA5STRING* str)
+    {
+        if (str && ASN1_STRING_type(str) == V_ASN1_IA5STRING && ASN1_STRING_length(str) > 0)
+        {
+            const unsigned char* data = ASN1_STRING_get0_data(str);
+            if (data)
+            {
+                return string(reinterpret_cast<const char*>(data), ASN1_STRING_length(str));
+            }
+        }
+        return {};
+    }
+
     vector<pair<int, string>> convertGeneralNames(GENERAL_NAMES* gens)
     {
         vector<pair<int, string>> alt;
@@ -512,24 +525,12 @@ namespace
             {
                 case GEN_EMAIL:
                 {
-                    ASN1_IA5STRING* str = gen->d.rfc822Name;
-                    if (str && ASN1_STRING_type(str) == V_ASN1_IA5STRING && ASN1_STRING_get0_data(str) &&
-                        ASN1_STRING_length(str) > 0)
-                    {
-                        p.second =
-                            string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(str)), ASN1_STRING_length(str));
-                    }
+                    p.second = convertIA5StringToString(gen->d.rfc822Name);
                     break;
                 }
                 case GEN_DNS:
                 {
-                    ASN1_IA5STRING* str = gen->d.dNSName;
-                    if (str && ASN1_STRING_type(str) == V_ASN1_IA5STRING && ASN1_STRING_get0_data(str) &&
-                        ASN1_STRING_length(str) > 0)
-                    {
-                        p.second =
-                            string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(str)), ASN1_STRING_length(str));
-                    }
+                    p.second = convertIA5StringToString(gen->d.dNSName);
                     break;
                 }
                 case GEN_DIRNAME:
@@ -539,32 +540,29 @@ namespace
                 }
                 case GEN_URI:
                 {
-                    ASN1_IA5STRING* str = gen->d.uniformResourceIdentifier;
-                    if (str && ASN1_STRING_type(str) == V_ASN1_IA5STRING && ASN1_STRING_get0_data(str) &&
-                        ASN1_STRING_length(str) > 0)
-                    {
-                        p.second =
-                            string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(str)), ASN1_STRING_length(str));
-                    }
+                    p.second = convertIA5StringToString(gen->d.uniformResourceIdentifier);
                     break;
                 }
                 case GEN_IPADD:
                 {
                     ASN1_OCTET_STRING* addr = gen->d.iPAddress;
                     // TODO: Support IPv6 someday.
-                    if (addr && ASN1_STRING_type(addr) == V_ASN1_OCTET_STRING && ASN1_STRING_get0_data(addr) &&
-                        ASN1_STRING_length(addr) == 4)
+                    if (addr && ASN1_STRING_type(addr) == V_ASN1_OCTET_STRING && ASN1_STRING_length(addr) == 4)
                     {
-                        ostringstream ostr;
-                        for (int j = 0; j < 4; ++j)
+                        const unsigned char* data = ASN1_STRING_get0_data(addr);
+                        if (data)
                         {
-                            if (j > 0)
+                            ostringstream ostr;
+                            for (int j = 0; j < 4; ++j)
                             {
-                                ostr << '.';
+                                if (j > 0)
+                                {
+                                    ostr << '.';
+                                }
+                                ostr << static_cast<int>(data[j]);
                             }
-                            ostr << static_cast<int>(ASN1_STRING_get0_data(addr)[j]);
+                            p.second = ostr.str();
                         }
-                        p.second = ostr.str();
                     }
                     break;
                 }

--- a/cpp/src/Ice/SSL/SSLUtil.cpp
+++ b/cpp/src/Ice/SSL/SSLUtil.cpp
@@ -513,18 +513,22 @@ namespace
                 case GEN_EMAIL:
                 {
                     ASN1_IA5STRING* str = gen->d.rfc822Name;
-                    if (str && str->type == V_ASN1_IA5STRING && str->data && str->length > 0)
+                    if (str && ASN1_STRING_type(str) == V_ASN1_IA5STRING && ASN1_STRING_get0_data(str) &&
+                        ASN1_STRING_length(str) > 0)
                     {
-                        p.second = string(reinterpret_cast<const char*>(str->data), str->length);
+                        p.second =
+                            string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(str)), ASN1_STRING_length(str));
                     }
                     break;
                 }
                 case GEN_DNS:
                 {
                     ASN1_IA5STRING* str = gen->d.dNSName;
-                    if (str && str->type == V_ASN1_IA5STRING && str->data && str->length > 0)
+                    if (str && ASN1_STRING_type(str) == V_ASN1_IA5STRING && ASN1_STRING_get0_data(str) &&
+                        ASN1_STRING_length(str) > 0)
                     {
-                        p.second = string(reinterpret_cast<const char*>(str->data), str->length);
+                        p.second =
+                            string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(str)), ASN1_STRING_length(str));
                     }
                     break;
                 }
@@ -536,9 +540,11 @@ namespace
                 case GEN_URI:
                 {
                     ASN1_IA5STRING* str = gen->d.uniformResourceIdentifier;
-                    if (str && str->type == V_ASN1_IA5STRING && str->data && str->length > 0)
+                    if (str && ASN1_STRING_type(str) == V_ASN1_IA5STRING && ASN1_STRING_get0_data(str) &&
+                        ASN1_STRING_length(str) > 0)
                     {
-                        p.second = string(reinterpret_cast<const char*>(str->data), str->length);
+                        p.second =
+                            string(reinterpret_cast<const char*>(ASN1_STRING_get0_data(str)), ASN1_STRING_length(str));
                     }
                     break;
                 }
@@ -546,7 +552,8 @@ namespace
                 {
                     ASN1_OCTET_STRING* addr = gen->d.iPAddress;
                     // TODO: Support IPv6 someday.
-                    if (addr && addr->type == V_ASN1_OCTET_STRING && addr->data && addr->length == 4)
+                    if (addr && ASN1_STRING_type(addr) == V_ASN1_OCTET_STRING && ASN1_STRING_get0_data(addr) &&
+                        ASN1_STRING_length(addr) == 4)
                     {
                         ostringstream ostr;
                         for (int j = 0; j < 4; ++j)
@@ -555,7 +562,7 @@ namespace
                             {
                                 ostr << '.';
                             }
-                            ostr << static_cast<int>(addr->data[j]);
+                            ostr << static_cast<int>(ASN1_STRING_get0_data(addr)[j]);
                         }
                         p.second = ostr.str();
                     }


### PR DESCRIPTION
Motivated by the Debian OpenSSL 4.0 transition, which flagged that `libzeroc-ice` fails to build against OpenSSL 4.0 — Debian bug [#1138403](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1138403). (The fix is prepared here on `main` and will be cherry-picked to `3.8`, since 3.8.3 is what we upload to Debian sid.)

## Problem

OpenSSL 4.0 makes `ASN1_STRING` (and its typedefs `ASN1_IA5STRING`, `ASN1_OCTET_STRING`, …) **opaque** — code that accesses `->data` / `->length` / `->type` directly no longer compiles. The OpenSSL-based IceSSL transport does exactly that in `convertGeneralNames` (Subject Alternative Name parsing), so it fails to build against OpenSSL 4.0:

```
error: invalid use of incomplete type 'ASN1_IA5STRING' {aka 'struct asn1_string_st'}
```

## Fix

Replace the direct `ASN1_STRING` member accesses with the accessor functions `ASN1_STRING_get0_data`, `ASN1_STRING_length`, and `ASN1_STRING_type`. These have existed since OpenSSL 1.1.0 and behave identically on 3.x, so no version guards are needed. `GENERAL_NAME` itself is not opaque, so `gen->type` / `gen->d.*` are unchanged.

## Verification

| Test | OpenSSL | Result |
|---|---|---|
| Original pattern | 4.0.1 (fedora:rawhide) | ❌ `invalid use of incomplete type 'ASN1_IA5STRING'` |
| Fixed pattern | 4.0.1 | ✅ compiles |
| Fixed pattern | 3.6.3 (host) | ✅ compiles — no regression |

This is the only OpenSSL-4.0 blocker in the current transport: the SSL sources already build with `OPENSSL_API_COMPAT 30000` + `OPENSSL_NO_DEPRECATED`, use no ENGINE API, no SSLv3, and no other opaque-struct access.
