### PR TITLE
Fix transient IceStorm topic guards and register the Finder in transient mode

### DIFF
--- a/changelog.d/service-icestorm/transient-destroyed-guard.md
+++ b/changelog.d/service-icestorm/transient-destroyed-guard.md
@@ -1,0 +1,4 @@
+- Fixed transient IceStorm (`IceStorm.Transient=1`) to reject `subscribeAndGetPublisher` and `link` calls on a
+  destroyed topic with `ObjectNotExistException`, matching the persistent implementation. Previously such a call
+  succeeded on a topic that could no longer deliver events and could permanently block re-subscribing that
+  subscriber. Also registered the `IceStorm/Finder` object in transient mode, as documented.

--- a/changelog.d/service-icestorm/transient-destroyed-guard.md
+++ b/changelog.d/service-icestorm/transient-destroyed-guard.md
@@ -2,3 +2,4 @@
   destroyed topic with `ObjectNotExistException`, matching the persistent implementation. Previously such a call
   succeeded on a topic that could no longer deliver events and could permanently block re-subscribing that
   subscriber.
+- Fixed transient IceStorm (`IceStorm.Transient=1`) to register the `IceStorm/Finder` object, as documented.

--- a/changelog.d/service-icestorm/transient-destroyed-guard.md
+++ b/changelog.d/service-icestorm/transient-destroyed-guard.md
@@ -1,4 +1,4 @@
 - Fixed transient IceStorm (`IceStorm.Transient=1`) to reject `subscribeAndGetPublisher` and `link` calls on a
   destroyed topic with `ObjectNotExistException`, matching the persistent implementation. Previously such a call
   succeeded on a topic that could no longer deliver events and could permanently block re-subscribing that
-  subscriber. Also registered the `IceStorm/Finder` object in transient mode, as documented.
+  subscriber.

--- a/cpp/src/IceStorm/Service.cpp
+++ b/cpp/src/IceStorm/Service.cpp
@@ -111,6 +111,10 @@ ServiceI::start([[maybe_unused]] const string& serviceName, const CommunicatorPt
         {
             _transientManager = make_shared<TransientTopicManagerImpl>(_instance);
             _managerProxy = topicAdapter->add<TopicManagerPrx>(_transientManager, topicManagerId);
+
+            topicAdapter->add(
+                make_shared<FinderI>(topicAdapter->createProxy<TopicManagerPrx>(topicManagerId)),
+                stringToIdentity("IceStorm/Finder"));
         }
         catch (const Ice::LocalException& ex)
         {

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -157,6 +157,11 @@ TransientTopicImpl::subscribeAndGetPublisher(QoS qos, optional<Ice::ObjectPrx> o
 
     lock_guard lock(_mutex);
 
+    if (_destroyed)
+    {
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
+    }
+
     SubscriberRecord record;
     record.id = id;
     record.obj = obj;
@@ -230,6 +235,11 @@ TransientTopicImpl::link(optional<TopicPrx> topic, int cost, const Ice::Current&
     }
 
     lock_guard lock(_mutex);
+
+    if (_destroyed)
+    {
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
+    }
 
     auto id = topic->ice_getIdentity();
 


### PR DESCRIPTION
Fixes #5850
Fixes #5855

Transient `TransientTopicImpl::subscribeAndGetPublisher` and `link` did not check the `_destroyed` flag, unlike the persistent implementation (#5655) and transient `unlink`. A destroyed transient topic keeps its servant registered until the next manager reap, so such a call succeeded on a topic that can no longer deliver events and leaked a per-subscriber servant, permanently blocking re-subscription of that identity. These now throw `ObjectNotExistException` on a destroyed topic, matching the persistent implementation.

Also registers the `IceStorm/Finder` object when `IceStorm.Transient=1`, as the Slice interface documents that it is always registered (#5855).

### Testing
The `single` and `createOrRetrieve` suites run in transient mode and remain green.

<sub>🤖 Produced by an automated correctness audit (Claude Fable 5) and cross-verified by Codex; reviewed but flagged for human triage.</sub>
