### PR TITLE
Unregister a session from the ConnectionManager on wire disconnected()

### DIFF
--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -649,6 +649,13 @@ SessionI::disconnected(const ConnectionPtr& connection, exception_ptr ex)
         runWithTopics(topicId, [topicId, self](TopicI* topic, TopicSubscriber&) { topic->detach(topicId, self); });
     }
 
+    // The peer's wire disconnected() op is not a connection close, so unregister the session that connected()
+    // registered with the connection manager here (a no-op if the connection already closed).
+    if (_connection)
+    {
+        _instance->getConnectionManager()->remove(self, _connection);
+    }
+
     _session = nullopt;
     _connection = nullptr;
     _retryCount = 0;


### PR DESCRIPTION
Fixes #5831.

`SessionI::connected()` registers the session in the `ConnectionManager`, keyed on its connection. The shared
`disconnected()` path nulls `_session`/`_connection` but never unregisters, and `destroyImpl`'s removal is gated on
`if (_session)`. So after the peer's **wire `disconnected()`** op nulls `_session`, no path removes the entry — it
lingers on the connection until that connection closes or the node shuts down. Because `ConnectionManager::add`
disables the inactivity check, a shared long-lived relay connection may never close on its own, so destroyed sessions
(each pinned by the `self` captured in the registration) accumulate on it across peer churn. Memory-hygiene only.

## Fix

Unregister in `disconnected()`, where the session is already detaching its topics, before `_session`/`_connection` are
reset:

```cpp
if (_connection)
{
    _instance->getConnectionManager()->remove(self, _connection);
}
```

This is the more complete of the two directions suggested in the issue:

- **Wire `disconnected()`** — the entry is removed immediately.
- **Reconnect before destroy** — covered for free: the old connection's entry is dropped as soon as the session
  leaves it, so a subsequent `connected()` on a new connection can't orphan the old one.
- **Connection close** — a no-op: `ConnectionManager::remove(connection)` already erased the entry before invoking
  this callback.
- **Direct destroy while still connected** (shutdown / `remove()`) — still handled by `destroyImpl`, since `_session`
  is set there.

`destroyImpl`'s existing `if (_session)` gate is then correct as-is (when `_session == nullopt`, a `disconnected`
already removed the entry), so no `destroyImpl` change or separate connection bookkeeping is needed.

## Testing

No new test: a deterministic reproduction needs a shared relay connection that stays open across a peer's wire
`disconnected()`, which isn't practical to set up in the DataStorm test harness — matching the sibling memory-hygiene
fixes. Verified the full DataStorm suite (including `reliability`'s disconnect/reconnect cases) still passes.

No changelog fragment: Low-severity, no observable behavior change, no field reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
