### PR TITLE
Use HEAD test certificates in the binary compatibility workflow (3.8)

### DIFF
--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -163,6 +163,13 @@ jobs:
           ls -la stable/java/lib/
         shell: bash
 
+      # The test certificates committed on the stable tag have a limited validity period (398 days) and eventually
+      # expire, causing all SSL tests to fail. The HEAD certificates are regenerated regularly and use the same
+      # layout, so the stable tests can use them as-is.
+      - name: Swap HEAD test certificates
+        run: cp -afv head/certs/. stable/certs/
+        shell: bash
+
       - name: Install testing dependencies
         run: python3 -m pip install passlib cryptography numpy
         shell: bash


### PR DESCRIPTION
Cherry-pick of #5835 to the 3.8 branch, which maintains its own copy of the binary compatibility workflow and is where the nightly runs.

This fixes the [failing nightly](https://github.com/zeroc-ice/ice/actions/runs/28846184392/job/85550567430): the test certificates committed on the v3.8.1 tag expired on June 25, 2026, so every SSL-protocol test configuration fails with `IceSSL: certificate verification failed: certificate has expired`. The new step overlays the HEAD `certs` tree onto the stable checkout before running the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)