### PR TITLE
Fix server stuck in synchronizing state after a no-restart update

### DIFF
--- a/changelog.d/service-icegrid/no-restart-update-server-stuck-synchronizing.md
+++ b/changelog.d/service-icegrid/no-restart-update-server-stuck-synchronizing.md
@@ -1,0 +1,3 @@
+- Fixed an IceGrid registry issue: after an application update that did not restart a running server (no-restart
+  update), restarting the registry could leave this server stuck in a synchronizing state, causing administrative
+  operations on this server to hang until the server was stopped.

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -2474,6 +2474,11 @@ ServerI::updateRuntimePropertiesCallback(const shared_ptr<InternalServerDescript
     assert(_process);
     if (_load->finishRuntimePropertiesUpdate(desc, *_process))
     {
+        // The server's runtime properties now match the updated descriptor: adopt it as the server's descriptor
+        // so that loading the same descriptor again replies immediately instead of waiting on the load command.
+        // The load command remains set: it still needs to run once the server stops, to write the updated
+        // configuration to disk.
+        _desc = _load->getInternalServerDescriptor();
         finishLoad();
     }
 }
@@ -2491,6 +2496,9 @@ ServerI::updateRuntimePropertiesCallback(exception_ptr ex, const shared_ptr<Inte
     if (_load->finishRuntimePropertiesUpdate(desc, *_process))
     {
         _load->failed(ex);
+        // Drop the load command so that loading the same descriptor again retries the runtime properties update
+        // instead of waiting forever on this completed command.
+        _load = nullptr;
     }
 }
 


### PR DESCRIPTION
Fixes item L12 of #5844.

### Background

A no-restart update of an active server only pushes the changed properties to the running process (via its Admin facet); the on-disk configuration is written later, by the `LoadCommand` that deliberately survives on `ServerI` and executes at the next server stop. So after the runtime-properties update completes, `_load` legitimately lingers — but `ServerI::_desc` was never refreshed either, and that's the bug.

### The bug

With `_desc` still holding the pre-update descriptor, a reload of the *same* descriptor — which the registry sends routinely when its session with the node is re-established, e.g. after a registry restart — matched the "new descriptor waiting to be loaded" condition in `ServerI::load()` and parked its reply on the completed load command. Nothing ever flushes that reply until the server stops, so the registry's `ServerEntry` stayed synchronizing indefinitely: administrative operations on the server hang.

### The fix

In `ServerI::updateRuntimePropertiesCallback`:

- **Success**: once the runtime update converges, adopt the applied descriptor as the server's descriptor before completing the load command. An identical reload now takes the existing already-loaded path and replies immediately. The load command still survives to write the configuration to disk at the next stop (its execution path does not compare descriptors, so the aliasing is harmless).
- **Failure**: after completing the callbacks with the exception, drop the load command. An identical reload then goes down the regular load path and retries the runtime-properties update (the fresh command re-diffs from the old descriptor), instead of parking forever on the completed command — the same stall in a different flavor.

The `cpp/IceGrid/noRestartUpdate` and `cpp/IceGrid/update` test suites pass.

Note: this is unrelated to #5898, which fixed the destroy-path leak of the same surviving load command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)