### PR TITLE
Reject empty identities in TopicInternal::reap

### DIFF
--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 #include "TopicI.h"
+#include "../Ice/CheckIdentity.h"
 #include "Ice/LoggerUtil.h"
 #include "Instance.h"
 #include "NodeI.h"
@@ -188,6 +189,11 @@ namespace
 
         void reap(Ice::IdentitySeq ids, const Ice::Current&) override
         {
+            for (const auto& id : ids)
+            {
+                checkIdentity(id, __FILE__, __LINE__);
+            }
+
             auto node = _instance->node();
             if (!node->updateMaster(__FILE__, __LINE__))
             {


### PR DESCRIPTION
A persistent topic's placeholder database record is keyed by `{topicId, empty identity}`, and the startup loader relies on it being the first record of each topic. `TopicImpl::removeSubscribers` builds subscriber record keys directly from the identities passed to `reap` with no validation, so a `reap` invocation carrying an empty identity deleted the topic's placeholder record; the deletion was committed and replicated to all replicas, corrupting the persistent layout (assert failure on restart in debug builds, topic mis-parsing in release builds).

This fix validates the identities at the dispatch entry with `checkIdentity` — an identity with an empty name is illegal in all Ice APIs — mirroring how the sibling operations validate their proxy parameters with `checkNotNull`. `TransientTopicImpl::reap` is a no-op, so persistent topics are the only affected surface.

No CHANGELOG entry: no legitimate caller can send an empty identity — internal reap requests carry real subscriber identities, and `unsubscribe`/`unlink` reject a null (empty-identity) proxy — so this cannot trigger during normal operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)