### PR TITLE
Fix flaky DataStorm/partial reader-side updater exception test

### DIFF
--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -327,6 +327,11 @@ void ::Reader::run(int argc, char* argv[])
         test(sample.getEvent() == SampleEvent::PartialUpdate);
         test(sample.getValue()->price == 15.0f);   // the throwing sample was dropped...
         test(sample.getValue()->lastBid == 13.0f); // ...and the update resolved against the Add sample
+
+        // Tell the writer the samples were verified.
+        auto done = makeSingleKeyWriter(throwBarrier, "done");
+        done.waitForReaders();
+        done.update(0);
     }
 }
 

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -261,8 +261,9 @@ void ::Writer::run(int argc, char* argv[])
         barrier.waitForReaders();
         barrier.update(0);
 
-        writer.waitForReaders();
-        writer.waitForNoReaders();
+        // The reader only consumes initialization samples, so it can attach and detach before this thread runs
+        // again: waiting on the reader count would race. Wait until the reader verified its samples instead.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(throwBarrier, "done").getNextUnread();
     }
     cout << "ok" << endl;
 }


### PR DESCRIPTION
Fixes a flaky hang in `cpp/DataStorm/partial` that has hit three unrelated PRs across three platforms in the
~15 hours since the case landed with #5882:

- [win32 release on #5897](https://github.com/zeroc-ice/ice/actions/runs/28967242145/job/85953428717?pr=5897) (multicast variant)
- [ubuntu-arm release on #5898](https://github.com/zeroc-ice/ice/actions/runs/28970923614/job/85966119376?pr=5898) (both variants)
- [ubuntu x64 debug on #5903](https://github.com/zeroc-ice/ice/actions/runs/29003954587/job/86070935129?pr=5903) (both variants — the failure analyzed below)

All three show the same signature: the writer blocked in `waitForReaders()`, the reader exited successfully.

In the reader-side updater exception case, the reader only consumes initialization samples, so nothing it waits
for is gated on the writer's actions after the join barrier: the reader can attach, verify its samples, and detach
before the writer's main thread reaches `waitForReaders()`, which then waits forever for a reader that already
came and went. The CI logs show exactly this: the reader attached at `.208`, received its samples (with the
expected `dropped sample 2: ... negative price` warning — the #5882 fix behaved correctly), passed all assertions,
and detached at `.209`; the writer's stack shows it blocked in `waitForReaders()`.

This differs from the sibling flake fixed by #5892: every other case in the suite publishes live data after the
reader-count wait, which pins the reader until the count is observed. Here the reader's exit is not gated on
anything the writer does, so both `waitForReaders()` and `waitForNoReaders()` race with it.

Test-only fix: replace the reader-count waits with a completion barrier — the reader signals after verifying its
samples and the writer waits for that signal, which also keeps the writer element alive until the reader consumed
its initialization samples. Verified with 30 consecutive debug runs (the failing configuration) plus 15 release
runs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

