### PR TITLE
Treat Ice.ClassGraphDepthMax < 1 as unlimited in Swift

### DIFF
--- a/changelog.d/swift/class-graph-depth-max-unlimited.md
+++ b/changelog.d/swift/class-graph-depth-max-unlimited.md
@@ -1,2 +1,2 @@
 - Fixed communicator initialization to treat `Ice.ClassGraphDepthMax` values less than 1 as unlimited, matching the
-  other language mappings. Previously, setting this property to 0 aborted the program with a `fatalError`.
+  other language mappings. Previously, setting this property to 0 or a negative value aborted the program.

--- a/changelog.d/swift/class-graph-depth-max-unlimited.md
+++ b/changelog.d/swift/class-graph-depth-max-unlimited.md
@@ -1,0 +1,2 @@
+- Fixed communicator initialization to treat `Ice.ClassGraphDepthMax` values less than 1 as unlimited, matching the
+  other language mappings. Previously, setting this property to 0 aborted the program with a `fatalError`.

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -14,10 +14,8 @@ final class CommunicatorI: LocalObject<ICECommunicator>, Communicator, @unchecke
         self.initData = initData
         do {
             defaultsAndOverrides = try DefaultsAndOverrides(initData.properties!)
-            classGraphDepthMax = try initData.properties!.getIcePropertyAsInt("Ice.ClassGraphDepthMax")
-            precondition(
-                classGraphDepthMax >= 1 && classGraphDepthMax <= 0x7FFF_FFFF,
-                "Ice.ClassGraphDepthMax must be >= 0 and <= 0x7FFF_FFFF")
+            let classGraphDepthMax = try initData.properties!.getIcePropertyAsInt("Ice.ClassGraphDepthMax")
+            self.classGraphDepthMax = classGraphDepthMax < 1 ? Int32.max : classGraphDepthMax
             traceSlicing = try initData.properties!.getIcePropertyAsInt("Ice.Trace.Slicing") > 0
             acceptClassCycles = try initData.properties!.getIcePropertyAsInt("Ice.AcceptClassCycles") > 0
         } catch {


### PR DESCRIPTION
Swift was the only mapping that rejected `Ice.ClassGraphDepthMax` values less than 1, aborting communicator initialization with a `fatalError` where every other mapping treats such values as "unlimited".

- Coerce `Ice.ClassGraphDepthMax < 1` to `Int32.max`, matching C++, C#, Java, JS, and MATLAB.
- Removed the now-redundant `precondition` (the upper-bound check was a no-op since the property is already an `Int32`, and its message incorrectly said `>= 0`).
- Added a changelog fragment.

Fixes zeroc-ice/ice-audit#102.