### PR TITLE
Support bcrypt password hashes in the Glacier2 Crypt permissions verifier

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -25,6 +25,7 @@
         "icestorm",
         "istr",
         "jgoodies",
+        "libxcrypt",
         "LMDB",
         "nohup",
         "nullopt",
@@ -47,6 +48,7 @@
         "unregisters",
         "upcall",
         "upcalls",
+        "yescrypt",
         "zeroc"
     ],
     "flagWords": [

--- a/changelog.d/service-glacier2/crypt-verifier-bcrypt.md
+++ b/changelog.d/service-glacier2/crypt-verifier-bcrypt.md
@@ -1,0 +1,1 @@
+- The Glacier2 Crypt permissions verifier now supports bcrypt password hashes (`$2a$`, `$2b$`, `$2y$`) on Linux.

--- a/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
@@ -165,6 +165,15 @@ namespace
     }
 #endif
 
+    // Verifies the password against the stored hash for the given user ID. The accepted hash formats are
+    // platform-specific:
+    //
+    // - Linux and FreeBSD: any format supported by the system's crypt library; with libxcrypt this includes DES,
+    //   $1$ (MD5), $5$/$6$ (sha-crypt), $2b$ (bcrypt), and $y$ (yescrypt).
+    // - macOS and Windows: passlib-style PBKDF2 only ($pbkdf2$, $pbkdf2-sha256$, $pbkdf2-sha512$).
+    //
+    // On Windows, the BCrypt* APIs used below belong to Microsoft's CNG (Cryptography API: Next Generation); they
+    // are unrelated to the bcrypt password-hashing scheme, which is not supported on Windows.
     bool CryptPermissionsVerifierI::checkPermissions(string userId, string password, string&, const Current&) const
     {
         auto p = _passwords.find(userId);
@@ -174,31 +183,11 @@ namespace
             return false;
         }
 #if defined(__GLIBC__) || defined(__FreeBSD__)
-        size_t i = p->second.rfind('$');
-        string salt;
-        if (i == string::npos)
-        {
-            //
-            // Crypt DES
-            //
-            if (p->second.size() != 13) // DES passwords are 13 characters long.
-            {
-                return false;
-            }
-            salt = p->second.substr(0, 2);
-        }
-        else
-        {
-            salt = p->second.substr(0, i + 1);
-            if (salt.empty())
-            {
-                return false;
-            }
-        }
-
+        // Pass the whole stored hash as the setting: crypt_r only reads its salt prefix, and this works for all
+        // schemes, including bcrypt whose salt is not terminated by '$'.
         struct crypt_data data;
         data.initialized = 0;
-        const char* hashed = crypt_r(password.c_str(), salt.c_str(), &data);
+        const char* hashed = crypt_r(password.c_str(), p->second.c_str(), &data);
 
         if (hashed == nullptr || p->second.size() != strlen(hashed))
         {
@@ -319,7 +308,7 @@ namespace
 
         //
         // passlib encoding is identical to base64 except that it uses . instead of +,
-        // and omits trailing padding = and whitepsace.
+        // and omits trailing padding = and whitespace.
         //
         std::replace(salt.begin(), salt.end(), '.', '+');
         salt += paddingBytes(salt.size());


### PR DESCRIPTION
Fixes #5862.

On Linux, the Glacier2 Crypt permissions verifier derived the crypt "setting" by truncating the stored hash at its last `$`. That works for DES, `$1$`, `$5$`/`$6$`, and `$y$` hashes, but not for bcrypt (`$2a$`/`$2b$`/`$2y$`), whose 22-character salt has no trailing `$`: the setting passed to `crypt_r` lost its salt, the call failed, and the entry never verified.

This PR passes the whole stored hash as the setting instead — the canonical `crypt(password, storedHash)` idiom, since crypt only reads the salt prefix of its second argument. This works for every scheme supported by the system's crypt library, including bcrypt. The DES special case is subsumed: crypt uses only the first 2 characters as the DES salt, and the existing output-length + constant-time comparison still rejects any mismatch or failure token.

Also adds a comment documenting the platform-specific accepted hash formats (crypt-based on Linux, passlib-style PBKDF2 on macOS and Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)