### PR TITLE
Use HEAD test certificates in the binary compatibility workflow

### DIFF
--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -163,6 +163,13 @@ jobs:
           ls -la stable/java/lib/
         shell: bash
 
+      # The test certificates committed on the stable tag have a limited validity period (398 days) and eventually
+      # expire, causing all SSL tests to fail. The HEAD certificates are regenerated regularly and use the same
+      # layout, so the stable tests can use them as-is.
+      - name: Swap HEAD test certificates
+        run: cp -afv head/certs/. stable/certs/
+        shell: bash
+
       - name: Install testing dependencies
         run: python3 -m pip install passlib cryptography numpy
         shell: bash


### PR DESCRIPTION
The nightly binary compatibility run on the 3.8 branch is [failing](https://github.com/zeroc-ice/ice/actions/runs/28846184392/job/85550567430): the test certificates committed on the v3.8.1 tag expired on June 25, 2026 (certificates are generated with a 398-day validity), so every SSL-protocol test configuration fails with `IceSSL: certificate verification failed: certificate has expired`.

This adds a step that overlays the HEAD `certs` tree onto the stable checkout before running the tests:

- The certs layout is unchanged between v3.8.1 and HEAD, and the test harness only uses `certs/common/ca` for `--protocol=ssl` runs.
- HEAD certificates are regenerated regularly, so this also protects future runs from the next expiry.

This needs a cherry-pick to the 3.8 branch, which maintains its own copy of this workflow and is where the nightly actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)