### PR TITLE
Reject invalid Glacier2.RoutingTable.MaxSize values at startup

### DIFF
--- a/cpp/src/Glacier2/Instance.cpp
+++ b/cpp/src/Glacier2/Instance.cpp
@@ -17,8 +17,17 @@ Glacier2::Instance::Instance(
       _logger(_communicator->getLogger()),
       _clientAdapter(std::move(clientAdapter)),
       _serverAdapter(std::move(serverAdapter)),
-      _proxyVerifier(make_shared<ProxyVerifier>(_communicator))
+      _proxyVerifier(make_shared<ProxyVerifier>(_communicator)),
+      _routingTableMaxSize(_properties->getIcePropertyAsInt("Glacier2.RoutingTable.MaxSize"))
 {
+    if (_routingTableMaxSize < 1)
+    {
+        throw Ice::InitializationException(
+            __FILE__,
+            __LINE__,
+            "invalid value for Glacier2.RoutingTable.MaxSize: " + to_string(_routingTableMaxSize));
+    }
+
     //
     // If an Ice metrics observer is setup on the communicator, also enable metrics for Glacier2.
     //

--- a/cpp/src/Glacier2/Instance.h
+++ b/cpp/src/Glacier2/Instance.h
@@ -25,6 +25,7 @@ namespace Glacier2
 
         [[nodiscard]] std::shared_ptr<ProxyVerifier> proxyVerifier() const { return _proxyVerifier; }
         [[nodiscard]] std::shared_ptr<SessionRouterI> sessionRouter() const { return _sessionRouter; }
+        [[nodiscard]] int routingTableMaxSize() const { return _routingTableMaxSize; }
 
         [[nodiscard]] const std::shared_ptr<Glacier2::Instrumentation::RouterObserver>& getObserver() const
         {
@@ -42,6 +43,7 @@ namespace Glacier2
         const Ice::ObjectAdapterPtr _clientAdapter;
         const Ice::ObjectAdapterPtr _serverAdapter;
         const std::shared_ptr<ProxyVerifier> _proxyVerifier;
+        const int _routingTableMaxSize;
         std::shared_ptr<SessionRouterI> _sessionRouter;
         const std::shared_ptr<Glacier2::Instrumentation::RouterObserver> _observer;
     };

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -20,7 +20,10 @@ Glacier2::RouterI::RouterI(
     shared_ptr<FilterManager> filters,
     const Context& context)
     : _instance(std::move(instance)),
-      _routingTable(make_shared<RoutingTable>(_instance->communicator(), _instance->proxyVerifier())),
+      _routingTable(make_shared<RoutingTable>(
+          _instance->communicator(),
+          _instance->proxyVerifier(),
+          _instance->routingTableMaxSize())),
       _clientBlobject(make_shared<ClientBlobject>(_instance, std::move(filters), context, _routingTable)),
       _connection(std::move(connection)),
       _userId(std::move(userId)),

--- a/cpp/src/Glacier2/RoutingTable.cpp
+++ b/cpp/src/Glacier2/RoutingTable.cpp
@@ -7,10 +7,10 @@ using namespace std;
 using namespace Ice;
 using namespace Glacier2;
 
-Glacier2::RoutingTable::RoutingTable(CommunicatorPtr communicator, shared_ptr<ProxyVerifier> verifier)
+Glacier2::RoutingTable::RoutingTable(CommunicatorPtr communicator, shared_ptr<ProxyVerifier> verifier, int maxSize)
     : _communicator(std::move(communicator)),
       _traceLevel(_communicator->getProperties()->getIcePropertyAsInt("Glacier2.Trace.RoutingTable")),
-      _maxSize(_communicator->getProperties()->getIcePropertyAsInt("Glacier2.RoutingTable.MaxSize")),
+      _maxSize(maxSize),
       _verifier(std::move(verifier))
 {
 }

--- a/cpp/src/Glacier2/RoutingTable.h
+++ b/cpp/src/Glacier2/RoutingTable.h
@@ -16,7 +16,7 @@ namespace Glacier2
     class RoutingTable final
     {
     public:
-        RoutingTable(Ice::CommunicatorPtr, std::shared_ptr<ProxyVerifier>);
+        RoutingTable(Ice::CommunicatorPtr, std::shared_ptr<ProxyVerifier>, int maxSize);
 
         void destroy();
 


### PR DESCRIPTION
Fixes #5863.

`Glacier2.RoutingTable.MaxSize` was read without validation. A negative value made the routing table's eviction loop pop from an empty queue (undefined behavior, crash) on the first `ice_add_proxy`, and `0` evicted every proxy immediately after adding it, causing clients to retry `ice_add_proxy` forever.

The Glacier2 router now rejects `MaxSize < 1` at startup with `InitializationException` ("invalid value for Glacier2.RoutingTable.MaxSize: 0"), reported through the existing "Glacier2 initialization failed" startup error path.

The property is now read and validated once in `Instance` and injected into the `RoutingTable` constructor, instead of being re-read from the properties by every per-session routing table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)