### PR TITLE
Fix null node dereference in TopicI::reap in non-replicated IceStorm

### DIFF
--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -189,7 +189,7 @@ namespace
         void reap(Ice::IdentitySeq ids, const Ice::Current&) override
         {
             auto node = _instance->node();
-            if (!node->updateMaster(__FILE__, __LINE__))
+            if (node && !node->updateMaster(__FILE__, __LINE__))
             {
                 throw ReapWouldBlock();
             }


### PR DESCRIPTION
`TopicInternal::reap` was the only operation on the topic servant that dereferenced `_instance->node()` without a null check — every sibling operation either checks `if (node)` or goes through the null-safe `CachedReadHelper`/`FinishUpdateHelper` helpers. Since the election node is only set in replicated mode, invoking `reap` on a non-replicated IceStorm dereferenced a null pointer and crashed the service.

This fix guards on the node like the sibling operations. When the node is null, the reap is performed locally, consistent with how the other operations behave in non-replicated mode.

No CHANGELOG entry: `reap` is never invoked during normal operation of a non-replicated deployment — the only internal caller (`TopicImpl::publish`) calls `reapAsync` solely when a master replica exists. Triggering the crash requires a client deliberately invoking this internal, undocumented operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)