### PR TITLE
Use getIceProperty for known Ice properties in Ice for MATLAB

### DIFF
--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -86,16 +86,12 @@ classdef Communicator < IceInternal.WrapperObject
                     obj.SliceLoader, notFoundCacheSize, cacheFullLogger);
             end
 
-            enc = options.Properties.getProperty('Ice.Default.EncodingVersion');
-            if isempty(enc)
-                obj.encoding = IceInternal.Protocol.Encoding_1_1;
-            else
-                arr = sscanf(enc, '%u.%u');
-                if length(arr) ~= 2
-                    error('Ice:ArgumentException', 'Invalid value for Ice.Default.EncodingVersion');
-                end
-                obj.encoding = Ice.EncodingVersion(arr(1), arr(2));
+            enc = options.Properties.getIceProperty('Ice.Default.EncodingVersion');
+            arr = sscanf(enc, '%u.%u');
+            if length(arr) ~= 2
+                error('Ice:ArgumentException', 'Invalid value for Ice.Default.EncodingVersion');
             end
+            obj.encoding = Ice.EncodingVersion(arr(1), arr(2));
             if options.Properties.getIcePropertyAsInt('Ice.Default.SlicedFormat') > 0
                 obj.format = Ice.FormatType.SlicedFormat;
             else

--- a/matlab/lib/+Ice/InputStream.m
+++ b/matlab/lib/+Ice/InputStream.m
@@ -16,8 +16,7 @@ classdef InputStream < handle
             obj.encoding = encoding;
             obj.encoding_1_0 = encoding.major == 1 && encoding.minor == 0;
             obj.size = length(buf);
-            obj.classGraphDepthMax = ...
-                communicator.getProperties().getPropertyAsIntWithDefault('Ice.ClassGraphDepthMax', 100);
+            obj.classGraphDepthMax = communicator.getProperties().getIcePropertyAsInt('Ice.ClassGraphDepthMax');
             if obj.classGraphDepthMax < 1 || obj.classGraphDepthMax > intmax('int32')
                 obj.classGraphDepthMax = intmax('int32');
             end

--- a/matlab/test/Ice/enums/AllTests.m
+++ b/matlab/test/Ice/enums/AllTests.m
@@ -98,7 +98,7 @@ classdef AllTests
 
             fprintf('testing enum streaming... ');
 
-            encoding_1_0 = strcmp(communicator.getProperties().getProperty('Ice.Default.EncodingVersion'), '1.0');
+            encoding_1_0 = strcmp(communicator.getProperties().getIceProperty('Ice.Default.EncodingVersion'), '1.0');
 
             os = Ice.OutputStream(communicator.getEncoding());
             ByteEnum.ice_write(os, ByteEnum.benum11);

--- a/matlab/test/Ice/facets/AllTests.m
+++ b/matlab/test/Ice/facets/AllTests.m
@@ -8,23 +8,23 @@ classdef AllTests
             communicator = helper.communicator();
 
             fprintf('testing Ice.Admin.Facets property... ');
-            assert(length(communicator.getProperties().getPropertyAsList('Ice.Admin.Facets')) == 0);
+            assert(length(communicator.getProperties().getIcePropertyAsList('Ice.Admin.Facets')) == 0);
             communicator.getProperties().setProperty('Ice.Admin.Facets', 'foobar');
-            facetFilter = communicator.getProperties().getPropertyAsList('Ice.Admin.Facets');
+            facetFilter = communicator.getProperties().getIcePropertyAsList('Ice.Admin.Facets');
             assert(length(facetFilter) == 1 && strcmp(facetFilter{1}, 'foobar'));
             communicator.getProperties().setProperty('Ice.Admin.Facets', 'foo\''bar');
-            facetFilter = communicator.getProperties().getPropertyAsList('Ice.Admin.Facets');
+            facetFilter = communicator.getProperties().getIcePropertyAsList('Ice.Admin.Facets');
             assert(length(facetFilter) == 1 && strcmp(facetFilter{1}, 'foo''bar'));
             communicator.getProperties().setProperty('Ice.Admin.Facets', '''foo bar'' toto ''titi''');
-            facetFilter = communicator.getProperties().getPropertyAsList('Ice.Admin.Facets');
+            facetFilter = communicator.getProperties().getIcePropertyAsList('Ice.Admin.Facets');
             assert(length(facetFilter) == 3 && strcmp(facetFilter{1}, 'foo bar') && ...
                    strcmp(facetFilter{2}, 'toto') && strcmp(facetFilter{3}, 'titi'));
             communicator.getProperties().setProperty('Ice.Admin.Facets', '''foo bar\'' toto'' ''titi''');
-            facetFilter = communicator.getProperties().getPropertyAsList('Ice.Admin.Facets');
+            facetFilter = communicator.getProperties().getIcePropertyAsList('Ice.Admin.Facets');
             assert(length(facetFilter) == 2 && strcmp(facetFilter{1}, 'foo bar'' toto') && ...
                    strcmp(facetFilter{2}, 'titi'));
             % communicator.getProperties().setProperty('Ice.Admin.Facets', '''foo bar'' ''toto titi');
-            % facetFilter = communicator.getProperties().getPropertyAsList('Ice.Admin.Facets');
+            % facetFilter = communicator.getProperties().getIcePropertyAsList('Ice.Admin.Facets');
             % assert(length(facetFilter) == 0);
             communicator.getProperties().setProperty('Ice.Admin.Facets', '');
             fprintf('ok\n');

--- a/matlab/test/Ice/info/AllTests.m
+++ b/matlab/test/Ice/info/AllTests.m
@@ -54,7 +54,7 @@ classdef AllTests
 
             endpointPort = helper.getTestPort();
 
-            defaultHost = communicator.getProperties().getProperty('Ice.Default.Host');
+            defaultHost = communicator.getProperties().getIceProperty('Ice.Default.Host');
             fprintf('test connection endpoint information... ');
 
             info = testIntf.ice_getConnection().getEndpoint().getInfo();

--- a/matlab/test/Ice/objects/LocalTests.m
+++ b/matlab/test/Ice/objects/LocalTests.m
@@ -13,13 +13,13 @@ classdef LocalTests
 
             fprintf('testing class members locally... ');
 
-            if props.getPropertyAsIntWithDefault('Ice.Default.SlicedFormat', 0) == 1
+            if props.getIcePropertyAsInt('Ice.Default.SlicedFormat') > 0
                 format = Ice.FormatType.SlicedFormat;
             else
                 format = Ice.FormatType.CompactFormat;
             end
 
-            if strcmp(props.getPropertyWithDefault('Ice.Default.EncodingVersion', '1.1'), '1.1')
+            if strcmp(props.getIceProperty('Ice.Default.EncodingVersion'), '1.1')
                 encoding = Ice.EncodingVersion(1, 1);
             else
                 encoding = Ice.EncodingVersion(1, 0);

--- a/matlab/test/Ice/operations/BatchOneways.m
+++ b/matlab/test/Ice/operations/BatchOneways.m
@@ -70,7 +70,7 @@ classdef BatchOneways
             batch.ice_ping();
 
             p.ice_ping();
-            if ~isempty(p.ice_getConnection()) && isempty(properties.getProperty('Ice.Override.Compress'))
+            if ~isempty(p.ice_getConnection()) && isempty(properties.getIceProperty('Ice.Override.Compress'))
                 prx = MyClassPrx.uncheckedCast(...
                     p.ice_getConnection().createProxy(p.ice_getIdentity()).ice_batchOneway());
 

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -368,7 +368,7 @@ classdef AllTests
 
             fprintf('ok\n');
 
-            if communicator.getProperties().getPropertyAsInt('Ice.Default.SlicedFormat') > 0
+            if communicator.getProperties().getIcePropertyAsInt('Ice.Default.SlicedFormat') > 0
                 fprintf('testing marshaling with unknown class slices... ');
 
                 c = C();

--- a/matlab/test/Ice/proxy/AllTests.m
+++ b/matlab/test/Ice/proxy/AllTests.m
@@ -773,7 +773,7 @@ classdef AllTests
             p2 = communicator.stringToProxy('test -e 1.1:opaque -e 1.1 -t 1 -v CTEyNy4wLjAuMeouAAAQJwAAAA==');
             assert(strcmp(communicator.proxyToString(p2), 'test:tcp -h 127.0.0.1 -p 12010 -t 10000'));
 
-            if communicator.getProperties().getPropertyAsInt('Ice.IPv6') == 0
+            if communicator.getProperties().getIcePropertyAsInt('Ice.IPv6') == 0
                 % Two legal TCP endpoints expressed as opaque endpoints
                 p1 = communicator.stringToProxy('test -e 1.0:opaque -t 1 -e 1.0 -v CTEyNy4wLjAuMeouAAAQJwAAAA==:opaque -t 1 -e 1.0 -v CTEyNy4wLjAuMusuAAAQJwAAAA==');
                 pstr = communicator.proxyToString(p1);

--- a/matlab/test/lib/TestHelper.m
+++ b/matlab/test/lib/TestHelper.m
@@ -40,7 +40,7 @@ classdef TestHelper < handle
             end
 
             if length(protocol) == 0
-                protocol = properties.getPropertyWithDefault('Ice.Default.Protocol', 'default');
+                protocol = properties.getIceProperty('Ice.Default.Protocol');
             end
             port = properties.getPropertyAsIntWithDefault('Test.BasePort', 12010) + num;
             endpoint = sprintf('%s -p %d', protocol, port);
@@ -63,7 +63,7 @@ classdef TestHelper < handle
             else
                 properties = varargin{1};
             end
-            host = properties.getPropertyWithDefault('Ice.Default.Protocol', 'tcp');
+            host = properties.getIceProperty('Ice.Default.Protocol');
         end
 
         function port = getTestPort(obj, varargin)


### PR DESCRIPTION
The `getIceProperty` / `getIcePropertyAsInt` / `getIcePropertyAsList` accessors (added in Ice 3.8) resolve the default of a *known* Ice property from the registered property table. The MATLAB mapping was never updated to use them and still read several known Ice properties with `getProperty` or `getProperty…WithDefault` plus a hardcoded default, which can diverge from the registered default.

The most significant case: `InputStream` defaulted `Ice.ClassGraphDepthMax` to `100` instead of the registered `10`, so an unconfigured MATLAB client accepted class/value graphs nested up to 10× deeper than every other mapping (C++/C#/Java/JS/Swift/Python all default to 10 via `getIcePropertyAsInt`). `Communicator` likewise hardcoded the `Ice.Default.EncodingVersion` fallback, and `Ice.IPv6` (registered default `1`) was read with a plain getter that returns `0` when unset.

This updates the MATLAB library and tests to use `getIceProperty` for known Ice properties, matching C++:

**Library**
- `+Ice/InputStream.m` — `Ice.ClassGraphDepthMax`
- `+Ice/Communicator.m` — `Ice.Default.EncodingVersion` (and drop the now-unreachable empty-string branch, since `getIceProperty` returns the registered default)

**Tests** — `Ice.Default.SlicedFormat`, `Ice.Default.EncodingVersion`, `Ice.IPv6`, `Ice.Admin.Facets`, `Ice.Default.Host`, `Ice.Override.Compress`, `Ice.Default.Protocol`, matching the corresponding C++ tests.

Genuinely test-specific defaults (e.g. `Ice.Default.Host` → `127.0.0.1` in `TestHelper`) and non-Ice properties (`Test.BasePort`) intentionally keep `getProperty…WithDefault`, as in C++.

🤖 Generated with [Claude Code](https://claude.com/claude-code)