### PR TITLE
Handle duplicate DataStorm disconnect notifications without consuming a retry attempt

### DIFF
--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -524,12 +524,9 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
 void
 SessionI::disconnected(const Current& current)
 {
-    if (disconnected(current.con, nullptr))
+    if (!handleDisconnected(current.con, nullptr))
     {
-        if (!retry(getNode(), nullptr))
-        {
-            remove();
-        }
+        remove();
     }
 }
 
@@ -555,12 +552,9 @@ SessionI::connected(SessionPrx session, const ConnectionPtr& newConnection, cons
             self,
             [self](const auto& connection, auto ex)
             {
-                if (self->disconnected(connection, ex))
+                if (!self->handleDisconnected(connection, ex))
                 {
-                    if (!self->retry(self->getNode(), nullptr))
-                    {
-                        self->remove();
-                    }
+                    self->remove();
                 }
             });
     }
@@ -601,6 +595,25 @@ bool
 SessionI::disconnected(const ConnectionPtr& connection, exception_ptr ex)
 {
     lock_guard<mutex> lock(_mutex);
+    return disconnectedImpl(connection, ex);
+}
+
+bool
+SessionI::handleDisconnected(const ConnectionPtr& connection, exception_ptr ex)
+{
+    lock_guard<mutex> lock(_mutex);
+    if (!disconnectedImpl(connection, ex))
+    {
+        // Nothing to do: the session is destroyed, already reconnected, or the disconnect was already handled.
+        return true;
+    }
+    return retryImpl(_node, nullptr); // getNode() would deadlock, the mutex is locked
+}
+
+bool
+SessionI::disconnectedImpl(const ConnectionPtr& connection, exception_ptr ex)
+{
+    // Called with the session mutex locked.
     if (_destroyed)
     {
         // Ignore already destroyed.
@@ -608,8 +621,12 @@ SessionI::disconnected(const ConnectionPtr& connection, exception_ptr ex)
     }
     else if (!_session)
     {
-        // A recovery attempt was in progress and failed. Return true to let the caller retry.
-        return true;
+        // When a retry is already scheduled, this is a second notification for the same disconnect: a peer shutdown
+        // produces both the wire disconnected() request and the connection closure, in either order. Letting the
+        // caller retry again would cancel the pending immediate reconnect and replace it with a delayed one,
+        // consuming a retry slot. Otherwise, a recovery attempt was in progress and failed: return true to let the
+        // caller retry.
+        return !_retryTask;
     }
     else if (connection && _connection != connection)
     {
@@ -666,7 +683,13 @@ bool
 SessionI::retry(NodePrx node, exception_ptr exception)
 {
     lock_guard<mutex> lock(_mutex);
+    return retryImpl(std::move(node), std::move(exception));
+}
 
+bool
+SessionI::retryImpl(NodePrx node, exception_ptr exception)
+{
+    // Called with the session mutex locked.
     if (exception)
     {
         // Don't retry if we are shutting down.

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -286,8 +286,21 @@ namespace DataStormI
         void
         connected(DataStormContract::SessionPrx, const Ice::ConnectionPtr&, const DataStormContract::TopicInfoSeq&);
         [[nodiscard]] bool disconnected(const Ice::ConnectionPtr&, std::exception_ptr);
+
+        /// Handles a disconnect notification (the peer's disconnected() request or the connection closure) and,
+        /// when the session was connected, schedules the reconnection retry. Handling both under a single lock
+        /// acquisition keeps a concurrent duplicate notification for the same disconnect from consuming an
+        /// additional retry attempt.
+        /// @return `false` when the retry limit was reached or no retry is possible: the caller must remove the
+        /// session.
+        [[nodiscard]] bool handleDisconnected(const Ice::ConnectionPtr&, std::exception_ptr);
+
         [[nodiscard]] bool retry(DataStormContract::NodePrx, std::exception_ptr);
         void destroyImpl(const std::exception_ptr&);
+
+        // The implementations of disconnected and retry; called with the session mutex locked.
+        [[nodiscard]] bool disconnectedImpl(const Ice::ConnectionPtr&, std::exception_ptr);
+        [[nodiscard]] bool retryImpl(DataStormContract::NodePrx, std::exception_ptr);
 
         // Cancels and clears any pending retry task, breaking the _retryTask -> task -> lambda -> self reference
         // cycle so the session can be reclaimed. Used by NodeI::destroy, which drops sessions without calling


### PR DESCRIPTION
Fixes #5832.

A peer shutdown produces two disconnect notifications: the wire `disconnected()` request and the connection
closure, racing in either order. The first notification tears the session down and schedules the immediate
reconnection; the second landed in `SessionI::disconnected`'s `!_session` branch, which returned `true`
unconditionally, so its caller ran `retry()` again — cancelling the pending immediate reconnect, rescheduling it
with a real delay, and consuming a retry attempt. With a small `DataStorm.Session.RetryCount`, sessions gave up
sooner than configured. (#5838 removed the connection-manager callback on the wire path, which covers the
sequential orders; the notifications can still race when both are in flight concurrently.)

## Fix

- The `!_session` branch only lets the caller retry when no retry task is pending: a pending task means the
  disconnect was already handled and this is a duplicate notification.
- The disconnect handling and the retry scheduling now run under a **single lock acquisition**
  (`SessionI::handleDisconnected`, used by both notification paths), so a concurrent duplicate cannot slip between
  the disconnect processing and the installation of the retry task. `disconnected()` and `retry()` remain as thin
  locking wrappers for their other callers (`checkSession`, `NodeI`'s session-creation failure paths). The callers
  are unchanged; note that `checkSession`'s `!_session` path inherits the duplicate gate — with a retry pending it
  now returns `false` and re-loops, returning based on the fresh session state (previously it returned `true`
  unconditionally).

Reconnect-attempt failures are unaffected: they report through `retry(node, exception)` directly, never through
`disconnected()`, so ignoring a duplicate can't stall a recovery in progress.

## Testing

The race is not deterministically drivable from the test harness (the two notifications must be concurrently in
flight). Verified with session traces that a peer shutdown schedules exactly one reconnection, and the full
DataStorm suite passes. The fix was adversarially cross-checked (both the duplicate-detection gate and the
atomicity of the disconnect+retry pair, including lock-ordering of everything called under the session mutex).

No changelog fragment: narrow race window, no field reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

