### PR TITLE
Fix master session deref in ServerI::activate and keep-alive thread terminate

### DIFF
--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -1480,14 +1480,14 @@ ServerI::activate()
         //
         // We first ensure that the application is replicated on all the
         // registries before to start the server. We only do this each
-        // time the server is updated or initialy loaded on the node.
+        // time the server is updated or initially loaded on the node.
         //
         if (waitForReplication)
         {
             auto session = _node->getMasterNodeSession();
             if (session)
             {
-                _node->getMasterNodeSession()->waitForApplicationUpdateAsync(
+                session->waitForApplicationUpdateAsync(
                     desc->uuid,
                     desc->revision,
                     [self = shared_from_this()] { self->waitForApplicationUpdateCompleted(); },

--- a/cpp/src/IceGrid/SessionManager.h
+++ b/cpp/src/IceGrid/SessionManager.h
@@ -162,14 +162,19 @@ namespace IceGrid
             {
                 Ice::Error out(_logger);
                 out << "unknown exception in session manager keep alive thread:\n" << ex.what();
-                throw;
             }
             catch (...)
             {
                 Ice::Error out(_logger);
                 out << "unknown exception in session manager keep alive thread";
-                throw;
             }
+
+            // Mark this thread as destroyed once it exits (it normally already is); otherwise threads blocked in
+            // waitForCreate or waitTryCreateSession could wait forever.
+            std::lock_guard<std::mutex> lock(_mutex);
+            _state = Destroyed;
+            _nextAction = None;
+            _condVar.notify_all();
         }
 
         bool isWaitingForCreate()


### PR DESCRIPTION
This PR fixes items L2 and L9 of #5844.

### L2 — `ServerI::activate` re-fetches the master node session unchecked

`activate()` fetched `_node->getMasterNodeSession()`, null-checked it, then called `_node->getMasterNodeSession()` a *second* time and dereferenced the result unchecked. The keep-alive thread can disconnect or destroy the session between the two calls — and since #5899, `getSession()` returns `nullopt` once the thread is destroyed — so the second fetch can return a disengaged optional and crash the node during server activation. The fix uses the already-checked local.

### L9 — keep-alive thread rethrows out of the thread proc

`SessionKeepAliveThread::run()`'s catch handlers logged and then re-threw, which for an exception escaping `createSession`/`keepAlive`/`destroySession` means `std::terminate()`. Just swallowing would trade the abort for a hang, though: the throwing calls run with `_state == InProgress`, and if `run()` exits in that state, `waitForCreate()` and `waitTryCreateSession()` block forever. The handlers now log without rethrowing, and `run()` unconditionally marks the thread `Destroyed` (and notifies waiters) on exit — a no-op on the normal path, where the loop can only exit in that state. On the exception path, waiters unblock and `getSession()` returns `nullopt`, so callers see the same thing as a cleanly destroyed session.

The expected connection failures are already handled inside the `createSession`/`keepAlive` implementations, so this only changes behavior for unexpected escapes (e.g. `bad_alloc`); no CHANGELOG entry.

Also fixes an "initialy" typo in a comment near the L2 change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)