### PR TITLE
Validate non-primitive sequence count before allocating in IcePy/IceRuby/IcePHP

### DIFF
--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -1538,7 +1538,7 @@ IcePHP::SequenceInfo::unmarshal(
     array_init(&zv);
     AutoDestroy destroy(&zv);
 
-    int32_t sz = is->readSize();
+    int32_t sz = is->readAndCheckSeqSize(elementType->wireSize());
     for (int32_t i = 0; i < sz; ++i)
     {
         void* cl = reinterpret_cast<void*>(i);

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -1446,7 +1446,7 @@ IcePy::SequenceInfo::unmarshal(
         return;
     }
 
-    int32_t sz = is->readSize();
+    int32_t sz = is->readAndCheckSeqSize(elementType->wireSize());
     PyObjectHandle result{sm->createContainer(sz)};
 
     if (!result.get())

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -1225,7 +1225,7 @@ IceRuby::SequenceInfo::unmarshal(
         return;
     }
 
-    int32_t sz = is->readSize();
+    int32_t sz = is->readAndCheckSeqSize(elementType->wireSize());
     volatile VALUE arr = createArray(sz);
 
     for (int32_t i = 0; i < sz; ++i)


### PR DESCRIPTION
IcePy, IceRuby, and IcePHP read a non-primitive sequence's element count with a bare `readSize()` and act on it immediately — IcePy/IceRuby pre-allocate a container of that many slots, IcePHP loops that many times. Since `readSize()` only rejects negatives, a peer can declare a count near `INT32_MAX` via the 5-byte size escape and trigger a multi-GB allocation from a tiny message. The primitive path and the C++/C#/Java readers already guard this via `readAndCheckSeqSize`.

This routes the non-primitive path through `readAndCheckSeqSize(elementType->wireSize())`, so a count that can't fit the buffer throws `MarshalException` up front. Dictionaries were already safe (empty map, insert per entry) and are unchanged.

Fixes zeroc-ice/ice-audit#98.