### PR TITLE
Destroy communicator in destroyAsync even with a null callback

### DIFF
--- a/cpp/src/Ice/Communicator.cpp
+++ b/cpp/src/Ice/Communicator.cpp
@@ -48,11 +48,12 @@ Ice::Communicator::destroy() noexcept
 void
 Ice::Communicator::destroyAsync(function<void()> completed) noexcept
 {
-    if (completed)
+    if (!completed)
     {
-        _instance->destroyAsync(std::move(completed));
+        // we tolerate null callbacks
+        completed = [] {};
     }
-    // we tolerate null callbacks, they do nothing
+    _instance->destroyAsync(std::move(completed));
 }
 
 void


### PR DESCRIPTION
Previously, `Ice::Communicator::destroyAsync` did nothing when the caller supplied a null `completed` callback. This is surprising: you'd expect the communicator to be destroyed regardless. With this change, a null callback is replaced by a no-op, so the communicator is always destroyed.

The only caller of this function is currently Ice for Python, which always supplies a non-null callback, so this change has no effect on existing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)