### PR TITLE
Detach the elements of a destroyed DataStorm topic when the session is disconnected

### DIFF
--- a/changelog.d/datastorm/5821.md
+++ b/changelog.d/datastorm/5821.md
@@ -1,0 +1,3 @@
+- Fixed a bug in DataStorm where destroying a topic while its session's connection was closing could leave the
+  topic's readers or writers permanently attached to the disconnected peer: `hasWriters()`/`hasReaders()` stayed
+  true, `waitForNoWriters()`/`waitForNoReaders()` hung, and the disconnect callbacks never fired.

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -961,15 +961,15 @@ void
 SessionI::disconnect(int64_t topicId, TopicI* topic)
 {
     lock_guard<mutex> lock(_mutex); // Called by TopicI::destroy
-    if (!_session)
-    {
-        return;
-    }
 
+    // No _session check: a session disconnected after the topic was marked destroyed skipped this topic when
+    // detaching (runWithTopics skips destroyed topics), so the subscriber entry must be cleaned up here even when
+    // the session is gone. The checks below cover every other state: the entry is absent when the peer detached the
+    // topic first or the session was destroyed.
     auto t = _topics.find(topicId);
     if (t == _topics.end())
     {
-        return; // Peer topic detached first.
+        return; // Peer topic detached first, or the session was destroyed.
     }
     auto& subscriber = t->second;
 


### PR DESCRIPTION
Fixes #5821.

`SessionI::disconnect` — called by `TopicI::destroy` via `TopicI::disconnect` — contains the cleanup that detaches
the elements of a destroyed topic directly, because the session's own detach paths (`runWithTopics`) skip destroyed
topics. That cleanup was gated behind an early return on `!_session`, so when a connection loss won the race
against the topic destruction — `disconnected()` skips the already-marked-destroyed topic, then nulls `_session` —
nothing detached the topic's elements. Their listener entries and the topic's listener count stayed behind:

- debug builds abort on `assert(_listenerCount == 0)` at the end of `TopicI::disconnect`;
- release builds keep `hasWriters()`/`hasReaders()` true for a peer that is gone, hang
  `waitForNoWriters()`/`waitForNoReaders()`, never fire the `onConnected*` disconnect callbacks, and pin the
  session servant through the listener `shared_ptr`s until each element is individually destroyed.

## Fix

The cleanup now runs whenever the session still holds the topic's subscriber entry, regardless of `_session`. The
entry is absent in every state where the cleanup already happened: `TopicI::detach` (driven by a disconnect that
saw the topic before it was destroyed) erases the session from the topic's listeners so this path isn't reached
again, a peer `detachTopic` erases the entry first, and `destroyImpl` clears the map.

Two narrower siblings of this race — a peer `detachTopic` or `destroyImpl` erasing the subscriber entry in the same
window (both require the peer/node teardown to land between `_destroyed = true` and `TopicI::disconnect`) — are
deliberately not covered here and are tracked separately; a uniform fix needs care because a double element detach
is not safe (`Listener::get` dereferences an unchecked `find()`).

## Testing

No new test: the race window is between `TopicI::destroy` marking the topic destroyed and `TopicI::disconnect`
taking the session lock, with the connection-close notification landing in between — not drivable deterministically
from the public API. The full DataStorm suite passes. A changelog fragment is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
