### PR TITLE
Fix ProxyInfo::wireSize() in Python, Ruby, and PHP

### DIFF
--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -2621,7 +2621,7 @@ IcePHP::ProxyInfo::variableLength() const
 int
 IcePHP::ProxyInfo::wireSize() const
 {
-    return 1;
+    return 2;
 }
 
 Ice::OptionalFormat

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -2714,7 +2714,7 @@ IcePy::ProxyInfo::variableLength() const
 int
 IcePy::ProxyInfo::wireSize() const
 {
-    return 1;
+    return 2;
 }
 
 Ice::OptionalFormat

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -2236,7 +2236,7 @@ IceRuby::ProxyInfo::variableLength() const
 int
 IceRuby::ProxyInfo::wireSize() const
 {
-    return 1;
+    return 2;
 }
 
 Ice::OptionalFormat


### PR DESCRIPTION
This PR fixes `ProxyInfo::wireSize()` in the Python, Ruby, and PHP runtimes to return 2, the minimum wire size of a proxy (a null proxy is encoded as an empty identity, i.e., 2 bytes). This matches `Slice::InterfaceDecl::minWireSize()` and the values used by the C++ and JS mappings.

This bug has no observable effect on the encoding: `wireSize()` is only consulted on fixed-length paths, and proxies are variable-length, so the incorrect value was never used. No changelog entry for this reason.

Fixes #5817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
