### PR TITLE
Fix IceStorm shutdown hang from lost wakeup in SubscriberLink::flush()

### DIFF
--- a/changelog.d/service-icestorm/5657.md
+++ b/changelog.d/service-icestorm/5657.md
@@ -1,0 +1,2 @@
+- Fixed a hang that could prevent IceStorm from shutting down cleanly when a cost-based topic link discarded all of
+  its remaining queued events (because their cost exceeded the link's cost) as its last outstanding request completed.

--- a/changelog.d/service-icestorm/5657.md
+++ b/changelog.d/service-icestorm/5657.md
@@ -1,2 +1,2 @@
-- Fixed a hang that could prevent IceStorm from shutting down cleanly when a cost-based topic link discarded all of
-  its remaining queued events (because their cost exceeded the link's cost) as its last outstanding request completed.
+- Fixed a hang that could prevent IceStorm from shutting down cleanly after a topic received messages whose
+  cost prevented their propagation on one of its links.

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -372,6 +372,13 @@ namespace
                 error(true, current_exception());
             }
         }
+
+        // If every queued event was filtered out by cost, we emptied _events without forwarding anything and no
+        // completion callback will fire; wake a waiting shutdown() ourselves, as SubscriberOneway::flush() does.
+        if (_events.empty() && _outstanding == 0 && _shutdown)
+        {
+            _condVar.notify_one();
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #5657.

`SubscriberLink::flush()` can drain its event queue to empty without ever calling `_condVar.notify_one()`. It swaps
`_events` into a local vector, cost-filters that vector, and discards every event whose `"cost"` request-context value
exceeds the link cost. When every event is discarded the send block (`if (!v.empty())`) is skipped, so the function
returns with `_events` empty and `_outstanding` still `0` but with no notify.

If that drain runs as the last outstanding forward completes during shutdown (`Subscriber::completed()` → `flush()`),
the `shutdown()` wait predicate (`_outstanding == 0 && _events.empty()`) is satisfied but never signalled, so
`shutdown()` blocks forever. Because `ServiceI::stop()` runs while holding the topic and topic-manager mutexes, the
whole IceStorm process hangs.

This is the same lost-wakeup class fixed for `Subscriber::error()` in #5655, on a sibling drain path that PR did not
touch. The fix adds the terminal notify that `SubscriberOneway::flush()` already performs. `SubscriberTwoway::flush()`
is unaffected: it only empties `_events` by sending (always `++_outstanding`), never by discarding.

A changelog fragment is included under `changelog.d/service-icestorm/`.

No test: like #5655, this timing- and config-gated lost wakeup has no proportionate deterministic reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
