### PR TITLE
Clear a surviving load command when a server reaches Destroyed

### DIFF
--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -2699,6 +2699,13 @@ ServerI::setStateNoSync(InternalServerState st, const string& reason)
                 _destroy->finished();
                 _destroy = nullptr;
             }
+            if (_load)
+            {
+                // load() can queue a load command while the server is being destroyed, since destroy() runs mostly
+                // without the mutex. Fail it here so its reply is sent and the servant is removed below.
+                _load->failed(make_exception_ptr(DeploymentException("The server was destroyed.")));
+                _load = nullptr;
+            }
             _condVar.notify_all(); // for getProperties()
             break;
         default:


### PR DESCRIPTION
The `Destroying` case of `ServerI::setStateNoSync` fails and clears a pending `_load` command, but the `Destroyed` case did not. `ServerI::destroy()` runs mostly without the mutex (it snapshots `_adapters`, then does `removeServer` + `removeRecursive` + adapter destruction unlocked), so `load()` can acquire the mutex and queue a `_load` in that window. If such a `_load` survived into `Destroyed`:

- its reply was never sent, and
- the servant-removal guard `if (_state == Destroyed && !_load)` was skipped, so the `ServerI` servant stayed registered in the adapter and `_desc` was never cleared. A later `loadServer` retry could then re-find the retained servant and, since `checkDestroyed()` throws `ObjectNotExistException` for it, spin in `NodeI::loadServer` while holding `NodeI::_mutex`.

The fix handles `_load` in the `Destroyed` case exactly as the `Destroying` case already does.

### Reachability

This is defensive symmetry rather than a fix for an observed hang. IceGrid node server synchronization is driven only by the node's session with the **master** registry, and the master serializes load and destroy per server (`ServerEntry::syncImpl`'s `_synchronizing` guard) — it only replies to / clears a destroy once the node reports the server `Destroyed` (`DestroyCommand::finished()` runs from the `Destroyed` state transition). So under supported single-master operation a `loadServer` is not dispatched on the node while the server is still `Destroying`, and this window does not open. The change makes the two terminal-state cases consistent and removes the latent hazard.

Fixes #5840

🤖 Generated with [Claude Code](https://claude.com/claude-code)
