### PR TITLE
Fix incorrect API doc comments and .d.ts declarations in the JS Ice library

### DIFF
--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2762,7 +2762,7 @@ Slice::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << " */";
     _out << nl << "static checkedCast(prx: " << _iceImportPrefix << "Ice.ObjectPrx | null"
          << ", "
-         << "facet?: string, context?: Map<string, string>): " << _iceImportPrefix << "Ice.AsyncResult"
+         << "facet?: string, context?: Map<string, string>): globalThis.Promise"
          << "<" << prxName << " | null>;";
     _out << eb;
 

--- a/js/packages/ice/src/Ice/Communicator.d.ts
+++ b/js/packages/ice/src/Ice/Communicator.d.ts
@@ -3,7 +3,13 @@
 declare module "@zeroc/ice" {
     namespace Ice {
         /**
-         * The central object in Ice. One or more communicators can be instantiated for an Ice application.
+         * Communicator is the central object in Ice. Its responsibilities include:
+         * - creating and managing outgoing connections
+         * - creating and destroying object adapters
+         * - managing properties (configuration), retries, logging, and more.
+         *
+         * You create a communicator with `new Ice.Communicator()`, and it's usually the first object you create when
+         * programming with Ice.
          *
          * @see {@link Logger}
          * @see {@link ObjectAdapter}
@@ -11,18 +17,9 @@ declare module "@zeroc/ice" {
          */
         class Communicator {
             /**
-             * Creates a communicator with default options.
-             *
-             * @returns The initialized communicator.
-             * @throws {@link InitializationException} If an error occurs during initialization.
-             */
-            constructor();
-
-            /**
              * Creates a communicator.
              *
              * @param initData Options for the new communicator.
-             * @returns The initialized communicator.
              * @throws {@link InitializationException} If an error occurs during initialization.
              */
             constructor(initData?: InitializationData);
@@ -32,7 +29,6 @@ declare module "@zeroc/ice" {
              *
              * @param args A command-line argument vector. Any Ice-related options in this vector are used to initialize
              * the communicator. This method modifies the argument vector by removing any Ice-related options.
-             * @returns The initialized communicator.
              * @throws {@link InitializationException} If an error occurs during initialization.
              */
             constructor(args: string[]);
@@ -87,6 +83,7 @@ declare module "@zeroc/ice" {
              * @param proxyString - The proxy string to convert.
              *
              * @returns The proxy, or `null` if `proxyString` is an empty string.
+             * @throws {@link ParseException} - Thrown when `proxyString` is not a valid proxy string.
              *
              * @see {@link proxyToString}
              */
@@ -98,7 +95,7 @@ declare module "@zeroc/ice" {
              * @param prx - The proxy to convert into a string.
              * @returns The string representation of the proxy, or an empty string if `prx` is `null`.
              */
-            proxyToString(prx: Ice.ObjectPrx): string;
+            proxyToString(prx: Ice.ObjectPrx | null): string;
 
             /**
              * Converts a set of proxy properties into a proxy. The "base" name supplied in the`property` argument
@@ -107,6 +104,7 @@ declare module "@zeroc/ice" {
              *
              * @param property The base property name.
              * @returns The proxy, or null if the property is not set.
+             * @throws {@link ParseException} - Thrown when the property value is not a valid proxy string.
              */
             propertyToProxy(property: string): Ice.ObjectPrx | null;
 
@@ -131,12 +129,16 @@ declare module "@zeroc/ice" {
              * Creates a new object adapter.
              *
              * It is valid to create an object adapter with an empty string as its name. Such an object adapter is
-             * accessible via bidirectional connections. Attempts to create a named object adapter for which no
-             * configuration can be found will raise an `InitializationException`.
+             * accessible via bidirectional connections.
              *
              * @param name - The object adapter name.
              * @returns A promise that resolves to the created object adapter.
-             * @throws {@link InitializationException} - Thrown if the object adapter cannot be created.
+             *
+             * @remarks The returned promise rejects with {@link InitializationException} when a named object adapter
+             * has no configuration, with {@link PropertyException} when the adapter properties are invalid (for
+             * example, `name.Endpoints` is not supported: JavaScript object adapters do not listen on endpoints; only
+             * bidirectional adapters and router-associated adapters are supported), and with
+             * {@link AlreadyRegisteredException} when an adapter with the same name already exists.
              *
              * @see {@link ObjectAdapter}
              * @see {@link Properties}
@@ -188,7 +190,7 @@ declare module "@zeroc/ice" {
              * @returns The implicit context associated with this communicator, or `null` if the `Ice.ImplicitContext`
              *          property is not set or is set to `None`.
              */
-            getImplicitContext(): Ice.ImplicitContext;
+            getImplicitContext(): Ice.ImplicitContext | null;
 
             /**
              * Retrieves the properties associated with this communicator.

--- a/js/packages/ice/src/Ice/Communicator.d.ts
+++ b/js/packages/ice/src/Ice/Communicator.d.ts
@@ -17,9 +17,10 @@ declare module "@zeroc/ice" {
          */
         class Communicator {
             /**
-             * Creates a communicator.
+             * Creates a communicator. When called without initialization data, the communicator is created with
+             * default options.
              *
-             * @param initData Options for the new communicator.
+             * @param initData The optional initialization data for the new communicator.
              * @throws {@link InitializationException} If an error occurs during initialization.
              */
             constructor(initData?: InitializationData);

--- a/js/packages/ice/src/Ice/CompositeSliceLoader.d.ts
+++ b/js/packages/ice/src/Ice/CompositeSliceLoader.d.ts
@@ -10,7 +10,7 @@ declare module "@zeroc/ice" {
              * Constructs a new `CompositeSliceLoader` object.
              * @param sliceLoaders The initial list of Slice loaders; can be empty.
              */
-            constructor(sliceLoaders: SliceLoader[]);
+            constructor(sliceLoaders?: SliceLoader[]);
 
             /**
              * Adds a Slice loader to this composite Slice loader.

--- a/js/packages/ice/src/Ice/Connection.d.ts
+++ b/js/packages/ice/src/Ice/Connection.d.ts
@@ -23,7 +23,8 @@ declare module "@zeroc/ice" {
              * Manually closes the connection gracefully after waiting for all pending invocations
              * to complete.
              *
-             * @returns A promise that resolves when the close operation is complete.
+             * @returns A promise that resolves when the connection is gracefully closed, and rejects when the
+             * connection is lost or the graceful closure times out ({@link CloseTimeoutException}).
              */
             close(): Promise<void>;
 
@@ -79,9 +80,9 @@ declare module "@zeroc/ice" {
              * Sets a close callback on the connection. The callback is invoked by the connection when it is closed.
              * If the callback needs more information about the closure, it can call {@link Connection#throwException}.
              *
-             * @param callback - The close callback object.
+             * @param callback - The close callback object. Pass `null` to clear the callback.
              */
-            setCloseCallback(callback: Ice.CloseCallback): void;
+            setCloseCallback(callback: Ice.CloseCallback | null): void;
 
             /**
              * Disables the inactivity check on this connection.
@@ -89,7 +90,7 @@ declare module "@zeroc/ice" {
             disableInactivityCheck(): void;
 
             /**
-             * Returns the connection type, which corresponds to the endpoint type (e.g., "tcp", "udp", etc.).
+             * Returns the connection type, which corresponds to the endpoint type (e.g., "tcp", "ws", "wss").
              *
              * @returns The type of the connection.
              */
@@ -106,14 +107,16 @@ declare module "@zeroc/ice" {
              * Retrieves the connection information.
              *
              * @returns The connection information.
+             * @throws The exception that caused the closure, when this connection is closed.
              */
             getInfo(): Ice.ConnectionInfo;
 
             /**
              * Throw an exception indicating the reason for connection closure. For example,
-             * {@link CloseConnectionException} is raised if the connection was closed gracefully, whereas
+             * {@link CloseConnectionException} is raised if the connection was closed gracefully by the peer, whereas
              * {@link ConnectionAbortedException}/{@link ConnectionClosedException} is raised if the connection was
-             * manually closed by the application. This operation does nothing if the connection is not yet closed.
+             * manually closed by the application. This operation does nothing if the connection is not yet closing
+             * or closed.
              */
             throwException(): void;
         }
@@ -143,12 +146,13 @@ declare module "@zeroc/ice" {
          */
         class IPConnectionInfo extends ConnectionInfo {
             /**
-             * The local address.
+             * The local address. For WebSocket connections, the local address is not available and `localAddress`
+             * is `""`.
              */
             get localAddress(): string;
 
             /**
-             * The local port.
+             * The local port. For WebSocket connections, the local port is not available and `localPort` is `-1`.
              */
             get localPort(): number;
 

--- a/js/packages/ice/src/Ice/Current.d.ts
+++ b/js/packages/ice/src/Ice/Current.d.ts
@@ -98,7 +98,7 @@ declare module "@zeroc/ice" {
             createEmptyOutgoingResponse(): OutgoingResponse;
 
             /**
-             * Creates an outgoing response that marshals an exception or the request being dispatched corresponding
+             * Creates an outgoing response that marshals an exception for the request being dispatched corresponding
              * to this current object.
              *
              * @param exception The exception to marshal into the response payload.

--- a/js/packages/ice/src/Ice/Endpoint.d.ts
+++ b/js/packages/ice/src/Ice/Endpoint.d.ts
@@ -38,7 +38,8 @@ declare module "@zeroc/ice" {
             get underlying(): Ice.EndpointInfo | null;
 
             /**
-             * The timeout for the endpoint in milliseconds. -1 means no timeout.
+             * The timeout for the endpoint in milliseconds. -1 means no timeout. This timeout is provided for
+             * backwards compatibility and has no effect in Ice 3.8 or greater.
              */
             get timeout(): number;
 
@@ -54,8 +55,8 @@ declare module "@zeroc/ice" {
             type(): number;
 
             /**
-             * Returns `true` if this endpoint's transport uses WSS, `false` otherwise.
-             * @returns `true` for WSS transport, `false` otherwise.
+             * Returns `true` if this endpoint's transport is secure (SSL or WSS), `false` otherwise.
+             * @returns `true` when the transport is secure, `false` otherwise.
              */
             secure(): boolean;
         }
@@ -108,7 +109,7 @@ declare module "@zeroc/ice" {
             get rawEncoding(): EncodingVersion;
 
             /**
-             * The raw encoding of the opaque endpoint.
+             * The raw bytes of the opaque endpoint.
              */
             get rawBytes(): ByteSeq;
         }

--- a/js/packages/ice/src/Ice/HashMap.d.ts
+++ b/js/packages/ice/src/Ice/HashMap.d.ts
@@ -14,7 +14,7 @@ declare module "@zeroc/ice" {
 
         class HashMap<Key extends HashMapKey, Value> {
             /**
-             * Creates an empty HashMap that uses the operator === for key and value comparisons.
+             * Creates an empty HashMap that uses the operator `===` for key comparisons.
              */
             constructor();
 
@@ -45,7 +45,7 @@ declare module "@zeroc/ice" {
              * Retrieves the value associated with the specified key.
              *
              * @param key The key of the entry to retrieve.
-             * @return The value associated with the key, or undefined if the key does not exist.
+             * @returns The value associated with the key, or undefined if the key does not exist.
              */
             get(key: Key): Value | undefined;
 
@@ -53,7 +53,7 @@ declare module "@zeroc/ice" {
              * Checks if the specified key exists in the HashMap.
              *
              * @param key The key to check for existence.
-             * @return True if the key exists, false otherwise.
+             * @returns True if the key exists, false otherwise.
              */
             has(key: Key): boolean;
 
@@ -61,7 +61,7 @@ declare module "@zeroc/ice" {
              * Deletes the entry associated with the specified key.
              *
              * @param key The key of the entry to delete.
-             * @return The value associated with the deleted key, or undefined if the key did not exist.
+             * @returns The value associated with the deleted key, or undefined if the key did not exist.
              */
             delete(key: Key): Value | undefined;
 
@@ -81,28 +81,28 @@ declare module "@zeroc/ice" {
             /**
              * Returns an iterator over the key-value pairs in the HashMap.
              *
-             * @return An iterator of [key, value] pairs.
+             * @returns An iterator of [key, value] pairs.
              */
             [Symbol.iterator](): IterableIterator<[Key, Value]>;
 
             /**
              * Returns an iterable of key-value pairs in the HashMap.
              *
-             * @return An iterable iterator of [key, value] pairs.
+             * @returns An iterable iterator of [key, value] pairs.
              */
             entries(): IterableIterator<[Key, Value]>;
 
             /**
              * Returns an iterable of keys in the HashMap.
              *
-             * @return An iterable iterator of keys.
+             * @returns An iterable iterator of keys.
              */
             keys(): IterableIterator<Key>;
 
             /**
              * Returns an iterable of values in the HashMap.
              *
-             * @return An iterable iterator of values.
+             * @returns An iterable iterator of values.
              */
             values(): IterableIterator<Value>;
 

--- a/js/packages/ice/src/Ice/InitializationData.d.ts
+++ b/js/packages/ice/src/Ice/InitializationData.d.ts
@@ -12,27 +12,27 @@ declare module "@zeroc/ice" {
             constructor();
 
             /**
-             * Creates a deep copy of the object.
+             * Creates a shallow copy of this object.
              *
-             * @returns A deep copy of the object
+             * @returns A shallow copy of this object
              */
             clone(): InitializationData;
 
             /**
              * The properties for the communicator.
-             * When not-null, this corresponds to the object returned by the Communicator::getProperties function.
+             * When not-null, this corresponds to the object returned by {@link Communicator#getProperties}.
              */
-            properties: Properties;
+            properties: Properties | null;
 
             /**
              * The logger for the communicator.
              */
-            logger: Logger;
+            logger: Logger | null;
 
             /**
              * The Slice loader, used to unmarshal Slice classes and exceptions.
              */
-            sliceLoader: SliceLoader;
+            sliceLoader: SliceLoader | null;
         }
     }
 }

--- a/js/packages/ice/src/Ice/Initialize.d.ts
+++ b/js/packages/ice/src/Ice/Initialize.d.ts
@@ -3,12 +3,13 @@
 declare module "@zeroc/ice" {
     namespace Ice {
         /**
-         * Creates a communicator.
+         * Creates a communicator. When called without initialization data, the communicator is created with default
+         * options.
          *
          * This method is provided for backwards compatibility. New code should call the {@link Communicator}
          * constructor directly.
          *
-         * @param initData Options for the new communicator.
+         * @param initData The optional initialization data for the new communicator.
          * @returns The initialized communicator.
          * @throws {@link InitializationException} If an error occurs during initialization.
          */

--- a/js/packages/ice/src/Ice/Initialize.d.ts
+++ b/js/packages/ice/src/Ice/Initialize.d.ts
@@ -8,17 +8,6 @@ declare module "@zeroc/ice" {
          * This method is provided for backwards compatibility. New code should call the {@link Communicator}
          * constructor directly.
          *
-         * @returns The initialized communicator.
-         * @throws {@link InitializationException} If an error occurs during initialization.
-         */
-        function initialize(): Communicator;
-
-        /**
-         * Creates a communicator.
-         *
-         * This method is provided for backwards compatibility. New code should call the {@link Communicator}
-         * constructor directly.
-         *
          * @param initData Options for the new communicator.
          * @returns The initialized communicator.
          * @throws {@link InitializationException} If an error occurs during initialization.
@@ -52,14 +41,14 @@ declare module "@zeroc/ice" {
         function createProperties(args?: string[], defaults?: Properties): Properties;
 
         /**
-         * Returns the Ice version as a string in the format "A.B.C", where:
+         * Returns the Ice version as a string in the form "A.B.C", where:
          * - A: major version
          * - B: minor version
          * - C: patch version
          *
-         * For example, "3.9.0".
+         * The version may include a pre-release suffix, for example, "3.9.0-alpha.0".
          *
-         * @returns The Ice version as a string.
+         * @returns The Ice version in the form `A.B.C`, with an optional pre-release suffix, e.g. `3.9.0-alpha.0`.
          */
         function stringVersion(): string;
 
@@ -70,6 +59,9 @@ declare module "@zeroc/ice" {
          * - CC: patch version
          *
          * For example, for Ice 3.9.1, the returned value is 30901.
+         *
+         * For pre-releases, CC encodes the pre-release instead of the patch version. For example, for
+         * Ice 3.9.0-alpha.0, the returned value is 30950.
          *
          * @returns The Ice version as an integer.
          */

--- a/js/packages/ice/src/Ice/InputStream.d.ts
+++ b/js/packages/ice/src/Ice/InputStream.d.ts
@@ -49,9 +49,10 @@ declare module "@zeroc/ice" {
             /**
              * Marks the end of a class instance.
              *
-             * @returns A SlicedData object containing the preserved slices for unknown types.
+             * @returns A SlicedData object containing the preserved slices for unknown types, or null if the instance
+             * has no preserved slices.
              */
-            endValue(): SlicedData;
+            endValue(): SlicedData | null;
 
             /**
              * Marks the start of an exception.
@@ -84,7 +85,7 @@ declare module "@zeroc/ice" {
             skipEmptyEncapsulation(): EncodingVersion;
 
             /**
-             * Reads and encapsulation from the stream.
+             * Reads an encapsulation from the stream.
              *
              * @returns a tuple containing:
              * - The encoding version of the encapsulation.
@@ -93,7 +94,7 @@ declare module "@zeroc/ice" {
             readEncapsulation(): [EncodingVersion, Uint8Array];
 
             /**
-             * Gets the current encoding version of the encapsulation.
+             * Gets the current encoding version.
              *
              * @returns The encoding version.
              */
@@ -146,7 +147,7 @@ declare module "@zeroc/ice" {
             /**
              * Reads and validates a sequence size.
              *
-             * @param minSize The minimum size of the sequence elements.
+             * @param minSize The minimum number of bytes required to encode each element of the sequence.
              * @returns The size read from the stream.
              */
             readAndCheckSeqSize(minSize: number): number;
@@ -232,25 +233,22 @@ declare module "@zeroc/ice" {
             readString(): string;
 
             /**
-             * Reads a proxy from the stream. The stream must have been initialized with a communicator.
+             * Reads a proxy from the stream.
              *
              * @param type the type of the proxy to read.
-             * @returns The proxy.
-             * @throws {@link Ice.MarshalException} If the stream has not been initialized with a communicator and
-             * cannot be used for unmarshaling proxies.
+             * @returns The proxy, or null if the proxy read from the stream is a nil (null) proxy.
              */
-            readProxy<T extends ObjectPrx>(type: new () => T): T;
+            readProxy<T extends ObjectPrx>(type: new () => T): T | null;
 
             /**
-             * Reads an optional proxy from the stream. The stream must have been initialized with a communicator.
+             * Reads an optional proxy from the stream.
              *
              * @param tag The numeric tag associated with the value.
              * @param type The type of the proxy to read.
-             * @returns The proxy or undefined if the optional value is not present.
-             * @throws {@link Ice.MarshalException} If the stream has not been initialized with a communicator and
-             * cannot be used for unmarshaling proxies.
+             * @returns The proxy, null if the proxy read from the stream is a nil (null) proxy, or undefined if the
+             * optional value is not present.
              */
-            readOptionalProxy<T extends ObjectPrx>(tag: number, type: new () => T): T | undefined;
+            readOptionalProxy<T extends ObjectPrx>(tag: number, type: new () => T): T | null | undefined;
 
             /**
              * Reads an enumerated value.
@@ -273,10 +271,12 @@ declare module "@zeroc/ice" {
              * Reads the index of a Slice value from the stream.
              *
              * @param cb The callback to notify the application when the extracted instance is available.
-             * The stream extracts Slice values in stages. The Ice run time invokes the callback when the
-             * corresponding instance has been fully unmarshaled.
+             * The stream extracts Slice values in stages. The Ice runtime invokes the callback when the
+             * corresponding instance has been fully unmarshaled; the callback receives null for a nil instance.
+             * @param type The expected type of the instance; unmarshaling throws {@link MarshalException} when the
+             * unmarshaled instance is not an instance of this type.
              */
-            readValue<T extends Value>(cb: (value: T) => void, type: new () => T): void;
+            readValue<T extends Value>(cb: (value: T | null) => void, type: new () => T): void;
 
             /**
              * Reads a user exception from the stream and throws it.

--- a/js/packages/ice/src/Ice/LocalExceptions.d.ts
+++ b/js/packages/ice/src/Ice/LocalExceptions.d.ts
@@ -30,6 +30,15 @@ declare module "@zeroc/ice" {
          * The base class for the 3 NotExist exceptions.
          */
         class RequestFailedException extends DispatchException {
+            /**
+             * Constructs a RequestFailedException.
+             *
+             * @param replyStatus The reply status.
+             * @param id The identity of the target Ice object.
+             * @param facet The facet of the target Ice object.
+             * @param operation The name of the operation.
+             */
+            protected constructor(replyStatus: ReplyStatus, id?: Identity, facet?: string, operation?: string);
             readonly id: Identity;
             readonly facet: string;
             readonly operation: string;
@@ -145,7 +154,7 @@ declare module "@zeroc/ice" {
         }
 
         /**
-         * This exception indicates that an invocation failed because it timed out.
+         * The exception that is thrown when an invocation times out.
          */
         class InvocationTimeoutException extends TimeoutException {
             constructor();
@@ -223,7 +232,7 @@ declare module "@zeroc/ice" {
 
         /**
          * The exception that is thrown when an operation fails because the communicator has been destroyed.
-         * @see {@link Communicator#destroy()}
+         * @see {@link Communicator#destroy}
          */
         class CommunicatorDestroyedException extends LocalException {}
 
@@ -256,12 +265,13 @@ declare module "@zeroc/ice" {
         class FixedProxyException extends LocalException {}
 
         /**
-         * The exception that is thrown when communicator initialization fails.
+         * The exception that is thrown when a failure occurs during initialization.
          */
         class InitializationException extends LocalException {}
 
         /**
-         * This exception indicates that an asynchronous invocation failed because it was canceled explicitly by the user.
+         * The exception that is thrown when an asynchronous invocation fails because it was canceled explicitly by
+         * the user.
          */
         class InvocationCanceledException extends LocalException {
             constructor();

--- a/js/packages/ice/src/Ice/Logger.d.ts
+++ b/js/packages/ice/src/Ice/Logger.d.ts
@@ -4,7 +4,7 @@ declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Represents Ice's abstraction for logging and tracing. Applications can provide their own logger by
-         * implementing this abstraction and setting a logger on the communicator.
+         * implementing this abstraction and supplying a logger in {@link InitializationData}.
          * @see {@link InitializationData}
          */
         interface Logger {
@@ -35,12 +35,6 @@ declare module "@zeroc/ice" {
              * @see #warning
              */
             error(message: string): void;
-
-            /**
-             * Returns this logger's prefix.
-             * @returns The prefix.
-             */
-            getPrefix(): string;
 
             /**
              * Returns a clone of the logger with a new prefix.

--- a/js/packages/ice/src/Ice/Object.d.ts
+++ b/js/packages/ice/src/Ice/Object.d.ts
@@ -50,7 +50,7 @@ declare module "@zeroc/ice" {
             dispatch(request: IncomingRequest): OutgoingResponse | PromiseLike<OutgoingResponse>;
 
             /**
-             * Returns the Slice type id of the interface or class associated with this proxy class.
+             * Returns the Slice type id of the interface or class associated with this class.
              *
              * @returns The type id, "::Ice::Object".
              */

--- a/js/packages/ice/src/Ice/ObjectAdapter.d.ts
+++ b/js/packages/ice/src/Ice/ObjectAdapter.d.ts
@@ -54,6 +54,8 @@ declare module "@zeroc/ice" {
              * @param servant The servant to add.
              * @param id The identity of the Ice object that is implemented by the servant.
              * @returns A proxy with the given id, created by this object adapter.
+             * @throws {@link AlreadyRegisteredException} Thrown when a servant with the same identity is already
+             * registered.
              *
              * @see {@link Identity}
              * @see {@link ObjectAdapter#addFacet}
@@ -73,6 +75,8 @@ declare module "@zeroc/ice" {
              * @param id The identity of the Ice object that is implemented by the servant.
              * @param facet The facet of the Ice object that is implemented by the servant.
              * @returns A proxy with the given id and facet, created by this object adapter.
+             * @throws {@link AlreadyRegisteredException} Thrown when a servant with the same identity and facet is
+             * already registered.
              */
             addFacet(servant: Ice.Object, id: Identity, facet: string): Ice.ObjectPrx;
 
@@ -158,14 +162,14 @@ declare module "@zeroc/ice" {
             removeDefaultServant(category: string): Ice.Object;
 
             /**
-             * Looks up a servant..
+             * Looks up a servant.
              * @param id The identity of an Ice object.
              * @returns The servant that implements the Ice object with the given identity, or null if no such servant
              * has been found.
              * @remarks This function only tries to find the servant in the ASM and among the default servants. It does
              * not attempt to locate a servant using servant locators.
              */
-            find(id: Identity): Ice.Object;
+            find(id: Identity): Ice.Object | null;
 
             /**
              * Looks up a servant with an identity and facet.
@@ -174,10 +178,10 @@ declare module "@zeroc/ice" {
              * @param facet The facet of an Ice object. An empty facet means the default facet.
              * @returns The servant that implements the Ice object with the given identity and facet, or null if no
              * such servant has been found.
-             * @remark This function only tries to find the servant in the ASM and among the default servants. It does
+             * @remarks This function only tries to find the servant in the ASM and among the default servants. It does
              * not attempt to locate a servant using servant locators.
              */
-            findFacet(id: Identity, facet: string): Ice.Object;
+            findFacet(id: Identity, facet: string): Ice.Object | null;
 
             /**
              * Find all facets with the given identity in the Active Servant Map.
@@ -190,13 +194,14 @@ declare module "@zeroc/ice" {
             findAllFacets(id: Identity): Map<string, Ice.Object>;
 
             /**
-             * Looks up a servant with an identity and a facet. It's equivalent to calling #findFacet.
+             * Looks up a servant with an identity and a facet. It's equivalent to calling
+             * {@link ObjectAdapter#findFacet}.
              *
              * @param proxy The proxy that provides the identity and facet to search.
              * @returns The servant that matches the identity and facet carried by the proxy, or null if no such
              * servant has been found.
              */
-            findByProxy(proxy: Ice.ObjectPrx): Ice.Object;
+            findByProxy(proxy: Ice.ObjectPrx): Ice.Object | null;
 
             /**
              * Adds a ServantLocator to this object adapter for a specific category.
@@ -213,7 +218,7 @@ declare module "@zeroc/ice" {
              *
              * @param category The category.
              * @returns The servant locator.
-             * @throws {@link NotRegisteredException}Thrown when no servant locator with the given category is
+             * @throws {@link NotRegisteredException} Thrown when no servant locator with the given category is
              * registered.
              */
             removeServantLocator(category: string): Ice.ServantLocator;
@@ -229,21 +234,19 @@ declare module "@zeroc/ice" {
              * @see {@link ObjectAdapter#removeServantLocator}
              * @see {@link ServantLocator}
              */
-            findServantLocator(category: string): Ice.ServantLocator;
+            findServantLocator(category: string): Ice.ServantLocator | null;
 
             /**
-             * Finds a ServantLocator registered with this object adapter.
+             * Finds the default servant for a specific category.
              *
              * @param category The category.
-             * @returns The servant locator, or null if not found.
+             * @returns The default servant, or null if not found.
              */
-            findDefaultServant(category: string): Ice.Object;
+            findDefaultServant(category: string): Ice.Object | null;
 
             /**
-             * Creates a proxy from an Ice identity. If this object adapter is configured with an adapter ID, the proxy
-             * is an indirect proxy that refers to this adapter ID. If a replica group ID is also defined, the proxy is an
-             * indirect proxy that refers to this replica group ID. Otherwise, the proxy is a direct proxy containing this
-             * object adapter's published endpoints.
+             * Creates a proxy from an Ice identity. The proxy is a direct proxy containing this object adapter's
+             * published endpoints.
              *
              * @param id The object's identity.
              * @returns A proxy for the object with the given identity.
@@ -262,6 +265,7 @@ declare module "@zeroc/ice" {
              * Gets the set of endpoints configured on this object adapter.
              *
              * @returns The set of endpoints.
+             * @remarks Always returns an empty array: JavaScript object adapters do not listen on endpoints.
              */
             getEndpoints(): Endpoint[];
 

--- a/js/packages/ice/src/Ice/ObjectPrx.d.ts
+++ b/js/packages/ice/src/Ice/ObjectPrx.d.ts
@@ -70,7 +70,14 @@ declare module "@zeroc/ice" {
              *
              * @returns A stringified proxy.
              */
-            ice_toString(): string;
+            toString(): string;
+
+            /**
+             * Returns the hash code of this proxy.
+             *
+             * @returns the hash code of this proxy.
+             */
+            hashCode(): number;
 
             /**
              * Creates a proxy that is identical to this proxy, except for the identity.
@@ -78,7 +85,7 @@ declare module "@zeroc/ice" {
              * @param id - The identity for the new proxy.
              * @returns A proxy with the new identity.
              */
-            ice_identity(id: Identity): this;
+            ice_identity(id: Identity): ObjectPrx;
 
             /**
              * Gets the identity embedded in this proxy.
@@ -150,10 +157,10 @@ declare module "@zeroc/ice" {
             /**
              * Creates a proxy that is identical to this proxy, except for the facet.
              *
-             * @param facet The facet for the new proxy.
+             * @param facet - The facet for the new proxy.
              * @returns A proxy with the new facet.
              */
-            ice_facet(facet: string): this;
+            ice_facet(facet: string): ObjectPrx;
 
             /**
              * Gets the facet for this proxy.
@@ -311,7 +318,8 @@ declare module "@zeroc/ice" {
             ice_isFixed(): boolean;
 
             /**
-             * Gets the connection ID of this proxy.
+             * Gets the connection for this proxy. If the proxy does not yet have an established connection, it first
+             * attempts to create a connection.
              *
              * @returns An asynchronous result that resolves to the connection used by this proxy.
              * @remarks You can call this function to establish a connection or associate the proxy with an existing
@@ -326,7 +334,7 @@ declare module "@zeroc/ice" {
              * @returns The cached connection for this proxy, or `null` if the proxy does not have an established
              * connection.
              */
-            ice_getCachedConnection(): Connection;
+            ice_getCachedConnection(): Connection | null;
 
             /**
              * Creates a proxy that is identical to this proxy, except for connection caching.
@@ -364,7 +372,7 @@ declare module "@zeroc/ice" {
              *
              * @param prx - The source proxy.
              * @param facet - An optional facet name.
-             * @returns A proxy with the requested type and facet, or null if the source proxy is null.
+             * @returns A proxy with the requested type and facet.
              */
             static uncheckedCast(prx: ObjectPrx, facet?: string): ObjectPrx;
 
@@ -384,14 +392,14 @@ declare module "@zeroc/ice" {
              * @param prx - The source proxy.
              * @param facet - An optional facet name.
              * @param context - The request context.
-             * @returns An asynchronous result resolving to a proxy with the requested type and facet, or `null` if the
+             * @returns A promise that resolves to a proxy with the requested type and facet, or `null` if the
              *          target object does not support the requested type.
              */
             static checkedCast(
                 prx: ObjectPrx | null,
                 facet?: string,
                 context?: Map<string, string>,
-            ): AsyncResult<ObjectPrx | null>;
+            ): globalThis.Promise<ObjectPrx | null>;
         }
     }
 }

--- a/js/packages/ice/src/Ice/OptionalFormat.d.ts
+++ b/js/packages/ice/src/Ice/OptionalFormat.d.ts
@@ -39,7 +39,7 @@ declare module "@zeroc/ice" {
 
             /**
              * Fixed "size encoding" using 4 bytes followed by data.
-             * Used by variable-size structs, and containers whose sizes can't be computed prior to unmarshaling.
+             * Used by variable-size structs, and containers whose sizes can't be computed prior to marshaling.
              */
             static readonly FSize: OptionalFormat;
 

--- a/js/packages/ice/src/Ice/OutgoingResponse.d.ts
+++ b/js/packages/ice/src/Ice/OutgoingResponse.d.ts
@@ -19,8 +19,8 @@ declare module "@zeroc/ice" {
             constructor(
                 outputStream: OutputStream,
                 replyStatus?: ReplyStatus,
-                exceptionId?: string,
-                exceptionDetails?: string,
+                exceptionId?: string | null,
+                exceptionDetails?: string | null,
             );
 
             /**
@@ -34,18 +34,18 @@ declare module "@zeroc/ice" {
             outputStream: OutputStream;
 
             /**
-             * The exception ID of the response. It's null or undefined when `replyStatus` is {@link ReplyStatus.Ok}
-             * or {@link ReplyStatus.UserException}. Otherwise, this ID is the value returned by
+             * The exception ID of the response. It's `null` when `replyStatus` is {@link ReplyStatus.Ok} or
+             * {@link ReplyStatus.UserException}. Otherwise, this ID is the value returned by
              * {@link LocalException#ice_id}. For other exceptions, this ID is the value returned by `Error#name`.
              */
-            exceptionId: string | null | undefined;
+            exceptionId: string | null;
 
             /**
              * The full details of the exception (typically the `Error` stack), used for logging; not marshaled into
-             * the response. It's null or undefined when replyStatus is {@link ReplyStatus.Ok} or
+             * the response. It's `null` when replyStatus is {@link ReplyStatus.Ok} or
              * {@link ReplyStatus.UserException}.
              */
-            exceptionDetails: string | null | undefined;
+            exceptionDetails: string | null;
 
             /**
              * The number of bytes in the response's payload.

--- a/js/packages/ice/src/Ice/OutgoingResponse.d.ts
+++ b/js/packages/ice/src/Ice/OutgoingResponse.d.ts
@@ -10,7 +10,7 @@ declare module "@zeroc/ice" {
              * Constructs an outgoing response.
              *
              * @param outputStream The output stream that holds the response.
-             * @param replyStatus The status of the response.
+             * @param replyStatus The status of the response. Defaults to {@link ReplyStatus.Ok}.
              * @param exceptionId The type ID of the exception, when the response carries an exception other than a
              * user exception.
              * @param exceptionDetails The full details of the exception, when the response carries an exception other
@@ -18,7 +18,7 @@ declare module "@zeroc/ice" {
              */
             constructor(
                 outputStream: OutputStream,
-                replyStatus: ReplyStatus,
+                replyStatus?: ReplyStatus,
                 exceptionId?: string,
                 exceptionDetails?: string,
             );
@@ -34,17 +34,18 @@ declare module "@zeroc/ice" {
             outputStream: OutputStream;
 
             /**
-             * The exception ID of the response. It's empty when `replyStatus` is {@link ReplyStatus.Ok} or
-             * {@link ReplyStatus.UserException}. Otherwise, this ID is the value returned by
+             * The exception ID of the response. It's null or undefined when `replyStatus` is {@link ReplyStatus.Ok}
+             * or {@link ReplyStatus.UserException}. Otherwise, this ID is the value returned by
              * {@link LocalException#ice_id}. For other exceptions, this ID is the value returned by `Error#name`.
              */
-            exceptionId: string;
+            exceptionId: string | null | undefined;
 
             /**
-             * The exception details marshaled into the response. It's null when replyStatus is {@link ReplyStatus.Ok}
-             * or {@link ReplyStatus.UserException}.
+             * The full details of the exception (typically the `Error` stack), used for logging; not marshaled into
+             * the response. It's null or undefined when replyStatus is {@link ReplyStatus.Ok} or
+             * {@link ReplyStatus.UserException}.
              */
-            exceptionDetails: string;
+            exceptionDetails: string | null | undefined;
 
             /**
              * The number of bytes in the response's payload.

--- a/js/packages/ice/src/Ice/OutgoingResponse.js
+++ b/js/packages/ice/src/Ice/OutgoingResponse.js
@@ -8,10 +8,8 @@ export class OutgoingResponse {
     constructor(outputStream, replyStatus, exceptionId, exceptionDetails) {
         this._outputStream = outputStream;
         this._replyStatus = replyStatus || ReplyStatus.Ok;
-        if (replyStatus !== ReplyStatus.Ok) {
-            this._exceptionId = exceptionId;
-            this._exceptionDetails = exceptionDetails;
-        }
+        this._exceptionId = exceptionId ?? null;
+        this._exceptionDetails = exceptionDetails ?? null;
     }
 
     get replyStatus() {

--- a/js/packages/ice/src/Ice/OutputStream.d.ts
+++ b/js/packages/ice/src/Ice/OutputStream.d.ts
@@ -7,7 +7,7 @@ declare module "@zeroc/ice" {
          */
         class OutputStream {
             /**
-             * Constructs an OutputStream using the encoding, and format provided by the communicator.
+             * Constructs an OutputStream using the encoding and format provided by the communicator.
              *
              * @param communicator The communicator.
              */
@@ -27,7 +27,7 @@ declare module "@zeroc/ice" {
             clear(): void;
 
             /**
-             * Indicates that marshaling is complete. This function must only be called once.
+             * Indicates that marshaling is complete.
              * @returns The `Uint8Array` containing the encoded request or reply
              */
             finished(): Uint8Array;
@@ -44,22 +44,15 @@ declare module "@zeroc/ice" {
              *
              * @param sz The new size of the stream in bytes.
              */
-
             resize(sz: number): void;
-
-            /**
-             * Prepares the internal buffer for writing to a socket.
-             *
-             * @returns The `Uint8Array` containing the encoded request or reply.
-             */
-            prepareWrite(): Uint8Array;
 
             /**
              * Marks the start of a class instance.
              *
-             * @param slicedData Preserved slices for this instance, or `null`.
+             * @param slicedData Preserved slices for this instance, or `null`. These slices are marshaled with the
+             * instance only when this stream uses the sliced format; otherwise they are ignored.
              */
-            startValue(slicedData: SlicedData): void;
+            startValue(slicedData: SlicedData | null): void;
 
             /**
              * Marks the end of a class instance.
@@ -77,12 +70,14 @@ declare module "@zeroc/ice" {
             endException(): void;
 
             /**
-             * Writes the start of an encapsulation to the stream.
+             * Writes the start of an encapsulation. A nested encapsulation uses the encoding version and class format
+             * of the enclosing encapsulation; a top-level encapsulation uses the stream's encoding version and class
+             * format.
              */
             startEncapsulation(): void;
 
             /**
-             * Writes the end of an encapsulation to the stream.
+             * Writes the start of an encapsulation using the specified encoding version and class format.
              *
              * @param encoding The encoding version of the encapsulation.
              * @param format The class format of the encapsulation. If not specified, the OutputStream's class format
@@ -91,7 +86,7 @@ declare module "@zeroc/ice" {
             startEncapsulation(encoding: EncodingVersion, format?: FormatType): void;
 
             /**
-             * Ends the previous encapsulation.
+             * Ends the current encapsulation.
              */
             endEncapsulation(): void;
 
@@ -110,7 +105,7 @@ declare module "@zeroc/ice" {
             writeEncapsulation(buff: Uint8Array): void;
 
             /**
-             * Gets the stream encoding version.
+             * Gets the current encoding version.
              *
              * @returns The encoding version.
              */
@@ -132,7 +127,10 @@ declare module "@zeroc/ice" {
             endSlice(): void;
 
             /**
-             * Writes the state of Slice classes whose index was previously written with writeValue() to the stream.
+             * Encodes the state of class instances whose insertion was delayed during a previous call to
+             * {@link OutputStream#writeValue}. This function must be called only once. For backward compatibility with
+             * encoding version 1.0, this function must be called only when non-optional fields or parameters use class
+             * types.
              */
             writePendingValues(): void;
 
@@ -171,8 +169,10 @@ declare module "@zeroc/ice" {
              *
              * @param tag The numeric tag associated with the value.
              * @param format The optional format of the value.
+             * @returns `true` if the current encoding version supports optional values, `false` otherwise. If `true`,
+             * the data associated with the optional value must be written next.
              */
-            writeOptional(tag: number, format: OptionalFormat): void;
+            writeOptional(tag: number, format: OptionalFormat): boolean;
 
             /**
              * Writes a byte to the stream.
@@ -238,14 +238,14 @@ declare module "@zeroc/ice" {
              * @param v The string to write to the stream. Passing `null` causes an empty string to be written to the
              *          stream.
              */
-            writeString(v: string): void;
+            writeString(v: string | null): void;
 
             /**
              * Writes a proxy to the stream.
              *
              * @param v The proxy to write.
              */
-            writeProxy(v: ObjectPrx): void;
+            writeProxy(v: ObjectPrx | null): void;
 
             /**
              * Writes an optional proxy to the stream.
@@ -263,24 +263,25 @@ declare module "@zeroc/ice" {
             writeEnum(v: EnumBase): void;
 
             /**
-             * Writes a class instance to the stream. This method writes the index of an instance; the state of the
-             * value is written once {@link OutputStream.writePendingValues} is called.
+             * Writes a class instance to the stream.
              *
-             * @param v The value to write.
+             * @param v The value to write. With the 1.0 encoding, this method writes an index and the state of the
+             * value is marshaled when {@link OutputStream#writePendingValues} is called; with the 1.1 encoding, the
+             * state is marshaled eagerly, without waiting for {@link OutputStream#writePendingValues}.
              */
             writeValue(v: Ice.Value): void;
 
             /**
              * Writes a user exception to the stream.
              *
-             * @param exception The user exception to write.</param>
+             * @param exception The user exception to write.
              */
             writeException(exception: UserException): void;
 
             /**
              *  Returns whether the stream is empty.
              *
-             * @returns True if no data has been written yet, false otherwise.</returns>
+             * @returns True if no data has been written yet, false otherwise.
              */
             isEmpty(): boolean;
 
@@ -300,11 +301,6 @@ declare module "@zeroc/ice" {
              * Gets the size of the stream.
              */
             readonly size: number;
-
-            /**
-             * Gets the buffer containing the stream data.
-             */
-            readonly buffer: Uint8Array;
         }
     }
 }

--- a/js/packages/ice/src/Ice/Promise.d.ts
+++ b/js/packages/ice/src/Ice/Promise.d.ts
@@ -23,7 +23,7 @@ declare module "@zeroc/ice" {
              *
              * @param value - The value to resolve the promise with.
              */
-            resolve<T>(value?: T | PromiseLike<T>): void;
+            resolve(value?: T | PromiseLike<T>): void;
 
             /**
              * Rejects the promise with the specified reason.

--- a/js/packages/ice/src/Ice/Properties.d.ts
+++ b/js/packages/ice/src/Ice/Properties.d.ts
@@ -12,7 +12,7 @@ declare module "@zeroc/ice" {
              * Constructs a property set.
              *
              * @param args  The command-line arguments. This constructor parses arguments starting with `--` and one
-             * of the reserved prefixes (Ice, IceSSL, etc.) as properties and removes these elements from the vector.
+             * of the reserved prefixes (Ice, IceSSL, etc.) as properties and removes these elements from the array.
              * @param defaults Default values for the new Properties object. Settings in args override these defaults.
              * May be null.
              */
@@ -111,14 +111,15 @@ declare module "@zeroc/ice" {
 
             /**
              * Retrieves a property value as a list of strings. The strings must be separated by whitespace or commas.
-             * If the property is not set, an empty list is returned. The strings in the list can contain whitespace
-             * and commas if they are enclosed in single or double quotes. If quotes are mismatched, an empty list is
-             * returned. Within single or double quotes, the respective quote character can be escaped with a backslash.
-             * For example, O'Reilly can be written as O'Reilly, "O'Reilly", or 'O\'Reilly'.
+             * If the property is not set, the default list is returned. The strings in the list can contain whitespace
+             * and commas if they are enclosed in single or double quotes. If quotes are mismatched, the default list
+             * is returned. Within single or double quotes, the respective quote character can be escaped with a
+             * backslash. For example, O'Reilly can be written as O'Reilly, "O'Reilly", or 'O\'Reilly'.
              *
              * @param key - The property key.
              * @param value - The default value to use if the property is not set.
-             * @returns The property value interpreted as a list of strings.
+             * @returns The property value interpreted as a list of strings, or the default value if the property is
+             * not set.
              * @see {@link setProperty}
              */
             getPropertyAsListWithDefault(key: string, value: StringSeq): StringSeq;
@@ -133,10 +134,20 @@ declare module "@zeroc/ice" {
             getPropertiesForPrefix(prefix: string): PropertyDict;
 
             /**
+             * Gets the properties that were never read.
+             *
+             * @returns A list of unused properties.
+             */
+            getUnusedProperties(): string[];
+
+            /**
              * Sets a property. To unset a property, set it to the empty string.
              *
              * @param key - The property key.
              * @param value - The property value.
+             * @throws {@link InitializationException} - Thrown when the key is empty or contains only whitespace.
+             * @throws {@link PropertyException} - Thrown when the key uses a reserved Ice prefix (`Ice`, `IceSSL`,
+             * etc.) but is not a known Ice property.
              * @see {@link getProperty}
              */
             setProperty(key: string, value: string): void;

--- a/js/packages/ice/src/Ice/Protocol.d.ts
+++ b/js/packages/ice/src/Ice/Protocol.d.ts
@@ -8,6 +8,8 @@ declare module "@zeroc/ice" {
         const Protocol_1_0: ProtocolVersion;
 
         class Protocol {
+            private constructor();
+
             //
             // Size of the Ice protocol header
             //
@@ -82,7 +84,7 @@ declare module "@zeroc/ice" {
          *
          * @param version The string to convert.
          *
-         * @returns The converted object identity.
+         * @returns The converted encoding version.
          */
         function stringToEncodingVersion(version: string): EncodingVersion;
 

--- a/js/packages/ice/src/Ice/Protocol.js
+++ b/js/packages/ice/src/Ice/Protocol.js
@@ -136,7 +136,7 @@ export function stringToProtocolVersion(version) {
  *
  * @param version The string to convert.
  *
- * @return The converted object identity.
+ * @return The converted encoding version.
  */
 export function stringToEncodingVersion(version) {
     return new EncodingVersion(stringToMajor(version), stringToMinor(version));

--- a/js/packages/ice/src/Ice/ServantLocator.d.ts
+++ b/js/packages/ice/src/Ice/ServantLocator.d.ts
@@ -37,7 +37,7 @@ declare module "@zeroc/ice" {
              * The object adapter calls this function only when {@link locate} returns a non-null servant.
              *
              * @remarks The implementation can throw any exception, including {@link UserException}. The Ice runtime
-             * marshals this  exception in the response. If both the dispatch and `finished` throw an exception, the
+             * marshals this exception in the response. If both the dispatch and `finished` throw an exception, the
              * exception thrown by `finished` prevails and is marshaled back to the client.
              *
              * @param current - Information about the incoming request being dispatched.
@@ -52,7 +52,7 @@ declare module "@zeroc/ice" {
             finished(current: Current, servant: Ice.Object, cookie: object | null): void;
 
             /**
-             * Notifies this servant locator that the object adapter in which it's installed is being deactivated.
+             * Notifies this servant locator that the object adapter in which it's installed is being destroyed.
              *
              * @param category - The category with which this servant locator was registered.
              *

--- a/js/packages/ice/src/Ice/SliceLoader.d.ts
+++ b/js/packages/ice/src/Ice/SliceLoader.d.ts
@@ -9,10 +9,11 @@ declare module "@zeroc/ice" {
             /**
              * Creates an instance of a class mapped from a Slice class or exception based on a Slice type ID.
              *
-             * @param typeId The Slice type ID or compact type ID.
-             * @return A new instance of the class or exception identified by `typeId`, or `null` if the implementation
-             *         cannot find the corresponding class.
-             * @throws MarshalException If the corresponding class was found but its instantiation failed.
+             * @param typeId The Slice type ID or compact type ID (a compact type ID is passed as its decimal string
+             *        representation).
+             * @returns A new instance of the class or exception identified by `typeId`, or `null` if the
+             *          implementation cannot find the corresponding class.
+             * @throws {@link MarshalException} If the corresponding class was found but its instantiation failed.
              */
             newInstance(typeId: string): Ice.Value | Ice.UserException | null;
         }

--- a/js/packages/ice/src/Ice/StringToIdentity.d.ts
+++ b/js/packages/ice/src/Ice/StringToIdentity.d.ts
@@ -3,12 +3,11 @@
 declare module "@zeroc/ice" {
     namespace Ice {
         /**
-         * Converts a string to an object identity, throwing a {@link ParseException} if the string cannot be
-         * converted.
+         * Converts a string to an object identity.
          *
          * @param s - The string to convert.
          * @returns The converted object identity.
-         * @throws {@link ParseException} - Thrown if the string cannot be converted to a valid object identity.
+         * @throws {@link ParseException} - Thrown if the string cannot be parsed.
          */
         function stringToIdentity(s: string): Identity;
     }

--- a/js/packages/ice/src/Ice/ToStringMode.d.ts
+++ b/js/packages/ice/src/Ice/ToStringMode.d.ts
@@ -23,8 +23,8 @@ declare module "@zeroc/ice" {
 
             /**
              * Characters with ordinal values greater than 127 are encoded as a sequence of UTF-8 bytes using octal escapes.
-             * Characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or an octal escape. Use this mode
-             * to generate strings compatible with Ice 3.6 and earlier.
+             * Non-printable ASCII characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or an
+             * octal escape. Use this mode to generate strings compatible with Ice 3.6 and earlier.
              */
             static readonly Compat: ToStringMode;
 

--- a/js/packages/ice/src/Ice/UserException.d.ts
+++ b/js/packages/ice/src/Ice/UserException.d.ts
@@ -7,12 +7,6 @@ declare module "@zeroc/ice" {
          */
         abstract class UserException extends Exception {
             constructor();
-
-            /**
-             * Obtains the Slice type ID of this exception.
-             * @returns The fully-scoped type ID.
-             */
-            static ice_staticId(): string;
         }
     }
 }

--- a/js/packages/ice/src/Ice/Value.d.ts
+++ b/js/packages/ice/src/Ice/Value.d.ts
@@ -7,13 +7,13 @@ declare module "@zeroc/ice" {
          */
         class Value {
             /**
-             * The Ice run time invokes this method prior to marshaling an object's data members. This allows a subclass
+             * The Ice runtime invokes this method prior to marshaling an object's data members. This allows a subclass
              * to override this method in order to validate its data members.
              */
             ice_preMarshal(): void;
 
             /**
-             * The Ice run time invokes this method after unmarshaling an object's data members. This allows a
+             * The Ice runtime invokes this method after unmarshaling an object's data members. This allows a
              * subclass to override this method in order to perform additional initialization.
              */
             ice_postUnmarshal(): void;
@@ -35,10 +35,10 @@ declare module "@zeroc/ice" {
             /**
              * Obtains the sliced data associated with this instance.
              *
-             * @returns The sliced data if the value has a preserved-slice base class and has been sliced during
-             * unmarshaling of the value, nil otherwise.
+             * @returns The sliced data if this value was sliced during unmarshaling, null otherwise. Unknown slices
+             * are preserved only when the sender uses the sliced format.
              */
-            ice_getSlicedData(): SlicedData;
+            ice_getSlicedData(): SlicedData | null;
         }
     }
 }

--- a/js/packages/test/Ice/adapterDeactivation/Client.ts
+++ b/js/packages/test/Ice/adapterDeactivation/Client.ts
@@ -72,7 +72,7 @@ export class Client extends TestHelper {
         out.write("testing object adapter with bi-dir connection... ");
         {
             test(communicator.getDefaultObjectAdapter() === null);
-            test(obj.ice_getCachedConnection().getAdapter() === null);
+            test(obj.ice_getCachedConnection()!.getAdapter() === null);
 
             let adapter = await communicator.createObjectAdapter("");
 
@@ -80,27 +80,27 @@ export class Client extends TestHelper {
             test(communicator.getDefaultObjectAdapter() === adapter);
 
             // create new connection
-            await obj.ice_getCachedConnection().close();
+            await obj.ice_getCachedConnection()!.close();
             await obj.ice_ping();
 
-            test(obj.ice_getCachedConnection().getAdapter() === adapter);
+            test(obj.ice_getCachedConnection()!.getAdapter() === adapter);
 
             // Ensure destroying the OA doesn't affect the ability to send outgoing requests.
             adapter.destroy();
-            await obj.ice_getCachedConnection().close();
+            await obj.ice_getCachedConnection()!.close();
             await obj.ice_ping();
 
             communicator.setDefaultObjectAdapter(null);
 
             // create new connection
-            await obj.ice_getCachedConnection().close();
+            await obj.ice_getCachedConnection()!.close();
             await obj.ice_ping();
-            test(obj.ice_getCachedConnection().getAdapter() === null);
+            test(obj.ice_getCachedConnection()!.getAdapter() === null);
 
             adapter = await communicator.createObjectAdapter("");
-            obj.ice_getCachedConnection().setAdapter(adapter);
-            test(obj.ice_getCachedConnection().getAdapter() === adapter);
-            obj.ice_getCachedConnection().setAdapter(null);
+            obj.ice_getCachedConnection()!.setAdapter(adapter);
+            test(obj.ice_getCachedConnection()!.getAdapter() === adapter);
+            obj.ice_getCachedConnection()!.setAdapter(null);
 
             adapter.destroy();
             try {

--- a/js/packages/test/Ice/ami/Client.ts
+++ b/js/packages/test/Ice/ami/Client.ts
@@ -222,7 +222,7 @@ export class Client extends TestHelper {
             }
 
             {
-                const con: Ice.Connection = p.ice_getCachedConnection();
+                const con: Ice.Connection = p.ice_getCachedConnection()!;
                 let p2 = p.ice_batchOneway();
                 p2.ice_ping();
                 await con.flushBatchRequests();

--- a/js/packages/test/Ice/binding/Client.ts
+++ b/js/packages/test/Ice/binding/Client.ts
@@ -229,10 +229,9 @@ export class Client extends TestHelper {
                 }
                 const connections: Ice.Connection[] = [];
                 for (let i = 0; i < proxies.length; i++) {
-                    if (proxies[i].ice_getCachedConnection() !== null) {
-                        if (!connections.includes(proxies[i].ice_getCachedConnection())) {
-                            connections.push(proxies[i].ice_getCachedConnection());
-                        }
+                    const connection = proxies[i].ice_getCachedConnection();
+                    if (connection !== null && !connections.includes(connection)) {
+                        connections.push(connection);
                     }
                 }
                 test(connections.length <= adapterCount);

--- a/js/packages/test/Ice/defaultServant/Client.ts
+++ b/js/packages/test/Ice/defaultServant/Client.ts
@@ -11,7 +11,7 @@ export class Client extends TestHelper {
 
         const adapter = await communicator.createObjectAdapter("");
         await echo.setConnection();
-        echo.ice_getCachedConnection().setAdapter(adapter);
+        echo.ice_getCachedConnection()!.setAdapter(adapter);
 
         const out = this.getWriter();
 

--- a/js/packages/test/Ice/exceptions/Server.ts
+++ b/js/packages/test/Ice/exceptions/Server.ts
@@ -20,10 +20,10 @@ export class Server extends TestHelper {
             const adapter = await communicator.createObjectAdapter("");
             adapter.add(new ThrowerI(), Ice.stringToIdentity("thrower"));
             await echo.setConnection();
-            const connection = echo.ice_getCachedConnection();
+            const connection = echo.ice_getCachedConnection()!;
             connection.setCloseCallback(() => {
                 // Re-establish connection if it fails (necessary for MemoryLimitException test)
-                echo!.setConnection().then(() => echo!.ice_getCachedConnection().setAdapter(adapter));
+                echo!.setConnection().then(() => echo!.ice_getCachedConnection()!.setAdapter(adapter));
             });
             connection.setAdapter(adapter);
             this.serverReady();

--- a/js/packages/test/Ice/exceptions/ServerAMD.ts
+++ b/js/packages/test/Ice/exceptions/ServerAMD.ts
@@ -19,13 +19,13 @@ export class ServerAMD extends TestHelper {
             const adapter = await communicator.createObjectAdapter("");
             adapter.add(new AMDThrowerI(), Ice.stringToIdentity("thrower"));
             await echo.setConnection();
-            const connection = echo.ice_getCachedConnection();
+            const connection = echo.ice_getCachedConnection()!;
             connection.setCloseCallback(() => {
                 // Re-establish connection if it fails (necessary for MemoryLimitException test)
-                echo!.setConnection().then(() => echo!.ice_getCachedConnection().setAdapter(adapter));
+                echo!.setConnection().then(() => echo!.ice_getCachedConnection()!.setAdapter(adapter));
             });
             connection.setAdapter(adapter);
-            echo.ice_getCachedConnection().setAdapter(adapter);
+            echo.ice_getCachedConnection()!.setAdapter(adapter);
             this.serverReady();
             await communicator.waitForShutdown();
         } finally {

--- a/js/packages/test/Ice/facets/Server.ts
+++ b/js/packages/test/Ice/facets/Server.ts
@@ -73,7 +73,7 @@ export class Server extends TestHelper {
             const hi = new HI();
             adapter.addFacet(hi, Ice.stringToIdentity("d"), "facetGH");
             await echo.setConnection();
-            echo.ice_getCachedConnection().setAdapter(adapter);
+            echo.ice_getCachedConnection()!.setAdapter(adapter);
             this.serverReady();
             await communicator.waitForShutdown();
         } finally {

--- a/js/packages/test/Ice/inheritance/Server.ts
+++ b/js/packages/test/Ice/inheritance/Server.ts
@@ -16,7 +16,7 @@ export class Server extends TestHelper {
             const base = new Ice.ObjectPrx(communicator, `initial:${this.getTestEndpoint()}`);
             adapter.add(new InitialI(adapter, base), Ice.stringToIdentity("initial"));
             await echo.setConnection();
-            echo.ice_getCachedConnection().setAdapter(adapter);
+            echo.ice_getCachedConnection()!.setAdapter(adapter);
             this.serverReady();
             await communicator.waitForShutdown();
         } finally {

--- a/js/packages/test/Ice/middleware/Server.ts
+++ b/js/packages/test/Ice/middleware/Server.ts
@@ -57,7 +57,7 @@ export class Server extends TestHelper {
             const adapter = await communicator.createObjectAdapter("");
 
             await echo.setConnection();
-            echo.ice_getCachedConnection().setAdapter(adapter);
+            echo.ice_getCachedConnection()!.setAdapter(adapter);
             this.serverReady();
 
             adapter.add(new MyObjectI(), new Ice.Identity("test"));

--- a/js/packages/test/Ice/objects/Server.ts
+++ b/js/packages/test/Ice/objects/Server.ts
@@ -41,7 +41,7 @@ export class Server extends TestHelper {
             adapter.add(new F2I(), Ice.stringToIdentity("F21"));
             adapter.add(new UnexpectedObjectExceptionTestI(), Ice.stringToIdentity("uoet"));
             await echo.setConnection();
-            echo.ice_getCachedConnection().setAdapter(adapter);
+            echo.ice_getCachedConnection()!.setAdapter(adapter);
             this.serverReady();
             await communicator.waitForShutdown();
         } finally {

--- a/js/packages/test/Ice/operations/Server.ts
+++ b/js/packages/test/Ice/operations/Server.ts
@@ -20,7 +20,7 @@ export class Server extends TestHelper {
             const adapter = await communicator.createObjectAdapter("");
             adapter.add(new MyDerivedClassI(echo.ice_getEndpoints()), Ice.stringToIdentity("test"));
             await echo.setConnection();
-            echo.ice_getCachedConnection().setAdapter(adapter);
+            echo.ice_getCachedConnection()!.setAdapter(adapter);
             this.serverReady();
             await communicator.waitForShutdown();
         } finally {

--- a/js/packages/test/Ice/operations/ServerAMD.ts
+++ b/js/packages/test/Ice/operations/ServerAMD.ts
@@ -20,7 +20,7 @@ export class ServerAMD extends TestHelper {
             const adapter = await communicator.createObjectAdapter("");
             adapter.add(new AMDMyDerivedClassI(echo.ice_getEndpoints()), Ice.stringToIdentity("test"));
             await echo.setConnection();
-            echo.ice_getCachedConnection().setAdapter(adapter);
+            echo.ice_getCachedConnection()!.setAdapter(adapter);
             this.serverReady();
             await communicator.waitForShutdown();
         } finally {

--- a/js/packages/test/Ice/operations/Twoways.ts
+++ b/js/packages/test/Ice/operations/Twoways.ts
@@ -1334,7 +1334,7 @@ export async function twoways(
 
         let p3 = new Test.MyClassPrx(ic, "test:" + helper.getTestEndpoint());
 
-        const implicitContext = ic.getImplicitContext();
+        const implicitContext = ic.getImplicitContext()!;
         implicitContext.setContext(ctx);
         test(Ice.MapUtil.equals(implicitContext.getContext(), ctx));
         test(Ice.MapUtil.equals(await p3.opContext(), ctx));

--- a/js/packages/test/Ice/optional/Server.ts
+++ b/js/packages/test/Ice/optional/Server.ts
@@ -15,7 +15,7 @@ export class Server extends TestHelper {
             const adapter = await communicator.createObjectAdapter("");
             adapter.add(new InitialI(), Ice.stringToIdentity("initial"));
             await echo.setConnection();
-            echo.ice_getCachedConnection().setAdapter(adapter);
+            echo.ice_getCachedConnection()!.setAdapter(adapter);
             this.serverReady();
             await communicator.waitForShutdown();
         } finally {

--- a/js/packages/test/Ice/optional/ServerAMD.ts
+++ b/js/packages/test/Ice/optional/ServerAMD.ts
@@ -15,7 +15,7 @@ export class ServerAMD extends TestHelper {
             const adapter = await communicator.createObjectAdapter("");
             adapter.add(new AMDInitialI(), Ice.stringToIdentity("initial"));
             await echo.setConnection();
-            echo.ice_getCachedConnection().setAdapter(adapter);
+            echo.ice_getCachedConnection()!.setAdapter(adapter);
             this.serverReady();
             await communicator.waitForShutdown();
         } finally {

--- a/js/packages/test/Ice/servantLocator/Server.ts
+++ b/js/packages/test/Ice/servantLocator/Server.ts
@@ -25,7 +25,7 @@ export class Server extends TestHelper {
             adapter.add(new TestI(), Ice.stringToIdentity("asm"));
             adapter.add(new TestActivationI(), Ice.stringToIdentity("test/activation"));
             await echo.setConnection();
-            echo.ice_getCachedConnection().setAdapter(adapter);
+            echo.ice_getCachedConnection()!.setAdapter(adapter);
             this.serverReady();
             await communicator.waitForShutdown();
         } finally {


### PR DESCRIPTION
Fixes incorrect TSDoc comments and hand-written `.d.ts` declarations in the JS Ice library, found during the JavaScript API doc review (follow-up to #5867/#5868). Declaration/doc changes only — no runtime behavior change (the only `.js` edit is a one-word comment fix in `Protocol.js`); runtime bugs found by the same review are tracked separately in #5875-#5879.

Declared APIs that don't exist at runtime (calling them throws `TypeError`):

- `ObjectPrx.ice_toString()` → replaced with the actually-implemented `toString()`; also declared the implemented `hashCode()` (needed to use typed proxies as `HashMap` keys).
- `Logger.getPrefix()` → removed (no runtime logger implements it; implementing it for cross-mapping parity would be a follow-up).
- `UserException.ice_staticId()` → removed (slice2js generates `_ice_id` for exceptions; `ice_staticId` statics exist only for Value/proxy classes).

Declaration-vs-runtime mismatches corrected:

- `ObjectPrx.checkedCast` returns a native promise (it's an `async function`), not an `AsyncResult` with `cancel()`/`isSent()` — now `globalThis.Promise<ObjectPrx | null>`. Same one-line fix in `slice2js` for the generated proxies' `checkedCast` declaration.
- `ice_identity`/`ice_facet` return a plain `ObjectPrx`, not `this`.
- Missing nullability: `ice_getCachedConnection`, `getImplicitContext`, `proxyToString(prx)`, `setCloseCallback(callback)`, `InitializationData.properties/logger/sliceLoader`, ObjectAdapter `find`/`findFacet`/`findByProxy`/`findServantLocator`/`findDefaultServant`, `InputStream.endValue`/`readProxy`/`readOptionalProxy`/`readValue` callback, `OutputStream.startValue`/`writeString`/`writeProxy`, `Value.ice_getSlicedData`, `OutgoingResponse.exceptionId`/`exceptionDetails` (nullish for Ok/UserException).
- `OutputStream.writeOptional` returns a load-bearing `boolean`, not `void`; `OutgoingResponse` constructor's `replyStatus` is optional (defaults to `Ok`); `CompositeSliceLoader` constructor's array is optional; `RequestFailedException` now declares its real `(replyStatus, id?, facet?, operation?)` constructor as `protected` (previously TS exposed the inherited `(replyStatus, message?)` arity, which crashes at runtime); `Promise.resolve` no longer re-declares a shadowing `<T>`; `Protocol` gets a `private constructor()` (the runtime value is a plain object — `new Ice.Protocol()` throws); removed the redundant no-arg `Communicator`/`initialize` overloads; added the implemented-but-undeclared `Properties.getUnusedProperties()`.
- Removed `OutputStream.prepareWrite()` and `OutputStream.buffer` from the declarations: both return the internal `Buffer` class, not the declared `Uint8Array`, and the `.d.ts` files deliberately omit internal members elsewhere (e.g. `InputStream`'s `buffer` getter). `finished()` is the public API. Happy to re-add with an opaque type instead if you prefer.

Incorrect doc claims corrected (many are the same stale pre-3.8 patterns fixed in #5867/#5868):

- `writeValue` 1.0-only deferral, `writePendingValues`, "Ends the previous encapsulation", `startEncapsulation` overload saying "Writes the end", nested-encapsulation inheritance, `startValue` sliced-format-only caveat, `OptionalFormat.FSize` "prior to unmarshaling", `readAndCheckSeqSize` per-element, `ice_getSlicedData` "preserved-slice base class", `InitializationException` scope, `ToStringMode.Compat` non-printable-only, `Connection.throwException` "closing or closed" + "by the peer".
- JS-specific: `ObjectAdapter.createProxy` claimed adapter-ID/replica-group indirect proxies (JS always creates a direct proxy from published endpoints); `findDefaultServant` doc was a copy-paste of `findServantLocator`; `ServantLocator.deactivate` is called on adapter destroy; `EndpointInfo.secure()` claimed WSS-only (also true for ssl); `Connection.type()` listed "udp"; `close()` now documents rejection semantics; `getInfo()` documents the throw-after-closure; WS `localAddress`/`localPort` sentinels; `EndpointInfo.timeout` no-effect note; dead "@throws MarshalException if the stream has not been initialized with a communicator" on `readProxy`/`readOptionalProxy` (communicator-less streams are unconstructible in JS); `ice_getConnection` summary said "Gets the connection ID"; `createObjectAdapter` never throws synchronously (the promise rejects) and only bidir/routed adapters are supported; `getPropertyAsListWithDefault` claimed "empty list" instead of the default; `InitializationData.clone` is a shallow copy; `stringVersion`/`intVersion` pre-release forms; `getEndpoints` always returns an empty array; `HashMap` never compares values; `stringToIdentity` doesn't validate identities; `stringToEncodingVersion` returns doc said "object identity".
- Coverage/markup: `@throws` tags added for `stringToProxy`/`propertyToProxy` (`ParseException`), `setProperty` (`InitializationException`/`PropertyException`), `add`/`addFacet` (`AlreadyRegisteredException`); rewritten pre-3.8 `Communicator` class summary; `@return`→`@returns` (8×); stray `</param>`/`</returns>` C# residue; assorted typos ("Reads and encapsulation", double periods/spaces, "Ice run time", `{@link Communicator#destroy()}` parens, constructor `@returns` tags).

Verified with a differential `tsc` check over all 46 hand-written `.d.ts` files against the pre-change baseline: the only new diagnostic is a `Cannot find name 'ReplyStatus'` on the new `RequestFailedException` constructor line, the same pre-existing class of noise as the untouched `DispatchException` members (`ReplyStatus` is a build-generated declaration, absent in an unbuilt tree).
