### PR TITLE
Fix ice_getConnectionAsync for collocated proxies and the event loop adapter

### DIFF
--- a/changelog.d/python/5888.md
+++ b/changelog.d/python/5888.md
@@ -1,0 +1,5 @@
+- Fixed `ice_getConnectionAsync` on a collocated proxy. It resolved with an unusable `Connection` object that crashed
+  the interpreter as soon as it was used, or never resolved at all, instead of resolving with `None` like the
+  synchronous `ice_getConnection`.
+- Fixed `ice_getConnectionAsync` to return a future created by the configured event loop adapter, like the other
+  asynchronous proxy operations. Awaiting it in an asyncio application no longer yields a non-asyncio future.

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -2396,9 +2396,9 @@ IcePy::GetConnectionAsyncCallback::setFuture(PyObject* future)
     //
     // Check if any callbacks have been invoked already.
     //
-    if (_connection)
+    if (_responseReceived)
     {
-        PyObjectHandle pyConn{createConnection(_connection, _communicator)};
+        PyObjectHandle pyConn{_connection ? createConnection(_connection, _communicator) : Py_NewRef(Py_None)};
         assert(pyConn.get());
         PyObjectHandle tmp{callMethod(future, "set_result", pyConn.get())};
         PyErr_Clear();
@@ -2425,10 +2425,11 @@ IcePy::GetConnectionAsyncCallback::response(const Ice::ConnectionPtr& conn)
         // The future hasn't been set yet, which means the request is still being invoked. Save the results for later.
         //
         _connection = conn;
+        _responseReceived = true;
         return;
     }
 
-    PyObjectHandle pyConn{createConnection(conn, _communicator)};
+    PyObjectHandle pyConn{conn ? createConnection(conn, _communicator) : Py_NewRef(Py_None)};
     PyObjectHandle tmp{callMethod(_future, "set_result", pyConn.get())};
     PyErr_Clear();
 

--- a/python/modules/IcePy/Operation.h
+++ b/python/modules/IcePy/Operation.h
@@ -38,6 +38,9 @@ namespace IcePy
         std::string _op;
         PyObject* _future{nullptr};
         Ice::ConnectionPtr _connection;
+        // A collocated proxy has no connection, so a successful response can carry a null connection. _connection
+        // alone cannot tell an early response apart from no response at all.
+        bool _responseReceived{false};
         PyObject* _exception{nullptr};
     };
     using GetConnectionAsyncCallbackPtr = std::shared_ptr<GetConnectionAsyncCallback>;

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -1133,7 +1133,7 @@ proxyIceGetConnectionAsync(ProxyObject* self, PyObject* /*args*/, PyObject* /*kw
         return nullptr;
     }
     callback->setFuture(future.get());
-    return future.release();
+    return IcePy::wrapFuture(*self->communicator, future.get());
 }
 
 extern "C" PyObject*
@@ -1399,11 +1399,11 @@ static PyMethodDef ProxyMethods[] = {
     {"ice_getConnection",
      reinterpret_cast<PyCFunction>(proxyIceGetConnection),
      METH_NOARGS,
-     PyDoc_STR("ice_getConnection() -> Ice.Connection")},
+     PyDoc_STR("ice_getConnection() -> Ice.Connection | None")},
     {"ice_getConnectionAsync",
      reinterpret_cast<PyCFunction>(proxyIceGetConnectionAsync),
      METH_NOARGS,
-     PyDoc_STR("ice_getConnectionAsync() -> Ice.Future")},
+     PyDoc_STR("ice_getConnectionAsync() -> Awaitable[Ice.Connection | None]")},
     {"ice_getCachedConnection",
      reinterpret_cast<PyCFunction>(proxyIceGetCachedConnection),
      METH_NOARGS,

--- a/python/test/Ice/asyncio/AllTests.py
+++ b/python/test/Ice/asyncio/AllTests.py
@@ -31,6 +31,25 @@ async def allTestsAsync(helper: TestHelper, communicator: Ice.Communicator):
     test(p1 is not None)
     print("ok")
 
+    sys.stdout.write("testing ice_getConnectionAsync... ")
+    sys.stdout.flush()
+
+    # Like the other async proxy operations, ice_getConnectionAsync must go through the event loop adapter.
+    future = p.ice_getConnectionAsync()
+    assert isinstance(future, asyncio.Future)
+    test(await future is not None)
+
+    # A collocated proxy has no connection: the future resolves with None, like the synchronous ice_getConnection.
+    adapter = communicator.createObjectAdapter("")
+    collocated = adapter.addWithUUID(Ice.Object())
+    future = collocated.ice_getConnectionAsync()
+    assert isinstance(future, asyncio.Future)
+    test(await future is None)
+    test(collocated.ice_getConnection() is None)
+    adapter.destroy()
+
+    print("ok")
+
     sys.stdout.write("testing exceptions... ")
     sys.stdout.flush()
     try:


### PR DESCRIPTION
Fixes #5888.

`GetConnectionAsyncCallback` used its `_connection` member as the "response already delivered" sentinel. A collocated proxy has no connection, so the core completes the operation with a null `ConnectionPtr` and the sentinel never becomes true:

- when the response arrived **before** `setFuture`, the future was never settled;
- when it arrived **after**, `createConnection` wrapped the null pointer and returned a `Connection` object that **segfaults the interpreter** on first use.

The synchronous `ice_getConnection` already returned `None` here. Note the issue understates this: it is a crash, not just a hang or a broken wrapper.

```
sync  ice_getConnection()      -> None
async ice_getConnectionAsync() -> <IcePy.Connection object at 0x...>
      con.toString()           -> exit code 139 (SIGSEGV)
```

The fix tracks the response with a dedicated `_responseReceived` flag and resolves the future with `None` when the connection is null, so both orderings settle and both mirror the synchronous operation.

`proxyIceGetConnectionAsync` also returned its future raw — the only `createFuture` site in the extension that skipped `IcePy::wrapFuture`. Under an asyncio `EventLoopAdapter` it was the one async proxy operation yielding a non-asyncio future. It now wraps like `ice_flushBatchRequestsAsync`, and the two method-table docstrings that omitted `None` from the return type are corrected.

### Testing

New block in `Ice/asyncio`, which already asserts `isinstance(f, asyncio.Future)` for sibling async calls. Verified it **fails against the unfixed extension** (`AssertionError` on the `isinstance` check) and passes with it. A remote proxy still returns a real `Connection`; a collocated one returns `None`. `Ice/{ami,proxy,operations,timeout,info,asyncio,exceptions,blobject,adapterDeactivation}` all pass.