### PR TITLE
Make DataStorm reader-side partial update resolution robust to discards and errors

### DIFF
--- a/changelog.d/datastorm/5824.md
+++ b/changelog.d/datastorm/5824.md
@@ -1,0 +1,5 @@
+- Improved the robustness of DataStorm partial updates on the reader side: a sample discarded by the reader's
+  discard policy still establishes the value a later partial update on its key resolves against, a partial update
+  without such a value is now dropped with a trace instead of being applied to a default-constructed value (which
+  typically crashed applications using class-typed values), and an updater or decoder that throws now drops only
+  that sample with a warning instead of discarding the rest of the initialization samples.

--- a/changelog.d/datastorm/5824.md
+++ b/changelog.d/datastorm/5824.md
@@ -1,5 +1,0 @@
-- Improved the robustness of DataStorm partial updates on the reader side: a sample discarded by the reader's
-  discard policy still establishes the value a later partial update on its key resolves against, a partial update
-  without such a value is now dropped with a trace instead of being applied to a default-constructed value (which
-  typically crashed applications using class-typed values), and an updater or decoder that throws now drops only
-  that sample with a warning instead of discarding the rest of the initialization samples.

--- a/changelog.d/datastorm/reader-partial-update-robustness.md
+++ b/changelog.d/datastorm/reader-partial-update-robustness.md
@@ -1,0 +1,6 @@
+- Fixed a bug in DataStorm where a sample discarded by the reader's discard policy left later partial updates on
+  its key without a base value to resolve against.
+- A DataStorm partial update without a base value is now dropped with a trace, instead of being applied to a
+  default-constructed value — which typically crashed applications using class-typed values.
+- A DataStorm reader-side updater or decoder that throws now drops only that sample and logs a warning; previously
+  the exception could discard an entire batch of initialization samples.

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -188,8 +188,9 @@ namespace DataStorm
 
         /// Calls the given function to provide the initial set of unread samples and when new samples are queued.
         /// If a function is already set, it will be replaced.
-        /// The @p init callback is always called after this method returns to provide the initial set of unread
-        /// samples. The @p queue callback is called when a new sample is received.
+        /// The @p init callback is called after this method returns to provide the initial set of unread samples;
+        /// it is only called when the reader has unread samples. The @p queue callback is called when a new sample
+        /// is received.
         /// @param init The function to call with the initial set of unread samples.
         /// @param queue The function to call when a new sample is received.
         void onSamples(
@@ -378,6 +379,8 @@ namespace DataStorm
         /// Sets an updater function for the given update tag. The function is called when a partial update is
         /// received or sent to compute the new value. The function is provided the latest value and the partial
         /// update. It should return the new value.
+        /// An updater that throws when applying a received partial update causes the sample to be dropped: a
+        /// warning is logged and the following samples are delivered normally.
         /// @param tag The update tag.
         /// @param updater The updater function.
         template<typename UpdateValue>

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -768,27 +768,79 @@ DataReaderI::initSamples(
             (_discardPolicy == DataStorm::DiscardPolicy::Priority &&
              hasLowerPriorityThanConnected(priority, sample->key)))
         {
+            // The discard only affects the application-visible delivery: when the key has no base yet, still record
+            // the discarded sample as the base partial updates resolve against, otherwise a later partial update on
+            // the key would have no base.
+            if (sample->event != DataStorm::SampleEvent::PartialUpdate &&
+                previousByKey.find(sample->key) == previousByKey.end())
+            {
+                try
+                {
+                    if (!sample->hasValue())
+                    {
+                        sample->decode(_parent->instance()->getCommunicator());
+                    }
+                    previousByKey[sample->key] = sample;
+                }
+                catch (const std::exception&)
+                {
+                    // Ignore, the sample was discarded anyway.
+                }
+            }
             continue;
         }
 
         assert(sample->key);
-        valid.push_back(sample);
 
         if (!sample->hasValue())
         {
             if (sample->event == DataStorm::SampleEvent::PartialUpdate)
             {
                 auto p = previousByKey.find(sample->key);
-                _parent->getUpdater(sample->tag)(
-                    p == previousByKey.end() ? nullptr : p->second,
-                    sample,
-                    _parent->instance()->getCommunicator());
+                if (p == previousByKey.end())
+                {
+                    // No base to resolve the partial update against (for example a peer writer that doesn't
+                    // bootstrap the base): drop the sample rather than apply the update to a default-constructed
+                    // value.
+                    if (_traceLevels->data > 0)
+                    {
+                        Trace out(_traceLevels->logger, _traceLevels->dataCat);
+                        out << this << ": discarded partial update sample " << sample->id
+                            << ": no base value for the key";
+                    }
+                    continue;
+                }
+
+                try
+                {
+                    _parent->getUpdater(sample->tag)(p->second, sample, _parent->instance()->getCommunicator());
+                }
+                catch (const std::exception& ex)
+                {
+                    // An updater or decoder that throws (a user updater error, or a writer/reader update type
+                    // mismatch) drops the sample; the base is left unchanged so the next full sample resynchronizes
+                    // the key.
+                    Warning out(_traceLevels->logger);
+                    out << "dropped sample " << sample->id << ": the partial update could not be applied:\n"
+                        << ex.what();
+                    continue;
+                }
             }
             else
             {
-                sample->decode(_parent->instance()->getCommunicator());
+                try
+                {
+                    sample->decode(_parent->instance()->getCommunicator());
+                }
+                catch (const std::exception& ex)
+                {
+                    Warning out(_traceLevels->logger);
+                    out << "dropped sample " << sample->id << ": the value could not be decoded:\n" << ex.what();
+                    continue;
+                }
             }
         }
+        valid.push_back(sample);
         previousByKey[sample->key] = sample;
     }
 
@@ -813,6 +865,9 @@ DataReaderI::initSamples(
 
     if (valid.empty())
     {
+        // Even when every sample was discarded or dropped, keep the bases recorded above so a later partial update
+        // on their keys can resolve.
+        _lastByKey = std::move(previousByKey);
         return;
     }
     _lastSendTime = valid.back()->timestamp;
@@ -913,6 +968,25 @@ DataReaderI::queue(
             Trace out(_traceLevels->logger, _traceLevels->dataCat);
             out << this << ": discarded sample" << sample->id;
         }
+
+        // The discard only affects the application-visible delivery: when the key has no base yet, still record the
+        // discarded sample as the base partial updates resolve against, otherwise a later partial update on the key
+        // would have no base.
+        if (sample->event != DataStorm::SampleEvent::PartialUpdate && _lastByKey.find(sample->key) == _lastByKey.end())
+        {
+            try
+            {
+                if (!sample->hasValue())
+                {
+                    sample->decode(_parent->instance()->getCommunicator());
+                }
+                _lastByKey[sample->key] = sample;
+            }
+            catch (const std::exception&)
+            {
+                // Ignore, the sample was discarded anyway.
+            }
+        }
         return;
     }
 
@@ -921,14 +995,43 @@ DataReaderI::queue(
         if (sample->event == DataStorm::SampleEvent::PartialUpdate)
         {
             auto p = _lastByKey.find(sample->key);
-            _parent->getUpdater(sample->tag)(
-                p == _lastByKey.end() ? nullptr : p->second,
-                sample,
-                _parent->instance()->getCommunicator());
+            if (p == _lastByKey.end())
+            {
+                // No base to resolve the partial update against (for example a peer writer that doesn't bootstrap
+                // the base): drop the sample rather than apply the update to a default-constructed value.
+                if (_traceLevels->data > 0)
+                {
+                    Trace out(_traceLevels->logger, _traceLevels->dataCat);
+                    out << this << ": discarded partial update sample " << sample->id << ": no base value for the key";
+                }
+                return;
+            }
+
+            try
+            {
+                _parent->getUpdater(sample->tag)(p->second, sample, _parent->instance()->getCommunicator());
+            }
+            catch (const std::exception& ex)
+            {
+                // An updater or decoder that throws (a user updater error, or a writer/reader update type mismatch)
+                // drops the sample; the base is left unchanged so the next full sample resynchronizes the key.
+                Warning out(_traceLevels->logger);
+                out << "dropped sample " << sample->id << ": the partial update could not be applied:\n" << ex.what();
+                return;
+            }
         }
         else
         {
-            sample->decode(_parent->instance()->getCommunicator());
+            try
+            {
+                sample->decode(_parent->instance()->getCommunicator());
+            }
+            catch (const std::exception& ex)
+            {
+                Warning out(_traceLevels->logger);
+                out << "dropped sample " << sample->id << ": the value could not be decoded:\n" << ex.what();
+                return;
+            }
         }
     }
     _lastSendTime = sample->timestamp;

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -297,6 +297,37 @@ void ::Reader::run(int argc, char* argv[])
         test(msft->lastBid == 51.0f); // MSFT's base survived the cap despite the key count exceeding sampleCount
         test(msft->lastAsk == 52.0f);
     }
+
+    // The reader-side updater throws on one of the initialization samples: only that sample is dropped, the other
+    // initialization samples are delivered, and the following partial update resolves against the last successfully
+    // applied value.
+    Topic<string, StockPtr> throwTopic(node, "throwingUpdater");
+    throwTopic.setReaderDefaultConfig(config); // keep full history, so the samples arrive unmerged
+    throwTopic.setUpdater<float>(
+        "price",
+        [](StockPtr& stock, float price)
+        {
+            if (price < 0)
+            {
+                throw std::runtime_error("negative price");
+            }
+            stock->price = price;
+        });
+    Topic<string, int> throwBarrier(node, "throwingUpdaterBarrier");
+    {
+        [[maybe_unused]] auto _ = makeSingleKeyReader(throwBarrier, "barrier").getNextUnread();
+
+        auto reader = makeSingleKeyReader(throwTopic, "AAPL");
+
+        auto sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Add);
+        test(sample.getValue()->price == 12.0f);
+
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::PartialUpdate);
+        test(sample.getValue()->price == 15.0f);   // the throwing sample was dropped...
+        test(sample.getValue()->lastBid == 13.0f); // ...and the update resolved against the Add sample
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -238,6 +238,30 @@ void ::Writer::run(int argc, char* argv[])
         writer.waitForNoReaders();
     }
     cout << "ok" << endl;
+
+    // The reader-side updater throws on one of the initialization samples: only that sample is dropped, the other
+    // initialization samples are delivered, and the following partial update resolves against the last successfully
+    // applied value.
+    Topic<string, StockPtr> throwTopic(node, "throwingUpdater");
+    throwTopic.setWriterDefaultConfig(config); // keep full history
+    throwTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> throwBarrier(node, "throwingUpdaterBarrier");
+    cout << "testing reader-side updater exception... " << flush;
+    {
+        auto writer = makeSingleKeyWriter(throwTopic, "AAPL");
+        writer.add(make_shared<Stock>(12.0f, 13.0f, 14.0f));
+        writer.partialUpdate<float>("price")(-99.0f); // the reader's updater throws on negative prices
+        writer.partialUpdate<float>("price")(15.0f);
+
+        // Let the reader join late, so the three samples above are delivered as initialization samples.
+        auto barrier = makeSingleKeyWriter(throwBarrier, "barrier");
+        barrier.waitForReaders();
+        barrier.update(0);
+
+        writer.waitForReaders();
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
 }
 
 DEFINE_TEST(::Writer)


### PR DESCRIPTION
Fixes #5824, fixes #5833, fixes #5834.

Three related hardening changes in the reader sample paths (`DataReaderI::queue` and `DataReaderI::initSamples`),
plus a documentation correction:

- **#5824** — A sample discarded by the reader's discard policy (`SendTime` or `Priority`) was dropped *before*
  the per-key base partial updates resolve against was recorded, so a later partial update on the key had no base.
  The discard now only affects the application-visible delivery: when the key has no base yet, the discarded
  sample still establishes it (only-if-absent, so a discarded lower-priority or older sample never replaces an
  existing base; partial updates are not recorded since they cannot be resolved).

- **Reader-side null-base guard** (the follow-up agreed in the #5809 review) — a partial update whose key has no
  base (for example from a peer writer that doesn't bootstrap the bases) invoked the updater with a null previous
  value, resolving the update against a default-constructed value — typically a crash for applications using
  class-typed values. Such samples are now traced and dropped: degraded delivery instead of a crash.

- **#5833** — A user updater or decoder that throws unwound out of the dispatch: the whole initialization batch
  was discarded — a late-joining reader lost every initialization sample, including full values preceding the
  failed one — and the base was left stale. The failure now drops only the offending sample with a warning; the
  base is left unchanged so the next full sample resynchronizes the key. `Topic::setUpdater`'s documentation now
  states that a throwing updater causes the sample to be dropped.

- **#5834** — resolved as a documentation fix: the header claimed the `onSamples` init callback "is always
  called", but the implementation intentionally skips it when the reader has no history, and the callbacks test
  asserts that behavior (`test(false)` in the init callback of an empty reader). The documentation now matches the
  implementation; no behavior change.

## Testing

New case in `test/DataStorm/partial`, verified red→green: a late-joining reader whose updater throws on one of the
initialization samples receives the other samples, and the following partial update resolves against the last
successfully applied value (without the fix the throw discards the entire batch and the reader hangs). The
discarded-base seeding and the null-base guard are not deterministically drivable from the test harness (they need
timestamp/attach-order control); both were verified by an adversarial codex audit of the diff, which also caught —
and this PR fixes — the all-samples-discarded corner where the seeded bases were lost with the early return.

The full DataStorm suite passes. A changelog fragment is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
