### PR TITLE
Fix cosmetic issues in IceGrid DescriptorHelper

### DIFF
--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -884,7 +884,7 @@ Resolver::substitute(const string& v, bool useParams, bool useIgnored, set<strin
             }
             else
             {
-                throw invalid_argument("use of the '" + name + "' variable is now allowed here");
+                throw invalid_argument("use of the '" + name + "' variable is not allowed here");
             }
         }
 
@@ -2674,7 +2674,6 @@ ApplicationHelper::update(const ApplicationUpdateDescriptor& updt) const
         auto q = _nodes.find(node.name);
         if (q != _nodes.end()) // Updated node
         {
-            NodeDescriptor desc = q->second.update(node, resolve);
             def.nodes.insert(make_pair(node.name, q->second.update(node, resolve)));
         }
         else // New node

--- a/cpp/src/IceGrid/FileCache.cpp
+++ b/cpp/src/IceGrid/FileCache.cpp
@@ -162,6 +162,10 @@ FileCache::read(const string& file, int64_t offset, int size, int64_t& newOffset
     while (is.good())
     {
         getline(is, line);
+        if (is.eof() && line.empty()) // Don't return the last line if it's empty.
+        {
+            continue;
+        }
 
         int lineSize = static_cast<int>(line.size()) + 5; // 5 bytes for the encoding of the string size (worst case)
         if (lineSize + totalSize > size)

--- a/cpp/src/IceGrid/FileCache.cpp
+++ b/cpp/src/IceGrid/FileCache.cpp
@@ -162,10 +162,6 @@ FileCache::read(const string& file, int64_t offset, int size, int64_t& newOffset
     while (is.good())
     {
         getline(is, line);
-        if (is.eof() && line.empty()) // Don't return the last line if it's empty.
-        {
-            continue;
-        }
 
         int lineSize = static_cast<int>(line.size()) + 5; // 5 bytes for the encoding of the string size (worst case)
         if (lineSize + totalSize > size)


### PR DESCRIPTION
Fixes two of the three cosmetic items of #5844:

- `ApplicationHelper::update` computed `NodeHelper::update()` twice for each updated node, dead-storing the first result; it now calls it once (the function is `const` and `[[nodiscard]]`, so this was pure wasted work).
- Fixed an inverted error message: "use of the '...' variable is **now** allowed here" → "is **not** allowed here".

The third item — the spurious empty line `FileCache::read` returns when the requested range ends at the end of a newline-terminated file — is deferred to 3.9. Removing it changes observable behavior that the existing `IceGrid/deployer` test asserts on, and patch releases must keep behavior that prior-release tests can verify against.

No CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)