### PR TITLE
Apply nsToString to remaining iOS iAP UTF8String call sites

### DIFF
--- a/cpp/src/Ice/ios/iAPConnector.mm
+++ b/cpp/src/Ice/ios/iAPConnector.mm
@@ -8,6 +8,7 @@
 #    include "iAPConnector.h"
 #    include "iAPEndpointI.h"
 #    include "iAPTransceiver.h"
+#    include "iAPUtil.h"
 
 using namespace std;
 using namespace Ice;
@@ -38,10 +39,10 @@ string
 IceObjC::iAPConnector::toString() const
 {
     ostringstream os;
-    os << [_accessory.name UTF8String];
-    os << " model `" << [_accessory.modelNumber UTF8String] << "'";
-    os << " made by `" << [_accessory.manufacturer UTF8String] << "'";
-    os << " protocol `" << [_protocol UTF8String] << "'";
+    os << nsToString(_accessory.name);
+    os << " model '" << nsToString(_accessory.modelNumber) << "'";
+    os << " made by '" << nsToString(_accessory.manufacturer) << "'";
+    os << " protocol '" << nsToString(_protocol) << "'";
     return os.str();
 }
 

--- a/cpp/src/Ice/ios/iAPTransceiver.mm
+++ b/cpp/src/Ice/ios/iAPTransceiver.mm
@@ -426,8 +426,8 @@ IceObjC::iAPTransceiver::iAPTransceiver(const ProtocolInstancePtr& instance, EAS
       _state(StateNeedConnect)
 {
     ostringstream os;
-    os << "name = " << [session.accessory.name UTF8String] << "\n";
-    os << "protocol = " << [session.protocolString UTF8String];
+    os << "name = " << nsToString(session.accessory.name) << "\n";
+    os << "protocol = " << nsToString(session.protocolString);
     _desc = os.str();
 }
 
@@ -494,10 +494,7 @@ IceObjC::iAPTransceiver::checkErrorStatus(NSStream* stream, const char* file, in
     }
 
     // Otherwise throw a generic exception.
-    throw SocketException{
-        file,
-        line,
-        "CFNetwork error in domain " + string{[domain UTF8String]} + ": " + to_string([err code])};
+    throw SocketException{file, line, "CFNetwork error in domain " + nsToString(domain) + ": " + to_string([err code])};
 }
 
 #endif


### PR DESCRIPTION
Fixes #5804.

#5800 introduced the `IceObjC::nsToString(NSString*)` helper to safely convert an `NSString*` — including `nil` and strings not representable as UTF-8 — to a `std::string`, but only applied it to the `getInfo` paths. This PR sweeps the remaining sibling call sites that still used the raw `[... UTF8String]` pattern, which feeds `nullptr` into `std::string` (UB) when the string is `nil`:

- `iAPTransceiver.mm`: the `_desc` construction in the `EASession` constructor (`accessory.name` / `protocolString`), and the generic `SocketException` message built from the `NSError` domain.
- `iAPConnector.mm`: the accessory fields and `_protocol` in `toString()`.

The `toString`/`_desc` sites stream the same optional `EAAccessory` fields (`modelNumber` / `manufacturer`) as #5793/#5794, so they could still crash on an accessory with missing metadata.

Also replaced the legacy `` `...' `` quoting with `'...'` in the `toString()` lines this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)