### PR TITLE
Fix IceRuby setBufferSize to reject out-of-int-range sizes

### DIFF
--- a/ruby/src/IceRuby/Connection.cpp
+++ b/ruby/src/IceRuby/Connection.cpp
@@ -148,10 +148,17 @@ IceRuby_Connection_setBufferSize(VALUE self, VALUE r, VALUE s)
         Ice::ConnectionPtr* p = reinterpret_cast<Ice::ConnectionPtr*>(DATA_PTR(self));
         assert(p);
 
-        int rcvSize = static_cast<int>(getInteger(r));
-        int sndSize = static_cast<int>(getInteger(s));
+        long rcvSize = getInteger(r);
+        long sndSize = getInteger(s);
 
-        (*p)->setBufferSize(rcvSize, sndSize);
+        // Connection::setBufferSize takes int arguments in C++; reject values outside that range instead of silently
+        // truncating them.
+        if (rcvSize < INT_MIN || rcvSize > INT_MAX || sndSize < INT_MIN || sndSize > INT_MAX)
+        {
+            throw RubyException(rb_eRangeError, "buffer size must be in the range of a C++ int");
+        }
+
+        (*p)->setBufferSize(static_cast<int>(rcvSize), static_cast<int>(sndSize));
     }
     ICE_RUBY_CATCH
     return Qnil;

--- a/ruby/test/Ice/info/AllTests.rb
+++ b/ruby/test/Ice/info/AllTests.rb
@@ -93,6 +93,13 @@ def allTests(helper, communicator)
     connection = testIntf.ice_getConnection()
     connection.setBufferSize(1024, 2048)
 
+    # setBufferSize must reject values outside the C++ int range instead of silently truncating them.
+    begin
+        connection.setBufferSize(2 ** 40, 2048)
+        test(false)
+    rescue RangeError
+    end
+
     info = connection.getInfo()
     tcpinfo = getTCPConnectionInfo(info)
 


### PR DESCRIPTION
Fixes #5797.

`IceRuby_Connection_setBufferSize` cast its Ruby integer arguments to `int` without a range check, so an out-of-`int`-range value (e.g. `2**40`) was silently truncated instead of being rejected. It now reads the arguments as `long`, validates they are within `int` range, and raises `RangeError` on out-of-range input.

This mirrors the IcePHP fix in #5586. IcePy is unaffected — `PyArg_ParseTuple(args, "ii", ...)` already raises `OverflowError`.

### Testing

Adds a negative case to the Ice/info test that `setBufferSize(2 ** 40, 2048)` raises `RangeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)