### PR TITLE
Fix null Admin proxy handling for collocated node in RegistryNodeAdminRouter

### DIFF
--- a/cpp/src/IceGrid/RegistryAdminRouter.cpp
+++ b/cpp/src/IceGrid/RegistryAdminRouter.cpp
@@ -33,7 +33,7 @@ namespace
             // Retry to forward the call.
             //
             _adminRouter->ice_invokeAsync(
-                {&_inParams[0], &_inParams[0] + _inParams.size()},
+                {_inParams.data(), _inParams.data() + _inParams.size()},
                 std::move(_response),
                 std::move(_exception),
                 _current);
@@ -136,17 +136,17 @@ RegistryNodeAdminRouter::ice_invokeAsync(
         catch (const NodeNotExistException&)
         {
         }
+    }
 
-        if (target == nullopt)
+    if (target == nullopt)
+    {
+        if (_traceLevels->admin > 0)
         {
-            if (_traceLevels->admin > 0)
-            {
-                Ice::Trace out(_traceLevels->logger, _traceLevels->adminCat);
-                out << "could not find Admin proxy for node '" << current.id.name << "'";
-            }
-
-            throw ObjectNotExistException{__FILE__, __LINE__};
+            Ice::Trace out(_traceLevels->logger, _traceLevels->adminCat);
+            out << "could not find Admin proxy for node '" << current.id.name << "'";
         }
+
+        throw ObjectNotExistException{__FILE__, __LINE__};
     }
 
     invokeOnTarget(target->ice_facet(current.facet), inParams, std::move(response), std::move(exception), current);


### PR DESCRIPTION
This PR addresses items L4 and L10 of #5844.

### L4 — disengaged optional dereference for the collocated node

In `RegistryNodeAdminRouter::ice_invokeAsync`, the `target == nullopt` guard sat inside the `else` branch, so it only protected the remote-node path. On the collocated-node path, `target = current.adapter->getCommunicator()->getAdmin()` can return `nullopt` when the Admin facility is disabled (`Ice.Admin.Enabled=0` set explicitly on an `icegridnode`, overriding the default it forces on); the subsequent `target->ice_facet(...)` then dereferences a disengaged optional and crashes the node when an admin client routes a request to it, e.g. via `IceGridAdmin::getNodeAdmin`.

The fix hoists the guard out of the `else`, giving the function the same shape as `RegistryReplicaAdminRouter::ice_invokeAsync` (which already handles its own `getAdmin()` null case this way): the router now throws `ObjectNotExistException` and also traces the failure on the collocated path.

This requires a deliberate non-default configuration, so there is no CHANGELOG entry.

### L10 — cosmetic

`SynchronizationCallbackI::synchronized` now forms the forwarded payload with `_inParams.data()` instead of `&_inParams[0]`. This is purely an idiom cleanup, not a fix: `_inParams` always holds a complete Ice encapsulation (at least 6 bytes), since `InputStream::readEncapsulation` hands the Blobject dispatch the full encapsulation including its header and rejects anything shorter. The audit finding's empty-vector premise is unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)