### PR TITLE
Fix icegridnode --deploy swallowing the next option

### DIFF
--- a/changelog.d/service-icegrid/icegridnode-deploy-option-parsing.md
+++ b/changelog.d/service-icegrid/icegridnode-deploy-option-parsing.md
@@ -1,0 +1,2 @@
+- Fixed `icegridnode` command-line parsing: an option following `--deploy` and its arguments, as in
+  `icegridnode --deploy app.xml --readonly`, was silently ignored.

--- a/cpp/src/IceGrid/IceGridNode.cpp
+++ b/cpp/src/IceGrid/IceGridNode.cpp
@@ -220,9 +220,10 @@ NodeService::startImpl(int argc, char* argv[], int& status)
 
             desc = argv[++i];
 
-            while (i + 1 < argc && argv[++i][0] != '-')
+            // Consume the optional deployment targets following the descriptor, up to the next option.
+            while (i + 1 < argc && argv[i + 1][0] != '-')
             {
-                targets.emplace_back(argv[i]);
+                targets.emplace_back(argv[++i]);
             }
         }
         else


### PR DESCRIPTION
Fixes item L11 of #5844.

The `--deploy` target scan advanced `i` onto the terminating option before testing it (`argv[++i][0] != '-'`), and the outer `for` loop's `++i` then stepped past it. As a result, the first option following `--deploy DESCRIPTOR [TARGET...]` was silently dropped — `icegridnode --deploy app.xml --readonly` started the node read-write. This happened with or without deployment targets between the descriptor and the option.

The scan now looks ahead (`argv[i + 1]`) and only consumes an argument once it's known to be a target, so the outer loop parses the following option normally. Verified with the built binary: `icegridnode --deploy app.xml --bogus` and `icegridnode --deploy app.xml t1 t2 --bogus` now both report `invalid option: '--bogus'` where they previously ignored it.

Since an ignored `--readonly` is user-visible, this PR includes a changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)