### PR TITLE
Surface DataStorm configuration and API misuse errors as catchable failures

### DIFF
--- a/changelog.d/datastorm/5823.md
+++ b/changelog.d/datastorm/5823.md
@@ -1,8 +1,0 @@
-- Fixed several DataStorm error-handling bugs that aborted the process (`std::terminate`) instead of reporting the
-  error to the application: a `Node` constructor failure after a configuration error (such as an invalid
-  `DataStorm.Node.ConnectTo` endpoint) left worker threads running during unwinding; an invalid `DataStorm.Topic.*`
-  property value threw from the `noexcept` `Topic` methods that lazily create the topic reader or writer — the topic
-  defaults are now parsed by the `Node` constructor, so a bad value surfaces there as a catchable exception; and
-  `Node::getSessionConnection` threw on a malformed identity instead of returning null. In addition, the `Node`
-  shutdown members are now safe on a moved-from node, and the `DataStorm.Topic.DiscardPolicy` property accepts
-  `None` as an alias for `Never`, matching the `DiscardPolicy::None` enumerator.

--- a/changelog.d/datastorm/5823.md
+++ b/changelog.d/datastorm/5823.md
@@ -1,0 +1,8 @@
+- Fixed several DataStorm error-handling bugs that aborted the process (`std::terminate`) instead of reporting the
+  error to the application: a `Node` constructor failure after a configuration error (such as an invalid
+  `DataStorm.Node.ConnectTo` endpoint) left worker threads running during unwinding; an invalid `DataStorm.Topic.*`
+  property value threw from the `noexcept` `Topic` methods that lazily create the topic reader or writer — the topic
+  defaults are now parsed by the `Node` constructor, so a bad value surfaces there as a catchable exception; and
+  `Node::getSessionConnection` threw on a malformed identity instead of returning null. In addition, the `Node`
+  shutdown members are now safe on a moved-from node, and the `DataStorm.Topic.DiscardPolicy` property accepts
+  `None` as an alias for `Never`, matching the `DiscardPolicy::None` enumerator.

--- a/changelog.d/datastorm/node-config-error-handling.md
+++ b/changelog.d/datastorm/node-config-error-handling.md
@@ -1,0 +1,9 @@
+- Fixed a bug where a `DataStorm::Node` constructor failure, such as an invalid `DataStorm.Node.ConnectTo`
+  endpoint, aborted the process instead of throwing an exception.
+- Fixed a bug where an invalid `DataStorm.Topic.*` property value aborted the process when a topic reader or writer
+  was first created. The topic default configurations are now parsed by the `Node` constructor, so an invalid value
+  surfaces there as an exception. Additionally, the `DataStorm.Topic.DiscardPolicy` property now accepts `None` as
+  an alias for `Never`, matching the `DiscardPolicy::None` enumerator.
+- Fixed a bug where `Node::getSessionConnection` aborted the process when the given session identity was malformed,
+  instead of returning null.
+- Fixed a bug where calling `shutdown`, `isShutdown`, or `waitForShutdown` on a moved-from `Node` crashed.

--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -277,8 +277,6 @@ Instance::destroy(bool ownsCommunicator)
     }
     if (_node)
     {
-        // _node is only set once init() has progressed far enough; it is null when the Node constructor destroys a
-        // partially-initialized instance after an init() failure.
         _node->destroy(ownsCommunicator);
     }
 

--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -14,6 +14,58 @@ using namespace std;
 using namespace DataStormI;
 using namespace Ice;
 
+namespace
+{
+    DataStorm::ClearHistoryPolicy parseClearHistory(const std::string& value)
+    {
+        if (value == "OnAdd")
+        {
+            return DataStorm::ClearHistoryPolicy::OnAdd;
+        }
+        else if (value == "OnRemove")
+        {
+            return DataStorm::ClearHistoryPolicy::OnRemove;
+        }
+        else if (value == "OnAll")
+        {
+            return DataStorm::ClearHistoryPolicy::OnAll;
+        }
+        else if (value == "OnAllExceptPartialUpdate")
+        {
+            return DataStorm::ClearHistoryPolicy::OnAllExceptPartialUpdate;
+        }
+        else if (value == "Never")
+        {
+            return DataStorm::ClearHistoryPolicy::Never;
+        }
+        else
+        {
+            throw ParseException(__FILE__, __LINE__, "Invalid clear history policy: " + value);
+        }
+    }
+
+    DataStorm::DiscardPolicy parseDiscardPolicy(const std::string& value)
+    {
+        // "None" is accepted as an alias for "Never" to match the DataStorm::DiscardPolicy::None enumerator name.
+        if (value == "Never" || value == "None")
+        {
+            return DataStorm::DiscardPolicy::None;
+        }
+        else if (value == "SendTime")
+        {
+            return DataStorm::DiscardPolicy::SendTime;
+        }
+        else if (value == "Priority")
+        {
+            return DataStorm::DiscardPolicy::Priority;
+        }
+        else
+        {
+            throw ParseException(__FILE__, __LINE__, "Invalid discard policy: " + value);
+        }
+    }
+}
+
 Instance::Instance(
     CommunicatorPtr communicator,
     function<void(function<void()> call)> customExecutor,
@@ -27,6 +79,21 @@ Instance::Instance(
     }
 
     PropertiesPtr properties = _communicator->getProperties();
+
+    // Parse the topic default configurations eagerly, before any resource is created: an invalid DataStorm.Topic.*
+    // property value then surfaces as a catchable exception from the Node constructor. Parsing these lazily when a
+    // topic reader or writer is first created would let the exception escape the noexcept Topic methods
+    // (hasWriters/hasReaders/setReaderDefaultConfig/setWriterDefaultConfig) and call std::terminate.
+    _defaultReaderConfig.clearHistory = parseClearHistory(properties->getIceProperty("DataStorm.Topic.ClearHistory"));
+    _defaultReaderConfig.sampleCount = properties->getIcePropertyAsInt("DataStorm.Topic.SampleCount");
+    _defaultReaderConfig.sampleLifetime = properties->getIcePropertyAsInt("DataStorm.Topic.SampleLifetime");
+    _defaultReaderConfig.discardPolicy =
+        parseDiscardPolicy(properties->getIceProperty("DataStorm.Topic.DiscardPolicy"));
+
+    _defaultWriterConfig.clearHistory = *_defaultReaderConfig.clearHistory;
+    _defaultWriterConfig.sampleCount = *_defaultReaderConfig.sampleCount;
+    _defaultWriterConfig.sampleLifetime = *_defaultReaderConfig.sampleLifetime;
+    _defaultWriterConfig.priority = properties->getIcePropertyAsInt("DataStorm.Topic.Priority");
 
     if (properties->getIcePropertyAsInt("DataStorm.Node.Server.Enabled") > 0)
     {
@@ -208,7 +275,12 @@ Instance::destroy(bool ownsCommunicator)
             _multicastAdapter->destroy();
         }
     }
-    _node->destroy(ownsCommunicator);
+    if (_node)
+    {
+        // _node is only set once init() has progressed far enough; it is null when the Node constructor destroys a
+        // partially-initialized instance after an init() failure.
+        _node->destroy(ownsCommunicator);
+    }
 
     _executor->destroy();
     _connectionManager->destroy();

--- a/cpp/src/DataStorm/Instance.h
+++ b/cpp/src/DataStorm/Instance.h
@@ -56,11 +56,15 @@ namespace DataStormI
             return _adapter;
         }
 
-        // The topic default configurations are parsed from the DataStorm.Topic.* properties by the constructor, so an
-        // invalid property value surfaces as a catchable exception from the Node constructor rather than from the
-        // noexcept Topic methods that lazily create the topic reader or writer.
-        [[nodiscard]] const DataStorm::ReaderConfig& getDefaultReaderConfig() const { return _defaultReaderConfig; }
-        [[nodiscard]] const DataStorm::WriterConfig& getDefaultWriterConfig() const { return _defaultWriterConfig; }
+        [[nodiscard]] const DataStorm::ReaderConfig& getDefaultReaderConfig() const noexcept
+        {
+            return _defaultReaderConfig;
+        }
+
+        [[nodiscard]] const DataStorm::WriterConfig& getDefaultWriterConfig() const noexcept
+        {
+            return _defaultWriterConfig;
+        }
 
         [[nodiscard]] std::shared_ptr<ForwarderManager> getCollocatedForwarder() const
         {

--- a/cpp/src/DataStorm/Instance.h
+++ b/cpp/src/DataStorm/Instance.h
@@ -6,6 +6,7 @@
 #include "../Ice/Timer.h"
 #include "DataStorm/Config.h"
 #include "DataStorm/Contract.h"
+#include "DataStorm/Types.h"
 #include "Ice/Ice.h"
 
 #include <cmath>
@@ -54,6 +55,12 @@ namespace DataStormI
             assert(_adapter);
             return _adapter;
         }
+
+        // The topic default configurations are parsed from the DataStorm.Topic.* properties by the constructor, so an
+        // invalid property value surfaces as a catchable exception from the Node constructor rather than from the
+        // noexcept Topic methods that lazily create the topic reader or writer.
+        [[nodiscard]] const DataStorm::ReaderConfig& getDefaultReaderConfig() const { return _defaultReaderConfig; }
+        [[nodiscard]] const DataStorm::WriterConfig& getDefaultWriterConfig() const { return _defaultWriterConfig; }
 
         [[nodiscard]] std::shared_ptr<ForwarderManager> getCollocatedForwarder() const
         {
@@ -149,6 +156,8 @@ namespace DataStormI
         std::chrono::milliseconds _retryDelay;
         int _retryMultiplier;
         int _retryCount;
+        DataStorm::ReaderConfig _defaultReaderConfig;
+        DataStorm::WriterConfig _defaultWriterConfig;
 
         mutable std::mutex _mutex;
         mutable std::condition_variable _cond;

--- a/cpp/src/DataStorm/Node.cpp
+++ b/cpp/src/DataStorm/Node.cpp
@@ -41,9 +41,6 @@ Node::Node(NodeOptions options)
     {
         if (_instance)
         {
-            // Destroy the instance: this joins the timer and callback executor threads started by the Instance
-            // constructor (destroying them still running would call std::terminate) and takes care of the
-            // communicator and adapter teardown for both ownership modes.
             _instance->destroy(_ownsCommunicator);
         }
         else if (_ownsCommunicator)
@@ -90,7 +87,6 @@ Node::shutdown() noexcept
 bool
 Node::isShutdown() const noexcept
 {
-    // A moved-from node is inert and can never transition to shutdown; report it as already shut down.
     return _instance ? _instance->isShutdown() : true;
 }
 

--- a/cpp/src/DataStorm/Node.cpp
+++ b/cpp/src/DataStorm/Node.cpp
@@ -39,7 +39,14 @@ Node::Node(NodeOptions options)
     }
     catch (...)
     {
-        if (_ownsCommunicator)
+        if (_instance)
+        {
+            // Destroy the instance: this joins the timer and callback executor threads started by the Instance
+            // constructor (destroying them still running would call std::terminate) and takes care of the
+            // communicator and adapter teardown for both ownership modes.
+            _instance->destroy(_ownsCommunicator);
+        }
+        else if (_ownsCommunicator)
         {
             communicator->destroy();
         }
@@ -74,19 +81,26 @@ Node::~Node()
 void
 Node::shutdown() noexcept
 {
-    _instance->shutdown();
+    if (_instance)
+    {
+        _instance->shutdown();
+    }
 }
 
 bool
 Node::isShutdown() const noexcept
 {
-    return _instance->isShutdown();
+    // A moved-from node is inert and can never transition to shutdown; report it as already shut down.
+    return _instance ? _instance->isShutdown() : true;
 }
 
 void
 Node::waitForShutdown() const noexcept
 {
-    _instance->waitForShutdown();
+    if (_instance)
+    {
+        _instance->waitForShutdown();
+    }
 }
 
 Node&

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -562,7 +562,19 @@ NodeI::removePublisherSession(const NodePrx& node, const shared_ptr<PublisherSes
 ConnectionPtr
 NodeI::getSessionConnection(string_view id) const
 {
-    auto session = getSession(stringToIdentity(id));
+    Identity ident;
+    try
+    {
+        ident = stringToIdentity(id);
+    }
+    catch (const ParseException&)
+    {
+        // A malformed identity cannot match any session; this accessor is fail-soft (and noexcept in the public
+        // Node API), so return null rather than letting the exception escape.
+        return nullptr;
+    }
+
+    auto session = getSession(ident);
     if (session)
     {
         return session->getConnection();

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -39,53 +39,6 @@ namespace
     };
     const auto alwaysMatchFilter = make_shared<AlwaysMatchFilter>(); // NOLINT(cert-err58-cpp)
 
-    DataStorm::ClearHistoryPolicy parseClearHistory(const std::string& value)
-    {
-        if (value == "OnAdd")
-        {
-            return DataStorm::ClearHistoryPolicy::OnAdd;
-        }
-        else if (value == "OnRemove")
-        {
-            return DataStorm::ClearHistoryPolicy::OnRemove;
-        }
-        else if (value == "OnAll")
-        {
-            return DataStorm::ClearHistoryPolicy::OnAll;
-        }
-        else if (value == "OnAllExceptPartialUpdate")
-        {
-            return DataStorm::ClearHistoryPolicy::OnAllExceptPartialUpdate;
-        }
-        else if (value == "Never")
-        {
-            return DataStorm::ClearHistoryPolicy::Never;
-        }
-        else
-        {
-            throw ParseException(__FILE__, __LINE__, "Invalid clear history policy: " + value);
-        }
-    }
-
-    DataStorm::DiscardPolicy parseDiscardPolicy(const std::string& value)
-    {
-        if (value == "Never")
-        {
-            return DataStorm::DiscardPolicy::None;
-        }
-        else if (value == "SendTime")
-        {
-            return DataStorm::DiscardPolicy::SendTime;
-        }
-        else if (value == "Priority")
-        {
-            return DataStorm::DiscardPolicy::Priority;
-        }
-        else
-        {
-            throw ParseException(__FILE__, __LINE__, "Invalid discard policy: " + value);
-        }
-    }
 }
 
 TopicI::TopicI(
@@ -916,7 +869,7 @@ TopicReaderI::TopicReaderI(
           std::move(name),
           id)
 {
-    _defaultConfig = parseConfig();
+    _defaultConfig = _instance->getDefaultReaderConfig();
 }
 
 shared_ptr<DataReader>
@@ -992,18 +945,6 @@ TopicReaderI::destroy()
 }
 
 DataStorm::ReaderConfig
-TopicReaderI::parseConfig() const
-{
-    auto properties = _instance->getCommunicator()->getProperties();
-    DataStorm::ReaderConfig config;
-    config.clearHistory = parseClearHistory(properties->getIceProperty("DataStorm.Topic.ClearHistory"));
-    config.sampleCount = properties->getIcePropertyAsInt("DataStorm.Topic.SampleCount");
-    config.sampleLifetime = properties->getIcePropertyAsInt("DataStorm.Topic.SampleLifetime");
-    config.discardPolicy = parseDiscardPolicy(properties->getIceProperty("DataStorm.Topic.DiscardPolicy"));
-    return config;
-}
-
-DataStorm::ReaderConfig
 TopicReaderI::mergeConfigs(DataStorm::ReaderConfig config) const
 {
     if (!config.sampleCount.has_value())
@@ -1053,7 +994,7 @@ TopicWriterI::TopicWriterI(
           std::move(name),
           id)
 {
-    _defaultConfig = parseConfig();
+    _defaultConfig = _instance->getDefaultWriterConfig();
 }
 
 shared_ptr<DataWriter>
@@ -1093,18 +1034,6 @@ TopicWriterI::destroy()
     {
         factory->removeTopicWriter(_name, shared_from_this());
     }
-}
-
-DataStorm::WriterConfig
-TopicWriterI::parseConfig() const
-{
-    auto properties = _instance->getCommunicator()->getProperties();
-    DataStorm::WriterConfig config;
-    config.clearHistory = parseClearHistory(properties->getIceProperty("DataStorm.Topic.ClearHistory"));
-    config.sampleCount = properties->getIcePropertyAsInt("DataStorm.Topic.SampleCount");
-    config.sampleLifetime = properties->getIcePropertyAsInt("DataStorm.Topic.SampleLifetime");
-    config.priority = properties->getIcePropertyAsInt("DataStorm.Topic.Priority");
-    return config;
 }
 
 DataStorm::WriterConfig

--- a/cpp/src/DataStorm/TopicI.h
+++ b/cpp/src/DataStorm/TopicI.h
@@ -215,7 +215,6 @@ namespace DataStormI
         void destroy() final;
 
     private:
-        [[nodiscard]] DataStorm::ReaderConfig parseConfig() const;
         [[nodiscard]] DataStorm::ReaderConfig mergeConfigs(DataStorm::ReaderConfig) const;
 
         DataStorm::ReaderConfig _defaultConfig;
@@ -244,7 +243,6 @@ namespace DataStormI
         void destroy() final;
 
     private:
-        [[nodiscard]] DataStorm::WriterConfig parseConfig() const;
         [[nodiscard]] DataStorm::WriterConfig mergeConfigs(DataStorm::WriterConfig) const;
 
         DataStorm::WriterConfig _defaultConfig;

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -33,9 +33,11 @@ void ::Writer::run(int argc, char* argv[])
             test(nm2.getSessionConnection("a/b/c") == nullptr);
 
             // The shutdown members are safe on a moved-from node; a moved-from node reports itself as shut down.
+            // NOLINTBEGIN(clang-analyzer-cplusplus.Move)
             n.shutdown();
             test(n.isShutdown());
             n.waitForShutdown();
+            // NOLINTEND(clang-analyzer-cplusplus.Move)
         }
 
         {

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -28,12 +28,90 @@ void ::Writer::run(int argc, char* argv[])
             auto nm2 = std::move(nm);
             [[maybe_unused]] Ice::CommunicatorPtr communicator = nm2.getCommunicator();
             [[maybe_unused]] Ice::ConnectionPtr connection = nm2.getSessionConnection("s");
+
+            // A malformed session identity is fail-soft.
+            test(nm2.getSessionConnection("a/b/c") == nullptr);
+
+            // The shutdown members are safe on a moved-from node; a moved-from node reports itself as shut down.
+            n.shutdown();
+            test(n.isShutdown());
+            n.waitForShutdown();
         }
 
         {
             Ice::CommunicatorPtr communicator = Ice::initialize();
             Ice::CommunicatorHolder communicatorHolder{communicator};
             Node n2{communicator};
+        }
+
+        {
+            auto makeInitData = [](const string& property, const string& value)
+            {
+                Ice::InitializationData initData;
+                initData.properties = Ice::createProperties();
+                initData.properties->setProperty(property, value);
+                return initData;
+            };
+
+            // A node configured with an invalid DataStorm.Node.ConnectTo endpoint surfaces a catchable exception
+            // from the Node constructor, with and without communicator ownership.
+            {
+                Ice::CommunicatorHolder holder{Ice::initialize(makeInitData("DataStorm.Node.ConnectTo", "invalid"))};
+                try
+                {
+                    Node n7{holder.communicator()};
+                    test(false);
+                }
+                catch (const Ice::ParseException&)
+                {
+                }
+            }
+            try
+            {
+                Node n8{NodeOptions{
+                    .communicator = Ice::initialize(makeInitData("DataStorm.Node.ConnectTo", "invalid")),
+                    .nodeOwnsCommunicator = true}};
+                test(false);
+            }
+            catch (const Ice::ParseException&)
+            {
+            }
+
+            // An invalid DataStorm.Topic.* property value surfaces a catchable exception from the Node constructor
+            // rather than from the noexcept Topic methods that lazily create the topic reader or writer.
+            {
+                Ice::CommunicatorHolder holder{Ice::initialize(makeInitData("DataStorm.Topic.ClearHistory", "onAdd"))};
+                try
+                {
+                    Node n9{holder.communicator()};
+                    test(false);
+                }
+                catch (const Ice::ParseException&)
+                {
+                }
+            }
+
+            // A non-numeric topic default surfaces the property exception from the Node constructor as well.
+            {
+                Ice::CommunicatorHolder holder{Ice::initialize(makeInitData("DataStorm.Topic.SampleCount", "abc"))};
+                try
+                {
+                    Node n10{holder.communicator()};
+                    test(false);
+                }
+                catch (const Ice::PropertyException&)
+                {
+                }
+            }
+
+            // "None" is accepted as an alias for the "Never" discard policy, matching the DiscardPolicy::None
+            // enumerator.
+            {
+                Ice::CommunicatorHolder holder{Ice::initialize(makeInitData("DataStorm.Topic.DiscardPolicy", "None"))};
+                Node n11{holder.communicator()};
+                Topic<int, string> topic(n11, "discardPolicyAlias");
+                auto reader = makeSingleKeyReader(topic, 0);
+            }
         }
 
         Node n3;


### PR DESCRIPTION
Fixes #5823, fixes #5828, fixes #5829, fixes #5830.

Several DataStorm error paths aborted the process via `std::terminate` instead of reporting the error to the
application:

- **#5823** — A `Node` constructor failure after the `Instance` was created (e.g. an invalid
  `DataStorm.Node.ConnectTo` endpoint, or a malformed `DataStorm.Node.Multicast.Proxy`) destroyed only the
  communicator; the stack unwind then dropped the last `Instance` reference and destructed the still-joinable
  `Timer` and `CallbackExecutor` worker threads → `std::terminate`. The constructor catch now calls
  `Instance::destroy`, which joins both threads and handles the communicator/adapter teardown for both ownership
  modes; `Instance::destroy` now tolerates an instance whose `init()` did not complete (`_node` guard).
- **#5828** — The `noexcept` `Topic` methods (`hasWriters`, `hasReaders`, `setReaderDefaultConfig`,
  `setWriterDefaultConfig`) lazily created the topic reader/writer, whose constructor parsed the
  `DataStorm.Topic.*` properties and threw `ParseException` on an invalid value — across the `noexcept` boundary →
  `std::terminate`. The topic defaults are now parsed **eagerly by the `Node` constructor** (before any resource or
  thread is created), so a bad value surfaces there as a catchable exception and the lazy paths no longer parse.
  `DataStorm.Topic.DiscardPolicy` additionally accepts `None` as an alias for `Never`, matching the
  `DiscardPolicy::None` enumerator that invites the typo.
- **#5829** — `Node::getSessionConnection` is `noexcept` but `Ice::stringToIdentity` throws on a malformed
  identity. The parse failure now returns null, consistent with the accessor's fail-soft contract.
- **#5830** — `Node::shutdown`/`isShutdown`/`waitForShutdown` dereferenced a null `_instance` on a moved-from node
  while every sibling member guards it. They are now no-ops; `isShutdown` reports a moved-from node as shut down
  (it is inert and can never transition, keeping `waitForShutdown` ≡ "wait until `isShutdown()`" consistent).

Behavior note: `DataStorm.Topic.*` defaults are now read once at `Node` construction instead of at the first topic
reader/writer creation, so a misconfigured value fails the `Node` constructor even if the application never creates
a topic. Per-topic overrides via `setReaderDefaultConfig`/`setWriterDefaultConfig` are unaffected.

## Testing

New cases in `test/DataStorm/api`, each verified red→green:

- invalid `DataStorm.Node.ConnectTo` → `ParseException` from the `Node` constructor, with and without communicator
  ownership (without the fix the process aborts via `std::terminate` during unwinding);
- invalid `DataStorm.Topic.ClearHistory` → `ParseException`, and non-numeric `DataStorm.Topic.SampleCount` →
  `PropertyException`, both from the `Node` constructor;
- `DataStorm.Topic.DiscardPolicy=None` accepted;
- `getSessionConnection("a/b/c")` returns null (without the fix: `libc++abi: terminating due to uncaught exception
  of type Ice::ParseException`);
- `shutdown`/`isShutdown`/`waitForShutdown` on a moved-from node (without the fix: SIGSEGV).

The full DataStorm suite passes. A changelog fragment is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
