### PR TITLE
Dispatch to the default servant when the identity is registered with a different facet

### DIFF
--- a/changelog.d/csharp/default-servant-facet-fallback.md
+++ b/changelog.d/csharp/default-servant-facet-fallback.md
@@ -1,0 +1,3 @@
+- Fixed the servant lookup for incoming requests: when the target identity is registered with a different facet, the
+  object adapter now dispatches the request to the default servant if one is registered, as documented, instead of
+  rejecting the request with `FacetNotExistException`.

--- a/changelog.d/java/default-servant-facet-fallback.md
+++ b/changelog.d/java/default-servant-facet-fallback.md
@@ -1,0 +1,3 @@
+- Fixed the servant lookup for incoming requests: when the target identity is registered with a different facet, the
+  object adapter now dispatches the request to the default servant if one is registered, as documented, instead of
+  rejecting the request with `FacetNotExistException`.

--- a/changelog.d/js/default-servant-facet-fallback.md
+++ b/changelog.d/js/default-servant-facet-fallback.md
@@ -1,0 +1,3 @@
+- Fixed the servant lookup for incoming requests: when the target identity is registered with a different facet, the
+  object adapter now dispatches the request to the default servant if one is registered, as documented, instead of
+  rejecting the request with `FacetNotExistException`.

--- a/changelog.d/swift/default-servant-facet-fallback.md
+++ b/changelog.d/swift/default-servant-facet-fallback.md
@@ -1,0 +1,3 @@
+- Fixed the servant lookup for incoming requests: when the target identity is registered with a different facet, the
+  object adapter now dispatches the request to the default servant if one is registered, as documented, instead of
+  rejecting the request with `FacetNotExistException`.

--- a/cpp/test/Ice/defaultServant/AllTests.cpp
+++ b/cpp/test/Ice/defaultServant/AllTests.cpp
@@ -118,6 +118,15 @@ allTests(Test::TestHelper* helper)
         }
     }
 
+    // The identity is registered with a facet servant only: a request on the default facet still dispatches to the
+    // default servant.
+    identity.category = "foo";
+    identity.name = "x";
+    oa->addFacet(std::make_shared<MyObjectI>(), identity, "theFacet");
+    prx = oa->createProxy<MyObjectPrx>(identity);
+    test(prx->getName() == "x");
+    oa->removeFacet(identity, "theFacet");
+
     oa->removeDefaultServant("foo");
     identity.category = "foo";
     prx = oa->createProxy<MyObjectPrx>(identity);

--- a/csharp/src/Ice/Internal/ServantManager.cs
+++ b/csharp/src/Ice/Internal/ServantManager.cs
@@ -186,7 +186,8 @@ internal sealed class ServantManager : Object
             {
                 m.TryGetValue(facet, out obj);
             }
-            else
+
+            if (obj is null)
             {
                 _defaultServantMap.TryGetValue(ident.category, out obj);
                 if (obj is null)

--- a/csharp/test/Ice/defaultServant/AllTests.cs
+++ b/csharp/test/Ice/defaultServant/AllTests.cs
@@ -115,6 +115,15 @@ public class AllTests : global::Test.AllTests
             }
         }
 
+        // The identity is registered with a facet servant only: a request on the default facet still dispatches
+        // to the default servant.
+        identity.category = "foo";
+        identity.name = "x";
+        oa.addFacet(new MyObjectI(), identity, "theFacet");
+        prx = Test.MyObjectPrxHelper.uncheckedCast(oa.createProxy(identity));
+        test(prx.getName() == "x");
+        oa.removeFacet(identity, "theFacet");
+
         oa.removeDefaultServant("foo");
         identity.category = "foo";
         prx = Test.MyObjectPrxHelper.uncheckedCast(oa.createProxy(identity));

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ServantManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ServantManager.java
@@ -188,13 +188,14 @@ final class ServantManager implements Object {
 
         Map<String, Object> m = _servantMapMap.get(ident);
         Object obj = null;
-        if (m == null) {
+        if (m != null) {
+            obj = m.get(facet);
+        }
+        if (obj == null) {
             obj = _defaultServantMap.get(ident.category);
             if (obj == null) {
                 obj = _defaultServantMap.get("");
             }
-        } else {
-            obj = m.get(facet);
         }
 
         return obj;

--- a/java/test/src/main/java/test/Ice/defaultServant/AllTests.java
+++ b/java/test/src/main/java/test/Ice/defaultServant/AllTests.java
@@ -112,6 +112,15 @@ public class AllTests {
             }
         }
 
+        // The identity is registered with a facet servant only: a request on the default facet still
+        // dispatches to the default servant.
+        identity.category = "foo";
+        identity.name = "x";
+        oa.addFacet(new MyObjectI(), identity, "theFacet");
+        prx = MyObjectPrx.uncheckedCast(oa.createProxy(identity));
+        test(prx.getName().equals("x"));
+        oa.removeFacet(identity, "theFacet");
+
         oa.removeDefaultServant("foo");
         identity.category = "foo";
         prx = MyObjectPrx.uncheckedCast(oa.createProxy(identity));

--- a/java/test/src/main/java/test/Ice/defaultServant/AllTests.java
+++ b/java/test/src/main/java/test/Ice/defaultServant/AllTests.java
@@ -118,7 +118,7 @@ public class AllTests {
         identity.name = "x";
         oa.addFacet(new MyObjectI(), identity, "theFacet");
         prx = MyObjectPrx.uncheckedCast(oa.createProxy(identity));
-        test(prx.getName().equals("x"));
+        test("x".equals(prx.getName()));
         oa.removeFacet(identity, "theFacet");
 
         oa.removeDefaultServant("foo");

--- a/js/packages/ice/src/Ice/ServantManager.js
+++ b/js/packages/ice/src/Ice/ServantManager.js
@@ -160,13 +160,14 @@ export class ServantManager {
 
         const m = this._servantMapMap.get(ident);
         let obj;
-        if (m === undefined) {
+        if (m !== undefined) {
+            obj = m.get(facet);
+        }
+        if (obj === undefined) {
             obj = this._defaultServantMap.get(ident.category);
             if (obj === undefined) {
                 obj = this._defaultServantMap.get("");
             }
-        } else {
-            obj = m.get(facet);
         }
 
         return obj === undefined ? null : obj;

--- a/js/packages/test/Ice/defaultServant/Client.ts
+++ b/js/packages/test/Ice/defaultServant/Client.ts
@@ -78,6 +78,14 @@ export class Client extends TestHelper {
             }
         }
 
+        // The identity is registered with a facet servant only: a request on the default facet still dispatches to
+        // the default servant.
+        const facetedId = new Ice.Identity("x", "foo");
+        adapter.addFacet(new MyObjectI(), facetedId, "theFacet");
+        prx = new Test.MyObjectPrx(communicator, `foo/x:${this.getTestEndpoint()}`);
+        test((await prx.getName()) == "x");
+        adapter.removeFacet(facetedId, "theFacet");
+
         adapter.removeDefaultServant("foo");
         prx = new Test.MyObjectPrx(communicator, `foo/x:${this.getTestEndpoint()}`);
         try {

--- a/swift/src/Ice/ServantManager.swift
+++ b/swift/src/Ice/ServantManager.swift
@@ -90,15 +90,15 @@ final class ServantManager: Dispatcher {
 
     func findServant(id: Identity, facet: String) -> Dispatcher? {
         return state.withLock {
-            guard let m = $0.servantMapMap[id] else {
-                guard let obj = $0.defaultServantMap[id.category] else {
-                    return $0.defaultServantMap[""]
-                }
-
+            if let obj = $0.servantMapMap[id]?[facet] {
                 return obj
             }
 
-            return m[facet]
+            guard let obj = $0.defaultServantMap[id.category] else {
+                return $0.defaultServantMap[""]
+            }
+
+            return obj
         }
     }
 

--- a/swift/test/Ice/defaultServant/AllTests.swift
+++ b/swift/test/Ice/defaultServant/AllTests.swift
@@ -117,6 +117,15 @@ func allTests(_ helper: TestHelper) async throws {
         } catch is Ice.ObjectNotExistException {}  // Expected
     }
 
+    // The identity is registered with a facet servant only: a request on the default facet still dispatches to the
+    // default servant.
+    identity.category = "foo"
+    identity.name = "x"
+    _ = try oa.addFacet(servant: MyObjectI(), id: identity, facet: "theFacet")
+    prx = try uncheckedCast(prx: oa.createProxy(identity), type: MyObjectPrx.self)
+    try await test(prx.getName() == "x")
+    _ = try oa.removeFacet(id: identity, facet: "theFacet")
+
     _ = try oa.removeDefaultServant("foo")
     identity.category = "foo"
     prx = try uncheckedCast(prx: oa.createProxy(identity), type: MyObjectPrx.self)


### PR DESCRIPTION
Fixes #5865.
Fixes #5875.

The default-servant fallback in `ServantManager.findServant` ran only when the request's identity was entirely absent from the Active Servant Map. When the identity was registered with a *different* facet, `findServant` returned null without consulting the default servant map, and the dispatch failed with `FacetNotExistException` — diverging from the documented lookup order ("tries to find a servant for the identity and facet in the Active Servant Map; if this fails, … a default servant for the category") and from the C++ implementation, which falls through to the default servant when either the identity or the facet lookup fails.

#5865 reported the C# mapping and #5875 the JS mapping, but the same faulty lookup was copied into every mapping with its own dispatch path: **C#, Java, JS, and Swift** are all fixed here, with the same restructure in each — perform the identity+facet lookup first, then fall back to the default-servant chain (category, then empty category) whenever it produced nothing. Python dispatches through the C++ core and is unaffected; Ruby, PHP, and MATLAB have no server side.

The existing `Ice/defaultServant` test in each fixed mapping — plus C++, as a guard on the reference behavior — now registers a facet servant on an identity while a default servant is active for its category and verifies that a request on the default facet dispatches to the default servant. All five pass; the new check fails on the pre-fix code.

One changelog fragment per fixed mapping.

Note: the same bug exists on the 3.7 branch (including `java-compat`); a hand-ported backport PR will follow, since the file layout and Swift internals differ there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)