### PR TITLE
Upgrade a DataStorm relay node session to forward announcements when requested

### DIFF
--- a/changelog.d/datastorm/5822.md
+++ b/changelog.d/datastorm/5822.md
@@ -1,0 +1,3 @@
+- Fixed a bug in DataStorm where, after a reconnection, a relay could permanently stop forwarding topic
+  announcements to a node without a public endpoint: readers and writers matched only through such announcements
+  never connected until the connection was re-established with a favorable timing.

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -171,6 +171,15 @@ NodeSessionI::NodeSessionI(
 {
     if (forwardAnnouncements)
     {
+        enableAnnouncementForwarding();
+    }
+}
+
+void
+NodeSessionI::enableAnnouncementForwarding()
+{
+    if (!_lookup)
+    {
         _lookup = _connection->createProxy<LookupPrx>(Identity{.name = "Lookup", .category = "DataStorm"});
     }
 }

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -145,6 +145,12 @@ namespace
         {
             if (node->ice_getEndpoints().empty() && node->ice_getAdapterId().empty())
             {
+                // Create the session without announcement forwarding. A node without a public endpoint can be a peer
+                // reached through the relay that current.con connects to, rather than the direct peer on that
+                // connection. Enabling forwarding for such a relayed identity would duplicate announcements over a
+                // connection whose direct peer already forwards them - once per relayed identity. A direct peer that
+                // wants forwarding has its session upgraded when its own Lookup::createSession arrives on the matching
+                // connection (see NodeSessionManager::createOrGet).
                 shared_ptr<NodeSessionI> nodeSession = _nodeSessionManager->createOrGet(node, current.con, false);
                 node = nodeSession->getPublicNode();
                 if (session)

--- a/cpp/src/DataStorm/NodeSessionI.h
+++ b/cpp/src/DataStorm/NodeSessionI.h
@@ -28,6 +28,11 @@ namespace DataStormI
         [[nodiscard]] std::optional<DataStormContract::LookupPrx> getLookup() const { return _lookup; }
         [[nodiscard]] const Ice::ConnectionPtr& getConnection() const { return _connection; }
 
+        /// Enables forwarding announcements to the peer node. Called by the node session manager - with its mutex
+        /// locked - when the peer requests announcement forwarding for an existing session that was created without
+        /// it.
+        void enableAnnouncementForwarding();
+
         // Helper method to create a forwarder proxy for a subscriber or publisher session proxy.
         template<typename Prx> [[nodiscard]] Prx forwarder(const Prx& session) const
         {

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -102,6 +102,15 @@ NodeSessionManager::createOrGet(NodePrx node, const ConnectionPtr& newConnection
         }
         else
         {
+            // The existing session may have been created without announcement forwarding by the NodeForwarder path
+            // racing this peer's createSession request over the same connection. Upgrade it and replay the recorded
+            // announcements, as when a forwarding session is created below; otherwise the relay would never forward
+            // announcements to the peer for the lifetime of the connection.
+            if (forwardAnnouncements && !p->second->getLookup())
+            {
+                p->second->enableAnnouncementForwarding();
+                announceKnownTopics(*p->second->getLookup(), newConnection);
+            }
             return p->second;
         }
     }


### PR DESCRIPTION
Fixes #5822.

`NodeSessionManager::createOrGet` returned an existing session with a matching connection without considering the
`forwardAnnouncements` argument, and a node session's lookup proxy was only ever created at construction. On a
reconnect, the relay's `NodeForwarder` path — which requests no announcement forwarding — could create the node
session before the peer's `Lookup::createSession` request arrived on the same connection; that request then found
the existing session and its forwarding flag was silently discarded. For the lifetime of the connection the relay
neither forwarded new topic announcements to the node (`forward` skips lookup-less sessions) nor replayed the
recorded ones (`announceKnownTopics`), so readers and writers matched only through such announcements never
connected — the same relay scenario as #5359/#5399.

<details>
<summary><b>Sequence diagram of the race</b> (endpoint-less node N and peer M both behind relay R)</summary>

```mermaid
sequenceDiagram
    autonumber
    participant N as Node N (no public endpoint)
    participant R as Relay R (NodeSessionManager)

    Note over N,R: connection connNR re-established

    N->>R: createSession(subscriber = N), relayed data-session retry toward M, forward = false
    Note over R: createOrGet(N, connNR, false)<br/>no session yet, so it constructs NodeSessionI(N) with _lookup = ∅<br/>(this call wins the race)

    N->>R: Lookup::createSession(N), node-session connect(), forward = true
    Note over R: createOrGet(N, connNR, true)<br/>connection matches, returns the existing session<br/>forward = true is discarded, _lookup stays ∅

    Note over R: Session stays lookup-less for the life of connNR:<br/>forward() skips it and announceKnownTopics() never replays,<br/>so N never receives M's announcements (silent discovery loss)
```

</details>

## Fix

`createOrGet` now upgrades a lookup-less session in place when announcement forwarding is requested for its
connection: `NodeSessionI::enableAnnouncementForwarding()` creates the connection-scoped lookup proxy (the
constructor delegates to it), and the recorded announcements are replayed exactly like the new-session path.

This also heals the sibling downgrade — a `NodeForwarder`-path call on a *new* connection destroying a
previously-forwarding session and recreating it without forwarding — as soon as the peer's `createSession` arrives
on that connection, which is the normal reconnect sequence. All `_lookup` accesses remain under the manager mutex.

## Why not just forward from the `NodeForwarder` path?

Making that path request forwarding (or dropping the `forwardAnnouncements` argument altogether) looks simpler but
is a relay-chain regression. The `false` is load-bearing: it maintains the invariant that **at most one
announcement-forwarding session exists per connection.** `forward()` iterates every session with no per-connection
de-duplication. A node reaching the `NodeForwarder` path can be a *remote* identity multiplexed over a
relay-to-relay connection — `current.con` is the connection to the relay, not to the node (see the comment in
`NodeI::createPublisherSession`) — so several such sessions can share one connection whose direct peer already
forwards announcements for the whole hop. Giving each its own lookup proxy would duplicate every announcement once
per relayed identity, per hop.

Upgrading in place is safe precisely because it only promotes on a connection-matching `Lookup::createSession`,
which only ever arrives on a node's own direct connection — where it is the sole peer. Remote pseudo-sessions never
receive a `createSession` and correctly stay lookup-less. A comment at the call site records this.

## Testing

No new test: the race requires a request forwarded through the relay to beat the peer's `Lookup::createSession`
onto a freshly established connection, which is not deterministically drivable from the test harness. The full
DataStorm suite (including the relay tests) passes. A changelog fragment is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
