### PR TITLE
Fix slice2py docstring escaping and proxy type-hint metadata

### DIFF
--- a/changelog.d/python/slice2py-docstring-and-type-hints.md
+++ b/changelog.d/python/slice2py-docstring-and-type-hints.md
@@ -1,0 +1,4 @@
+- Fixed `slice2py` to escape doc-comment text when emitting Python docstrings, so that comments containing a
+  triple-quote sequence or a backslash escape (such as `\u`) no longer produce invalid generated Python.
+- Fixed `slice2py` to honor parameter metadata (such as `["python:numpy.ndarray"]`) in the type hints of generated
+  proxy methods, matching the servant side, instead of dropping the metadata and leaving the added import unused.

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2479,7 +2479,12 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
         for (const auto& param : inParams)
         {
             out << nl << param->mappedName() << " : "
-                << typeToTypeHintString(param->type(), param->isOptional(), p, methodKind != MethodKind::Dispatch);
+                << typeToTypeHintString(
+                       param->type(),
+                       param->isOptional(),
+                       p,
+                       methodKind != MethodKind::Dispatch,
+                       param->getMetadata());
             const auto r = parametersDoc.find(param->name());
             if (r != parametersDoc.end())
             {
@@ -2544,7 +2549,12 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
             if (returnType)
             {
                 out << nl << "        - "
-                    << typeToTypeHintString(returnType, op->returnIsOptional(), p, methodKind == MethodKind::Dispatch);
+                    << typeToTypeHintString(
+                           returnType,
+                           op->returnIsOptional(),
+                           p,
+                           methodKind == MethodKind::Dispatch,
+                           op->getMetadata());
                 bool firstLine = true;
                 for (const string& line : returnsDoc)
                 {
@@ -2563,7 +2573,12 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
             for (const auto& param : outParams)
             {
                 out << nl << "        - "
-                    << typeToTypeHintString(param->type(), param->isOptional(), p, methodKind == MethodKind::Dispatch);
+                    << typeToTypeHintString(
+                           param->type(),
+                           param->isOptional(),
+                           p,
+                           methodKind == MethodKind::Dispatch,
+                           param->getMetadata());
                 const auto r = parametersDoc.find(param->name());
                 if (r != parametersDoc.end())
                 {
@@ -2595,7 +2610,12 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
             assert(outParams.size() == 1);
             const auto& param = outParams.front();
             out << nl;
-            out << typeToTypeHintString(param->type(), param->isOptional(), p, methodKind == MethodKind::Dispatch);
+            out << typeToTypeHintString(
+                param->type(),
+                param->isOptional(),
+                p,
+                methodKind == MethodKind::Dispatch,
+                param->getMetadata());
             const auto r = parametersDoc.find(param->name());
             if (r != parametersDoc.end())
             {

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -32,6 +32,24 @@ using namespace IceInternal;
 namespace
 {
     const char* const tripleQuotes = R"(""")";
+
+    // Escapes a line of documentation text for safe inclusion in a Python triple-quoted docstring.
+    // Backslashes are doubled so escape sequences such as '\u' are not interpreted, and double-quotes are
+    // escaped so a run of three or more cannot prematurely terminate the docstring.
+    string escapeDocstring(const string& line)
+    {
+        string result;
+        result.reserve(line.size());
+        for (char c : line)
+        {
+            if (c == '\\' || c == '"')
+            {
+                result += '\\';
+            }
+            result += c;
+        }
+        return result;
+    }
 }
 
 class PythonDocCommentFormatter final : public DocCommentFormatter
@@ -1617,7 +1635,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             }
             string param = q->mappedName();
             inParams.append(param);
-            param += ": " + typeToTypeHintString(q->type(), q->isOptional(), p, true);
+            param += ": " + typeToTypeHintString(q->type(), q->isOptional(), p, true, q->getMetadata());
             if (afterLastRequiredParameter)
             {
                 param += " = None";
@@ -2256,7 +2274,7 @@ Slice::Python::CodeVisitor::writeRemarksDocComment(const StringList& remarks, bo
         out << nl << "-----";
         for (const auto& line : remarks)
         {
-            out << nl << "    " << line;
+            out << nl << "    " << escapeDocstring(line);
         }
     }
 }
@@ -2275,7 +2293,7 @@ Slice::Python::CodeVisitor::writeSeeAlso(const StringList& seeAlso, bool needsNe
         out << nl << "--------";
         for (const string& line : seeAlso)
         {
-            out << nl << "    " << line;
+            out << nl << "    " << escapeDocstring(line);
         }
     }
 }
@@ -2335,7 +2353,7 @@ Slice::Python::CodeVisitor::writeDocstring(const ContainedPtr& p, Output& out, c
 
     for (const auto& line : overview)
     {
-        out << nl << line;
+        out << nl << escapeDocstring(line);
     }
 
     // Only emit Attributes if there's a docstring for at least one field.
@@ -2356,7 +2374,7 @@ Slice::Python::CodeVisitor::writeDocstring(const ContainedPtr& p, Output& out, c
             {
                 for (const auto& line : q->second)
                 {
-                    out << nl << "    " << line;
+                    out << nl << "    " << escapeDocstring(line);
                 }
             }
         }
@@ -2384,7 +2402,7 @@ Slice::Python::CodeVisitor::writeEnumeratorDocstring(const EnumeratorPtr& p, Out
 
     for (const auto& line : overview)
     {
-        out << nl << line;
+        out << nl << escapeDocstring(line);
     }
     writeRemarksDocComment(remarks, !overview.empty(), out);
     writeSeeAlso(seeAlso, !overview.empty() || !remarks.empty(), out);
@@ -2435,7 +2453,7 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
     out << nl << tripleQuotes;
     for (const string& line : overview)
     {
-        out << nl << line;
+        out << nl << escapeDocstring(line);
     }
 
     // Emit arguments.
@@ -2467,7 +2485,7 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
             {
                 for (const auto& line : r->second)
                 {
-                    out << nl << "    " << line;
+                    out << nl << "    " << escapeDocstring(line);
                 }
             }
         }
@@ -2533,11 +2551,11 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
                     if (firstLine)
                     {
                         firstLine = false;
-                        out << " " << line;
+                        out << " " << escapeDocstring(line);
                     }
                     else
                     {
-                        out << nl << "          " << line;
+                        out << nl << "          " << escapeDocstring(line);
                     }
                 }
             }
@@ -2555,11 +2573,11 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
                         if (firstLine)
                         {
                             firstLine = false;
-                            out << " " << line;
+                            out << " " << escapeDocstring(line);
                         }
                         else
                         {
-                            out << nl << "          " << line;
+                            out << nl << "          " << escapeDocstring(line);
                         }
                     }
                 }
@@ -2569,7 +2587,7 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
         {
             for (const string& line : returnsDoc)
             {
-                out << nl << "    " << line;
+                out << nl << "    " << escapeDocstring(line);
             }
         }
         else if (!outParams.empty())
@@ -2583,7 +2601,7 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
             {
                 for (const string& line : r->second)
                 {
-                    out << nl << "    " << line;
+                    out << nl << "    " << escapeDocstring(line);
                 }
             }
         }
@@ -2603,7 +2621,7 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
             out << nl << exception;
             for (const auto& line : exceptionDescription)
             {
-                out << nl << "    " << line;
+                out << nl << "    " << escapeDocstring(line);
             }
         }
     }

--- a/python/test/Slice/docComments/Client.py
+++ b/python/test/Slice/docComments/Client.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Copyright (c) ZeroC, Inc.
+
+import os
+import py_compile
+import sys
+import tempfile
+
+from TestHelper import TestHelper, test
+
+import Ice
+import IcePy
+
+
+class Client(TestHelper):
+    def run(self, args: list[str]):
+        sys.stdout.write("testing that doc-comments are escaped in generated docstrings... ")
+        sys.stdout.flush()
+
+        sliceFile = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Test.ice")
+        with tempfile.TemporaryDirectory() as outputDir:
+            rc = IcePy.compileSlice(["slice2py", f"-I{Ice.getSliceDir()}", "--output-dir", outputDir, sliceFile])
+            test(rc == 0)
+
+            sawEscapedQuotes = False
+            for root, _, files in os.walk(outputDir):
+                for name in files:
+                    if name.endswith(".py"):
+                        path = os.path.join(root, name)
+                        # The doc-comments contain '"""' and backslash escapes; if they were emitted
+                        # verbatim the generated file would not be valid Python.
+                        py_compile.compile(path, doraise=True)
+                        if '\\"\\"\\"' in open(path, encoding="utf-8").read():
+                            sawEscapedQuotes = True
+
+            # Make sure we actually exercised the escaping path rather than silently dropping the text.
+            test(sawEscapedQuotes)
+
+        print("ok")

--- a/python/test/Slice/docComments/Client.py
+++ b/python/test/Slice/docComments/Client.py
@@ -31,8 +31,9 @@ class Client(TestHelper):
                         # The doc-comments contain '"""' and backslash escapes; if they were emitted
                         # verbatim the generated file would not be valid Python.
                         py_compile.compile(path, doraise=True)
-                        if '\\"\\"\\"' in open(path, encoding="utf-8").read():
-                            sawEscapedQuotes = True
+                        with open(path, encoding="utf-8") as f:
+                            if '\\"\\"\\"' in f.read():
+                                sawEscapedQuotes = True
 
             # Make sure we actually exercised the escaping path rather than silently dropping the text.
             test(sawEscapedQuotes)

--- a/python/test/Slice/docComments/Test.ice
+++ b/python/test/Slice/docComments/Test.ice
@@ -1,0 +1,43 @@
+// Copyright (c) ZeroC, Inc.
+
+#pragma once
+
+// These doc-comments deliberately contain characters that are special inside a Python triple-quoted
+// docstring: an embedded triple-quote sequence, and backslash escape sequences such as '\u'. The
+// generated docstrings must escape them so that the generated code is valid Python.
+
+["python:identifier:generated.test.Slice.docComments.Test"]
+module Test
+{
+    /// A struct. Example: """triple""" quoted, path C:\users\name, escape é.
+    /// @see I
+    struct S
+    {
+        /// A field with """ in its \u description.
+        int x;
+    }
+
+    /// An exception with """ embedded.
+    exception E
+    {
+        /// A field \with a backslash.
+        string reason;
+    }
+
+    /// An enum. Example: """value""".
+    enum Color
+    {
+        /// Red with """ and \u escape.
+        Red,
+        Green
+    }
+
+    interface I
+    {
+        /// Does a thing. Example: """quoted""".
+        /// @param v the value \u with a backslash and """ quotes.
+        /// @return a result """ with quotes.
+        /// @throws E when it fails \with backslash.
+        int op(int v) throws E;
+    }
+}

--- a/python/test/Slice/proxyTypeHints/Client.py
+++ b/python/test/Slice/proxyTypeHints/Client.py
@@ -57,9 +57,12 @@ class Client(TestHelper):
                 tree = ast.parse(f.read())
 
             # The "python:numpy.ndarray" metadata is on the parameter, so the generated proxy method
-            # signature must include the NumPy type hint, just like the servant abstract method.
+            # signature and its docstring "Parameters" section must both include the NumPy type hint,
+            # just like the servant abstract method.
             for className in ["ProxyHintsPrx", "ProxyHints"]:
                 op = methodNamed(classNamed(tree, className), "op")
                 test("NDArray" in paramAnnotation(op, "values"))
+                docstring = ast.get_docstring(op) or ""
+                test("NDArray" in docstring)
 
         print("ok")

--- a/python/test/Slice/proxyTypeHints/Client.py
+++ b/python/test/Slice/proxyTypeHints/Client.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Copyright (c) ZeroC, Inc.
+
+import ast
+import os
+import py_compile
+import sys
+import tempfile
+
+from TestHelper import TestHelper, test
+
+import Ice
+import IcePy
+
+
+def findClass(tree: ast.Module, name: str) -> ast.ClassDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    return None
+
+
+def findMethod(classNode: ast.ClassDef, name: str) -> ast.FunctionDef | None:
+    for node in classNode.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def paramAnnotation(method: ast.FunctionDef, name: str) -> str:
+    for arg in method.args.args:
+        if arg.arg == name and arg.annotation is not None:
+            return ast.unparse(arg.annotation)
+    return ""
+
+
+class Client(TestHelper):
+    def run(self, args: list[str]):
+        sys.stdout.write("testing that proxy method signatures honor parameter metadata... ")
+        sys.stdout.flush()
+
+        sliceFile = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Test.ice")
+        with tempfile.TemporaryDirectory() as outputDir:
+            rc = IcePy.compileSlice(["slice2py", f"-I{Ice.getSliceDir()}", "--output-dir", outputDir, sliceFile])
+            test(rc == 0)
+
+            interfaceFiles = []
+            for root, _, files in os.walk(outputDir):
+                for name in files:
+                    if name.endswith(".py"):
+                        path = os.path.join(root, name)
+                        py_compile.compile(path, doraise=True)
+                        if name == "ProxyHints.py":
+                            interfaceFiles.append(path)
+            test(len(interfaceFiles) == 1)
+
+            with open(interfaceFiles[0], encoding="utf-8") as f:
+                tree = ast.parse(f.read())
+
+            # The "python:numpy.ndarray" metadata is on the parameter, so the generated proxy method
+            # signature must include the NumPy type hint, just like the servant abstract method.
+            proxyClass = findClass(tree, "ProxyHintsPrx")
+            test(proxyClass is not None)
+            servantClass = findClass(tree, "ProxyHints")
+            test(servantClass is not None)
+
+            for cls in [proxyClass, servantClass]:
+                op = findMethod(cls, "op")
+                test(op is not None)
+                test("NDArray" in paramAnnotation(op, "values"))
+
+        print("ok")

--- a/python/test/Slice/proxyTypeHints/Client.py
+++ b/python/test/Slice/proxyTypeHints/Client.py
@@ -14,18 +14,16 @@ import Ice
 import IcePy
 
 
-def findClass(tree: ast.Module, name: str) -> ast.ClassDef | None:
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef) and node.name == name:
-            return node
-    return None
+def classNamed(tree: ast.Module, name: str) -> ast.ClassDef:
+    nodes = [node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == name]
+    test(len(nodes) == 1)
+    return nodes[0]
 
 
-def findMethod(classNode: ast.ClassDef, name: str) -> ast.FunctionDef | None:
-    for node in classNode.body:
-        if isinstance(node, ast.FunctionDef) and node.name == name:
-            return node
-    return None
+def methodNamed(classNode: ast.ClassDef, name: str) -> ast.FunctionDef:
+    methods = [node for node in classNode.body if isinstance(node, ast.FunctionDef) and node.name == name]
+    test(len(methods) == 1)
+    return methods[0]
 
 
 def paramAnnotation(method: ast.FunctionDef, name: str) -> str:
@@ -60,14 +58,8 @@ class Client(TestHelper):
 
             # The "python:numpy.ndarray" metadata is on the parameter, so the generated proxy method
             # signature must include the NumPy type hint, just like the servant abstract method.
-            proxyClass = findClass(tree, "ProxyHintsPrx")
-            test(proxyClass is not None)
-            servantClass = findClass(tree, "ProxyHints")
-            test(servantClass is not None)
-
-            for cls in [proxyClass, servantClass]:
-                op = findMethod(cls, "op")
-                test(op is not None)
+            for className in ["ProxyHintsPrx", "ProxyHints"]:
+                op = methodNamed(classNamed(tree, className), "op")
                 test("NDArray" in paramAnnotation(op, "values"))
 
         print("ok")

--- a/python/test/Slice/proxyTypeHints/Test.ice
+++ b/python/test/Slice/proxyTypeHints/Test.ice
@@ -10,8 +10,12 @@ module Test
     interface ProxyHints
     {
         // The "python:numpy.ndarray" metadata is on the parameter, not the sequence definition, so it is
-        // only reflected in the generated code if the parameter's metadata is taken into account. The proxy
-        // method signature must include the corresponding type hint, matching the servant side.
+        // only reflected in the generated code if the parameter's metadata is taken into account. Both the
+        // method signature and the docstring "Parameters" section must include the corresponding type hint,
+        // matching the servant side.
+
+        /// Does something with the values.
+        /// @param values the values to use.
         void op(["python:numpy.ndarray"] IntSeq values);
     }
 }

--- a/python/test/Slice/proxyTypeHints/Test.ice
+++ b/python/test/Slice/proxyTypeHints/Test.ice
@@ -1,0 +1,17 @@
+// Copyright (c) ZeroC, Inc.
+
+#pragma once
+
+["python:identifier:generated.test.Slice.proxyTypeHints.Test"]
+module Test
+{
+    sequence<int> IntSeq;
+
+    interface ProxyHints
+    {
+        // The "python:numpy.ndarray" metadata is on the parameter, not the sequence definition, so it is
+        // only reflected in the generated code if the parameter's metadata is taken into account. The proxy
+        // method signature must include the corresponding type hint, matching the servant side.
+        void op(["python:numpy.ndarray"] IntSeq values);
+    }
+}


### PR DESCRIPTION
Two `slice2py` code-generation fixes.

### Docstring escaping
Doc-comment text was emitted verbatim inside a Python triple-quoted docstring. A comment containing a triple-quote sequence (`"""`) or a backslash escape (such as `\u`) therefore produced **invalid generated Python**. The text is now escaped before it is written into the docstring.

### Proxy type-hint metadata
The generated proxy method signatures dropped parameter metadata when building their type hints, unlike the servant side. For an operation such as `op(["python:numpy.ndarray"] IntSeq s)` the proxy hint omitted the accepted alternative type and left the import added for it unused. The proxy side now passes the parameter metadata through, matching the servant abstract method.

### Tests
- `python/test/Slice/docComments` — compiles a Slice file whose doc-comments contain `"""` and backslash escapes across structs, fields, exceptions, enums, and operations, then byte-compiles every generated file.
- `python/test/Slice/proxyTypeHints` — asserts the generated proxy method hint honors parameter-level metadata.

Both tests fail against the unfixed compiler and pass after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)