### PR TITLE
Fix incorrect and stale API doc comments in the C# Ice library

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -471,22 +471,22 @@ public enum ToStringMode
     /// <summary>
     /// Characters with ordinal values greater than 127 are kept as-is in the resulting string.
     /// Non-printable ASCII
-    /// characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or \\unnnn.
+    /// characters with ordinal values 127 and below are encoded as \t, \n (etc.) or \unnnn.
     /// </summary>
     Unicode,
 
     /// <summary>
     /// Characters with ordinal values greater than 127 are encoded as universal character names in the resulting
-    /// string: \\unnnn for BMP characters and \\Unnnnnnnn for non-BMP characters.
+    /// string: \unnnn for BMP characters and \Unnnnnnnn for non-BMP characters.
     /// Non-printable ASCII characters
-    /// with ordinal values 127 and below are encoded as \\t, \\n (etc.) or \\unnnn.
+    /// with ordinal values 127 and below are encoded as \t, \n (etc.) or \unnnn.
     /// </summary>
     ASCII,
 
     /// <summary>
     /// Characters with ordinal values greater than 127 are encoded as a sequence of UTF-8 bytes using octal escapes.
-    /// Characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or an octal escape. Use this mode
-    /// to generate strings compatible with Ice 3.6 and earlier.
+    /// Non-printable ASCII characters with ordinal values 127 and below are encoded as \t, \n (etc.) or an octal
+    /// escape. Use this mode to generate strings compatible with Ice 3.6 and earlier.
     /// </summary>
     Compat
 }

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -63,6 +63,8 @@ public interface Connection
     /// the default object adapter of an outgoing connection is the communicator's default object adapter.
     /// </summary>
     /// <param name="adapter">The object adapter to associate with this connection.</param>
+    /// <exception cref="InvalidOperationException">Thrown when this connection is an incoming connection: you can
+    /// only call this method on outgoing (client) connections.</exception>
     /// <seealso cref="Communicator.getDefaultObjectAdapter"/>
     /// <seealso cref="getAdapter"/>
     void setAdapter(ObjectAdapter? adapter);
@@ -136,8 +138,8 @@ public interface Connection
     /// <summary>
     /// Throws an exception that provides the reason for the closure of this connection. For example,
     /// this method throws <see cref="CloseConnectionException"/> when the connection was closed gracefully by the peer;
-    /// It throws <see cref="ConnectionAbortedException"/> or <see cref="ConnectionClosedException"/>
-    /// when the connection is aborted. This method does nothing if the connection is not yet closed.
+    /// it throws <see cref="ConnectionAbortedException"/> when the connection is aborted with <see cref="abort"/>.
+    /// This method does nothing if the connection is not yet closing or closed.
     /// </summary>
     void throwException();
 }
@@ -339,7 +341,8 @@ public sealed class UDPConnectionInfo : IPConnectionInfo
 public sealed class WSConnectionInfo : ConnectionInfo
 {
     /// <summary>
-    /// The headers from the HTTP upgrade request.
+    /// The HTTP headers from the WebSocket upgrade handshake: the request headers for an incoming connection, and
+    /// the response headers for an outgoing connection.
     /// </summary>
     public readonly Dictionary<string, string> headers;
 

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -136,11 +136,13 @@ public interface Connection
     void setBufferSize(int rcvSize, int sndSize);
 
     /// <summary>
-    /// Throws an exception that provides the reason for the closure of this connection. For example,
-    /// this method throws <see cref="CloseConnectionException"/> when the connection was closed gracefully by the peer;
-    /// it throws <see cref="ConnectionAbortedException"/> when the connection is aborted with <see cref="abort"/>.
-    /// This method does nothing if the connection is not yet closing or closed.
+    /// Throws the exception that provides the reason for the closure of this connection. Does nothing if the
+    /// connection is not yet closing or closed.
     /// </summary>
+    /// <exception cref="CloseConnectionException">Thrown when the connection was closed gracefully by the
+    /// peer.</exception>
+    /// <exception cref="ConnectionAbortedException">Thrown when the connection is aborted with <see cref="abort"/>.
+    /// </exception>
     void throwException();
 }
 

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -10,7 +10,7 @@ using Protocol = Ice.Internal.Protocol;
 namespace Ice;
 
 /// <summary>
-/// Interface for input streams used to extract Slice types from a sequence of bytes.
+/// Represents a byte buffer used for unmarshaling data encoded using the Slice encoding.
 /// </summary>
 public sealed class InputStream
 {
@@ -80,7 +80,7 @@ public sealed class InputStream
     }
 
     /// <summary>
-    /// Releases any data retained by encapsulations. Internally calls clear().
+    /// Releases any data retained by encapsulations.
     /// </summary>
     public void clear()
     {
@@ -225,7 +225,7 @@ public sealed class InputStream
     }
 
     /// <summary>
-    /// Ends the previous encapsulation.
+    /// Ends the current encapsulation.
     /// </summary>
     public void endEncapsulation()
     {

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -697,7 +697,7 @@ public sealed class ObjectAdapter
     /// Finds the default servant for a specific category.
     /// </summary>
     /// <param name="category">The category.</param>
-    /// <returns>The default servant, or nullptr if not found.</returns>
+    /// <returns>The default servant, or null if not found.</returns>
     public Object? findDefaultServant(string category)
     {
         lock (_mutex)

--- a/csharp/src/Ice/OptionalFormat.cs
+++ b/csharp/src/Ice/OptionalFormat.cs
@@ -44,7 +44,7 @@ public enum OptionalFormat
 
     /// <summary>
     /// Fixed "size encoding" using 4 bytes followed by data.
-    /// Used by variable-size structs, and containers whose sizes can't be computed prior to unmarshaling.
+    /// Used by variable-size structs, and containers whose sizes can't be computed prior to marshaling.
     /// </summary>
     FSize = 6,
 

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -9,8 +9,7 @@ using Protocol = Ice.Internal.Protocol;
 namespace Ice;
 
 /// <summary>
-/// Interface for output streams used to write Slice types to a sequence
-/// of bytes.
+/// Represents a byte buffer used for marshaling data using the Slice encoding.
 /// </summary>
 public sealed class OutputStream
 {
@@ -206,7 +205,7 @@ public sealed class OutputStream
     }
 
     /// <summary>
-    /// Ends the previous encapsulation.
+    /// Ends the current encapsulation.
     /// </summary>
     public void endEncapsulation()
     {
@@ -1590,8 +1589,9 @@ public sealed class OutputStream
     /// <summary>
     /// Writes a class instance to the stream.
     /// </summary>
-    /// <param name="v">The value to write. This method writes the index of an instance; the state of the value is
-    /// written once writePendingValues() is called.</param>
+    /// <param name="v">The value to write. With the 1.0 encoding, this method writes an index and the state of the
+    /// value is marshaled when <see cref="writePendingValues" /> is called; with the 1.1 encoding, the state is
+    /// marshaled eagerly, without waiting for <see cref="writePendingValues" />.</param>
     public void writeValue(Value? v)
     {
         initEncaps();

--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -14,7 +14,7 @@ namespace Ice;
 /// <summary>
 /// Represents a set of properties used to configure Ice and Ice-based applications. A property is a key/value pair,
 /// where both the key and the value are strings. By convention, property keys should have the form
-/// <c>application-name>[.category[.sub-category]].name</c>.
+/// <c>application-name[.category[.sub-category]].name</c>.
 /// </summary>
 /// <remarks>This class is thread-safe: multiple threads can safely read and write the properties.</remarks>
 public sealed class Properties
@@ -94,7 +94,7 @@ public sealed class Properties
     /// </summary>
     /// <param name="key">The property key.</param>
     /// <returns>The property value or the default value.</returns>
-    /// <exception name="PropertyException">Thrown if the property is not a known Ice property.</exception>
+    /// <exception cref="PropertyException">Thrown if the property is not a known Ice property.</exception>
     public string getIceProperty(string key) => getPropertyWithDefault(key, getDefaultProperty(key));
 
     /// <summary>
@@ -124,7 +124,7 @@ public sealed class Properties
     /// </summary>
     /// <param name="key">The property key.</param>
     /// <returns>The property value interpreted as an integer.</returns>
-    /// <exception name="PropertyException">Thrown if the property value is not a valid integer.</exception>
+    /// <exception cref="PropertyException">Thrown if the property value is not a valid integer.</exception>
     public int getPropertyAsInt(string key) => getPropertyAsIntWithDefault(key, 0);
 
     /// <summary>
@@ -133,7 +133,7 @@ public sealed class Properties
     /// </summary>
     /// <param name="key">The property key.</param>
     /// <returns>The property value interpreted as an integer, or the default value.</returns>
-    /// <exception name="PropertyException">Thrown if the property is not a known Ice property or the value is not a
+    /// <exception cref="PropertyException">Thrown if the property is not a known Ice property or the value is not a
     /// valid integer.</exception>
     public int getIcePropertyAsInt(string key)
     {
@@ -154,7 +154,7 @@ public sealed class Properties
     /// <param name="key">The property key.</param>
     /// <param name="value">The default value to use if the property does not exist.</param>
     /// <returns>The property value interpreted as an integer, or the default value.</returns>
-    /// <exception name="PropertyException">Thrown if the property value is not a valid integer.</exception>
+    /// <exception cref="PropertyException">Thrown if the property value is not a valid integer.</exception>
     public int getPropertyAsIntWithDefault(string key, int value)
     {
         lock (_mutex)
@@ -394,13 +394,12 @@ public sealed class Properties
 
     /// <summary>
     /// Convert a sequence of command-line options into properties.
-    /// All options that begin with one of the following
-    /// prefixes are converted into properties: --Ice, --IceBox, --IceGrid,
-    /// --IceSSL, --IceStorm, and --Glacier2.
+    /// All options that begin with one of the reserved Ice prefixes (--Ice, --IceSSL, --IceBox, etc.) are converted
+    /// into properties.
     /// </summary>
     /// <param name="options">The command-line options.</param>
-    /// <returns>The command-line options that do not start with one of the listed prefixes, in their original order.
-    /// </returns>
+    /// <returns>The command-line options that do not start with one of the reserved prefixes, in their original
+    /// order.</returns>
     public string[] parseIceCommandLineOptions(string[] options)
     {
         string[] args = options;

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -142,22 +142,22 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
 
     /// <summary>
     /// Gets the identity embedded in this proxy.
-    /// <returns>The identity of the target object.</returns>
     /// </summary>
+    /// <returns>The identity of the target object.</returns>
     Identity ice_getIdentity();
 
     /// <summary>
-    /// Creates a new proxy that is identical to this proxy, except for the per-proxy context.
-    /// <param name="newIdentity">The identity for the new proxy.</param>
-    /// <returns>The proxy with the new identity.</returns>
+    /// Creates a new proxy that is identical to this proxy, except for the proxy identity.
     /// </summary>
+    /// <param name="newIdentity">The identity for the new proxy.</param>
+    /// <returns>The new proxy with the specified identity.</returns>
     ObjectPrx ice_identity(Identity newIdentity);
 
     /// <summary>
     /// Gets the per-proxy context for this proxy.
     /// </summary>
-    /// <returns>The per-proxy context. If the proxy does not have a per-proxy (implicit) context, the return value
-    /// is null.</returns>
+    /// <returns>A copy of the per-proxy context. The dictionary is empty when this proxy has no per-proxy
+    /// context.</returns>
     Dictionary<string, string> ice_getContext();
 
     /// <summary>
@@ -275,12 +275,12 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// Creates a new proxy that is identical to this proxy, except for the encoding used to marshal
     /// parameters.
     /// </summary>
-    /// <param name="encodingVersion">The encoding version to use to marshal requests parameters.</param>
+    /// <param name="encodingVersion">The encoding version to use to marshal request parameters.</param>
     /// <returns>The new proxy with the specified encoding version.</returns>
     ObjectPrx ice_encodingVersion(EncodingVersion encodingVersion);
 
     /// <summary>
-    /// Gets the encoding version used to marshal requests parameters.
+    /// Gets the encoding version used to marshal request parameters.
     /// </summary>
     /// <returns>The encoding version.</returns>
     EncodingVersion ice_getEncodingVersion();
@@ -900,8 +900,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Gets the per-proxy context for this proxy.
     /// </summary>
-    /// <returns>The per-proxy context. If the proxy does not have a per-proxy (implicit) context, the return value
-    /// is null.</returns>
+    /// <returns>A copy of the per-proxy context. The dictionary is empty when this proxy has no per-proxy
+    /// context.</returns>
     public Dictionary<string, string> ice_getContext() => new Dictionary<string, string>(_reference.getContext());
 
     /// <summary>
@@ -1107,7 +1107,7 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// Creates a new proxy that is identical to this proxy, except for the encoding used to marshal
     /// parameters.
     /// </summary>
-    /// <param name="encodingVersion">The encoding version to use to marshal requests parameters.</param>
+    /// <param name="encodingVersion">The encoding version to use to marshal request parameters.</param>
     /// <returns>The new proxy with the specified encoding version.</returns>
     public ObjectPrx ice_encodingVersion(EncodingVersion encodingVersion)
     {
@@ -1122,7 +1122,7 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     }
 
     /// <summary>
-    /// Gets the encoding version used to marshal requests parameters.
+    /// Gets the encoding version used to marshal request parameters.
     /// </summary>
     /// <returns>The encoding version.</returns>
     public EncodingVersion ice_getEncodingVersion() => _reference.getEncoding();
@@ -1709,7 +1709,7 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
 }
 
 /// <summary>
-/// Base class for all proxy helpers.
+/// The concrete proxy class that implements <see cref="ObjectPrx" />.
 /// </summary>
 public class ObjectPrxHelper : ObjectPrxHelperBase
 {
@@ -1719,7 +1719,7 @@ public class ObjectPrxHelper : ObjectPrxHelperBase
     /// <param name="communicator">The communicator of the new proxy.</param>
     /// <param name="proxyString">The string representation of the proxy.</param>
     /// <returns>The new proxy.</returns>
-    /// <exception name="ParseException">Thrown when <paramref name="proxyString" /> is not a valid proxy string.
+    /// <exception cref="ParseException">Thrown when <paramref name="proxyString" /> is not a valid proxy string.
     /// </exception>
     public static ObjectPrx createProxy(Communicator communicator, string proxyString)
     {

--- a/csharp/src/Ice/ServantLocator.cs
+++ b/csharp/src/Ice/ServantLocator.cs
@@ -28,7 +28,7 @@ public interface ServantLocator
     /// Notifies this servant locator that the dispatch on the servant returned by <see cref="locate"/> is complete.
     /// The object adapter calls this method only when <see cref="locate"/> returns a non-null servant.
     /// </summary>
-    /// <param name="curr">Information about the incoming request for which a servant is required.</param>
+    /// <param name="curr">Information about the request being dispatched.</param>
     /// <param name="servant">The servant that was returned by <see cref="locate"/>.</param>
     /// <param name="cookie">The cookie that was returned by <see cref="locate"/>.</param>
     /// <remarks>The implementation can throw any exception, including user exceptions. The Ice runtime marshals this
@@ -37,7 +37,7 @@ public interface ServantLocator
     void finished(Current curr, Object servant, object? cookie);
 
     /// <summary>
-    /// Notifies this servant locator that the object adapter in which it's installed is being deactivated.
+    /// Notifies this servant locator that the object adapter in which it's installed is being destroyed.
     /// </summary>
     /// <param name="category">The category with which this servant locator was registered.</param>
     /// <seealso cref="ObjectAdapter.destroy"/>

--- a/csharp/src/Ice/SliceTypeIdAttribute.cs
+++ b/csharp/src/Ice/SliceTypeIdAttribute.cs
@@ -16,7 +16,7 @@ public sealed class SliceTypeIdAttribute : Attribute
     public string Value { get; }
 
     /// <summary>Initializes a new instance of the <see cref="SliceTypeIdAttribute" /> class.</summary>
-    /// <param name="value">The Slice type ID.</param>>
+    /// <param name="value">The Slice type ID.</param>
     public SliceTypeIdAttribute(string value) => Value = value;
 }
 
@@ -31,6 +31,6 @@ public sealed class CompactSliceTypeIdAttribute : Attribute
     public int Value { get; }
 
     /// <summary>Initializes a new instance of the <see cref="CompactSliceTypeIdAttribute" /> class.</summary>
-    /// <param name="value">The compact type ID.</param>>
+    /// <param name="value">The compact type ID.</param>
     public CompactSliceTypeIdAttribute(int value) => Value = value;
 }

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -134,7 +134,8 @@ public sealed class Util
     /// Converts an object identity to a string.
     /// </summary>
     /// <param name="ident">The object identity to convert.</param>
-    /// <param name="toStringMode">Specifies if and how non-printable ASCII characters are escaped in the result.</param>
+    /// <param name="toStringMode">Specifies how to handle non-ASCII characters and non-printable ASCII
+    /// characters.</param>
     /// <returns>The string representation of the object identity.</returns>
     public static string identityToString(Identity ident, ToStringMode toStringMode = ToStringMode.Unicode)
     {

--- a/csharp/src/Ice/Value.cs
+++ b/csharp/src/Ice/Value.cs
@@ -44,8 +44,8 @@ public abstract class Value
     /// <summary>
     /// Returns the sliced data associated with this instance.
     /// </summary>
-    /// <returns>If this value has a preserved-slice base class and has been sliced during unmarshaling,
-    /// this returns the sliced data; otherwise this returns null.</returns>
+    /// <returns>The sliced data if this value was sliced during unmarshaling; otherwise null. Unknown slices are
+    /// preserved only when the sender uses the sliced format.</returns>
     public SlicedData? ice_getSlicedData() => _slicedData;
 
     [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
Fixes incorrect or stale XML doc comments in the C# Ice library, found during a C++/C# API doc review. Comment-only changes; no behavior change.

Incorrect behavior claims corrected:

- `ObjectPrx.ice_getContext`: never returns null — it returns a copy that is empty when there is no per-proxy context (also dropped the per-proxy/implicit conflation).
- `ObjectPrx.ice_identity` (interface): summary said "except for the per-proxy context" (copy-paste from `ice_context`).
- `ObjectPrxHelper`: not the "base class for all proxy helpers" — generated helpers derive from `ObjectPrxHelperBase`.
- `Connection.throwException`: `ConnectionClosedException` marks graceful closure, not abort; also throws while the connection is closing (matches the C++ doc).
- `Connection.setAdapter`: documents the `InvalidOperationException` thrown on incoming connections.
- `WSConnectionInfo.headers`: holds the upgrade *response* headers on outgoing connections.
- `OutputStream.writeValue`: deferral to `writePendingValues` is 1.0-only; with the 1.1 encoding the state is marshaled eagerly.
- `Value.ice_getSlicedData`: removed the stale "preserved-slice base class" condition (slice preservation is unconditional with the sliced format since 3.8).
- `Properties.parseIceCommandLineOptions`: the stale six-prefix list is replaced by the open-ended reserved-prefix wording (16 prefixes are converted today, including `--IceMX` and `--DataStorm`).
- `ServantLocator.deactivate`: called when the object adapter is destroyed, not deactivated.
- `ToStringMode.Compat`: only *non-printable* ASCII characters are escaped, matching the other two enumerators.
- `InputStream`/`OutputStream` class summaries: sealed classes described as "Interface for…"; `endEncapsulation` ends the *current* encapsulation; `clear()` no longer documents itself as "internally calls clear()".
- `Util.identityToString`: the mode governs non-ASCII handling too, not just non-printable ASCII (matches the C++ doc).
- `OptionalFormat.FSize`: "prior to marshaling", not unmarshaling.

Markup/typo fixes: `<returns>`/`<param>` tags nested inside `<summary>` on `ice_getIdentity`/`ice_identity` (they didn't render), `<exception name=...>` → `<exception cref=...>` (5 sites in `Proxy.cs`/`Properties.cs`), stray `>` after `</param>` in both `SliceTypeIdAttribute.cs` constructors, Doxygen-style `\\t` double backslashes in the `ToStringMode` docs (rendered literally in XML docs), a stray `>` in the `Properties` key-format example, "requests parameters" (×4), "nullptr" in `findDefaultServant`, and the `ServantLocator.finished` param doc copy-pasted from `locate`.
