### PR TITLE
Fix DataStorm partial-update crash when the receiver has no base for a key

### DIFF
--- a/changelog.d/datastorm/5661.md
+++ b/changelog.d/datastorm/5661.md
@@ -1,5 +1,7 @@
 - Fixed a bug in DataStorm where a partial update was not merged with the key's previous value when the receiver did
-  not already have that value: an element configured with `sampleCount = 0` (keep no history), or a reader that joins
-  after the value was published to a writer that keeps no history or whose history has aged out (`sampleLifetime`).
-  Applications using class-typed values typically crashed; with other value types, the fields not carried by the
-  update were silently reset to their defaults.
+  not already have that value: an element configured with `sampleCount = 0` (keep no history), a reader that joins
+  after the value was published to a writer that keeps no history or whose history has aged out (`sampleLifetime`),
+  or an any-key/filtered reader that receives history for only some of a writer's keys (for example with
+  `ClearHistory = OnAll`). The current per-key value is now bootstrapped for every such key. Applications using
+  class-typed values typically crashed; with other value types, the fields not carried by the update were silently
+  reset to their defaults.

--- a/changelog.d/datastorm/5661.md
+++ b/changelog.d/datastorm/5661.md
@@ -1,3 +1,4 @@
-- Fixed a crash in DataStorm when partial updates were used with `sampleCount = 0` (keep no history): the previous
-  sample used as the base for merging the update was never recorded, so the partial update resolved against a null
-  base. The per-key base is now maintained independently of history retention.
+- Fixed a bug in DataStorm where a partial update was not merged with the key's previous value when the
+  reader or writer was configured with `sampleCount = 0` (keep no history). Applications using class-typed
+  values typically crashed; with other value types, the fields not carried by the update were silently
+  reset to their defaults.

--- a/changelog.d/datastorm/5661.md
+++ b/changelog.d/datastorm/5661.md
@@ -1,4 +1,5 @@
-- Fixed a bug in DataStorm where a partial update was not merged with the key's previous value when the
-  reader or writer was configured with `sampleCount = 0` (keep no history). Applications using class-typed
-  values typically crashed; with other value types, the fields not carried by the update were silently
-  reset to their defaults.
+- Fixed a bug in DataStorm where a partial update was not merged with the key's previous value when the receiver did
+  not already have that value: an element configured with `sampleCount = 0` (keep no history), or a reader that joins
+  after the value was published to a writer that keeps no history or whose history has aged out (`sampleLifetime`).
+  Applications using class-typed values typically crashed; with other value types, the fields not carried by the
+  update were silently reset to their defaults.

--- a/changelog.d/datastorm/5661.md
+++ b/changelog.d/datastorm/5661.md
@@ -1,0 +1,3 @@
+- Fixed a crash in DataStorm when partial updates were used with `sampleCount = 0` (keep no history): the previous
+  sample used as the base for merging the update was never recorded, so the partial update resolved against a null
+  base. The per-key base is now maintained independently of history retention.

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -1286,9 +1286,45 @@ KeyDataWriterI::getSamples(
     DataSamples samples;
     samples.id = _keys.empty() ? -_id : _id;
 
-    // If the caller sample queueing is disabled, there is no need to return any samples.
+    // Append the current per-key base value(s) so a reader with no other init sample can still resolve subsequent
+    // partial updates. A removed key has no value and is skipped; a partial base is sent as a full Update. A single-key
+    // writer stores its base under a null publish key, so the key is matched on the sample rather than the map key.
+    auto appendBaseSamples = [&]
+    {
+        vector<DataSample> bases;
+        for (const auto& [baseKey, baseSample] : _lastByKey)
+        {
+            if (baseSample->id <= lastId || !baseSample->hasValue() || (key && key != baseSample->key) ||
+                (sampleFilter && !sampleFilter->match(baseSample)))
+            {
+                continue;
+            }
+
+            DataSample ds = toSample(baseSample, getCommunicator(), _keys.empty());
+            if (baseSample->event == DataStorm::SampleEvent::PartialUpdate)
+            {
+                ds.tag = 0;
+                ds.event = DataStorm::SampleEvent::Update;
+                ds.value = baseSample->encodeValue(getCommunicator());
+            }
+            bases.push_back(std::move(ds));
+        }
+
+        // _lastByKey is ordered by key (pointer), not by sample id. The subscriber records the last delivered
+        // sample's id as its lastId, so deliver the bases in ascending id order to keep the newest last; otherwise a
+        // higher-id base could be re-sent as a duplicate on the next resync.
+        sort(bases.begin(), bases.end(), [](const DataSample& lhs, const DataSample& rhs) { return lhs.id < rhs.id; });
+        for (auto& base : bases)
+        {
+            samples.samples.push_back(std::move(base));
+        }
+    };
+
+    // A reader that keeps no history still needs the current per-key base to resolve partial updates. Send just the
+    // base, not the history.
     if (config->sampleCount && *config->sampleCount == 0)
     {
+        appendBaseSamples();
         return samples;
     }
 
@@ -1349,10 +1385,17 @@ KeyDataWriterI::getSamples(
         }
     }
 
+    // If the reader received no history (a no-history writer, or all history aged out or was cleared), bootstrap it
+    // from the current per-key base so it can still resolve subsequent partial updates.
+    if (samples.samples.empty())
+    {
+        appendBaseSamples();
+    }
+
     if (!samples.samples.empty())
     {
         // If the first sample is a partial update, transform it to a full Update
-        if (first->event == DataStorm::SampleEvent::PartialUpdate)
+        if (first && first->event == DataStorm::SampleEvent::PartialUpdate)
         {
             samples.samples[0] = DataSample{
                 .id = first->id,

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -816,6 +816,11 @@ DataReaderI::initSamples(
     }
     _lastSendTime = valid.back()->timestamp;
 
+    // Record the resolved per-key bases before the sampleCount == 0 early-return below: the base is independent of
+    // history retention, so a reader that keeps no history must still resolve future partial updates against these
+    // values. valid is non-empty here (checked above), matching the previous placement of this assignment.
+    _lastByKey = std::move(previousByKey);
+
     if (_config->sampleLifetime && *_config->sampleLifetime > 0)
     {
         cleanOldSamples(_samples, now, *_config->sampleLifetime);
@@ -865,7 +870,6 @@ DataReaderI::initSamples(
         }
     }
     assert(!_samples.empty());
-    _lastByKey = std::move(previousByKey);
     _parent->_cond.notify_all();
 }
 
@@ -935,6 +939,11 @@ DataReaderI::queue(
     }
     _lastSendTime = sample->timestamp;
 
+    // Record the sample as the per-key base for resolving future partial updates. This must happen before the
+    // sampleCount == 0 early-return below: the base is independent of history retention, so a reader that keeps no
+    // history (sampleCount == 0) must still resolve a subsequent partial update against this value.
+    _lastByKey[sample->key] = sample;
+
     if (_onSamples)
     {
         _executor->queue([callback = _onSamples, sample] { callback(sample); });
@@ -976,7 +985,6 @@ DataReaderI::queue(
         _samples.clear();
     }
     _samples.push_back(sample);
-    _lastByKey[sample->key] = sample;
     _parent->_cond.notify_all();
 }
 
@@ -1065,6 +1073,10 @@ DataWriterI::publish(const shared_ptr<Key>& key, const shared_ptr<Sample>& sampl
     }
     send(key, sample);
 
+    // Record the sample as the per-key base for resolving future partial updates. This must happen before the
+    // sampleCount == 0 early-return below: the base is independent of history retention.
+    _lastByKey[key] = sample;
+
     if (_config->sampleLifetime && *_config->sampleLifetime > 0)
     {
         cleanOldSamples(_samples, sample->timestamp, *_config->sampleLifetime);
@@ -1096,7 +1108,6 @@ DataWriterI::publish(const shared_ptr<Key>& key, const shared_ptr<Sample>& sampl
     }
     assert(sample->key);
     _samples.push_back(sample);
-    _lastByKey[key] = sample;
 }
 
 KeyDataReaderI::KeyDataReaderI(

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -939,9 +939,7 @@ DataReaderI::queue(
     }
     _lastSendTime = sample->timestamp;
 
-    // Record the sample as the per-key base for resolving future partial updates. This must happen before the
-    // sampleCount == 0 early-return below: the base is independent of history retention, so a reader that keeps no
-    // history (sampleCount == 0) must still resolve a subsequent partial update against this value.
+    // The per-key base for partial updates is maintained even when the element keeps no history (sampleCount == 0).
     _lastByKey[sample->key] = sample;
 
     if (_onSamples)

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -816,9 +816,7 @@ DataReaderI::initSamples(
     }
     _lastSendTime = valid.back()->timestamp;
 
-    // Record the resolved per-key bases before the sampleCount == 0 early-return below: the base is independent of
-    // history retention, so a reader that keeps no history must still resolve future partial updates against these
-    // values. valid is non-empty here (checked above), matching the previous placement of this assignment.
+    // The per-key bases for partial updates are maintained even when the element keeps no history (sampleCount == 0).
     _lastByKey = std::move(previousByKey);
 
     if (_config->sampleLifetime && *_config->sampleLifetime > 0)

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -1069,8 +1069,7 @@ DataWriterI::publish(const shared_ptr<Key>& key, const shared_ptr<Sample>& sampl
     }
     send(key, sample);
 
-    // Record the sample as the per-key base for resolving future partial updates. This must happen before the
-    // sampleCount == 0 early-return below: the base is independent of history retention.
+    // The per-key base for partial updates is maintained even when the element keeps no history (sampleCount == 0).
     _lastByKey[key] = sample;
 
     if (_config->sampleLifetime && *_config->sampleLifetime > 0)

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -9,6 +9,7 @@
 #include "TraceUtil.h"
 
 #include <algorithm>
+#include <set>
 
 using namespace std;
 using namespace DataStormI;
@@ -1286,45 +1287,97 @@ KeyDataWriterI::getSamples(
     DataSamples samples;
     samples.id = _keys.empty() ? -_id : _id;
 
-    // Append the current per-key base value(s) so a reader with no other init sample can still resolve subsequent
-    // partial updates. A removed key has no value and is skipped; a partial base is sent as a full Update. A single-key
-    // writer stores its base under a null publish key, so the key is matched on the sample rather than the map key.
-    auto appendBaseSamples = [&]
+    // Orders the source samples to deliver by id, caps them to the reader's history depth, and delivers them. A
+    // partial base is sent as a full Update, and the earliest delivered sample of each key is likewise resolved to a
+    // full value so the reader always has a base to merge later partial updates for that key onto.
+    auto finalize = [&](vector<shared_ptr<Sample>> sources)
     {
-        vector<DataSample> bases;
-        for (const auto& [baseKey, baseSample] : _lastByKey)
-        {
-            if (baseSample->id <= lastId || !baseSample->hasValue() || (key && key != baseSample->key) ||
-                (sampleFilter && !sampleFilter->match(baseSample)))
-            {
-                continue;
-            }
+        sort(
+            sources.begin(),
+            sources.end(),
+            [](const shared_ptr<Sample>& lhs, const shared_ptr<Sample>& rhs) { return lhs->id < rhs->id; });
 
-            DataSample ds = toSample(baseSample, getCommunicator(), _keys.empty());
-            if (baseSample->event == DataStorm::SampleEvent::PartialUpdate)
+        // Never deliver more than the reader's sampleCount: the reader applies the batch atomically and caps its own
+        // history to sampleCount, so a larger batch would exceed the cap. sampleCount == 0 keeps no history and is
+        // handled by the caller (the reader records the bases in its per-key state without keeping them). When
+        // capping, keep the newest sample of each key first so every key the reader may later receive a partial
+        // update for keeps a resolvable base, then fill any remaining budget with the newest of the other samples.
+        if (config->sampleCount && *config->sampleCount > 0 &&
+            sources.size() > static_cast<size_t>(*config->sampleCount))
+        {
+            auto maxCount = static_cast<size_t>(*config->sampleCount);
+            vector<bool> keep(sources.size(), false);
+            size_t kept = 0;
+            set<shared_ptr<Key>> keptKeys;
+            // First pass (newest to oldest): reserve a slot for the newest sample of each key.
+            for (size_t i = sources.size(); i-- > 0 && kept < maxCount;)
+            {
+                if (keptKeys.insert(sources[i]->key).second)
+                {
+                    keep[i] = true;
+                    ++kept;
+                }
+            }
+            // Second pass (newest to oldest): fill the remaining budget with the newest not-yet-kept samples.
+            for (size_t i = sources.size(); i-- > 0 && kept < maxCount;)
+            {
+                if (!keep[i])
+                {
+                    keep[i] = true;
+                    ++kept;
+                }
+            }
+            vector<shared_ptr<Sample>> capped;
+            capped.reserve(kept);
+            for (size_t i = 0; i < sources.size(); ++i)
+            {
+                if (keep[i])
+                {
+                    capped.push_back(sources[i]);
+                }
+            }
+            sources = std::move(capped);
+        }
+
+        set<shared_ptr<Key>> seen;
+        for (const auto& sample : sources)
+        {
+            DataSample ds = toSample(sample, getCommunicator(), _keys.empty());
+            // The earliest delivered sample of each key must carry a full value; a partial is sent as a full Update
+            // built from the sample's own resolved value.
+            if (seen.insert(sample->key).second && sample->event == DataStorm::SampleEvent::PartialUpdate)
             {
                 ds.tag = 0;
                 ds.event = DataStorm::SampleEvent::Update;
-                ds.value = baseSample->encodeValue(getCommunicator());
+                ds.value = sample->encodeValue(getCommunicator());
             }
-            bases.push_back(std::move(ds));
+            samples.samples.push_back(std::move(ds));
         }
+    };
 
-        // _lastByKey is ordered by key (pointer), not by sample id. The subscriber records the last delivered
-        // sample's id as its lastId, so deliver the bases in ascending id order to keep the newest last; otherwise a
-        // higher-id base could be re-sent as a duplicate on the next resync.
-        sort(bases.begin(), bases.end(), [](const DataSample& lhs, const DataSample& rhs) { return lhs.id < rhs.id; });
-        for (auto& base : bases)
+    // Collects the current per-key base for every key that passes the caller's key/sample filter and is newer than
+    // lastId; `covered` excludes keys already represented by the writer's history. A removed key has no value and is
+    // skipped. A single-key writer stores its base under a null publish key, so the key is matched on the sample.
+    auto collectBases = [&](const set<shared_ptr<Key>>& covered)
+    {
+        vector<shared_ptr<Sample>> bases;
+        for (const auto& [baseKey, baseSample] : _lastByKey)
         {
-            samples.samples.push_back(std::move(base));
+            if (baseSample->id <= lastId || !baseSample->hasValue() || (key && key != baseSample->key) ||
+                (sampleFilter && !sampleFilter->match(baseSample)) || covered.count(baseSample->key))
+            {
+                continue;
+            }
+            bases.push_back(baseSample);
         }
+        return bases;
     };
 
     // A reader that keeps no history still needs the current per-key base to resolve partial updates. Send just the
     // base, not the history.
     if (config->sampleCount && *config->sampleCount == 0)
     {
-        appendBaseSamples();
+        finalize(collectBases({}));
         return samples;
     }
 
@@ -1341,16 +1394,15 @@ KeyDataWriterI::getSamples(
         staleTime = now - chrono::milliseconds(*config->sampleLifetime);
     }
 
-    shared_ptr<Sample> first;
     // Iterate through samples in reverse chronological order, starting with the newest.
     // Stop iterating if any of the following conditions are met:
     // - A sample's timestamp is older than the specified stale time.
     // - A sample's ID is less than or equal to the specified last ID.
     // - The requested number of samples has been collected.
     // - A sample event triggers history clearing based on the caller's clear history policy.
-    // For each sample:
-    // - Check if it matches the optional key and sample filter.
-    // - If it matches, add it to the result set and update the first matched sample.
+    // For each matching sample, add it to the source set and record the key it covers.
+    vector<shared_ptr<Sample>> sources;
+    set<shared_ptr<Key>> covered;
     for (auto p = _samples.rbegin(); p != _samples.rend(); ++p)
     {
         if ((*p)->timestamp < staleTime)
@@ -1364,10 +1416,10 @@ KeyDataWriterI::getSamples(
 
         if ((!key || key == (*p)->key) && (!sampleFilter || sampleFilter->match(*p)))
         {
-            first = *p;
-            samples.samples.push_front(toSample(*p, getCommunicator(), _keys.empty()));
+            sources.push_back(*p);
+            covered.insert((*p)->key);
             if (config->sampleCount && *config->sampleCount > 0 &&
-                static_cast<size_t>(*config->sampleCount) == samples.samples.size())
+                static_cast<size_t>(*config->sampleCount) == sources.size())
             {
                 break;
             }
@@ -1385,28 +1437,11 @@ KeyDataWriterI::getSamples(
         }
     }
 
-    // If the reader received no history (a no-history writer, or all history aged out or was cleared), bootstrap it
-    // from the current per-key base so it can still resolve subsequent partial updates.
-    if (samples.samples.empty())
-    {
-        appendBaseSamples();
-    }
-
-    if (!samples.samples.empty())
-    {
-        // If the first sample is a partial update, transform it to a full Update
-        if (first && first->event == DataStorm::SampleEvent::PartialUpdate)
-        {
-            samples.samples[0] = DataSample{
-                .id = first->id,
-                .keyId = samples.samples[0].keyId,
-                .keyValue = samples.samples[0].keyValue,
-                .timestamp = chrono::time_point_cast<chrono::microseconds>(first->timestamp).time_since_epoch().count(),
-                .tag = 0,
-                .event = DataStorm::SampleEvent::Update,
-                .value = first->encodeValue(getCommunicator())};
-        }
-    }
+    // Bootstrap the base for every key the history does not already cover (trimmed by ClearHistory, aged out, or a
+    // no-history writer) so the reader can resolve later partial updates for those keys too.
+    auto bases = collectBases(covered);
+    sources.insert(sources.end(), bases.begin(), bases.end());
+    finalize(std::move(sources));
     return samples;
 }
 

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -825,26 +825,9 @@ DataReaderI::initSamples(
         cleanOldSamples(_samples, now, *_config->sampleLifetime);
     }
 
-    if (_config->sampleCount)
+    if (_config->sampleCount && *_config->sampleCount == 0)
     {
-        if (*_config->sampleCount > 0)
-        {
-            size_t count = _samples.size();
-            auto maxCount = static_cast<size_t>(*_config->sampleCount);
-            if (count + valid.size() > maxCount)
-            {
-                count = count + valid.size() - maxCount;
-                while (!_samples.empty() && count-- > 0)
-                {
-                    _samples.pop_front();
-                }
-                assert(_samples.size() + valid.size() == maxCount);
-            }
-        }
-        else if (*_config->sampleCount == 0)
-        {
-            return; // Don't keep history
-        }
+        return; // Don't keep history
     }
 
     if (_config->clearHistory && *_config->clearHistory == ClearHistoryPolicy::OnAll)
@@ -868,6 +851,18 @@ DataReaderI::initSamples(
             _samples.push_back(s);
         }
     }
+
+    // Keep at most sampleCount samples. The init batch can exceed sampleCount when the writer delivers one base per
+    // key (an any-key reader joining a writer with more distinct keys than sampleCount); those per-key bases were
+    // already recorded in _lastByKey above, so trimming the surplus from the visible history here is safe.
+    if (_config->sampleCount && *_config->sampleCount > 0)
+    {
+        while (_samples.size() > static_cast<size_t>(*_config->sampleCount))
+        {
+            _samples.pop_front();
+        }
+    }
+
     assert(!_samples.empty());
     _parent->_cond.notify_all();
 }
@@ -1297,11 +1292,12 @@ KeyDataWriterI::getSamples(
             sources.end(),
             [](const shared_ptr<Sample>& lhs, const shared_ptr<Sample>& rhs) { return lhs->id < rhs->id; });
 
-        // Never deliver more than the reader's sampleCount: the reader applies the batch atomically and caps its own
-        // history to sampleCount, so a larger batch would exceed the cap. sampleCount == 0 keeps no history and is
-        // handled by the caller (the reader records the bases in its per-key state without keeping them). When
-        // capping, keep the newest sample of each key first so every key the reader may later receive a partial
-        // update for keeps a resolvable base, then fill any remaining budget with the newest of the other samples.
+        // Cap the batch to the reader's sampleCount, but keep the newest sample of every key even when the number of
+        // distinct keys exceeds sampleCount: each key the reader may later receive a partial update for needs a
+        // resolvable base. The reader records these bases in _lastByKey before capping its own visible history, so
+        // delivering one per key never overflows it. sampleCount == 0 keeps no history and is handled by the caller
+        // (the reader still records the bases). First reserve the newest sample of each key, then fill any remaining
+        // budget with the newest of the other samples.
         if (config->sampleCount && *config->sampleCount > 0 &&
             sources.size() > static_cast<size_t>(*config->sampleCount))
         {
@@ -1309,8 +1305,8 @@ KeyDataWriterI::getSamples(
             vector<bool> keep(sources.size(), false);
             size_t kept = 0;
             set<shared_ptr<Key>> keptKeys;
-            // First pass (newest to oldest): reserve a slot for the newest sample of each key.
-            for (size_t i = sources.size(); i-- > 0 && kept < maxCount;)
+            // First pass (newest to oldest): reserve the newest sample of every key, even past maxCount.
+            for (size_t i = sources.size(); i-- > 0;)
             {
                 if (keptKeys.insert(sources[i]->key).second)
                 {

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1220,8 +1220,13 @@ SessionI::subscriberInitialized(
     }
     else
     {
-        assert(samples.front().id > elementSubscriber->lastId);
-        elementSubscriber->lastId = samples.back().id;
+        // A multi-key subscriber shares a single ElementSubscriber across its keys, and the peer acks one batch per
+        // key, so this runs once per key with sample ids interleaved across keys — a later batch need not strictly
+        // follow the previous one. Advance lastId monotonically to the newest id seen (samples are ordered by id).
+        if (samples.back().id > elementSubscriber->lastId)
+        {
+            elementSubscriber->lastId = samples.back().id;
+        }
 
         vector<shared_ptr<Sample>> samplesI;
         samplesI.reserve(samples.size());

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -117,8 +117,7 @@ void ::Reader::run(int argc, char* argv[])
     }
 
     // A sampleCount=0 reader keeps no history but must still resolve a partial update against the previous full
-    // sample of the same key. Before the fix the per-key base was recorded only on the history-keeping path, so with
-    // sampleCount=0 the partial resolved against a null base and the class-typed updater dereferenced it.
+    // sample of the same key.
     Topic<string, StockPtr> noHistoryTopic(node, "noHistoryTopic");
     noHistoryTopic.setReaderDefaultConfig(config);
     noHistoryTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -245,6 +245,57 @@ void ::Reader::run(int argc, char* argv[])
         test(aapl->lastBid == 13.0f); // resolved against the bootstrapped base
         test(aapl->lastAsk == 14.0f);
     }
+
+    // A late any-key reader with the default history policy fetches only the newest sample for all keys, so AAPL's
+    // full value (trimmed from the writer's history) must be bootstrapped from the per-key base for the partial
+    // update to resolve rather than crash on a null base.
+    Topic<string, StockPtr> trimTopic(node, "trimHistoryTopic"); // default config: ClearHistory=OnAll
+    trimTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> trimBarrier(node, "trimHistoryBarrier");
+    {
+        [[maybe_unused]] auto _ = makeSingleKeyReader(trimBarrier, "barrier").getNextUnread();
+
+        auto reader = makeAnyKeyReader(trimTopic);
+        shared_ptr<Stock> aapl;
+        while (!aapl)
+        {
+            auto sample = reader.getNextUnread();
+            if (sample.getKey() == "AAPL" && sample.getEvent() == SampleEvent::PartialUpdate)
+            {
+                aapl = sample.getValue();
+            }
+        }
+        test(aapl->price == 15.0f);
+        test(aapl->lastBid == 13.0f); // carried from AAPL's own base, bootstrapped after the history trim
+        test(aapl->lastAsk == 14.0f);
+    }
+
+    // A reader with a limited sampleCount joins a writer where one key (GOOG) has more history samples than another
+    // (AAPL). Capping the init batch to sampleCount must keep AAPL's base, not just GOOG's two newest samples, so a
+    // later partial update on AAPL resolves rather than crashing on a null base.
+    Topic<string, StockPtr> capTopic(node, "capTopic");
+    capTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> capBarrier(node, "capBarrier");
+    {
+        [[maybe_unused]] auto _ = makeSingleKeyReader(capBarrier, "barrier").getNextUnread();
+
+        ReaderConfig limited;
+        limited.sampleCount = 2;
+        limited.clearHistory = ClearHistoryPolicy::Never;
+        auto reader = makeAnyKeyReader(capTopic, "", limited);
+        shared_ptr<Stock> aapl;
+        while (!aapl)
+        {
+            auto sample = reader.getNextUnread();
+            if (sample.getKey() == "AAPL" && sample.getEvent() == SampleEvent::PartialUpdate)
+            {
+                aapl = sample.getValue();
+            }
+        }
+        test(aapl->price == 15.0f);
+        test(aapl->lastBid == 13.0f); // AAPL's base survived the cap (not evicted by GOOG's extra history)
+        test(aapl->lastAsk == 14.0f);
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -4,6 +4,8 @@
 #include "Test.h"
 #include "TestHelper.h"
 
+#include <future>
+
 using namespace DataStorm;
 using namespace std;
 using namespace Test;
@@ -112,6 +114,43 @@ void ::Reader::run(int argc, char* argv[])
 
         sample = reader.getNextUnread(); // from writer 2: attach runs getLastIds over the stale entry
         test(sample.getValue() == 2);
+    }
+
+    // A sampleCount=0 reader keeps no history but must still resolve a partial update against the previous full
+    // sample of the same key. Before the fix the per-key base was recorded only on the history-keeping path, so with
+    // sampleCount=0 the partial resolved against a null base and the class-typed updater dereferenced it.
+    Topic<string, StockPtr> noHistoryTopic(node, "noHistoryTopic");
+    noHistoryTopic.setReaderDefaultConfig(config);
+    noHistoryTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> noHistoryBarrier(node, "noHistoryBarrier");
+    {
+        ReaderConfig noHistory;
+        noHistory.sampleCount = 0;
+        auto reader = makeSingleKeyReader(noHistoryTopic, "AAPL", "", noHistory);
+
+        // A sampleCount=0 reader keeps no history, so getNextUnread would never return; observe samples through the
+        // update callback instead. It fires for the Add (which establishes the base) and then the partial update.
+        promise<shared_ptr<Stock>> partial;
+        reader.onSamples(
+            [](const vector<Sample<string, StockPtr>>&) {},
+            [&partial](const Sample<string, StockPtr>& sample)
+            {
+                if (sample.getEvent() == SampleEvent::PartialUpdate)
+                {
+                    partial.set_value(sample.getValue());
+                }
+            });
+
+        // Tell the writer the callback is installed so it can publish.
+        auto barrier = makeSingleKeyWriter(noHistoryBarrier, "barrier");
+        barrier.waitForReaders();
+        barrier.update(0);
+
+        auto aapl = partial.get_future().get();
+        test(aapl);
+        test(aapl->price == 15.0f);   // the partial update
+        test(aapl->lastBid == 13.0f); // carried over from the base, not a default-constructed 0
+        test(aapl->lastAsk == 14.0f);
     }
 }
 

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -151,6 +151,100 @@ void ::Reader::run(int argc, char* argv[])
         test(aapl->lastBid == 13.0f); // carried over from the base, not a default-constructed 0
         test(aapl->lastAsk == 14.0f);
     }
+
+    // A reader that joins after a no-history (sampleCount == 0) writer's initial value is bootstrapped with the
+    // writer's current per-key base value, so a subsequent partial update resolves against it instead of crashing on
+    // a null base.
+    Topic<string, StockPtr> lateJoinTopic(node, "lateJoinTopic");
+    lateJoinTopic.setReaderDefaultConfig(config);
+    lateJoinTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> lateJoinBarrier(node, "lateJoinBarrier");
+    {
+        // Wait until the writer has published its initial value, then attach as a late joiner.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(lateJoinBarrier, "barrier").getNextUnread();
+
+        auto reader = makeSingleKeyReader(lateJoinTopic, "AAPL");
+
+        // The reader receives the bootstrapped base, then the resolved partial update, then a later full value.
+        shared_ptr<Stock> resolved;
+        for (int i = 0; i < 3; ++i)
+        {
+            auto sample = reader.getNextUnread();
+            if (sample.getEvent() == SampleEvent::PartialUpdate)
+            {
+                resolved = sample.getValue();
+            }
+        }
+        test(resolved);
+        test(resolved->price == 15.0f);   // the partial update
+        test(resolved->lastBid == 13.0f); // carried from the bootstrapped base, not a default-constructed 0
+        test(resolved->lastAsk == 14.0f);
+    }
+
+    // Same as above, but the writer keeps history with a short sampleLifetime; the full sample ages out before the
+    // reader joins, so the reader must still be bootstrapped from the (lifetime-independent) per-key base.
+    Topic<string, StockPtr> lifetimeTopic(node, "lifetimeTopic");
+    lifetimeTopic.setReaderDefaultConfig(config);
+    lifetimeTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> lifetimeBarrier(node, "lifetimeBarrier");
+    {
+        [[maybe_unused]] auto _ = makeSingleKeyReader(lifetimeBarrier, "barrier").getNextUnread();
+
+        auto reader = makeSingleKeyReader(lifetimeTopic, "AAPL");
+
+        shared_ptr<Stock> resolved;
+        for (int i = 0; i < 3; ++i)
+        {
+            auto sample = reader.getNextUnread();
+            if (sample.getEvent() == SampleEvent::PartialUpdate)
+            {
+                resolved = sample.getValue();
+            }
+        }
+        test(resolved);
+        test(resolved->price == 15.0f);
+        test(resolved->lastBid == 13.0f); // carried from the aged-out-but-still-current base
+        test(resolved->lastAsk == 14.0f);
+    }
+
+    // A reader that keeps no history (sampleCount == 0) and joins after the writer's add is bootstrapped with the base
+    // value, so the subsequent partial update resolves against it. A sampleCount=0 reader keeps no history, so it is
+    // observed through the onSamples callback.
+    Topic<string, StockPtr> lateReaderTopic(node, "lateReaderTopic");
+    lateReaderTopic.setReaderDefaultConfig(config);
+    lateReaderTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> lateReaderJoinBarrier(node, "lateReaderJoinBarrier");
+    Topic<string, int> lateReaderReadyBarrier(node, "lateReaderReadyBarrier");
+    {
+        // Wait until the add is published, then join late with sampleCount=0.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(lateReaderJoinBarrier, "barrier").getNextUnread();
+
+        ReaderConfig noHistory;
+        noHistory.sampleCount = 0;
+        auto reader = makeSingleKeyReader(lateReaderTopic, "AAPL", "", noHistory);
+
+        promise<shared_ptr<Stock>> partial;
+        reader.onSamples(
+            [](const vector<Sample<string, StockPtr>>&) {},
+            [&partial](const Sample<string, StockPtr>& sample)
+            {
+                if (sample.getEvent() == SampleEvent::PartialUpdate)
+                {
+                    partial.set_value(sample.getValue());
+                }
+            });
+
+        // Tell the writer the callback is installed.
+        auto readyBarrier = makeSingleKeyWriter(lateReaderReadyBarrier, "barrier");
+        readyBarrier.waitForReaders();
+        readyBarrier.update(0);
+
+        auto aapl = partial.get_future().get();
+        test(aapl);
+        test(aapl->price == 15.0f);
+        test(aapl->lastBid == 13.0f); // resolved against the bootstrapped base
+        test(aapl->lastAsk == 14.0f);
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -270,9 +270,10 @@ void ::Reader::run(int argc, char* argv[])
         test(aapl->lastAsk == 14.0f);
     }
 
-    // A reader with a limited sampleCount joins a writer where one key (GOOG) has more history samples than another
-    // (AAPL). Capping the init batch to sampleCount must keep AAPL's base, not just GOOG's two newest samples, so a
-    // later partial update on AAPL resolves rather than crashing on a null base.
+    // A reader with a limited sampleCount joins a writer that has more distinct keys (MSFT, AAPL, GOOG) than the
+    // reader's sampleCount, with GOOG carrying extra history. Capping the init batch to sampleCount must keep a base
+    // for every key, including MSFT (the oldest, which a naive "newest N samples" cap drops), so a later partial
+    // update on MSFT resolves rather than crashing on a null base.
     Topic<string, StockPtr> capTopic(node, "capTopic");
     capTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
     Topic<string, int> capBarrier(node, "capBarrier");
@@ -283,18 +284,18 @@ void ::Reader::run(int argc, char* argv[])
         limited.sampleCount = 2;
         limited.clearHistory = ClearHistoryPolicy::Never;
         auto reader = makeAnyKeyReader(capTopic, "", limited);
-        shared_ptr<Stock> aapl;
-        while (!aapl)
+        shared_ptr<Stock> msft;
+        while (!msft)
         {
             auto sample = reader.getNextUnread();
-            if (sample.getKey() == "AAPL" && sample.getEvent() == SampleEvent::PartialUpdate)
+            if (sample.getKey() == "MSFT" && sample.getEvent() == SampleEvent::PartialUpdate)
             {
-                aapl = sample.getValue();
+                msft = sample.getValue();
             }
         }
-        test(aapl->price == 15.0f);
-        test(aapl->lastBid == 13.0f); // AAPL's base survived the cap (not evicted by GOOG's extra history)
-        test(aapl->lastAsk == 14.0f);
+        test(msft->price == 55.0f);
+        test(msft->lastBid == 51.0f); // MSFT's base survived the cap despite the key count exceeding sampleCount
+        test(msft->lastAsk == 52.0f);
     }
 }
 

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -189,6 +189,52 @@ void ::Writer::run(int argc, char* argv[])
         writer.waitForNoReaders();
     }
     cout << "ok" << endl;
+
+    // An any-key (or filtered) reader fetches all keys in a single request. With the default history policy
+    // (ClearHistory=OnAll) the writer keeps only the newest sample, so a late joiner receives the newest key's
+    // value and every other key's base must be bootstrapped from the per-key base, not merged onto a null base.
+    Topic<string, StockPtr> trimTopic(node, "trimHistoryTopic"); // default config: ClearHistory=OnAll
+    trimTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> trimBarrier(node, "trimHistoryBarrier");
+    cout << "testing partial update to a late any-key reader after the writer trimmed the key's history... " << flush;
+    {
+        auto writer = makeAnyKeyWriter(trimTopic);
+        writer.add("AAPL", make_shared<Stock>(12.0f, 13.0f, 14.0f));
+        writer.add("GOOG", make_shared<Stock>(100.0f, 101.0f, 102.0f)); // clears history: only GOOG's full value kept
+
+        auto barrier = makeSingleKeyWriter(trimBarrier, "barrier");
+        barrier.waitForReaders();
+        barrier.update(0);
+
+        writer.waitForReaders();
+        writer.partialUpdate<float>("price")("AAPL", 15.0f); // AAPL's full value was trimmed; must still resolve
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // When a reader with a limited sampleCount joins a multi-key writer, capping the init batch must keep at least
+    // one value per key, not just the newest N samples overall: here GOOG has two samples and AAPL one, and a
+    // sampleCount=2 reader must still receive AAPL's base so a later partial update on AAPL resolves.
+    Topic<string, StockPtr> capTopic(node, "capTopic");
+    capTopic.setWriterDefaultConfig(config); // keep full history
+    capTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> capBarrier(node, "capBarrier");
+    cout << "testing sampleCount cap keeps a base per key... " << flush;
+    {
+        auto writer = makeAnyKeyWriter(capTopic);
+        writer.add("AAPL", make_shared<Stock>(12.0f, 13.0f, 14.0f)); // id 1
+        writer.add("GOOG", make_shared<Stock>(100.0f, 101.0f, 102.0f));
+        writer.update("GOOG", make_shared<Stock>(200.0f, 201.0f, 202.0f)); // two GOOG samples
+
+        auto barrier = makeSingleKeyWriter(capBarrier, "barrier");
+        barrier.waitForReaders();
+        barrier.update(0);
+
+        writer.waitForReaders();
+        writer.partialUpdate<float>("price")("AAPL", 15.0f); // resolves only if AAPL's base survived the cap
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
 }
 
 DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -7,6 +7,9 @@
 #include "Test.h"
 #include "TestHelper.h"
 
+#include <chrono>
+#include <thread>
+
 using namespace DataStorm;
 using namespace std;
 using namespace Test;
@@ -98,6 +101,90 @@ void ::Writer::run(int argc, char* argv[])
         // observes samples only through that callback, which must be registered before we publish.
         [[maybe_unused]] auto _ = makeSingleKeyReader(noHistoryBarrier, "barrier").getNextUnread();
         writer.add(make_shared<Stock>(12.0f, 13.0f, 14.0f));
+        writer.partialUpdate<float>("price")(15.0f);
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // A reader that joins after a no-history (sampleCount == 0) writer's initial value is bootstrapped with the
+    // writer's current per-key base value, so a subsequent partial update resolves against it rather than crashing on
+    // a null base.
+    Topic<string, StockPtr> lateJoinTopic(node, "lateJoinTopic");
+    WriterConfig noHistoryWriter;
+    noHistoryWriter.sampleCount = 0;
+    lateJoinTopic.setWriterDefaultConfig(noHistoryWriter);
+    lateJoinTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> lateJoinBarrier(node, "lateJoinBarrier");
+    cout << "testing partial update to a late joiner of a no-history writer... " << flush;
+    {
+        auto writer = makeSingleKeyWriter(lateJoinTopic, "AAPL");
+
+        // Publish the initial full value before any reader connects. The writer keeps no history, so this snapshot is
+        // not retained and a later reader cannot be bootstrapped with it.
+        writer.add(make_shared<Stock>(12.0f, 13.0f, 14.0f));
+
+        // Let the reader attach as a late joiner, after the add.
+        auto barrier = makeSingleKeyWriter(lateJoinBarrier, "barrier");
+        barrier.waitForReaders();
+        barrier.update(0);
+
+        writer.waitForReaders();
+        writer.partialUpdate<float>("price")(15.0f);            // resolves against the bootstrapped base
+        writer.update(make_shared<Stock>(20.0f, 21.0f, 22.0f)); // a later full value
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // The base is also unavailable when the writer keeps history (sampleCount != 0) but the full sample has aged out
+    // of that history (sampleLifetime). A late joiner then gets no init sample, yet must still be bootstrapped from
+    // the per-key base, which is not subject to the sample lifetime.
+    Topic<string, StockPtr> lifetimeTopic(node, "lifetimeTopic");
+    WriterConfig lifetimeWriter;
+    lifetimeWriter.sampleCount = -1;     // keep history...
+    lifetimeWriter.sampleLifetime = 100; // ...but only for 100ms
+    lifetimeWriter.clearHistory = ClearHistoryPolicy::Never;
+    lifetimeTopic.setWriterDefaultConfig(lifetimeWriter);
+    lifetimeTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> lifetimeBarrier(node, "lifetimeBarrier");
+    cout << "testing partial update to a late joiner after the base aged out (sampleLifetime)... " << flush;
+    {
+        auto writer = makeSingleKeyWriter(lifetimeTopic, "AAPL");
+        writer.add(make_shared<Stock>(12.0f, 13.0f, 14.0f));
+
+        // Wait until the full sample has aged out of the writer's history, then let the reader join.
+        this_thread::sleep_for(chrono::milliseconds(500));
+
+        auto barrier = makeSingleKeyWriter(lifetimeBarrier, "barrier");
+        barrier.waitForReaders();
+        barrier.update(0);
+
+        writer.waitForReaders();
+        writer.partialUpdate<float>("price")(15.0f);
+        writer.update(make_shared<Stock>(20.0f, 21.0f, 22.0f));
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // A reader that keeps no history (sampleCount == 0) and joins after the writer's add is bootstrapped with the base
+    // value (sent even though it keeps no history), so a subsequent partial update resolves against it.
+    Topic<string, StockPtr> lateReaderTopic(node, "lateReaderTopic");
+    lateReaderTopic.setWriterDefaultConfig(config); // writer keeps history
+    lateReaderTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> lateReaderJoinBarrier(node, "lateReaderJoinBarrier");
+    Topic<string, int> lateReaderReadyBarrier(node, "lateReaderReadyBarrier");
+    cout << "testing partial update to a late-joining sampleCount=0 reader... " << flush;
+    {
+        auto writer = makeSingleKeyWriter(lateReaderTopic, "AAPL");
+        writer.add(make_shared<Stock>(12.0f, 13.0f, 14.0f));
+
+        // Tell the reader the add is published; it can now join as a late joiner.
+        auto joinBarrier = makeSingleKeyWriter(lateReaderJoinBarrier, "barrier");
+        joinBarrier.waitForReaders();
+        joinBarrier.update(0);
+
+        // Wait until the reader has installed its onSamples callback before publishing the partial.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(lateReaderReadyBarrier, "barrier").getNextUnread();
+
         writer.partialUpdate<float>("price")(15.0f);
         writer.waitForNoReaders();
     }

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -212,9 +212,11 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
-    // When a reader with a limited sampleCount joins a multi-key writer, capping the init batch must keep at least
-    // one value per key, not just the newest N samples overall: here GOOG has two samples and AAPL one, and a
-    // sampleCount=2 reader must still receive AAPL's base so a later partial update on AAPL resolves.
+    // When a reader with a limited sampleCount joins a writer whose number of distinct keys exceeds that sampleCount,
+    // capping the init batch must keep one value per key (a resolvable base), not just the newest N samples overall.
+    // Here three keys (MSFT, AAPL, GOOG) share a sampleCount=2 reader and GOOG has extra history, so a naive "newest
+    // two samples" cap would drop MSFT's base entirely. The cap must keep it so a later partial update on MSFT
+    // resolves.
     Topic<string, StockPtr> capTopic(node, "capTopic");
     capTopic.setWriterDefaultConfig(config); // keep full history
     capTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
@@ -222,16 +224,17 @@ void ::Writer::run(int argc, char* argv[])
     cout << "testing sampleCount cap keeps a base per key... " << flush;
     {
         auto writer = makeAnyKeyWriter(capTopic);
-        writer.add("AAPL", make_shared<Stock>(12.0f, 13.0f, 14.0f)); // id 1
-        writer.add("GOOG", make_shared<Stock>(100.0f, 101.0f, 102.0f));
-        writer.update("GOOG", make_shared<Stock>(200.0f, 201.0f, 202.0f)); // two GOOG samples
+        writer.add("MSFT", make_shared<Stock>(50.0f, 51.0f, 52.0f));       // id 1 (oldest)
+        writer.add("AAPL", make_shared<Stock>(12.0f, 13.0f, 14.0f));       // id 2
+        writer.add("GOOG", make_shared<Stock>(100.0f, 101.0f, 102.0f));    // id 3
+        writer.update("GOOG", make_shared<Stock>(200.0f, 201.0f, 202.0f)); // id 4, two GOOG samples
 
         auto barrier = makeSingleKeyWriter(capBarrier, "barrier");
         barrier.waitForReaders();
         barrier.update(0);
 
         writer.waitForReaders();
-        writer.partialUpdate<float>("price")("AAPL", 15.0f); // resolves only if AAPL's base survived the cap
+        writer.partialUpdate<float>("price")("MSFT", 55.0f); // resolves only if MSFT's base survived the cap
         writer.waitForNoReaders();
     }
     cout << "ok" << endl;

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -83,6 +83,25 @@ void ::Writer::run(int argc, char* argv[])
         writer.add("k2", 2);
     }
     cout << "ok" << endl;
+
+    // A reader that keeps no history (sampleCount == 0) must still resolve a partial update against the previous
+    // full sample of the same key, because the per-key base is recorded independently of history retention.
+    Topic<string, StockPtr> noHistoryTopic(node, "noHistoryTopic");
+    noHistoryTopic.setWriterDefaultConfig(config);
+    noHistoryTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> noHistoryBarrier(node, "noHistoryBarrier");
+    cout << "testing partial update delivered to a sampleCount=0 reader... " << flush;
+    {
+        auto writer = makeSingleKeyWriter(noHistoryTopic, "AAPL");
+        writer.waitForReaders();
+        // Wait until the reader has installed its onSamples callback: a sampleCount=0 reader keeps no history, so it
+        // observes samples only through that callback, which must be registered before we publish.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(noHistoryBarrier, "barrier").getNextUnread();
+        writer.add(make_shared<Stock>(12.0f, 13.0f, 14.0f));
+        writer.partialUpdate<float>("price")(15.0f);
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
 }
 
 DEFINE_TEST(::Writer)


### PR DESCRIPTION
Fixes Symptom 2 of #5661 — a partial update crashing (or silently losing state) when the receiver has no base for
the key it applies to. The unbounded-growth concern (Symptom 1) remains tracked in #5661, retargeted to 3.9.0.

DataStorm resolves a partial update against the previous full value of the *same* key, held in the per-key base map
`_lastByKey`. That base is independent of history retention. When it is missing, the updater receives a
default-constructed value — a null `shared_ptr` for a class-typed value — and the user updater dereferences it →
crash; for scalar/struct values the fields not carried by the update are silently reset to their defaults.

This PR closes the cases where the receiver could be left without a base:

- **`sampleCount == 0` (keep no history).** `DataReaderI::queue`, `DataWriterI::publish`, and
  `DataReaderI::initSamples` recorded `_lastByKey` only *after* the `sampleCount == 0` early-return, so such an
  element never stored the base. They now record it before the early-return.
- **Late joiners of a writer that keeps no history, or whose history aged out (`sampleLifetime`).** The writer now
  bootstraps a late-joining reader from the per-key base (which is not subject to history retention).
- **Any-key / filtered readers that receive history for only some of a writer's keys.** An any-key or filtered
  reader fetches all keys in a single request. When a key's full value is not in the returned history — e.g. with
  the default `ClearHistory = OnAll`, which keeps only the newest sample overall — `KeyDataWriterI::getSamples` now
  appends the current base for every key the history does not already cover, instead of only bootstrapping when the
  whole response is empty.

Supporting changes in `KeyDataWriterI::getSamples` / `DataReaderI::initSamples` / `SessionI::subscriberInitialized`:

- **The init batch keeps a base for every key, even when the writer has more distinct keys than the reader's
  `sampleCount`.** `getSamples` reserves the newest sample of each key first, then fills any remaining `sampleCount`
  budget with the newest of the other samples; `initSamples` records these per-key bases in `_lastByKey` before
  capping its own visible history back to `sampleCount`, so a batch larger than `sampleCount` can't overflow the
  reader. A naive "keep the newest N overall" cap could evict a key's only base whenever another key had more
  history samples, re-introducing the null-base crash.
- The earliest delivered sample of each key is resolved to a full `Update` (using that sample's own resolved value)
  so the reader always has a full base before any later partial for that key — generalizing the previous
  single-sample transform to per-key.
- `subscriberInitialized` now advances the subscriber `lastId` monotonically and no longer asserts that each batch
  strictly follows the previous one: a multi-key subscriber shares one `ElementSubscriber` and is acked one batch
  per key with ids interleaved across keys.

The base is the already-resolved sample and is independent of `_samples`, so history queries and notifications are
unaffected; single-key elements still hold at most one base entry.

One handshake direction is not yet fully covered: per-key init batches delivered via the `initSamples` / `i()` path
are still dropped after the first batch per element (#5819), so for a multi-key keyed writer the bootstrap isn't
guaranteed in that direction until #5819 is fixed. The remaining null-base path — a partial delivered under a
discard policy that left no base (#5824) — ends at the same call site and is left as a follow-up; a reader-side
guard that drops (and traces) a baseless partial would turn it from a crash into degraded delivery.

### Tests

Adds partial-update cases to `test/DataStorm/partial`, each verified red→green:

- a `sampleCount == 0` reader (observed via `onSamples`, since it keeps no history);
- a late joiner of a no-history writer, and one whose base aged out via `sampleLifetime`;
- a late any-key reader after the writer trimmed a key's history (`ClearHistory = OnAll`), which SIGSEGVs without
  the fix;
- a `sampleCount`-limited any-key reader against a writer with more distinct keys than `sampleCount`, verifying the
  writer delivers a base for every key and the reader caps its own history without evicting any base — without the
  fix the reader SIGSEGVs on the surplus key's partial, or aborts on the `initSamples` cap assert in a debug build.

The full DataStorm C++ suite passes. A changelog fragment is included under `changelog.d/datastorm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
