### PR TITLE
Fix iOS iAP getInfo: nil-safe IAPConnectionInfo and correct IAPEndpointInfo protocol

### DIFF
--- a/cpp/src/Ice/ios/iAPEndpointI.mm
+++ b/cpp/src/Ice/ios/iAPEndpointI.mm
@@ -18,6 +18,7 @@
 #    include "iAPConnector.h"
 #    include "iAPEndpointI.h"
 #    include "iAPMatch.h"
+#    include "iAPUtil.h"
 
 #    include <CoreFoundation/CoreFoundation.h>
 
@@ -132,7 +133,7 @@ IceObjC::iAPEndpointI::getInfo() const noexcept
         _manufacturer,
         _modelNumber,
         _name,
-        protocol(),
+        _protocol,
         type(),
         secure());
 }
@@ -244,12 +245,6 @@ IceObjC::iAPEndpointI::connectorsAsync(
 
         NSString* protocol =
             _protocol.empty() ? @"com.zeroc.ice" : [[NSString alloc] initWithUTF8String:_protocol.c_str()];
-        // Converts an NSString to a std::string, yielding "" when the string is nil or not representable as UTF-8.
-        auto toString = [](NSString* s)
-        {
-            const char* utf8 = [s UTF8String];
-            return utf8 ? string{utf8} : string{};
-        };
 
         NSArray* array = [manager connectedAccessories];
         NSEnumerator* enumerator = [array objectEnumerator];
@@ -264,17 +259,17 @@ IceObjC::iAPEndpointI::connectorsAsync(
             vector<string> accessoryProtocols;
             for (NSString* p in accessory.protocolStrings)
             {
-                accessoryProtocols.emplace_back(toString(p));
+                accessoryProtocols.emplace_back(nsToString(p));
             }
 
             if (iAPMatches(
                     _manufacturer,
                     _modelNumber,
                     _name,
-                    toString(protocol),
-                    toString(accessory.manufacturer),
-                    toString(accessory.modelNumber),
-                    toString(accessory.name),
+                    nsToString(protocol),
+                    nsToString(accessory.manufacturer),
+                    nsToString(accessory.modelNumber),
+                    nsToString(accessory.name),
                     accessoryProtocols))
             {
                 connectors.emplace_back(

--- a/cpp/src/Ice/ios/iAPTransceiver.mm
+++ b/cpp/src/Ice/ios/iAPTransceiver.mm
@@ -9,6 +9,7 @@
 #    include "Ice/LocalExceptions.h"
 #    include "iAPEndpointI.h"
 #    include "iAPTransceiver.h"
+#    include "iAPUtil.h"
 
 #    import <Foundation/NSError.h>
 #    import <Foundation/NSRunLoop.h>
@@ -389,12 +390,12 @@ IceObjC::iAPTransceiver::getInfo([[maybe_unused]] bool incoming, string adapterN
     return make_shared<Ice::IAPConnectionInfo>(
         std::move(adapterName),
         std::move(connectionId),
-        [_session.accessory.name UTF8String],
-        [_session.accessory.manufacturer UTF8String],
-        [_session.accessory.modelNumber UTF8String],
-        [_session.accessory.firmwareRevision UTF8String],
-        [_session.accessory.hardwareRevision UTF8String],
-        [_session.protocolString UTF8String]);
+        nsToString(_session.accessory.name),
+        nsToString(_session.accessory.manufacturer),
+        nsToString(_session.accessory.modelNumber),
+        nsToString(_session.accessory.firmwareRevision),
+        nsToString(_session.accessory.hardwareRevision),
+        nsToString(_session.protocolString));
 }
 
 void

--- a/cpp/src/Ice/ios/iAPUtil.h
+++ b/cpp/src/Ice/ios/iAPUtil.h
@@ -1,0 +1,20 @@
+// Copyright (c) ZeroC, Inc.
+
+#ifndef ICE_IAP_UTIL_H
+#define ICE_IAP_UTIL_H
+
+#import <Foundation/NSString.h>
+
+#include <string>
+
+namespace IceObjC
+{
+    // Converts an NSString to a std::string, yielding "" when the string is nil or not representable as UTF-8.
+    inline std::string nsToString(NSString* s)
+    {
+        const char* utf8 = [s UTF8String];
+        return utf8 ? std::string{utf8} : std::string{};
+    }
+}
+
+#endif

--- a/cpp/test/Ice/iap/AllTests.cpp
+++ b/cpp/test/Ice/iap/AllTests.cpp
@@ -49,6 +49,7 @@ namespace
             test(info->manufacturer == "Acme");
             test(info->modelNumber == "Model3");
             test(info->name == "HeadUnit");
+            test(info->protocol == "com.zeroc.ice");
         }
 
         {
@@ -59,6 +60,7 @@ namespace
             test(info->manufacturer.empty());
             test(info->modelNumber.empty());
             test(info->name.empty());
+            test(info->protocol.empty());
         }
 
         {


### PR DESCRIPTION
Fixes #5794 and #5793 — two bugs in the iOS iAP transport's `getInfo()` methods.

### #5794 — nil-safe `IAPConnectionInfo`
`iAPTransceiver::getInfo()` built each `IAPConnectionInfo` field by constructing a `std::string` directly from `[... UTF8String]`. When an `EAAccessory` field is `nil` (several are optional) or not representable as UTF-8, `UTF8String` returns `nullptr` and the `std::string` construction is undefined behavior. The fields now go through a nil-safe conversion helper.

### #5793 — correct `IAPEndpointInfo::protocol`
`iAPEndpointI::getInfo()` populated `IAPEndpointInfo::protocol` with `protocol()` — the transport name (`iap`/`iaps`) — instead of `_protocol`, the External Accessory protocol string set via the `-p` endpoint option. It now reports `_protocol`, matching the documented meaning ("The protocol supported by the accessory").

### Other changes
- Extracted the `NSString*`→`std::string` conversion (previously a local lambda in `connectorsAsync`) into a shared `IceObjC::nsToString` helper in a new `iAPUtil.h`.
- Added assertions for `IAPEndpointInfo::protocol` to the iAP endpoint test.

Both modified `.mm` files were syntax-checked against the iphonesimulator SDK. The iAP transport is iOS-only, so the test suite runs only on the iOS simulator/device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)