### PR TITLE
Add hardware-free IceBT endpoint tests and a Bluetooth CI probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,29 @@ jobs:
           echo "AppTargetFramework=net10.0" >> $env:GITHUB_ENV
         shell: pwsh
 
+      # Report whether the runner can host an emulated Bluetooth stack (virtual HCI + BlueZ) -- a
+      # prerequisite for eventually exercising the IceBT transport over Bluetooth in CI without radios.
+      - name: Probe Bluetooth runner capabilities
+        if: runner.os == 'Linux' && matrix.config == 'release'
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "## Load Bluetooth kernel modules"
+          for m in bluetooth l2cap rfcomm bnep hci_vhci; do
+            if sudo modprobe "$m" 2>/dev/null; then echo "  OK    $m"; else echo "  FAIL  $m"; fi
+          done
+          lsmod | grep -Ei 'blue|rfcomm|bnep|vhci|l2cap' || echo "  (no bt modules loaded)"
+          echo "## /dev/vhci"; ls -l /dev/vhci 2>/dev/null || echo "  not present"
+          echo "## CONFIG_BT* (RFCOMM matters for IceBT)"
+          { zcat /proc/config.gz 2>/dev/null || cat "/boot/config-$(uname -r)" 2>/dev/null; } \
+            | grep -E 'CONFIG_BT(_RFCOMM|_HCIVHCI|_BNEP)?=' || echo "  kernel config not exposed"
+          echo "## BlueZ user-space"
+          sudo apt-get install -y bluez bluez-tools >/dev/null 2>&1 || true
+          sudo apt-get install -y bluez-tests >/dev/null 2>&1 || echo "  bluez-tests not packaged"
+          if command -v btvirt >/dev/null; then echo "  btvirt: present"; else
+            echo "  btvirt: NOT packaged (would need building from BlueZ source)"; fi
+          sudo btmgmt info 2>/dev/null || true
+
       - name: Build ${{ matrix.config }} on ${{ matrix.os }}
         uses: ./.github/actions/build
         timeout-minutes: 90

--- a/cpp/test/IceBT/endpoints/Client.cpp
+++ b/cpp/test/IceBT/endpoints/Client.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "Ice/Ice.h"
+#include "IceBT/IceBT.h"
+#include "TestHelper.h"
+
+using namespace std;
+
+namespace
+{
+    // Walk the underlying chain (e.g. bts -> bt) to find the IceBT endpoint info.
+    IceBT::EndpointInfoPtr getBTEndpointInfo(const Ice::EndpointInfoPtr& info)
+    {
+        for (Ice::EndpointInfoPtr p = info; p; p = p->underlying)
+        {
+            if (auto bt = dynamic_pointer_cast<IceBT::EndpointInfo>(p))
+            {
+                return bt;
+            }
+        }
+        return nullptr;
+    }
+}
+
+class Client : public Test::TestHelper
+{
+public:
+    void run(int, char**) override;
+};
+
+void
+Client::run(int argc, char** argv)
+{
+    Ice::InitializationData initData;
+    initData.properties = createTestProperties(argc, argv);
+
+    // Register the IceBT plug-in but do NOT initialize it. Initializing the plug-in connects to the
+    // Bluetooth daemon over the D-Bus system bus, which requires Bluetooth services we don't have on
+    // CI. The bt/bts endpoint factories are registered when the plug-in is *constructed* (before
+    // initialization), so we can parse endpoints without a live Bluetooth stack.
+    //
+    // We only add IceBT here: Ice always registers the built-in TCP and SSL plug-in factories itself,
+    // so the SSL endpoint factory needed to parse a bts (SSL-over-Bluetooth) endpoint is present
+    // without us adding it.
+    initData.properties->setProperty("Ice.InitPlugins", "0");
+    initData.pluginFactories = {IceBT::btPluginFactory()};
+
+    Ice::CommunicatorHolder holder{initialize(std::move(initData))};
+    const Ice::CommunicatorPtr& communicator = holder.communicator();
+
+    const string addr = "01:23:45:67:89:AB";
+    const string uuid = "5ec1a9e6-8f7a-4f3a-9b2c-1234567890ab";
+
+    cout << "testing bt endpoint parsing... " << flush;
+    {
+        // The address is quoted because ':' is the proxy endpoint separator.
+        Ice::ObjectPrx prx{communicator, "dummy:bt -a \"" + addr + "\" -u " + uuid};
+
+        Ice::EndpointSeq endpoints = prx->ice_getEndpoints();
+        test(endpoints.size() == 1);
+
+        // A bt endpoint's info is directly an IceBT::EndpointInfo (no wrapper).
+        IceBT::EndpointInfoPtr info = dynamic_pointer_cast<IceBT::EndpointInfo>(endpoints[0]->getInfo());
+        test(info);
+        test(info->addr == addr);
+        test(info->uuid == uuid);
+        test(!info->secure());
+
+        // The stringified proxy must round-trip back to an equivalent proxy.
+        Ice::ObjectPrx prx2{communicator, prx->ice_toString()};
+        test(prx2 == prx);
+    }
+    cout << "ok" << endl;
+
+    cout << "testing bts (SSL over Bluetooth) endpoint parsing... " << flush;
+    {
+        Ice::ObjectPrx prx{communicator, "dummy:bts -a \"" + addr + "\" -u " + uuid};
+
+        Ice::EndpointSeq endpoints = prx->ice_getEndpoints();
+        test(endpoints.size() == 1);
+
+        // A bts endpoint layers SSL over Bluetooth: the top-level info is the SSL wrapper, and the
+        // IceBT::EndpointInfo is its underlying info.
+        Ice::EndpointInfoPtr info = endpoints[0]->getInfo();
+        test(!dynamic_pointer_cast<IceBT::EndpointInfo>(info));
+        IceBT::EndpointInfoPtr btInfo = getBTEndpointInfo(info);
+        test(btInfo);
+        test(btInfo->addr == addr);
+        test(btInfo->uuid == uuid);
+
+        // The stringified proxy must round-trip back to an equivalent proxy.
+        Ice::ObjectPrx prx2{communicator, prx->ice_toString()};
+        test(prx2 == prx);
+    }
+    cout << "ok" << endl;
+
+    cout << "testing malformed bt endpoints are rejected... " << flush;
+    {
+        // Invalid device address.
+        try
+        {
+            Ice::ObjectPrx bad{communicator, "dummy:bt -a not-an-address"};
+            test(false);
+        }
+        catch (const Ice::ParseException&)
+        {
+        }
+
+        // The channel option (-c) is only valid for object adapter endpoints, not proxy endpoints.
+        try
+        {
+            Ice::ObjectPrx bad{communicator, "dummy:bt -a \"" + addr + "\" -u " + uuid + " -c 1"};
+            test(false);
+        }
+        catch (const Ice::ParseException&)
+        {
+        }
+    }
+    cout << "ok" << endl;
+}
+
+DEFINE_TEST(Client)

--- a/cpp/test/IceBT/endpoints/Makefile.mk
+++ b/cpp/test/IceBT/endpoints/Makefile.mk
@@ -1,0 +1,14 @@
+# Copyright (c) ZeroC, Inc.
+
+#
+# The IceBT plug-in is only built when the Bluetooth system libraries (BlueZ/DBus) are available
+# (see config/Make.rules.Linux). Only build this test when the plug-in is available, so it can link
+# against IceBT and use IceBT::btPluginFactory.
+#
+ifneq ($(IceBT_system_libs),)
+
+$(project)_dependencies := TestCommon Ice IceBT
+
+tests += $(project)
+
+endif

--- a/cpp/test/IceBT/endpoints/test.py
+++ b/cpp/test/IceBT/endpoints/test.py
@@ -1,0 +1,29 @@
+# Copyright (c) ZeroC, Inc.
+
+import subprocess
+
+from Util import ClientTestCase, Linux, TestSuite, platform
+
+
+# The IceBT plug-in -- and therefore this test -- is only built on Linux when the Bluetooth system
+# libraries (BlueZ/DBus) are available. Guard the test the same way the build does (see
+# cpp/test/IceBT/endpoints/Makefile.mk and config/Make.rules.Linux) so the harness doesn't try to
+# run a client that was never built.
+def hasBluetoothLibraries():
+    try:
+        return (
+            subprocess.call(
+                ["pkg-config", "--exists", "bluez", "dbus-1"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            == 0
+        )
+    except OSError:
+        return False
+
+
+# This test only parses bt/bts endpoint strings; it does not open any Bluetooth connection, so it
+# runs under the default (tcp) configuration and needs no Bluetooth hardware.
+if isinstance(platform, Linux) and hasBluetoothLibraries():
+    TestSuite(__file__, [ClientTestCase()])


### PR DESCRIPTION
The IceBT transport has had no CI coverage because its RFCOMM data path and BlueZ/D-Bus control path both need real hardware. This adds:

- A hardware-free test (`cpp/test/IceBT/endpoints`) that parses `bt`/`bts` endpoint strings with the IceBT plug-in loaded but not initialized (`Ice.InitPlugins=0`) — no Bluetooth daemon or radios needed.
- Coverage that a `bts` endpoint layers SSL over an IceBT endpoint, and that malformed endpoints are rejected.
- Build/run gating so it compiles only on Linux with BlueZ/D-Bus and runs in the normal suite under the default tcp config (no `--host-bt`).
- A manual `bluetooth-probe` workflow (`workflow_dispatch` only) that probes whether GitHub runners can host an emulated Bluetooth stack (virtual HCI via `hci_vhci` + BlueZ) — a step toward running IceBT over Bluetooth in CI without hardware.