### PR TITLE
Fix IceGrid property-set diamond rejected as a circular dependency

### DIFF
--- a/changelog.d/service-icegrid/5662.md
+++ b/changelog.d/service-icegrid/5662.md
@@ -1,2 +1,2 @@
-- Fixed the IceGrid registry to accept a property set referenced through two independent parents (a diamond)
-  instead of incorrectly rejecting it as a circular dependency.
+- Fixed a bug where the IceGrid registry incorrectly rejected an application with a "circular dependency" error
+  when a property set was referenced by two other property sets.

--- a/changelog.d/service-icegrid/5662.md
+++ b/changelog.d/service-icegrid/5662.md
@@ -1,0 +1,2 @@
+- Fixed the IceGrid registry to accept a property set referenced through two independent parents (a diamond)
+  instead of incorrectly rejecting it as a circular dependency.

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -954,9 +954,8 @@ Resolver::getProperties(const Ice::StringSeq& references, set<string>& resolved)
         PropertySetDescriptor desc = getPropertySet(reference);
         if (!desc.references.empty())
         {
-            // Track references only for the current resolution path so a shared non-leaf property set reached through
-            // two independent parents (a diamond) is not mistaken for a cycle. Erasing after recursion mirrors the
-            // variable cycle check in substitute().
+            // 'resolved' tracks only the current resolution path: a property set reached twice through independent
+            // parents is not a cycle.
             resolved.insert(reference);
             PropertyDescriptorSeq q = getProperties(desc.references, resolved);
             resolved.erase(reference);

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -954,8 +954,12 @@ Resolver::getProperties(const Ice::StringSeq& references, set<string>& resolved)
         PropertySetDescriptor desc = getPropertySet(reference);
         if (!desc.references.empty())
         {
+            // Track references only for the current resolution path so a shared non-leaf property set reached through
+            // two independent parents (a diamond) is not mistaken for a cycle. Erasing after recursion mirrors the
+            // variable cycle check in substitute().
             resolved.insert(reference);
             PropertyDescriptorSeq q = getProperties(desc.references, resolved);
+            resolved.erase(reference);
             properties.insert(properties.end(), q.begin(), q.end());
         }
 

--- a/cpp/test/IceGrid/update/AllTests.cpp
+++ b/cpp/test/IceGrid/update/AllTests.cpp
@@ -686,6 +686,37 @@ allTests(Test::TestHelper* helper)
     }
 
     {
+        cout << "testing property set cycle detection... " << flush;
+
+        //
+        // A genuine property set reference cycle (B -> {C}, C -> {B}) must still be rejected as a circular
+        // dependency.
+        //
+        ApplicationDescriptor app;
+        app.name = "PropertySetCycleApp";
+
+        PropertySetDescriptor b;
+        b.references = {"C"};
+        app.propertySets["B"] = b;
+
+        PropertySetDescriptor c;
+        c.references = {"B"};
+        app.propertySets["C"] = c;
+
+        try
+        {
+            admin->addApplication(app);
+            test(false);
+        }
+        catch (const DeploymentException& ex)
+        {
+            test(ex.reason.find("circular dependency with property reference") != string::npos);
+        }
+
+        cout << "ok" << endl;
+    }
+
+    {
         cout << "testing node add... " << flush;
 
         ApplicationDescriptor testApp;

--- a/cpp/test/IceGrid/update/AllTests.cpp
+++ b/cpp/test/IceGrid/update/AllTests.cpp
@@ -641,6 +641,51 @@ allTests(Test::TestHelper* helper)
     }
 
     {
+        cout << "testing property set diamond resolution... " << flush;
+
+        //
+        // A non-leaf property set reached through two independent parents (a diamond) must resolve, not be
+        // rejected as a circular dependency. A -> {B, C}, B -> {D}, C -> {D}, D -> {E}: D is reached via both B
+        // and C, which is a legitimate DAG rather than a cycle.
+        //
+        ApplicationDescriptor app;
+        app.name = "DiamondApp";
+
+        PropertySetDescriptor a;
+        a.references = {"B", "C"};
+        app.propertySets["A"] = a;
+
+        PropertySetDescriptor b;
+        b.references = {"D"};
+        app.propertySets["B"] = b;
+
+        PropertySetDescriptor c;
+        c.references = {"D"};
+        app.propertySets["C"] = c;
+
+        PropertySetDescriptor d;
+        d.references = {"E"};
+        app.propertySets["D"] = d;
+
+        PropertySetDescriptor e;
+        e.properties.push_back(createProperty("Diamond", "1"));
+        app.propertySets["E"] = e;
+
+        try
+        {
+            admin->addApplication(app);
+        }
+        catch (const DeploymentException& ex)
+        {
+            cerr << ex.reason << endl;
+            test(false);
+        }
+        admin->removeApplication("DiamondApp");
+
+        cout << "ok" << endl;
+    }
+
+    {
         cout << "testing node add... " << flush;
 
         ApplicationDescriptor testApp;


### PR DESCRIPTION
Fixes #5662.

`Resolver::getProperties` in `cpp/src/IceGrid/DescriptorHelper.cpp` tracked resolved property-set references in a
visited-only set: it inserted each reference before recursing but never erased it, conflating "seen anywhere during
this resolution" with "on the current path". A non-leaf property set reached through two independent parents (a
diamond) — or simply referenced more than once — was therefore wrongly rejected as a circular dependency.

Example: property sets `A → {B, C}`, `B → {D}`, `C → {D}`, `D → {E}`. Resolving `A` inserts `D` while walking
`B`'s subtree and never removes it, so `C`'s subtree sees `D` still present and throws
`detected circular dependency with property reference 'D'` — even though `A→B→D` / `A→C→D` is a legitimate DAG.

The fix erases the reference after its subtree is resolved, so `resolved` holds only the active resolution path. True
cycles are still detected; diamonds and repeated references resolve. This mirrors the variable cycle check in
`substitute()` added in #5643.

### Test

Adds a diamond regression test to `IceGrid/update` (`A → {B, C}`, `B → {D}`, `C → {D}`, `D → {E}`). Verified
red→green: without the fix, deploying the application throws `detected circular dependency with property reference 'D'`
(the regression fails at `AllTests.cpp` `test(false)`); with the fix the application deploys and the suite passes.

A changelog fragment is included under `changelog.d/service-icegrid/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
