### PR TITLE
Fix clang-tidy modernize-return-braced-init-list failure in SSLUtil.cpp

### DIFF
--- a/cpp/src/Ice/SSL/SSLUtil.cpp
+++ b/cpp/src/Ice/SSL/SSLUtil.cpp
@@ -503,7 +503,7 @@ namespace
             const unsigned char* data = ASN1_STRING_get0_data(str);
             if (data)
             {
-                return string(reinterpret_cast<const char*>(data), ASN1_STRING_length(str));
+                return {reinterpret_cast<const char*>(data), static_cast<size_t>(ASN1_STRING_length(str))};
             }
         }
         return {};


### PR DESCRIPTION
Fixes the clang-tidy failure on main in `cpp/src/Ice/SSL/SSLUtil.cpp`:

- `convertIA5StringToString` now returns a braced initializer list instead of repeating the return type (`modernize-return-braced-init-list`).
- Added a `static_cast<size_t>` around `ASN1_STRING_length`'s `int` result, since braced initialization rejects the narrowing conversion to `std::string`'s `size_t` length parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)