### PR TITLE
Assign DataStorm topic element ids from a single counter

### DIFF
--- a/changelog.d/datastorm/5820.md
+++ b/changelog.d/datastorm/5820.md
@@ -1,0 +1,4 @@
+- Fixed a bug in DataStorm where an any-key reader and a filtered reader created on the same topic could be assigned
+  the same element ID and merge into a single subscription on the writer: one of the readers silently missed the
+  samples rejected by the other reader's filter, and destroying either reader detached the other. Topic elements now
+  draw their IDs from a single counter.

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -931,7 +931,7 @@ TopicReaderI::createFiltered(
     auto element = make_shared<FilteredDataReaderI>(
         this,
         std::move(name),
-        ++_nextFilteredId,
+        ++_nextId,
         filter,
         std::move(sampleFilterName),
         std::move(sampleFilterCriteria),

--- a/cpp/src/DataStorm/TopicI.h
+++ b/cpp/src/DataStorm/TopicI.h
@@ -179,8 +179,10 @@ namespace DataStormI
         // The number of connected listeners.
         size_t _listenerCount{0};
 
+        // Element ids are drawn from a single counter for all elements of a topic (keyed, any-key, and filtered).
+        // Any-key and filtered elements are both presented to the peer as negated ids (filter subscriptions), so
+        // distinct raw values are required across all of them to keep their subscriptions apart.
         std::int64_t _nextId{0};
-        std::int64_t _nextFilteredId{0};
         std::int64_t _nextSampleId{0};
     };
 

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -404,6 +404,36 @@ void ::Reader::run(int argc, char* argv[])
             testSample(reader2, SampleEvent::Update, "elem3", "value");
         }
     }
+
+    // Coexisting any-key and filtered readers on the same topic: each keeps its own subscription. Both receive a
+    // sample matching the filter, and destroying the filtered reader leaves the any-key reader subscribed.
+    {
+        Topic<string, string> topic(node, "readerCoexistence");
+        Topic<string, int> barrier(node, "readerCoexistenceBarrier");
+
+        auto anyKeyReader = makeAnyKeyReader(topic, "", config);
+        {
+            auto filteredReader = makeFilteredKeyReader(topic, Filter<string>("_regex", "k0"), "", config);
+            filteredReader.waitForWriters(1);
+            anyKeyReader.waitForWriters(1);
+
+            auto sample = filteredReader.getNextUnread();
+            test(sample.getKey() == "k0");
+            test(sample.getValue() == "v0");
+            sample = anyKeyReader.getNextUnread();
+            test(sample.getKey() == "k0");
+            test(sample.getValue() == "v0");
+        }
+
+        // Signal that the filtered reader is destroyed; the writer then publishes a second key.
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        auto sample = anyKeyReader.getNextUnread();
+        test(sample.getKey() == "k1");
+        test(sample.getValue() == "v1");
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -374,6 +374,25 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // An any-key reader and a filtered reader coexisting on the same topic must each keep their own subscription:
+    // both receive matching samples, and destroying one must not detach the other.
+    cout << "testing coexisting any-key and filtered readers... " << flush;
+    {
+        Topic<string, string> topic(node, "readerCoexistence");
+        Topic<string, int> barrier(node, "readerCoexistenceBarrier");
+
+        auto writer = makeAnyKeyWriter(topic, "", config);
+        writer.waitForReaders(2);  // the any-key reader and the filtered reader
+        writer.update("k0", "v0"); // matches the filter, delivered to both readers
+
+        // Wait until the peer destroyed the filtered reader.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        writer.update("k1", "v1"); // the any-key reader must still be subscribed and receive this
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
     cout << "testing topic collocated key reader and writer... " << flush;
     {
         Topic<string, string> topic(node, "collocated");


### PR DESCRIPTION
Fixes #5820.

`TopicReaderI` drew any-key reader element ids from `_nextId` but filtered reader ids from a separate
`_nextFilteredId` counter. Both kinds of element are presented to the peer as **negated** ids (filter
subscriptions), so the first any-key reader and the first filtered reader on a topic collided on the wire: the
writer's `Listener::addOrGet` merged them into a single subscription keyed by `(topicId, -1)`, keeping only the
first-attached reader's filter/sample filter/name/priority — and `detachElements({-1})` from destroying either
reader removed the merged entry, silently detaching the survivor until its session reconnects.

## Fix

Topic elements now draw their ids from the single per-topic `_nextId` counter (`_nextFilteredId` removed), making
raw ids unique across keyed, any-key, and filtered elements. The wire sign convention — positive for key
subscriptions, negative for filter subscriptions — still distinguishes their kind, and nothing depends on filtered
ids being dense or drawn from a separate counter. Writers already used the single counter and are unaffected.

## Testing

New case in `test/DataStorm/events`: an any-key reader and a filtered reader coexisting on the same topic — both
receive a sample matching the filter, then the filtered reader is destroyed and the any-key reader must still
receive a subsequent sample. Without the fix the writer hangs at `waitForReaders(2)` because the two readers merge
into a single subscription. The full DataStorm suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
