### PR TITLE
Fix _releasing leak and null request cancel in IceGrid Allocatable::release

### DIFF
--- a/cpp/src/IceGrid/Allocatable.cpp
+++ b/cpp/src/IceGrid/Allocatable.cpp
@@ -218,105 +218,122 @@ Allocatable::release(const shared_ptr<SessionI>& session, bool fromRelease)
         }
     }
 
-    // If we set _releasing above, clear it and notify waiting threads when we leave this function, no matter how.
-    ReleasingGuard releasingGuard(*this, hasRequests);
-
-    if (isReleased)
+    try
     {
-        releasedNoSync(session);
-    }
-
-    if (_parent)
-    {
-        _parent->release(session, fromRelease);
-    }
-    else if (!fromRelease)
-    {
-        if (hasRequests)
+        if (isReleased)
         {
-            while (true)
+            releasedNoSync(session);
+        }
+
+        if (_parent)
+        {
+            _parent->release(session, fromRelease);
+        }
+        else if (!fromRelease)
+        {
+            if (hasRequests)
             {
-                shared_ptr<AllocationRequest> request;
-                shared_ptr<Allocatable> allocatable;
+                while (true)
                 {
-                    lock_guard lock(_mutex);
-                    allocatable = dequeueAllocationAttempt(request);
-                    if (!allocatable)
+                    shared_ptr<AllocationRequest> request;
+                    shared_ptr<Allocatable> allocatable;
                     {
-                        assert(_requests.empty());
-                        assert(_count == 0);
-                        return;
-                    }
-                }
-
-                //
-                // Try to allocate the allocatable with the request or if
-                // there's no request, just notify the allocatable that it can
-                // be allocated again.
-                //
-                try
-                {
-                    if ((request && allocatable->allocate(request, true)) ||
-                        (!request && allocatable->canTryAllocate()))
-                    {
-                        while (true)
+                        lock_guard lock(_mutex);
+                        allocatable = dequeueAllocationAttempt(request);
+                        if (!allocatable)
                         {
+                            assert(_requests.empty());
+                            assert(_count == 0);
+                            _releasing = false;
+                            _condVar.notify_all();
+                            return;
+                        }
+                    }
+
+                    //
+                    // Try to allocate the allocatable with the request or if
+                    // there's no request, just notify the allocatable that it can
+                    // be allocated again.
+                    //
+                    try
+                    {
+                        if ((request && allocatable->allocate(request, true)) ||
+                            (!request && allocatable->canTryAllocate()))
+                        {
+                            while (true)
                             {
-                                lock_guard lock(_mutex);
-                                assert(_count);
-
-                                allocatable = nullptr;
-                                request = nullptr;
-
-                                //
-                                // Check if there's other requests from the session
-                                // waiting to allocate this allocatable.
-                                //
-                                auto p = _requests.begin();
-                                while (p != _requests.end())
                                 {
-                                    if (p->second && p->second->getSession() == _session)
+                                    lock_guard lock(_mutex);
+                                    assert(_count);
+
+                                    allocatable = nullptr;
+                                    request = nullptr;
+
+                                    //
+                                    // Check if there's other requests from the session
+                                    // waiting to allocate this allocatable.
+                                    //
+                                    auto p = _requests.begin();
+                                    while (p != _requests.end())
                                     {
-                                        allocatable = p->first;
-                                        request = p->second;
-                                        _requests.erase(p);
-                                        break;
+                                        if (p->second && p->second->getSession() == _session)
+                                        {
+                                            allocatable = p->first;
+                                            request = p->second;
+                                            _requests.erase(p);
+                                            break;
+                                        }
+                                        ++p;
                                     }
-                                    ++p;
+                                    if (!allocatable)
+                                    {
+                                        _releasing = false;
+                                        _condVar.notify_all();
+                                        return; // We're done, the allocatable was released (but is allocated again)!
+                                    }
                                 }
-                                if (!allocatable)
-                                {
-                                    return; // We're done, the allocatable was released (but is allocated again)!
-                                }
-                            }
 
-                            try
-                            {
-                                assert(allocatable && request);
-                                allocatable->allocate(request, true);
-                            }
-                            catch (const Ice::UserException&)
-                            {
-                                request->cancel(current_exception());
+                                try
+                                {
+                                    assert(allocatable && request);
+                                    allocatable->allocate(request, true);
+                                }
+                                catch (const Ice::UserException&)
+                                {
+                                    request->cancel(current_exception());
+                                }
                             }
                         }
                     }
-                }
-                catch (const Ice::UserException&)
-                {
-                    // request is null when the exception comes from the canTryAllocate() branch above: a
-                    // destroyed allocatable throws ObjectNotRegisteredException from checkAllocatable().
-                    if (request)
+                    catch (const Ice::UserException&)
                     {
-                        request->cancel(current_exception());
+                        // request is null when the exception comes from the canTryAllocate() branch above: a
+                        // destroyed allocatable throws ObjectNotRegisteredException from checkAllocatable().
+                        if (request)
+                        {
+                            request->cancel(current_exception());
+                        }
                     }
                 }
             }
+            else if (isReleased)
+            {
+                canTryAllocate(); // Notify that this allocatable can be allocated.
+            }
         }
-        else if (isReleased)
+    }
+    catch (...)
+    {
+        if (hasRequests)
         {
-            canTryAllocate(); // Notify that this allocatable can be allocated.
+            // Don't leave the function with _releasing set: later release() calls would wait forever. On the
+            // normal returns above, _releasing is cleared in the same critical section that observes _requests;
+            // new requests can't be queued behind a finished drain.
+            lock_guard lock(_mutex);
+            _releasing = false;
+            _condVar.notify_all();
         }
+        throw;
     }
 }
 

--- a/cpp/src/IceGrid/Allocatable.cpp
+++ b/cpp/src/IceGrid/Allocatable.cpp
@@ -218,6 +218,9 @@ Allocatable::release(const shared_ptr<SessionI>& session, bool fromRelease)
         }
     }
 
+    // If we set _releasing above, clear it and notify waiting threads when we leave this function, no matter how.
+    ReleasingGuard releasingGuard(*this, hasRequests);
+
     if (isReleased)
     {
         releasedNoSync(session);
@@ -242,8 +245,6 @@ Allocatable::release(const shared_ptr<SessionI>& session, bool fromRelease)
                     {
                         assert(_requests.empty());
                         assert(_count == 0);
-                        _releasing = false;
-                        _condVar.notify_all();
                         return;
                     }
                 }
@@ -285,8 +286,6 @@ Allocatable::release(const shared_ptr<SessionI>& session, bool fromRelease)
                                 }
                                 if (!allocatable)
                                 {
-                                    _releasing = false;
-                                    _condVar.notify_all();
                                     return; // We're done, the allocatable was released (but is allocated again)!
                                 }
                             }
@@ -305,10 +304,12 @@ Allocatable::release(const shared_ptr<SessionI>& session, bool fromRelease)
                 }
                 catch (const Ice::UserException&)
                 {
-                    // Reachable only via the allocate(request, true) branch above; canTryAllocate()
-                    // never throws a UserException, so request is non-null here.
-                    assert(request);
-                    request->cancel(current_exception());
+                    // request is null when the exception comes from the canTryAllocate() branch above: a
+                    // destroyed allocatable throws ObjectNotRegisteredException from checkAllocatable().
+                    if (request)
+                    {
+                        request->cancel(current_exception());
+                    }
                 }
             }
         }

--- a/cpp/src/IceGrid/Allocatable.h
+++ b/cpp/src/IceGrid/Allocatable.h
@@ -96,31 +96,6 @@ namespace IceGrid
 
         mutable std::mutex _mutex;
         std::condition_variable _condVar;
-
-    private:
-        // When active, clears _releasing and notifies waiting threads when it goes out of scope.
-        class ReleasingGuard
-        {
-        public:
-            ReleasingGuard(Allocatable& allocatable, bool active) : _allocatable(allocatable), _active(active) {}
-
-            ReleasingGuard(const ReleasingGuard&) = delete;
-            ReleasingGuard& operator=(const ReleasingGuard&) = delete;
-
-            ~ReleasingGuard()
-            {
-                if (_active)
-                {
-                    std::lock_guard<std::mutex> lock(_allocatable._mutex);
-                    _allocatable._releasing = false;
-                    _allocatable._condVar.notify_all();
-                }
-            }
-
-        private:
-            Allocatable& _allocatable;
-            const bool _active;
-        };
     };
 
 };

--- a/cpp/src/IceGrid/Allocatable.h
+++ b/cpp/src/IceGrid/Allocatable.h
@@ -96,6 +96,31 @@ namespace IceGrid
 
         mutable std::mutex _mutex;
         std::condition_variable _condVar;
+
+    private:
+        // When active, clears _releasing and notifies waiting threads when it goes out of scope.
+        class ReleasingGuard
+        {
+        public:
+            ReleasingGuard(Allocatable& allocatable, bool active) : _allocatable(allocatable), _active(active) {}
+
+            ReleasingGuard(const ReleasingGuard&) = delete;
+            ReleasingGuard& operator=(const ReleasingGuard&) = delete;
+
+            ~ReleasingGuard()
+            {
+                if (_active)
+                {
+                    std::lock_guard<std::mutex> lock(_allocatable._mutex);
+                    _allocatable._releasing = false;
+                    _allocatable._condVar.notify_all();
+                }
+            }
+
+        private:
+            Allocatable& _allocatable;
+            const bool _active;
+        };
     };
 
 };


### PR DESCRIPTION
This PR fixes two defects in `Allocatable::release` (items L1 and L6 of #5844).

### Null `request` dereference in the release-drain loop (L1)

The drain loop's `catch (const Ice::UserException&)` asserted that `request` is non-null, based on the assumption that `canTryAllocate()` never throws a `UserException`. That assumption is false:

`AllocatableObjectEntry::canTryAllocate()` → `AllocatableObjectCache::canTryAllocate()` → `TypeEntry::canTryAllocate()` → `Allocatable::tryAllocate()` → `allocate()` → `checkAllocatable()`, where a destroyed `AllocatableObjectEntry` throws `ObjectNotRegisteredException`. This exception is not derived from `AllocationException`, so it passes through `tryAllocate()`'s catch, and `TypeEntry::canTryAllocate()` only catches `SessionDestroyedException`. It can therefore reach the drain loop's catch with a null `request` (a queued can-try-allocate hook), firing the assert in debug builds and dereferencing a null pointer in release builds.

The fix replaces the assert with a null check, matching the sibling catch a few lines above.

### `_releasing` never cleared when an exception escapes `release()` (L6)

`release()` sets `_releasing = true` before draining queued allocation attempts, and cleared it only on the two normal return paths. Any exception escaping the drain — or `releasedNoSync()`, which runs remote node synchronization via `ServerEntry::sync()` — left `_releasing` permanently set: subsequent `release()` calls block forever on `_condVar` and new allocation requests queue without ever being drained.

Such an escape is possible: `NodeEntry::loadServer`/`destroyServer` only catch `NodeUnreachableException`, and `ServerEntry::syncImpl` only catches `NodeNotExistException`, so a synchronously-thrown `Ice::CommunicatorDestroyedException` from `loadServerAsync`/`destroyServerAsync` (e.g. when a session is released during registry shutdown) propagates all the way into `release()`.

The fix wraps everything that runs after `_releasing` is set in a `try/catch (...)` that clears the flag, notifies waiting threads, and rethrows. The two normal return paths keep their existing clear-and-notify, which must stay where it is: it runs in the same critical section that observes the request queue (empty, or re-allocated), so no allocation request can be queued behind a completed drain. A destructor- or catch-timed clear on those paths would open a window where a concurrent allocation is queued after the drain's final queue check and stranded until the next allocate/release cycle.

Neither fix changes behavior on any normal path, so there is no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)