### PR TITLE
Guard IceStorm observerAddSubscriber against a destroyed topic

### DIFF
--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -1006,6 +1006,12 @@ TopicImpl::observerAddSubscriber(const LogUpdate& llu, const SubscriberRecord& r
 {
     lock_guard lock(_subscribersMutex);
 
+    // Ignore updates for a destroyed topic.
+    if (_destroyed)
+    {
+        return;
+    }
+
     auto traceLevels = _instance->traceLevels();
     if (traceLevels->topic > 0)
     {


### PR DESCRIPTION
Adds a defensive `_destroyed` guard at the top of `TopicImpl::observerAddSubscriber` (the replica-side add-subscriber
apply path), matching the class idiom of checking `_destroyed` right after taking `_subscribersMutex` at every other
remote entry point (`observerDestroyTopic`, `subscribeAndGetPublisher`, `link`, `destroy`).

This is hardening, not a reachable bug fix. As analyzed in #5658, the master strictly serializes add-subscriber and
destroy for a topic: both hold the topic's `_subscribersMutex`, and `Observers::addSubscriber` waits synchronously for
every replica to apply the update before returning. So a destroy can't be in flight while an add is being applied on a
replica, and the lookup → release-`_mutex` → call window in `TopicManagerImpl::observerAddSubscriber` can never observe
`_destroyed` flip. No changelog fragment (no observable effect).

Closes #5658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
