### PR TITLE
Don't reuse a destroyed lingering TopicImpl in IceStorm observerInit

### DIFF
--- a/changelog.d/service-icestorm/replica-zombie-topic-resurrection.md
+++ b/changelog.d/service-icestorm/replica-zombie-topic-resurrection.md
@@ -1,0 +1,3 @@
+- Fixed a replication bug where a replica rejoining the group could reuse the in-memory remnant of a topic it
+  had destroyed locally. The rejoined replica then ignored a later replicated destroy of that topic, keeping the
+  topic's records in its database and resurrecting the destroyed topic on restart.

--- a/cpp/src/IceStorm/TopicManagerI.cpp
+++ b/cpp/src/IceStorm/TopicManagerI.cpp
@@ -479,6 +479,14 @@ TopicManagerImpl::observerInit(const LogUpdate& llu, const TopicContentSeq& cont
         {
             installTopic(name, q.id, true, q.records);
         }
+        else if (r->second->destroyed())
+        {
+            // A topic destroyed on this replica can linger in _topics until the next reap. Since a destroyed
+            // TopicImpl has no servants and ignores replicated updates, we can't reuse it: install a fresh
+            // topic from the content instead.
+            _topics.erase(r);
+            installTopic(name, q.id, true, q.records);
+        }
         else
         {
             r->second->update(q.records);


### PR DESCRIPTION
Fixes #5810.

## The bug

`TopicImpl::destroy` marks the impl destroyed and tears it down (deletes the topic's database records, unregisters its topic/publisher/link servants), but leaves it in `TopicManagerImpl::_topics` until the lazy reaper runs. If the destroy's replication fails entirely (e.g. a partition at that instant) and the node later rejoins as a slave while the topic is still alive group-wide, `observerInit`'s "topic exists in both" branch reused that destroyed remnant via `update()` — which neither clears `_destroyed` nor re-registers the servants. See #5810 for the full mechanism.

On the rejoined node the topic was then unreachable (no servants), and a later replicated destroy of the topic hit the `_destroyed` early return in `TopicImpl::observerDestroyTopic`, silently skipping the record deletion and LLU update: the node's database kept the destroyed topic and resurrected it at the next restart.

## The fix

In `observerInit`, when the local impl for a topic present in the group content is destroyed, erase it and install a fresh impl from the synced content (`installTopic`) instead of reusing it via `update()`. This keeps `_destroyed` monotonic per impl.

This is safe:

- A destroyed impl has already had its three servants (topic, publisher, link) removed — `destroyInternal` runs exactly once, guarded by `_destroyed` — so the reinstall cannot hit `AlreadyRegisteredException`.
- No database work is needed here: `observerInit` already rewrote the subscriber records and LLU before this loop.
- The stale reaper entry queued by the original destroy is harmless: `reap()` re-checks `destroyed()` on the current map entry, so it won't discard the fresh impl.
- The other `observerInit` scan (topic absent from the group content) already handles a destroyed impl correctly: `observerDestroyTopic` early-returns and the erase is all that's needed, since the database was already synced.

`initMaster` and `getContent` both call `reap()` before using `_topics`, so this was the only place a destroyed impl could be reused.

## Why no regression test

Reproducing this from the test harness is impractical, because the zombie exists only in the old master's memory — its database no longer contains the topic — so the formation sequence requires the old master's **process to survive** from the failed destroy all the way through rejoining as a slave. The harness's only partition primitive (stopping/starting replica processes) can't express that:

- Stopping both slaves makes the destroy's replication fail and forms the zombie, but the moment the slaves restart, the old master is reachable again and joins the election. The failed destroy incremented its LLU, so its state wins, and `initMaster` calls `reap()` first — which discards the zombie before it can be reused. The bug needs the old master's LLU to *lose*, i.e. the slaves must advance the generation while the old master is alive but unreachable — a real network partition.
- Restarting the old master instead clears the zombie trivially, since `_topics` is rebuilt from its database (which no longer has the topic).

The closest emulation would be `SIGSTOP`/`SIGCONT` on the master process so it stays alive but unresponsive while the slaves elect at a higher generation. That is POSIX-only, and because the kernel still completes TCP handshakes for a stopped process, every failure manifests as a timeout rather than a fast connection refusal — making the test slow and timing-sensitive. The observable consequence (leaked records after a later group-wide destroy) is also only visible via an offline database dump or another restart. That combination is a recipe for a CI flake, so this fix ships without an automated reproduction; it was verified by review of the affected paths plus a clean `IceStorm/rep1` run, which exercises `observerInit` on every replica rejoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
