### PR TITLE
Fix slice2js duplicate injected parameter for context/current-named parameters

### DIFF
--- a/changelog.d/js/context-param-name-clash.md
+++ b/changelog.d/js/context-param-name-clash.md
@@ -1,0 +1,4 @@
+- Fixed `slice2js` to rename the parameters it synthesizes for generated proxy and skeleton methods when an operation
+  already has an in-parameter with the same name. An operation with an in-parameter named `context` (proxy) or
+  `current` (skeleton) previously produced a TypeScript declaration with two parameters of that name, which failed to
+  compile.

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2689,7 +2689,7 @@ Slice::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                 << (param->mappedName() + optionalPrefix + ": " +
                     typeToTsString(param->type(), true, true, param->isOptional()));
         }
-        _out << "context?: Map<string, string>";
+        _out << (escapeParam(inParams, "context") + "?: Map<string, string>");
         _out << epar;
 
         _out << ": " << _iceImportPrefix << "Ice.AsyncResult";
@@ -2804,7 +2804,7 @@ Slice::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         {
             _out << (param->mappedName() + ": " + typeToTsString(param->type(), true, true, param->isOptional()));
         }
-        _out << ("current: " + _iceImportPrefix + "Ice.Current");
+        _out << (escapeParam(inParams, "current") + ": " + _iceImportPrefix + "Ice.Current");
         _out << epar << ": ";
 
         if (!ret && outParams.empty())

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1295,6 +1295,9 @@ Slice::TypesVisitor::visitOperation(const OperationPtr& op)
         const string paramLabel = (inParams.size() == 1 ? "_" : param->mappedName());
         _out << (paramLabel + " " + paramName + ": " + typeString + (isOptional ? " = nil" : ""));
     }
+    // We don't escape this synthesized "context" argument label even when an in-parameter is also named
+    // "context": Swift allows a function to declare two parameters with the same argument label, and call
+    // sites disambiguate positionally, so the duplicate label compiles fine.
     _out << "context: " + getUnqualified("Ice.Context", swiftModule) + "? = nil";
     _out << epar;
     _out << " async throws";

--- a/js/packages/test/Slice/escape/Client.ts
+++ b/js/packages/test/Slice/escape/Client.ts
@@ -3,6 +3,7 @@
 import { Ice } from "@zeroc/ice";
 import { TestHelper, test } from "../../Common/TestHelper.js";
 import { escapedAwait } from "./Key.js";
+import { Clash } from "./Clash.js";
 export class Client extends TestHelper {
     async allTests() {
         const communicator = this.communicator();
@@ -62,6 +63,12 @@ export class Client extends TestHelper {
         test(p._debugger === "");
         test(p._null instanceof escapedAwait.explicitPrx);
         out.writeLine("ok");
+
+        // Referencing this proxy type-checks the generated Clash.d.ts, whose Intf::op has in-parameters named
+        // `context` and `current`: the synthesized `context` (proxy) and `current` (skeleton) parameters must be
+        // renamed so the generated declarations don't declare the same parameter twice.
+        const clashPrx = new Clash.IntfPrx(communicator, `hello: ${this.getTestEndpoint()}`);
+        test(clashPrx instanceof Clash.IntfPrx);
     }
 
     async run(args: string[]) {


### PR DESCRIPTION
Fixes #5796.

`slice2js` synthesizes a `context` parameter on generated proxy methods and a `current` parameter on generated skeleton (dispatch) methods, appended after the user parameters. When an operation has an in-parameter with the same name, the generated TypeScript `.d.ts` declared that parameter twice — invalid TypeScript (`error TS2300: Duplicate identifier`):

- **proxy** — an in-parameter named `context` (the case reported in #5796)
- **skeleton** — an in-parameter named `current` (the same defect, surfaced by the new test)

Both injected names are now routed through the existing `escapeParam` helper — the same clash-avoidance approach the other generators use, and the one the neighboring doc-comment code already used. The name is renamed (e.g. `context_`, `current_`) only when it actually clashes.

### slice2swift is not affected

The issue originally suspected `slice2swift` too, but Swift permits a function to declare two parameters with the same argument label (call sites disambiguate positionally), so the duplicate `context:` label compiles fine even with two or more in-parameters. No functional change there — just a comment documenting why we don't escape the label.

### Testing

The `Slice/escape/Clash.ice` fixture already declares `op(string context, string current, ...)`, which exercises both clashes. `Client.ts` previously didn't reference the generated `Clash` proxy, so its `.d.ts` was never type-checked — which is why the latent bug went unnoticed. The test now constructs `Clash.IntfPrx`, so `tsc` type-checks the generated declaration (verified: it fails with TS2300 before this fix and compiles after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)