### PR TITLE
Fix flaky DataStorm/partial late-joining sampleCount=0 reader test

### DIFF
--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -182,8 +182,11 @@ void ::Writer::run(int argc, char* argv[])
         joinBarrier.waitForReaders();
         joinBarrier.update(0);
 
-        // Wait until the reader has installed its onSamples callback before publishing the partial.
+        // Wait until the reader has installed its onSamples callback before publishing the partial. The barrier
+        // only orders the callback installation; also wait for the reader's element to attach, otherwise
+        // waitForNoReaders below can return before the reader ever attached.
         [[maybe_unused]] auto _ = makeSingleKeyReader(lateReaderReadyBarrier, "barrier").getNextUnread();
+        writer.waitForReaders();
 
         writer.partialUpdate<float>("price")(15.0f);
         writer.waitForNoReaders();


### PR DESCRIPTION
Fixes a flaky hang in `cpp/DataStorm/partial` first observed in the multicast configuration on an unrelated PR
([failure on #5883](https://github.com/zeroc-ice/ice/actions/runs/28953814207/job/85907319265?pr=5883)).

In the late-joining `sampleCount=0` reader case, the writer only synchronized on the ready barrier, which orders
the installation of the reader's `onSamples` callback but **not** the attachment of the reader element — a
different topic with an independent handshake. When the reader's attach lagged, the writer's `waitForNoReaders()`
returned immediately (the reader had not attached yet), and the writer destroyed its element before the reader's
attach completed. The reader then received a detach instead of its initialization samples and waited forever for
the partial update, deadlocking the rest of the suite on the next case's barrier — the CI logs show the writer's
element destroyed at `.987` and the reader's attach ack arriving at `.988`.

Test-only fix: wait for the reader to attach before publishing the partial update, like every other case in the
test. Verified with 30 consecutive local runs of the suite (both variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
