### PR TITLE
Destroy the replaced close callback outside the connection lock

### DIFF
--- a/changelog.d/cpp/5926.md
+++ b/changelog.d/cpp/5926.md
@@ -1,0 +1,3 @@
+- Fixed a deadlock in `Connection::setCloseCallback`. Setting or clearing a close callback destroyed the callback it
+  replaced while holding the connection's lock, so a callback whose destructor called back into the connection
+  deadlocked. This affected the language mappings that attach a finalizer to the callback, such as Ice for Python.

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -763,18 +763,25 @@ Ice::ConnectionI::flushBatchRequestsAsync(
 void
 Ice::ConnectionI::setCloseCallback(CloseCallback callback)
 {
-    std::lock_guard lock(_mutex);
-    if (_state >= StateClosed)
+    // Holds the callback this call replaces, so that it is destroyed after the lock is released. Destroying a
+    // callback can run arbitrary user code - a language mapping may attach a finalizer to it - and that code can
+    // call back into this connection, which would deadlock on the non-recursive _mutex.
+    CloseCallback previous;
+
     {
-        if (callback)
+        std::lock_guard lock(_mutex);
+        if (_state >= StateClosed)
         {
-            auto self = shared_from_this();
-            _threadPool->execute([self, callback = std::move(callback)]() { self->closeCallback(callback); }, self);
+            if (callback)
+            {
+                auto self = shared_from_this();
+                _threadPool->execute([self, callback = std::move(callback)]() { self->closeCallback(callback); }, self);
+            }
         }
-    }
-    else
-    {
-        _closeCallback = std::move(callback);
+        else
+        {
+            previous = std::exchange(_closeCallback, std::move(callback));
+        }
     }
 }
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <stdexcept>
+#include <utility>
 
 #ifdef ICE_HAS_BZIP2
 #    include <bzlib.h>

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1102,7 +1102,11 @@ allTests(TestHelper* helper, bool collocated)
                 struct Reenter
                 {
                     ConnectionPtr connection;
-                    ~Reenter() { connection->getInfo(); } // reenter the connection from the callback's destructor
+
+                    explicit Reenter(ConnectionPtr con) : connection(std::move(con)) {}
+
+                    // Reenter the connection from the callback's destructor.
+                    ~Reenter() { static_cast<void>(connection->getInfo()); }
                 };
 
                 auto con = p->ice_connectionId("CloseCallbackReplacement")->ice_getConnection();

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1102,15 +1102,15 @@ allTests(TestHelper* helper, bool collocated)
                 struct Reenter
                 {
                     ConnectionPtr connection;
-                    ~Reenter() { connection->setCloseCallback(nullptr); }
+                    ~Reenter() { connection->getInfo(); } // reenter the connection from the callback's destructor
                 };
 
                 auto con = p->ice_connectionId("CloseCallbackReplacement")->ice_getConnection();
-                auto guard = make_shared<Reenter>(con);
-                con->setCloseCallback([guard](const ConnectionPtr&) {});
-                guard = nullptr; // only the connection's callback keeps the guard alive now
 
-                con->setCloseCallback(nullptr); // destroys the previous callback, and with it the guard
+                // The lambda is the sole owner of the Reenter object, so replacing the callback below destroys it.
+                con->setCloseCallback([owner = make_shared<Reenter>(con)](const ConnectionPtr&) {});
+
+                con->setCloseCallback(nullptr); // destroys the previous callback, and with it the Reenter object
                 con->close().get();
             }
             cout << "ok" << endl;

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1093,6 +1093,28 @@ allTests(TestHelper* helper, bool collocated)
 
         if (p->ice_getConnection() && !bluetooth)
         {
+            cout << "testing close callback replacement... " << flush;
+            {
+                // Replacing a close callback destroys the callback it replaces. That destructor can run user code -
+                // a language mapping may attach a finalizer to the callback - and that code may call back into the
+                // connection. It must therefore not run while the connection's mutex is held. This test deadlocks
+                // if it does.
+                struct Reenter
+                {
+                    ConnectionPtr connection;
+                    ~Reenter() { connection->setCloseCallback(nullptr); }
+                };
+
+                auto con = p->ice_connectionId("CloseCallbackReplacement")->ice_getConnection();
+                auto guard = make_shared<Reenter>(con);
+                con->setCloseCallback([guard](const ConnectionPtr&) {});
+                guard = nullptr; // only the connection's callback keeps the guard alive now
+
+                con->setCloseCallback(nullptr); // destroys the previous callback, and with it the guard
+                con->close().get();
+            }
+            cout << "ok" << endl;
+
             cout << "testing connection close... " << flush;
             {
                 //


### PR DESCRIPTION
Fixes #5926.

`ConnectionI::setCloseCallback` assigned the new callback to `_closeCallback` while holding `_mutex`, so the callback being replaced was destroyed under that lock. A callback destructor can run user code, and that code can call back into the connection — `_mutex` is a plain `std::mutex`, so the re-entrant lock deadlocks the process.

This is reachable today from Ice for Python: `~CloseCallbackWrapper` reacquires the GIL and decrefs the Python callable, running its `__del__`. A lambda closing over an object whose finalizer touches the connection hangs. C++ callers can hit it with a functor whose destructor calls back into the connection.

The fix moves the previous callback into a local under the lock and lets it be destroyed after the `lock_guard` goes out of scope. `finish()` also clears `_closeCallback`, but holds no lock there, so it needs no change.

### Testing

New test in `cpp/test/Ice/ami`, which holds a re-entrant destructor in a `shared_ptr` captured by the callback so it fires exactly once. Verified it **deadlocks against the current code** and passes against the fix. The two Python repros in #5926 likewise go from hang to clean exit.

### Merge order

Please merge this **before** #5889 (`Accept any callable in Connection.setCloseCallback`): widening the accepted callable types makes a callable instance with a `__del__` an equally direct trigger for this deadlock.