### PR TITLE
Add missing lock and null check in RegistryPluginFacadeI::getPropertyForAdapter

### DIFF
--- a/cpp/src/IceGrid/PluginFacadeI.cpp
+++ b/cpp/src/IceGrid/PluginFacadeI.cpp
@@ -143,6 +143,12 @@ RegistryPluginFacadeI::getNodeLoad(const string& name) const
 std::string
 RegistryPluginFacadeI::getPropertyForAdapter(const std::string& adapterId, const std::string& name) const
 {
+    lock_guard lock(_mutex);
+    if (!_database)
+    {
+        throw RegistryUnreachableException("", "registry not initialized yet");
+    }
+
     try
     {
         ServerInfo info = _database->getServer(_database->getAdapterServer(adapterId))->getInfo(true);


### PR DESCRIPTION
Fixes item L5 of #5844.

`RegistryPluginFacadeI::getPropertyForAdapter` was the only accessor of the plugin facade that read `_database` without taking `_mutex` and without the null check, racing `setDatabase(nullptr)` during registry shutdown. It now uses the exact same preamble as the other nine accessors: take the lock and throw `RegistryUnreachableException` when the registry is not initialized (or being shut down).

Only reachable from a custom `ReplicaGroupFilter`/`TypeFilter` plugin querying during the shutdown window; no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)