### PR TITLE
Add changelog fragment collation script

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,15 +29,18 @@ Breaking change(s):
 
 ## Changelog Validation
 
-**When reviewing PRs, check if code changes have a CHANGELOG.md entry.**
+**When reviewing PRs, check if code changes have a changelog fragment under `changelog.d/`.**
 
-### Requires changelog entry:
+Changelog entries are added as fragment files (`changelog.d/<section>/<id>.md`), not by editing `CHANGELOG.md`.
+See `changelog.d/README.md` for the convention.
+
+### Requires changelog fragment:
 
 - Non-trivial bug fixes, features, API changes, security fixes, performance improvements
 - Breaking changes, deprecations
 - Multi-language changes
 
-### Doesn't require entry:
+### Doesn't require fragment:
 
 - Comment/whitespace-only changes
 - Internal refactoring with no behavioral changes
@@ -47,8 +50,8 @@ Breaking change(s):
 ### Template if missing:
 
 ```
-This PR has [description], but doesn't update CHANGELOG.md.
-Please add an entry describing this change.
+This PR has [description], but doesn't add a changelog fragment under changelog.d/.
+Please add one describing this change (see changelog.d/README.md).
 
 Generated suggestion:
 - [Generated description based on the changes made]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ might need to be aware of.
 
 ## Changes in Ice 3.9.0
 
-Unreleased changes are recorded as fragments under `changelog.d/` and collated into this file at
-release time. See the `changelog.d/` directory for the pending entries.
-
 These are the changes since the [Ice 3.8.2] release.
 
 [Ice 3.8.2]: https://github.com/zeroc-ice/ice/blob/3.8/CHANGELOG-3.8.md
+
+Unreleased changes are recorded as fragments under `changelog.d/` and collated into this file at
+release time. See the `changelog.d/` directory for the pending entries.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -17,7 +17,8 @@ A PR that warrants a changelog entry adds `changelog.d/<section>/<id>.md`, where
 
 The fragment content is the literal changelog bullet(s), inserted verbatim by the collation script:
 
-- Each bullet starts with `- `, with continuation lines indented two spaces and wrapped at 120 columns.
+- Each bullet is a Markdown list item starting with `-`, with continuation lines indented two spaces and wrapped at
+  120 columns.
 - Describe the change from the user's perspective, symptom first. The issue/PR reference stays out of the entry;
   git ties the fragment to its PR.
 - A fragment may contain several bullets when one PR makes several user-visible changes.
@@ -49,16 +50,18 @@ A change with no user-facing impact gets **no fragment** — that is a deliberat
 
 ## Releasing
 
-On the release branch, run:
+Fragments are collated only when making a release, and releases are made from release branches: on `main`, the
+fragments simply accumulate until a release branch is cut. On the release branch, run:
 
 ```shell
 python3 scripts/collate_changelog.py <version>
 ```
 
-The script inserts the collated sections into the `## Changes in Ice <version>` section of the changelog
-(`CHANGELOG-<major>.<minor>.md` if it exists, else `CHANGELOG.md`), creating that section when it doesn't exist yet,
-and deletes the consumed fragments. It does not touch git: review the diff, reorder entries as needed, regenerate
-the table of contents in your editor, and commit. Use `--dry-run` to preview the collated sections.
+The script inserts the collated sections into the `## Changes in Ice <version>` section of
+`CHANGELOG-<major>.<minor>.md`, creating that section when it doesn't exist yet, and deletes the consumed fragments.
+It fails when `CHANGELOG-<major>.<minor>.md` doesn't exist; use `--file` to collate into another file. It does not
+touch git: review the diff, reorder entries as needed, regenerate the table of contents in your editor, and commit.
+Use `--dry-run` to preview the collated sections.
 
 Backporting a fix carries its fragment along with the cherry-pick. After a patch release from a release branch, the
 fragments it consumed are also removed from `main` by hand, since those fixes are documented in the release branch's

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,65 @@
+# Changelog Fragments
+
+Unreleased changelog entries live in this directory as fragment files, one file per PR, instead of being added to
+the shared changelog file. Different PRs add different files, so changelog entries never produce merge conflicts or
+duplicate section headings. At release time, `scripts/collate_changelog.py` collates the fragments into the
+changelog.
+
+## Adding a fragment
+
+A PR that warrants a changelog entry adds `changelog.d/<section>/<id>.md`, where:
+
+- `<section>` is one of the directories listed below and selects the changelog section — the collation script
+  generates the section headings from it.
+- `<id>` is the `zeroc-ice/ice` issue number when the PR fixes a single public issue, and a short descriptive slug
+  otherwise (no issue, several issues, or an issue tracked in a private repository — private issue numbers must
+  never appear here).
+
+The fragment content is the literal changelog bullet(s), inserted verbatim by the collation script:
+
+- Each bullet starts with `- `, with continuation lines indented two spaces and wrapped at 120 columns.
+- Describe the change from the user's perspective, symptom first. The issue/PR reference stays out of the entry;
+  git ties the fragment to its PR.
+- A fragment may contain several bullets when one PR makes several user-visible changes.
+
+A change with no user-facing impact gets **no fragment** — that is a deliberate decision, not an omission.
+
+## Sections
+
+| Directory | Changelog section |
+| --------- | ----------------- |
+| `general` | General Changes |
+| `slice` | Slice Language Changes |
+| `cpp` | C++ Changes |
+| `csharp` | C# Changes |
+| `java` | Java Changes |
+| `js` | JavaScript Changes |
+| `matlab` | MATLAB Changes |
+| `php` | PHP Changes |
+| `python` | Python Changes |
+| `ruby` | Ruby Changes |
+| `swift` | Swift Changes |
+| `datastorm` | Ice Service Changes > DataStorm |
+| `service-glacier2` | Ice Service Changes > Glacier2 |
+| `service-windows` | Ice Service Changes > Ice Service installed as a Windows Service |
+| `service-icebox` | Ice Service Changes > IceBox |
+| `service-icegrid` | Ice Service Changes > IceGrid |
+| `service-icestorm` | Ice Service Changes > IceStorm |
+| `packaging` | Packaging Changes |
+
+## Releasing
+
+On the release branch, run:
+
+```shell
+python3 scripts/collate_changelog.py <version>
+```
+
+The script inserts the collated sections into the `## Changes in Ice <version>` section of the changelog
+(`CHANGELOG-<major>.<minor>.md` if it exists, else `CHANGELOG.md`), creating that section when it doesn't exist yet,
+and deletes the consumed fragments. It does not touch git: review the diff, reorder entries as needed, regenerate
+the table of contents in your editor, and commit. Use `--dry-run` to preview the collated sections.
+
+Backporting a fix carries its fragment along with the cherry-pick. After a patch release from a release branch, the
+fragments it consumed are also removed from `main` by hand, since those fixes are documented in the release branch's
+changelog rather than the next major/minor release's changelog.

--- a/scripts/collate_changelog.py
+++ b/scripts/collate_changelog.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Copyright (c) ZeroC, Inc.
+
+"""
+Collate the changelog fragments under changelog.d/ into the changelog file, then delete the consumed fragments.
+
+The generated section headings are derived from the fragment locations (changelog.d/<section>/<id>.md); the fragment
+contents are inserted verbatim. This script does not touch git and does not update the table of contents: review the
+result, reorder entries as needed, regenerate the TOC in your editor, and commit.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Ordered (directory, heading) taxonomy. Fragment directories under changelog.d/ must appear here; sections
+# without fragments are omitted from the output.
+LANGUAGE_SECTIONS = [
+    ("general", "General Changes"),
+    ("slice", "Slice Language Changes"),
+    ("cpp", "C++ Changes"),
+    ("csharp", "C# Changes"),
+    ("java", "Java Changes"),
+    ("js", "JavaScript Changes"),
+    ("matlab", "MATLAB Changes"),
+    ("php", "PHP Changes"),
+    ("python", "Python Changes"),
+    ("ruby", "Ruby Changes"),
+    ("swift", "Swift Changes"),
+]
+
+# Rendered as "#### <name>" subsections of "### Ice Service Changes".
+SERVICE_SECTIONS = [
+    ("datastorm", "DataStorm"),
+    ("service-glacier2", "Glacier2"),
+    ("service-windows", "Ice Service installed as a Windows Service"),
+    ("service-icebox", "IceBox"),
+    ("service-icegrid", "IceGrid"),
+    ("service-icestorm", "IceStorm"),
+]
+
+PACKAGING_SECTION = ("packaging", "Packaging Changes")
+
+FRAGMENTS_PLACEHOLDER_PREFIX = "Unreleased changes are recorded as fragments"
+
+
+def die(message):
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def read_fragments(changelog_d):
+    """Return {section directory name: [fragment text, ...]}, with fragments ordered by filename."""
+    if not changelog_d.is_dir():
+        die(f"{changelog_d} does not exist")
+
+    known = {name for name, _ in LANGUAGE_SECTIONS + SERVICE_SECTIONS + [PACKAGING_SECTION]}
+    fragments = {}
+    for path in sorted(changelog_d.iterdir()):
+        if path.name == "README.md":
+            continue
+        if not path.is_dir():
+            die(f"unexpected file {path}: fragments belong in a section directory")
+        if path.name not in known:
+            die(f"unknown section directory {path}: add it to the taxonomy in {Path(__file__).name} first")
+        for fragment in sorted(path.glob("*.md")):
+            text = fragment.read_text(encoding="utf-8").strip()
+            if not text.startswith("- "):
+                die(f"{fragment} does not start with a '- ' bullet")
+            fragments.setdefault(path.name, []).append(text)
+    return fragments
+
+
+def bullet_lines(text):
+    """Return the fragment's lines with a blank line between top-level bullets."""
+    lines = []
+    for line in text.splitlines():
+        if line.startswith("- ") and lines and lines[-1] != "":
+            lines.append("")
+        lines.append(line)
+    return lines
+
+
+def collate(fragments):
+    """Return the collated '### ...' sections as a list of lines."""
+    lines = []
+
+    def add_section(heading, texts):
+        lines.extend([heading, ""])
+        for text in texts:
+            lines.extend(bullet_lines(text))
+            lines.append("")
+
+    for directory, heading in LANGUAGE_SECTIONS:
+        if directory in fragments:
+            add_section(f"### {heading}", fragments[directory])
+
+    if any(directory in fragments for directory, _ in SERVICE_SECTIONS):
+        lines.extend(["### Ice Service Changes", ""])
+        for directory, heading in SERVICE_SECTIONS:
+            if directory in fragments:
+                add_section(f"#### {heading}", fragments[directory])
+
+    if PACKAGING_SECTION[0] in fragments:
+        add_section(f"### {PACKAGING_SECTION[1]}", fragments[PACKAGING_SECTION[0]])
+
+    return lines[:-1]  # drop the trailing blank line
+
+
+def remove_placeholder(lines):
+    """Remove the paragraph pointing readers at changelog.d/, if present."""
+    for start, line in enumerate(lines):
+        if line.startswith(FRAGMENTS_PLACEHOLDER_PREFIX):
+            end = start
+            while end < len(lines) and lines[end] != "":
+                end += 1
+            while end < len(lines) and lines[end] == "":
+                end += 1
+            return lines[:start] + lines[end:]
+    return lines
+
+
+def insert_sections(changelog, version, sections):
+    """Return the changelog lines with the collated sections added to the '## Changes in Ice <version>' section,
+    creating that section if necessary."""
+    lines = changelog.read_text(encoding="utf-8").splitlines()
+    version_headings = [(i, line) for i, line in enumerate(lines) if re.match(r"^## Changes in Ice \S+$", line)]
+    heading = f"## Changes in Ice {version}"
+
+    match = [i for i, line in version_headings if line == heading]
+    if match:
+        # Insert at the end of the existing section, after dropping the fragments placeholder.
+        start = match[0]
+        end = next((i for i, _ in version_headings if i > start), len(lines))
+        section = remove_placeholder(lines[start:end])
+        while section and section[-1] == "":
+            section.pop()
+        return lines[:start] + section + [""] + sections + [""] + lines[end:]
+    elif version_headings:
+        # Create the section above the most recent release, e.g. running 'collate_changelog.py 3.8.3' on the
+        # 3.8 branch inserts '## Changes in Ice 3.8.3' above '## Changes in Ice 3.8.2'.
+        start, top = version_headings[0]
+        previous = top.removeprefix("## Changes in Ice ")
+        created = [heading, "", f"These are the changes since the Ice {previous} release.", "", *sections, ""]
+        return lines[:start] + created + lines[start:]
+    else:
+        die(f"{changelog} contains no '## Changes in Ice <version>' heading")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Collate changelog.d/ fragments into the changelog.")
+    parser.add_argument("version", help="the release version, e.g. 3.9.0")
+    parser.add_argument(
+        "--file",
+        type=Path,
+        help="the changelog file to update (default: CHANGELOG-<major>.<minor>.md if it exists, else CHANGELOG.md)",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="print the collated sections without changing anything")
+    parser.add_argument("--keep-fragments", action="store_true", help="do not delete the consumed fragment files")
+    args = parser.parse_args()
+
+    if not re.match(r"^\d+\.\d+\.\d+$", args.version):
+        die(f"'{args.version}' is not a <major>.<minor>.<patch> version")
+
+    root = Path(__file__).resolve().parent.parent
+    fragments = read_fragments(root / "changelog.d")
+    if not fragments:
+        die("no fragments to collate")
+    sections = collate(fragments)
+
+    if args.dry_run:
+        print("\n".join(sections))
+        return
+
+    changelog = args.file
+    if changelog is None:
+        major_minor = ".".join(args.version.split(".")[:2])
+        changelog = root / f"CHANGELOG-{major_minor}.md"
+        if not changelog.exists():
+            changelog = root / "CHANGELOG.md"
+    if not changelog.exists():
+        die(f"{changelog} does not exist")
+
+    lines = insert_sections(changelog, args.version, sections)
+    changelog.write_text("\n".join(lines).rstrip("\n") + "\n", encoding="utf-8")
+
+    count = sum(len(texts) for texts in fragments.values())
+    print(f"Collated {count} fragment(s) into {changelog}.")
+
+    if not args.keep_fragments:
+        for directory in fragments:
+            for fragment in (root / "changelog.d" / directory).glob("*.md"):
+                fragment.unlink()
+        print("Deleted the consumed fragments; review the result and regenerate the TOC before committing.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/collate_changelog.py
+++ b/scripts/collate_changelog.py
@@ -154,7 +154,7 @@ def main():
     parser.add_argument(
         "--file",
         type=Path,
-        help="the changelog file to update (default: CHANGELOG-<major>.<minor>.md if it exists, else CHANGELOG.md)",
+        help="the changelog file to update (default: CHANGELOG-<major>.<minor>.md)",
     )
     parser.add_argument("--dry-run", action="store_true", help="print the collated sections without changing anything")
     parser.add_argument("--keep-fragments", action="store_true", help="do not delete the consumed fragment files")
@@ -178,8 +178,8 @@ def main():
         major_minor = ".".join(args.version.split(".")[:2])
         changelog = root / f"CHANGELOG-{major_minor}.md"
         if not changelog.exists():
-            changelog = root / "CHANGELOG.md"
-    if not changelog.exists():
+            die(f"{changelog} does not exist: run this script on a release branch, or specify the file with --file")
+    elif not changelog.exists():
         die(f"{changelog} does not exist")
 
     lines = insert_sections(changelog, args.version, sections)


### PR DESCRIPTION
Closes #5653.

This PR implements the remaining piece of the changelog-fragments workflow (Option B in #5653): the collation script that turns the fragments under `changelog.d/` into changelog entries at release time.

## `scripts/collate_changelog.py`

```shell
python3 scripts/collate_changelog.py <version> [--file PATH] [--dry-run] [--keep-fragments]
```

- Collates the fragments into `CHANGELOG-<major>.<minor>.md` and deletes the consumed fragments. Releases are made from release branches, so the script fails when that file doesn't exist; on `main`, fragments simply accumulate until a release branch is cut. `--file` collates into another file explicitly.
- The section headings are generated from the fragment directories, in a fixed canonical order, with services nested under `### Ice Service Changes` (including `datastorm/` → `#### DataStorm`, matching its placement in previous releases). Fragment contents are inserted verbatim, except that a blank line always separates bullets.
- If the file already has a `## Changes in Ice <version>` heading, the entries are inserted at the end of that section and the "unreleased changes are recorded as fragments" placeholder is removed. Otherwise the script creates the section above the most recent release — e.g. running `collate_changelog.py 3.8.3` on the `3.8` branch inserts `## Changes in Ice 3.8.3` above `## Changes in Ice 3.8.2`, with the usual "These are the changes since …" lead-in.
- The script is deliberately a plain local tool: it does not touch git and does not generate the table of contents. After running it, you review the diff, reorder entries as needed, regenerate the TOC in your editor, and commit. `--dry-run` prints the collated sections without changing anything.

Tested against the `3.8` branch, where it builds a complete `## Changes in Ice 3.8.3` section from the 72 pending fragments there, and against `main`'s `CHANGELOG.md` via `--file` (fills the existing 3.9.0 section). Using it for the 3.8.3 release just requires cherry-picking these commits to `3.8`.

## Also in this PR

- `changelog.d/README.md` documents the fragment convention (section directories, filename = issue number or slug, bullet format, "no user-facing impact = no fragment") and the release/backport flow. It also keeps `changelog.d/` present in git once a release consumes every fragment.
- `.github/copilot-instructions.md`: the changelog validation section now asks for a `changelog.d/` fragment instead of a `CHANGELOG.md` edit.
- `CHANGELOG.md`: one-time layout tweak — the "changes since [Ice 3.8.2]" lead-in now sits directly under the 3.9.0 heading, matching the layout of the released sections in `CHANGELOG-3.8.md`, so the script inserts entries after it without special-casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
