### PR TITLE
Fix several low-severity IceStorm correctness issues

### DIFF
--- a/cpp/src/IceStorm/Instance.cpp
+++ b/cpp/src/IceStorm/Instance.cpp
@@ -104,6 +104,15 @@ Instance::Instance(
             warn << "invalid value '" << policy << "' for 'IceStorm.Send.QueueSizeMaxPolicy'";
         }
 
+        // A queue size max of 0 matches an empty queue and would drop or remove a subscriber on its first
+        // event; treat it as unbounded (the default), like a negative value.
+        if (_sendQueueSizeMax == 0)
+        {
+            Ice::Warning warn(_traceLevels->logger);
+            warn << "'IceStorm.Send.QueueSizeMax' value 0 is invalid; treating the send queue as unbounded";
+            const_cast<int&>(_sendQueueSizeMax) = -1;
+        }
+
         //
         // If an Ice metrics observer is setup on the communicator, also
         // enable metrics for IceStorm.

--- a/cpp/src/IceStorm/NodeI.cpp
+++ b/cpp/src/IceStorm/NodeI.cpp
@@ -155,7 +155,9 @@ NodeI::start()
     unique_lock<mutex> lock(_mutex);
 
     _checkTask = make_shared<CheckTask>(shared_from_this());
-    _timer->schedule(_checkTask, chrono::seconds(static_cast<int64_t>(_nodes.size() - static_cast<size_t>(_id)) * 2));
+    // Stagger the initial check by node id. Node ids need not be contiguous, so clamp at zero to avoid an
+    // out-of-range (negative) delay when the id is larger than the node count.
+    _timer->schedule(_checkTask, chrono::seconds(std::max<int64_t>(0, static_cast<int64_t>(_nodes.size()) - _id) * 2));
     recovery(lock);
 }
 
@@ -839,8 +841,10 @@ NodeI::accept(
     optional<Ice::ObjectPrx> observer,
     LogUpdate llu,
     int max,
-    const Ice::Current&)
+    const Ice::Current& current)
 {
+    checkNotNull(observer, __FILE__, __LINE__, current);
+
     // Verify that j exists in our node set.
     if (_nodes.find(j) == _nodes.end())
     {

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -307,24 +307,24 @@ Parser::subscribers(const list<string>& args)
 {
     if (args.empty())
     {
-        error("subscribers' requires at least one argument (type `help' for more info) ");
+        error("`subscribers' requires at least one argument (type `help' for more info)");
         return;
     }
-    try
+    for (const auto& arg : args)
     {
-        for (const auto& arg : args)
+        try
         {
-            auto topic = _defaultManager->retrieve(arg);
+            auto topic = findTopic(arg);
             consoleOut << arg << ": subscribers:" << endl;
             for (const auto& subscriber : topic->getSubscribers())
             {
                 consoleOut << "\t" << _communicator->identityToString(subscriber) << endl;
             }
         }
-    }
-    catch (const std::exception&)
-    {
-        exception(current_exception());
+        catch (const std::exception&)
+        {
+            exception(current_exception());
+        }
     }
 }
 

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -307,7 +307,7 @@ Parser::subscribers(const list<string>& args)
 {
     if (args.empty())
     {
-        error("`subscribers' requires at least one argument (type `help' for more info)");
+        error("'subscribers' requires at least one argument (type 'help' for more info)");
         return;
     }
     for (const auto& arg : args)

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -1226,6 +1226,12 @@ TopicImpl::destroyInternal(const LogUpdate& origLLU, bool master)
     assert(_publisherPrx);
     _instance->publishAdapter()->remove(_publisherPrx->ice_getIdentity());
 
+    // Remove the topic servant before publishing the reaper entry: a concurrent createTopic for the same
+    // name could otherwise consume the reaper entry and re-add the servant while this one is still
+    // registered, failing with AlreadyRegisteredException and leaving the new topic without a servant.
+    _instance->topicAdapter()->remove(_id);
+    _servant = nullptr;
+
     _instance->topicReaper()->add(_name);
 
     // Destroy each of the subscribers.
@@ -1234,10 +1240,6 @@ TopicImpl::destroyInternal(const LogUpdate& origLLU, bool master)
         subscriber->destroy();
     }
     _subscribers.clear();
-
-    _instance->topicAdapter()->remove(_id);
-
-    _servant = nullptr;
 
     return llu;
 }


### PR DESCRIPTION
Part of #5858 (fixes 5 of the grouped items; the remainder need an API change, generated-code regeneration, or a feature and are proposed for 3.9.0).

- **Node-id stagger underflow** — `NodeI::start` computed the initial election-check delay with unsigned arithmetic that underflowed when a node id exceeded the node count (ids need not be contiguous), throwing from the timer and preventing the replica from starting. The delay is now clamped at zero.
- **`accept` null observer** — `NodeI::accept` stored the peer's observer proxy without a null check (unlike `ready`), risking undefined behavior in `Observers::init`. A null observer is now rejected.
- **destroy/re-create race** — `TopicImpl::destroyInternal` published the topic name to the reaper before removing its servant, so a concurrent `createTopic` for the same name could fail with `AlreadyRegisteredException` and leave the new topic without a servant. The servant is now removed first.
- **`Send.QueueSizeMax=0`** — was unvalidated and matched an empty queue, causing a pop on an empty queue (`DropEvents`) or removing every subscriber on the first event. `0` is now treated as unbounded.
- **`subscribers` admin command** — did not accept `instance/topic` qualified names, aborted on the first missing topic, and had a malformed message. It now uses `findTopic`, continues past a failing topic, and the message is fixed.

### Testing
`single`, `federation2`, and `icestormdb` remain green.

<sub>🤖 Produced by an automated correctness audit (Claude Fable 5) and cross-verified by Codex; reviewed but flagged for human triage.</sub>
