### PR TITLE
Don't drop detected server terminations on a pipe read error in the Activator

### DIFF
--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -1316,6 +1316,7 @@ Activator::terminationListener()
 
         vector<Process> terminated;
         bool deactivated = false;
+        exception_ptr readException;
         {
             lock_guard lock(_mutex);
 
@@ -1346,9 +1347,21 @@ Activator::terminationListener()
                 //
                 // Read the message over the pipe.
                 //
-                while ((rs = read(fd, &s, 16)) > 0) // NOLINT(clang-analyzer-unix.BlockInCriticalSection)
+                while (true)
                 {
-                    message.append(s, static_cast<size_t>(rs));
+                    rs = read(fd, &s, 16); // NOLINT(clang-analyzer-unix.BlockInCriticalSection)
+                    if (rs > 0)
+                    {
+                        message.append(s, static_cast<size_t>(rs));
+                    }
+                    else if (rs == -1 && errno == EINTR)
+                    {
+                        continue; // Interrupted by a signal: retry.
+                    }
+                    else
+                    {
+                        break; // EOF or error.
+                    }
                 }
 
                 //
@@ -1363,7 +1376,9 @@ Activator::terminationListener()
                 {
                     if (errno != EAGAIN || message.empty())
                     {
-                        throw SyscallException{__FILE__, __LINE__, "read failed", errno};
+                        // Don't throw yet: the processes already moved to terminated must be notified first.
+                        readException = make_exception_ptr(SyscallException{__FILE__, __LINE__, "read failed", errno});
+                        break;
                     }
 
                     ++p;
@@ -1417,6 +1432,11 @@ Activator::terminationListener()
                 Ice::Warning out(_traceLevels->logger);
                 out << "unexpected exception raised by server '" << p.server->getId() << "' termination:\n" << ex;
             }
+        }
+
+        if (readException)
+        {
+            rethrow_exception(readException);
         }
 
         if (deactivated)


### PR DESCRIPTION
Fixes item L3 of #5844.

In the POSIX termination listener, once one server's status pipe reached EOF, its process was moved to the local `terminated` vector and erased from `_processes`. If a later fd in the same `select()` batch then failed its `read()`, the listener threw immediately: the `terminated` vector was destroyed and `server->terminated()` was never called for the already-erased processes, leaving those servers permanently "active" on the node (the listener restart re-scans `_processes`, which no longer contains them).

Two changes:

- A hard read failure is now captured in an `exception_ptr` and rethrown only after the detected terminations have been dispatched. The rethrow still lands in `runTerminationListener`'s catch, which logs the error and restarts the listener, exactly as before.
- `read()` is retried on `EINTR` instead of treating an interrupted call as a pipe failure — consistent with the `select()` call above, which already retries on `EINTR`/`EPROTO`.

Internal robustness with no realistic reported symptom, so no CHANGELOG entry. Windows uses per-process wait handles and has no shared failure path, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)