### PR TITLE
Support session creation from secure WebSocket (wss) connections in Glacier2 and IceGrid

### DIFF
--- a/changelog.d/service-glacier2/wss-secure-session.md
+++ b/changelog.d/service-glacier2/wss-secure-session.md
@@ -1,0 +1,3 @@
+- The Glacier2 router now supports `createSessionFromSecureConnection` calls from clients connecting over secure
+  WebSocket (wss), and sets the `_con.peerCert` context entry for these connections when
+  `Glacier2.AddConnectionContext` is enabled.

--- a/changelog.d/service-icegrid/wss-secure-session.md
+++ b/changelog.d/service-icegrid/wss-secure-session.md
@@ -1,0 +1,2 @@
+- The IceGrid registry now supports `createSessionFromSecureConnection` and `createAdminSessionFromSecureConnection`
+  calls from clients connecting over secure WebSocket (wss).

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -27,6 +27,20 @@ namespace
 
         return nullptr;
     }
+
+    shared_ptr<Ice::SSL::ConnectionInfo> getSSLConnectionInfo(const ConnectionInfoPtr& info)
+    {
+        for (ConnectionInfoPtr p = info; p; p = p->underlying)
+        {
+            auto sslInfo = dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(p);
+            if (sslInfo)
+            {
+                return sslInfo;
+            }
+        }
+
+        return nullptr;
+    }
 }
 
 namespace Glacier2
@@ -346,7 +360,7 @@ CreateSession::CreateSession(shared_ptr<SessionRouterI> sessionRouter, string us
             }
         }
         {
-            auto info = dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(current.con->getInfo());
+            auto info = getSSLConnectionInfo(current.con->getInfo());
             if (info && info->peerCertificate)
             {
                 _context["_con.peerCert"] = Ice::SSL::encodeCertificate(info->peerCertificate);
@@ -665,10 +679,10 @@ SessionRouterI::createSessionFromSecureConnectionAsync(
     //
     try
     {
-        auto info = dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(current.con->getInfo());
+        auto info = getSSLConnectionInfo(current.con->getInfo());
         if (!info)
         {
-            exception(make_exception_ptr(PermissionDeniedException("not ssl connection")));
+            exception(make_exception_ptr(PermissionDeniedException("not an ssl connection")));
             return;
         }
 

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -120,6 +120,19 @@ namespace
         return nullptr;
     }
 
+    shared_ptr<Ice::SSL::ConnectionInfo> getSSLConnectionInfo(const ConnectionInfoPtr& info)
+    {
+        for (auto p = info; p; p = p->underlying)
+        {
+            auto sslInfo = dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(p);
+            if (sslInfo)
+            {
+                return sslInfo;
+            }
+        }
+        return nullptr;
+    }
+
     ProcessI::ProcessI(shared_ptr<RegistryI> registry, shared_ptr<Process> origProcess)
         : _registry(std::move(registry)),
           _origProcess(std::move(origProcess))
@@ -1156,7 +1169,7 @@ RegistryI::getSSLInfo(const ConnectionPtr& connection, string& userDN)
     Glacier2::SSLInfo sslinfo;
     try
     {
-        auto info = dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(connection->getInfo());
+        auto info = getSSLConnectionInfo(connection->getInfo());
         if (!info)
         {
             throw PermissionDeniedException("not an ssl connection");

--- a/cpp/test/Glacier2/ssl/Client.cpp
+++ b/cpp/test/Glacier2/ssl/Client.cpp
@@ -89,6 +89,26 @@ Client::run(int argc, char** argv)
     }
     cout << "ok" << endl;
 
+    //
+    // Switch to the WSS router. The connection is secured by TLS underneath the WebSocket transport.
+    //
+    communicator->setDefaultRouter(nullopt);
+    router = Glacier2::RouterPrx(communicator, "Glacier2/router:" + getTestEndpoint(4, "wss"));
+    communicator->setDefaultRouter(router);
+
+    cout << "creating ssl session with wss connection... ";
+    try
+    {
+        auto session = router->createSessionFromSecureConnection();
+        session->ice_ping();
+        router->destroySession();
+    }
+    catch (const Glacier2::PermissionDeniedException&)
+    {
+        test(false);
+    }
+    cout << "ok" << endl;
+
     communicator->setDefaultRouter(nullopt);
     auto process = checkedCast<Ice::ProcessPrx>(
         communicator->stringToProxy("Glacier2/admin -f Process:" + getTestEndpoint(2, "tcp")));

--- a/cpp/test/Glacier2/ssl/Server.cpp
+++ b/cpp/test/Glacier2/ssl/Server.cpp
@@ -13,26 +13,50 @@ using namespace Test;
 
 namespace
 {
-    void testContext(bool ssl, const shared_ptr<Ice::Communicator>& communicator, const Ice::Context& context)
+    int testPortIndex(const string& type)
     {
-        Ice::Context ctx = context;
-        if (!ssl)
+        if (type == "tcp")
         {
-            test(ctx["_con.type"] == "tcp");
-            ostringstream port;
-            port << TestHelper::getTestPort(communicator->getProperties());
-            test(ctx["_con.localPort"] == port.str());
+            return 0;
+        }
+        else if (type == "ssl")
+        {
+            return 1;
         }
         else
         {
-            test(ctx["_con.type"] == "ssl");
-            ostringstream port;
-            port << TestHelper::getTestPort(communicator->getProperties(), 1);
-            test(ctx["_con.localPort"] == port.str());
+            test(type == "wss");
+            return 4;
         }
+    }
+
+    void testContext(const string& type, const shared_ptr<Ice::Communicator>& communicator, const Ice::Context& context)
+    {
+        Ice::Context ctx = context;
+        test(ctx["_con.type"] == type);
+        ostringstream port;
+        port << TestHelper::getTestPort(communicator->getProperties(), testPortIndex(type));
+        test(ctx["_con.localPort"] == port.str());
         test(ctx["_con.localAddress"] == "127.0.0.1");
         test(ctx["_con.remotePort"] != "");
         test(ctx["_con.remoteAddress"] == "127.0.0.1");
+        if (type == "tcp")
+        {
+            test(ctx.find("_con.peerCert") == ctx.end());
+        }
+        else
+        {
+            test(!ctx["_con.peerCert"].empty());
+        }
+    }
+
+    // The type of the secure connection ("ssl" or "wss") over which the client called the router.
+    string secureConnectionType(const Ice::Context& context)
+    {
+        auto p = context.find("_con.type");
+        test(p != context.end());
+        test(p->second == "ssl" || p->second == "wss");
+        return p->second;
     }
 
     void testSubjectName(const string& subjectName)
@@ -52,7 +76,7 @@ class PermissionsVerifierI final : public Glacier2::PermissionsVerifier
 public:
     bool checkPermissions(string userId, string, string&, const Ice::Current& current) const override
     {
-        testContext(userId == "ssl", current.adapter->getCommunicator(), current.ctx);
+        testContext(userId == "ssl" ? "ssl" : "tcp", current.adapter->getCommunicator(), current.ctx);
         return true;
     }
 };
@@ -62,7 +86,7 @@ class SSLPermissionsVerifierI final : public Glacier2::SSLPermissionsVerifier
 public:
     bool authorize(Glacier2::SSLInfo info, string&, const Ice::Current& current) const override
     {
-        testContext(true, current.adapter->getCommunicator(), current.ctx);
+        testContext(secureConnectionType(current.ctx), current.adapter->getCommunicator(), current.ctx);
 
         Ice::SSL::ScopedCertificate cert = Ice::SSL::decodeCertificate(info.certs[0]);
         testSubjectName(Ice::SSL::getSubjectName(cert.get()));
@@ -73,11 +97,11 @@ public:
 class SessionI final : public Glacier2::Session
 {
 public:
-    SessionI(bool shutdown, bool ssl) : _shutdown(shutdown), _ssl(ssl) {}
+    SessionI(bool shutdown, string type) : _shutdown(shutdown), _type(std::move(type)) {}
 
     void destroy(const Ice::Current& current) override
     {
-        testContext(_ssl, current.adapter->getCommunicator(), current.ctx);
+        testContext(_type, current.adapter->getCommunicator(), current.ctx);
 
         current.adapter->remove(current.id);
         if (_shutdown)
@@ -88,12 +112,12 @@ public:
 
     void ice_ping(const Ice::Current& current) const override
     {
-        testContext(_ssl, current.adapter->getCommunicator(), current.ctx);
+        testContext(_type, current.adapter->getCommunicator(), current.ctx);
     }
 
 private:
     const bool _shutdown;
-    const bool _ssl;
+    const string _type;
 };
 
 class SessionManagerI final : public Glacier2::SessionManager
@@ -102,9 +126,9 @@ public:
     optional<Glacier2::SessionPrx>
     create(string userId, optional<Glacier2::SessionControlPrx>, const Ice::Current& current) override
     {
-        testContext(userId == "ssl", current.adapter->getCommunicator(), current.ctx);
+        testContext(userId == "ssl" ? "ssl" : "tcp", current.adapter->getCommunicator(), current.ctx);
 
-        auto session = make_shared<SessionI>(false, userId == "ssl");
+        auto session = make_shared<SessionI>(false, userId == "ssl" ? "ssl" : "tcp");
         return current.adapter->addWithUUID<Glacier2::SessionPrx>(session);
     }
 };
@@ -115,11 +139,14 @@ public:
     optional<Glacier2::SessionPrx>
     create(Glacier2::SSLInfo info, optional<Glacier2::SessionControlPrx>, const Ice::Current& current) override
     {
-        testContext(true, current.adapter->getCommunicator(), current.ctx);
+        string type = secureConnectionType(current.ctx);
+        testContext(type, current.adapter->getCommunicator(), current.ctx);
 
         test(info.remoteHost == "127.0.0.1");
         test(info.localHost == "127.0.0.1");
-        test(info.localPort == TestHelper::getTestPort(current.adapter->getCommunicator()->getProperties(), 1));
+        test(
+            info.localPort ==
+            TestHelper::getTestPort(current.adapter->getCommunicator()->getProperties(), testPortIndex(type)));
 
         try
         {
@@ -131,7 +158,8 @@ public:
             test(false);
         }
 
-        auto session = make_shared<SessionI>(true, true);
+        // The wss session is the last session created by the client; destroying it shuts the server down.
+        auto session = make_shared<SessionI>(type == "wss", type);
         return current.adapter->addWithUUID<Glacier2::SessionPrx>(session);
     }
 };

--- a/cpp/test/Glacier2/ssl/test.py
+++ b/cpp/test/Glacier2/ssl/test.py
@@ -8,8 +8,10 @@ def routerProps(process, current):
     return {
         "Ice.Warn.Dispatch": "0",
         "Glacier2.AddConnectionContext": "1",
-        "Glacier2.Client.Endpoints": "{0}:{1}".format(
-            current.getTestEndpoint(0, "tcp"), current.getTestEndpoint(1, "ssl")
+        "Glacier2.Client.Endpoints": "{0}:{1}:{2}".format(
+            current.getTestEndpoint(0, "tcp"),
+            current.getTestEndpoint(1, "ssl"),
+            current.getTestEndpoint(4, "wss"),
         ),
         "Ice.Admin.Endpoints": current.getTestEndpoint(2, "tcp"),
         "Glacier2.SessionManager": "sessionmanager:{0}".format(current.getTestEndpoint(3, "tcp")),

--- a/cpp/test/IceGrid/replication/AllTests.cpp
+++ b/cpp/test/IceGrid/replication/AllTests.cpp
@@ -403,7 +403,8 @@ allTests(Test::TestHelper* helper)
 
         auto session = masterRegistry->createSession("dummy", "dummy");
         session->destroy();
-        if (communicator->getProperties()->getIceProperty("Ice.Default.Protocol") == "ssl")
+        const string protocol = communicator->getProperties()->getIceProperty("Ice.Default.Protocol");
+        if (protocol == "ssl" || protocol == "wss")
         {
             session = masterRegistry->createSessionFromSecureConnection();
             session->destroy();

--- a/cpp/test/IceGrid/session/AllTests.cpp
+++ b/cpp/test/IceGrid/session/AllTests.cpp
@@ -608,7 +608,8 @@ allTests(TestHelper* helper)
         cout << "ok" << endl;
     }
 
-    if (properties->getIceProperty("Ice.Default.Protocol") == "ssl")
+    const string protocol = properties->getIceProperty("Ice.Default.Protocol");
+    if (protocol == "ssl" || protocol == "wss")
     {
         cout << "testing sessions from secure connection... " << flush;
 
@@ -865,7 +866,7 @@ allTests(TestHelper* helper)
         cout << "ok" << endl;
     }
 
-    if (properties->getIceProperty("Ice.Default.Protocol") == "ssl")
+    if (protocol == "ssl" || protocol == "wss")
     {
         cout << "testing Glacier2 sessions from secure connection... " << flush;
 


### PR DESCRIPTION
Fixes #5860.

The Glacier2 router and the IceGrid registry located the SSL connection info with a direct `dynamic_pointer_cast` on `Connection::getInfo()`. For a wss connection, `getInfo()` returns a `WSConnectionInfo` whose `underlying` holds the SSL info, so the cast returned null and `createSessionFromSecureConnection` (and, for IceGrid, `createAdminSessionFromSecureConnection`) failed with a `PermissionDeniedException`, even though the connection is TLS-secured and carries a client certificate. Glacier2 also skipped the `_con.peerCert` context entry for wss connections for the same reason.

Both services now walk the `underlying` chain to find the SSL connection info, with a `getSSLConnectionInfo` helper mirroring the existing `getIPConnectionInfo`. Glacier2's "not ssl connection" exception message also becomes "not an ssl connection", matching IceGrid.

Test coverage:
- The `Glacier2/ssl` test client now also creates a certificate session over a wss endpoint, and the server-side connection-context checks were generalized from a tcp/ssl boolean to a connection-type string, additionally asserting that `_con.peerCert` is set on secure connections.
- The secure-session blocks in the `IceGrid/session` and `IceGrid/replication` tests now run when the test protocol is `wss` in addition to `ssl`. This was required anyway: the `IceGrid/session` test previously asserted that session creation from a secure connection is denied for any protocol other than `ssl`, which codified the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)