### PR TITLE
Fix icestormdb to use the IceStorm service's subscribers key comparator

### DIFF
--- a/changelog.d/service-icestorm/icestormdb-subscribers-comparator.md
+++ b/changelog.d/service-icestorm/icestormdb-subscribers-comparator.md
@@ -1,0 +1,4 @@
+- Fixed `icestormdb` to open the subscribers database with the same key comparator as the IceStorm service.
+  Previously a database produced by `icestormdb --import` was ordered differently than the service expected, so
+  after restoring a backup the service could fail to find subscriber and topic records whose identities have
+  differing lengths.

--- a/cpp/src/IceStorm/IceStormDB.cpp
+++ b/cpp/src/IceStorm/IceStormDB.cpp
@@ -7,6 +7,7 @@
 #include "DBTypes.h"
 #include "Ice/Ice.h"
 #include "Ice/StringUtil.h"
+#include "Util.h"
 
 #include <fstream>
 #include <iterator>
@@ -145,6 +146,7 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
         IceStorm::AllData data;
 
         IceDB::IceContext dbContext = {communicator};
+        IceStormInternal::setKeyComparatorCommunicator(communicator);
 
         if (import)
         {
@@ -231,7 +233,12 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
 
                 IceDB::
                     Dbi<IceStorm::SubscriberRecordKey, IceStorm::SubscriberRecord, IceDB::IceContext, Ice::OutputStream>
-                        subscriberMap(txn, "subscribers", dbContext, MDB_CREATE);
+                        subscriberMap(
+                            txn,
+                            "subscribers",
+                            dbContext,
+                            MDB_CREATE,
+                            IceStormInternal::compareSubscriberRecordKey);
 
                 for (const auto& subscriber : data.subscribers)
                 {
@@ -287,7 +294,7 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
 
                 IceDB::
                     Dbi<IceStorm::SubscriberRecordKey, IceStorm::SubscriberRecord, IceDB::IceContext, Ice::OutputStream>
-                        subscriberMap(txn, "subscribers", dbContext, 0);
+                        subscriberMap(txn, "subscribers", dbContext, 0, IceStormInternal::compareSubscriberRecordKey);
 
                 IceStorm::SubscriberRecordKey key;
                 IceStorm::SubscriberRecord record;
@@ -325,6 +332,11 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
             }
             fs.write(reinterpret_cast<const char*>(stream.b.begin()), static_cast<streamsize>(stream.b.size()));
             fs.close();
+            if (fs.fail())
+            {
+                consoleErr << args[0] << ": could not write output file: " << IceInternal::errorToString(errno) << endl;
+                return 1;
+            }
         }
     }
     catch (const Ice::Exception& ex)

--- a/cpp/src/IceStorm/Instance.cpp
+++ b/cpp/src/IceStorm/Instance.cpp
@@ -301,6 +301,7 @@ PersistentInstance::PersistentInstance(
     try
     {
         dbContext.communicator = std::move(communicator);
+        IceStormInternal::setKeyComparatorCommunicator(dbContext.communicator);
 
         IceDB::ReadWriteTxn txn(_dbEnv);
 
@@ -323,6 +324,7 @@ PersistentInstance::destroy() noexcept
 {
     _dbEnv.close();
     dbContext.communicator = nullptr;
+    IceStormInternal::setKeyComparatorCommunicator(nullptr);
 
     Instance::destroy();
 }

--- a/cpp/src/IceStorm/Makefile.mk
+++ b/cpp/src/IceStorm/Makefile.mk
@@ -25,6 +25,7 @@ IceStormService_sources         := $(addprefix $(currentdir)/,Instance.cpp \
                                                              TransientTopicI.cpp \
                                                              TransientTopicManagerI.cpp \
                                                              Util.cpp \
+                                                             SubscriberRecordKeyCompare.cpp \
                                                              ../IceDB/IceDB.cpp \
                                                              Election.ice \
                                                              IceStormInternal.ice \
@@ -46,6 +47,7 @@ icestormadmin_sources           := $(addprefix $(currentdir)/,Admin.cpp \
 icestormdb_targetdir            := $(bindir)
 icestormdb_libs                 := lmdb
 icestormdb_sources              := $(addprefix $(currentdir)/,IceStormDB.cpp \
+                                                              SubscriberRecordKeyCompare.cpp \
                                                               ../IceDB/IceDB.cpp \
                                                               SubscriberRecord.ice \
                                                               DBTypes.ice \

--- a/cpp/src/IceStorm/SubscriberRecordKeyCompare.cpp
+++ b/cpp/src/IceStorm/SubscriberRecordKeyCompare.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "Util.h"
+
+using namespace IceStorm;
+
+namespace
+{
+    // Marshaling context used to decode keys inside compareSubscriberRecordKey. An LMDB comparator is
+    // a plain function pointer with no user data, so the communicator is installed here (via
+    // setKeyComparatorCommunicator) before the subscribers database is opened.
+    IceDB::IceContext keyContext;
+}
+
+void
+IceStormInternal::setKeyComparatorCommunicator(const Ice::CommunicatorPtr& communicator)
+{
+    keyContext.communicator = communicator;
+}
+
+int
+IceStormInternal::compareSubscriberRecordKey(const MDB_val* v1, const MDB_val* v2)
+{
+    SubscriberRecordKey k1, k2;
+    IceDB::Codec<SubscriberRecordKey, IceDB::IceContext, Ice::OutputStream>::read(k1, *v1, keyContext);
+    IceDB::Codec<SubscriberRecordKey, IceDB::IceContext, Ice::OutputStream>::read(k2, *v2, keyContext);
+    if (k1 < k2)
+    {
+        return -1;
+    }
+    else if (k1 == k2)
+    {
+        return 0;
+    }
+    else
+    {
+        return 1;
+    }
+}

--- a/cpp/src/IceStorm/Util.cpp
+++ b/cpp/src/IceStorm/Util.cpp
@@ -59,26 +59,6 @@ IceStormInternal::describeEndpoints(const optional<Ice::ObjectPrx>& proxy)
     return os.str();
 }
 
-int
-IceStormInternal::compareSubscriberRecordKey(const MDB_val* v1, const MDB_val* v2)
-{
-    SubscriberRecordKey k1, k2;
-    IceDB::Codec<SubscriberRecordKey, IceDB::IceContext, Ice::OutputStream>::read(k1, *v1, dbContext);
-    IceDB::Codec<SubscriberRecordKey, IceDB::IceContext, Ice::OutputStream>::read(k2, *v2, dbContext);
-    if (k1 < k2)
-    {
-        return -1;
-    }
-    else if (k1 == k2)
-    {
-        return 0;
-    }
-    else
-    {
-        return 1;
-    }
-}
-
 IceStormElection::LogUpdate
 IceStormInternal::getIncrementedLLU(const IceDB::ReadWriteTxn& txn, LLUMap& lluMap)
 {

--- a/cpp/src/IceStorm/Util.h
+++ b/cpp/src/IceStorm/Util.h
@@ -30,6 +30,10 @@ namespace IceStormInternal
 
     std::string describeEndpoints(const std::optional<Ice::ObjectPrx>&);
 
+    // Installs the communicator used by compareSubscriberRecordKey; must be called before the
+    // subscribers database is opened.
+    void setKeyComparatorCommunicator(const Ice::CommunicatorPtr&);
+
     int compareSubscriberRecordKey(const MDB_val* v1, const MDB_val* v2);
 
     IceStormElection::LogUpdate getIncrementedLLU(const IceDB::ReadWriteTxn&, IceStorm::LLUMap&);

--- a/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
@@ -104,6 +104,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\..\IceDB\IceDB.cpp" />
     <ClCompile Include="..\..\IceStormDB.cpp" />
+    <ClCompile Include="..\..\SubscriberRecordKeyCompare.cpp" />
     <ClCompile Include="Win32\Debug\DBTypes.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj.filters
+++ b/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClCompile Include="..\..\IceStormDB.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\SubscriberRecordKeyCompare.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Win32\Debug\DBTypes.cpp">
       <Filter>Source Files\Win32\Debug</Filter>
     </ClCompile>

--- a/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
@@ -114,6 +114,7 @@
     <ClCompile Include="..\..\Observers.cpp" />
     <ClCompile Include="..\..\Service.cpp" />
     <ClCompile Include="..\..\Subscriber.cpp" />
+    <ClCompile Include="..\..\SubscriberRecordKeyCompare.cpp" />
     <ClCompile Include="..\..\TopicI.cpp" />
     <ClCompile Include="..\..\TopicManagerI.cpp" />
     <ClCompile Include="..\..\TraceLevels.cpp" />

--- a/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj.filters
+++ b/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj.filters
@@ -73,6 +73,9 @@
     <ClCompile Include="..\..\Subscriber.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\SubscriberRecordKeyCompare.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\TopicI.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/cpp/test/IceStorm/icestormdb/test.py
+++ b/cpp/test/IceStorm/icestormdb/test.py
@@ -34,8 +34,13 @@ class IceStormDbExportImportTestCase(IceStormTestCase):
     def runClientSide(self, current):
         testdir = current.testsuite.getPath()
 
+        # Topic names of different lengths: the marshaled key byte-order (which sorts by the
+        # length prefix first) differs from the service's decoded key comparator, so an imported
+        # database is only searchable if it was built with that same comparator.
+        topicNames = ["a", "xx", "short", "mediumname", "verylongtopicname"]
+
         current.write("creating topics... ")
-        self.runadmin(current, "create topic1 topic2 topic3")
+        self.runadmin(current, "create " + " ".join(topicNames))
         current.writeln("ok")
 
         # Shut down IceStorm to release the LMDB lock.
@@ -79,9 +84,25 @@ class IceStormDbExportImportTestCase(IceStormTestCase):
             self.icestorm[0].start(current)
 
             output = self.runadmin(current, "topics", quiet=True)
-            for topic in ["topic1", "topic2", "topic3"]:
-                if topic not in output:
+            for topic in topicNames:
+                if topic not in output.split():
                     raise RuntimeError("expected '{0}' in topics, got: {1}".format(topic, output))
+            current.writeln("ok")
+
+            # Destroy every topic and restart: destroy performs a keyed lookup of the topic's
+            # placeholder record, which only succeeds if the imported database is ordered with the
+            # service's key comparator. Otherwise the lookup misses, the records survive, and the
+            # topic resurrects on restart.
+            current.write("destroying topics and verifying they stay destroyed... ")
+            self.runadmin(current, "destroy " + " ".join(topicNames))
+            self.shutdown(current)
+            self.icestorm[0].stop(current, True)
+
+            self.icestorm[0].start(current)
+            output = self.runadmin(current, "topics", quiet=True)
+            for topic in topicNames:
+                if topic in output.split():
+                    raise RuntimeError("topic '{0}' resurrected after destroy: {1}".format(topic, output))
 
             self.shutdown(current)
             self.icestorm[0].stop(current, True)


### PR DESCRIPTION
Fixes #5847
Fixes #5857

`icestormdb` opened the `subscribers` LMDB database with LMDB's default byte ordering, while the IceStorm service opens it with the custom `compareSubscriberRecordKey` comparator. A database produced by `icestormdb --import` was therefore laid out in a different order than the service expects, so after restoring a backup the service could silently fail to find subscriber and topic records whose identities differ in length (keyed `del`/`find` miss — ghost subscriptions resurrect on restart, topic records leak).

The comparator previously lived in a translation unit that pulls in the whole service, so it is extracted into `SubscriberRecordKeyCompare.cpp`, compiled into **both** the service and `icestormdb` (a single source of truth), with its communicator installed on both before the database is opened. `icestormdb` now passes the comparator to its import and export opens.

Also makes `icestormdb --export` return a non-zero status on an output-stream write error instead of silently producing a truncated backup (#5857).

### Testing
Extended `test/IceStorm/icestormdb` to create topics with different-length names and exercise a keyed lookup after export → import → restart: it fails without the comparator fix (topics resurrect after a destroy) and passes with it. `single` and `federation` remain green.

<sub>🤖 Produced by an automated correctness audit (Claude Fable 5) and cross-verified by Codex; reviewed but flagged for human triage.</sub>
