### PR TITLE
Fix IceStorm subscriber and topic robustness issues

### DIFF
--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -207,9 +207,15 @@ SubscriberOneway::flush()
             {
                 ++_outstanding;
             }
-            else if (_observer)
+            else
             {
-                _observer->delivered(1);
+                // The event was delivered synchronously, so the subscriber is reachable: reset the
+                // consecutive-retry count as the twoway subscriber does on a successful reply.
+                _currentRetry = 0;
+                if (_observer)
+                {
+                    _observer->delivered(1);
+                }
             }
         }
         catch (const std::exception&)
@@ -233,6 +239,9 @@ SubscriberOneway::sentAsynchronously()
     // Decrement the _outstanding count.
     --_outstanding;
     assert(_outstanding >= 0 && _outstanding < _maxOutstanding);
+    // The event was delivered, so the subscriber is reachable: reset the consecutive-retry count as the
+    // twoway subscriber does on a successful reply.
+    _currentRetry = 0;
     if (_observer)
     {
         _observer->delivered(1);
@@ -626,9 +635,9 @@ Subscriber::destroy()
         {
             // Ignore
         }
-        catch (const Ice::ObjectAdapterDeactivatedException&)
+        catch (const Ice::ObjectAdapterDestroyedException&)
         {
-            // Ignore
+            // Ignore -- this can occur on shutdown.
         }
     }
 

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -558,6 +558,9 @@ TopicImpl::subscribeAndGetPublisher(QoS qos, Ice::ObjectPrx obj)
     catch (const IceDB::LMDBException& ex)
     {
         logError(_instance->communicator(), ex);
+        // The subscriber was created (and its publisher servant registered) before the transaction; remove
+        // it so a retry with the same subscriber identity is not rejected with AlreadyRegisteredException.
+        subscriber->destroy();
         throw; // will become UnknownException in caller
     }
 
@@ -791,7 +794,6 @@ TopicImpl::destroy()
     {
         throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
-    _destroyed = true;
 
     auto traceLevels = _instance->traceLevels();
     if (traceLevels->topic > 0)
@@ -800,9 +802,12 @@ TopicImpl::destroy()
         out << _name << ": destroy";
     }
 
-    // destroyInternal clears out the topic content.
+    // destroyInternal clears out the topic content. Mark the topic destroyed only once its database
+    // transaction has committed, so a failed commit leaves the topic intact and still destroyable.
     LogUpdate llu = {0, 0};
-    _instance->observers()->destroyTopic(destroyInternal(llu, true), _name);
+    LogUpdate destroyLLU = destroyInternal(llu, true);
+    _destroyed = true;
+    _instance->observers()->destroyTopic(destroyLLU, _name);
 
     _observer.detach();
 }
@@ -856,11 +861,19 @@ TopicImpl::update(const SubscriberRecordSeq& records)
                 (*p)->destroy();
                 p = _subscribers.erase(p);
             }
-            else
+            else if ((*p)->record() == *q)
             {
-                // Otherwise reset the reaped status if necessary.
+                // The record is unchanged; reset the reaped status if necessary.
                 (*p)->resetIfReaped();
                 ++p;
+            }
+            else
+            {
+                // The subscriber re-registered with a different proxy or QoS while this replica was out
+                // of sync. Destroy the stale in-memory subscriber; the second scan re-creates it from the
+                // incoming record so it matches the database.
+                (*p)->destroy();
+                p = _subscribers.erase(p);
             }
         }
     }
@@ -1064,6 +1077,9 @@ TopicImpl::observerAddSubscriber(const LogUpdate& llu, const SubscriberRecord& r
     catch (const IceDB::LMDBException& ex)
     {
         logError(_instance->communicator(), ex);
+        // The subscriber was created (and its publisher servant registered) before the transaction; remove
+        // it so a later replica sync does not fail re-registering the same subscriber identity.
+        subscriber->destroy();
         throw; // will become UnknownException in caller
     }
 


### PR DESCRIPTION
Fixes #5851
Fixes #5852
Fixes #5853
Fixes #5854

- **#5851** — `TopicImpl::destroy` marked the topic destroyed *before* its database transaction committed, so a failed commit left an undestroyable topic that still delivered events. `_destroyed` is now set only after `destroyInternal` commits.
- **#5852** — A replica reconciling its subscribers matched them by identity only, so a subscriber that re-registered with a different proxy or QoS while the replica was out of sync kept its stale in-memory record (and could push it cluster-wide on promotion). The in-memory subscriber is now replaced when the record differs.
- **#5853** — `subscribeAndGetPublisher` and `observerAddSubscriber` registered the per-subscriber publisher servant *before* the database transaction; on a transaction failure the servant leaked, permanently blocking re-subscription of that identity. The subscriber is now destroyed on failure. (This also corrects `Subscriber::destroy` to catch the current `ObjectAdapterDestroyedException`, which the cleanup relies on.)
- **#5854** — Oneway/datagram subscribers never reset their retry counter on a successful send (only the twoway completion path did), so retries accumulated over the subscription's lifetime and eventually removed healthy subscribers. The counter is now reset on a successful oneway send.

### Testing
`single`, `createOrRetrieve`, and `federation` remain green.

<sub>🤖 Produced by an automated correctness audit (Claude Fable 5) and cross-verified by Codex; reviewed but flagged for human triage.</sub>
