### PR TITLE
Fix slice2cpp invalid C++ literal for float constants in exponent form

### DIFF
--- a/changelog.d/cpp/slice2cpp-float-exponent-literal.md
+++ b/changelog.d/cpp/slice2cpp-float-exponent-literal.md
@@ -1,0 +1,3 @@
+- Fixed a `slice2cpp` bug where a `float` constant whose value is rendered in scientific notation (any magnitude
+  ≥ 1e6 or < 1e-4, e.g. `1e8`) generated an invalid C++ literal such as `1e+08.0F`, causing the generated header to
+  fail to compile.

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -124,7 +124,9 @@ namespace
             else if (bp && bp->kind() == Builtin::KindFloat)
             {
                 out << value;
-                if (value.find('.') == string::npos)
+                // Append ".0" only when the value is an integer literal, i.e. it has neither a decimal point nor an
+                // exponent (values such as "1e+07" are already valid floating-point literals).
+                if (value.find_first_of(".eE") == string::npos)
                 {
                     out << ".0";
                 }

--- a/cpp/test/Ice/defaultValue/AllTests.cpp
+++ b/cpp/test/Ice/defaultValue/AllTests.cpp
@@ -46,6 +46,7 @@ allTests()
         test(v.i == ConstInt);
         test(v.l == ConstLong);
         test(v.f == ConstFloat);
+        test(ConstExpFloat == 1e8f);
         test(v.d == ConstDouble);
         test(v.str == ConstString);
         test(v.c1 == ConstColor1);

--- a/cpp/test/Ice/defaultValue/Test.ice
+++ b/cpp/test/Ice/defaultValue/Test.ice
@@ -45,6 +45,7 @@ module Test
     const int ConstInt = 3;
     const long ConstLong = 4;
     const float ConstFloat = 5.1;
+    const float ConstExpFloat = 1e8;
     const double ConstDouble = 6.2;
     const string ConstString = "foo \\ \"bar\n \r\n\t\v\f\a\b\? \007 \x07";
     const Color ConstColor1 = ::Test::Color::red;


### PR DESCRIPTION
## Description

`slice2cpp` emits a `float` constant by appending `.0F` when the value string contains no `.`. But the value is stringified from a `double` with default `ostringstream` formatting, so any value whose magnitude forces scientific notation (roughly ≥ 1e6 or < 1e-4, e.g. `1e8` → `"1e+08"`) is rendered *without* a decimal point. The emitter then produced `1e+08.0F` — an invalid C++ literal (`invalid suffix '.0F'`) — and the generated header failed to compile.

The fix appends `.0` only when the value is an integer literal, i.e. it has neither a decimal point nor an exponent. Values already in floating-point form (containing `.`, `e`, or `E`) get only the `F` suffix.

`const float Big = 1e8;` now generates `constexpr float Big = 1e+08F;` instead of `1e+08.0F`.

Only the C++ mapping is affected: the C# generator appends just `F`, and `1e+08F` is valid C#.

## Test

Added `const float ConstExpFloat = 1e8;` to the `Ice/defaultValue` Slice test (a C++-local fixture) with a value check in `AllTests.cpp`. Without the fix, the generated header does not compile.

Fixes #5477

🤖 Generated with [Claude Code](https://claude.com/claude-code)