### PR TITLE
Fix DataStorm factory element cleanup and setUpdaters tag forwarding

### DIFF
--- a/changelog.d/datastorm/5826.md
+++ b/changelog.d/datastorm/5826.md
@@ -1,0 +1,2 @@
+- Fixed a memory leak in DataStorm where the per-topic key, tag, and filter factories kept one expired map entry per
+  distinct value that was no longer used, growing without bound on long-lived nodes with a changing key set.

--- a/changelog.d/datastorm/5827.md
+++ b/changelog.d/datastorm/5827.md
@@ -1,0 +1,3 @@
+- Fixed a bug in DataStorm where a subscriber that attached to a topic in the short window before the topic's
+  updaters were set with `setUpdaters` could silently apply partial updates as no-ops for the lifetime of the
+  session.

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -223,8 +223,10 @@ namespace DataStormI
             auto p = _elements.find(v->get());
             if (p != _elements.end())
             {
+                // remove() runs from the element's deleter, so the entry for v is always expired; erase it unless a
+                // concurrent createImpl already replaced it with a new, still live element for the same value.
                 e = p->second.lock();
-                if (e && e.get() == v)
+                if (!e || e.get() == v)
                 {
                     _elements.erase(p);
                 }

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -226,7 +226,7 @@ namespace DataStormI
                 // remove() runs from the element's deleter, so the entry for v is always expired; erase it unless a
                 // concurrent createImpl already replaced it with a new, still live element for the same value.
                 e = p->second.lock();
-                if (!e || e.get() == v)
+                if (!e)
                 {
                     _elements.erase(p);
                 }

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -684,6 +684,21 @@ TopicI::setUpdaters(map<shared_ptr<Tag>, Updater> updaters)
 {
     unique_lock<mutex> lock(_mutex);
     _updaters = std::move(updaters);
+
+    // Forward the tag set to the connected sessions, like setUpdater does: a peer that attached before the updaters
+    // were set (topics are announced first) would otherwise never learn the tags and silently resolve partial
+    // updates with the no-op updater.
+    if (!_updaters.empty())
+    {
+        try
+        {
+            _forwarder->attachTags(_id, getTags(), true);
+        }
+        catch (const std::exception&)
+        {
+            forwarderException();
+        }
+    }
 }
 
 map<shared_ptr<Tag>, Topic::Updater>

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 #include "DataStorm/DataStorm.h"
+#include "DataStorm/InternalT.h"
 #include "Test.h"
 #include "TestHelper.h"
 
@@ -293,6 +294,37 @@ void ::Writer::run(int argc, char* argv[])
         ostringstream os;
         os << skw.getLast();
         os << skw.getLast().getEvent();
+    }
+    cout << "ok" << endl;
+
+    cout << "testing element factory cleanup... " << flush;
+    {
+        // The factory interns elements by value; an element's entry must be erased when the last reference to the
+        // element goes away, so a value that is never used again does not keep a map entry alive.
+        struct TestKeyFactory : DataStormI::AbstractFactoryT<int, DataStormI::KeyT<int>>
+        {
+            [[nodiscard]] size_t size() const
+            {
+                lock_guard<mutex> lock(_mutex);
+                return _elements.size();
+            }
+        };
+
+        auto factory = make_shared<TestKeyFactory>();
+        factory->init();
+        {
+            auto key = factory->create(5);
+            test(factory->size() == 1);
+
+            // Creating the same value returns the interned element.
+            test(factory->create(5) == key);
+            test(factory->size() == 1);
+        }
+        test(factory->size() == 0); // the entry is erased when the element dies
+
+        // The value can be interned again afterwards.
+        auto key = factory->create(5);
+        test(factory->size() == 1);
     }
     cout << "ok" << endl;
 }


### PR DESCRIPTION
Fixes #5826, fixes #5827.

**#5826** — `AbstractFactoryT::remove` only erased the `_elements` entry when the entry still locked to the element
being removed. `remove()` runs from the element's custom deleter, after the use count reached zero, so the lock
always returned null and the erase never fired: one map node — holding a copy of the key/tag/filter value plus the
weak-count-pinned control block — leaked per distinct value that died and never recurred, growing without bound on
long-lived nodes with a changing key set. The entry is now erased when it is expired; a live replacement inserted
by a concurrent `createImpl` (which erases the expired entry and re-interns the value under the same mutex) is
still preserved, matching the deleter comment.

**#5827** — `TopicI::setUpdaters` stored the updaters without forwarding the tag set to connected sessions, unlike
the single-tag `setUpdater`. `Topic::getWriter()`/`getReader()` announce the topic before transferring the
updaters, so a peer whose `attachTopic` dispatch landed in that window never learned the tags — its partial updates
resolved to the no-op updater silently for the session's lifetime. `setUpdaters` now forwards the full tag set
(`attachTags` with `initialize = true`, which replaces the subscriber's tag set — correct for a bulk assignment,
where `setUpdater` remains incremental with `initialize = false`).

## Testing

- #5826: new white-box test in `test/DataStorm/api` (a `TestKeyFactory` deriving from `AbstractFactoryT`) —
  verified red→green: without the fix, `factory->size() == 0` fails after the last element reference goes away.
  Also covers interning stability (same value → same element) and re-creation after death.
- #5827: no test — the window is a few instructions on the creating thread against an independently-timed network
  round-trip, and is not reachable from the public API.

The full DataStorm suite passes. A changelog fragment is included for the leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
