### PR TITLE
Accept the request context as a keyword argument in ice_invoke

### DIFF
--- a/changelog.d/python/5887.md
+++ b/changelog.d/python/5887.md
@@ -1,0 +1,3 @@
+- Fixed `ObjectPrx.ice_invoke` and `ObjectPrx.ice_invokeAsync` to accept the request context as a keyword argument, as
+  their signatures advertise. `ice_invokeAsync` previously sent the request without any context when `ctx` was passed by
+  keyword, and `ice_invoke` rejected the call with a `TypeError`.

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -1708,14 +1708,25 @@ IcePy::AsyncTypedInvocation::handleResponse(PyObject* future, bool ok, pair<cons
 IcePy::SyncBlobjectInvocation::SyncBlobjectInvocation(const Ice::ObjectPrx& prx) : Invocation(prx) {}
 
 PyObject*
-IcePy::SyncBlobjectInvocation::invoke(PyObject* args, PyObject* /* kwds */)
+IcePy::SyncBlobjectInvocation::invoke(PyObject* args, PyObject* kwds)
 {
     char* operation;
     PyObject* mode{nullptr};
     PyObject* inParams{nullptr};
     PyObject* operationModeType{lookupType("Ice.OperationMode")};
     PyObject* ctx{nullptr};
-    if (!PyArg_ParseTuple(args, "sO!O!|O", &operation, operationModeType, &mode, &PyBytes_Type, &inParams, &ctx))
+    static const char* const kwlist[] = {"operation", "mode", "inParams", "ctx", nullptr};
+    if (!PyArg_ParseTupleAndKeywords(
+            args,
+            kwds,
+            "sO!O!|O",
+            const_cast<char**>(kwlist),
+            &operation,
+            operationModeType,
+            &mode,
+            &PyBytes_Type,
+            &inParams,
+            &ctx))
     {
         return nullptr;
     }
@@ -1795,14 +1806,25 @@ IcePy::AsyncBlobjectInvocation::AsyncBlobjectInvocation(const Ice::ObjectPrx& pr
 }
 
 function<void()>
-IcePy::AsyncBlobjectInvocation::handleInvoke(PyObject* args, PyObject* /* kwds */)
+IcePy::AsyncBlobjectInvocation::handleInvoke(PyObject* args, PyObject* kwds)
 {
     char* operation{nullptr};
     PyObject* mode{nullptr};
     PyObject* inParams{nullptr};
     PyObject* operationModeType{lookupType("Ice.OperationMode")};
     PyObject* ctx{nullptr};
-    if (!PyArg_ParseTuple(args, "sO!O!|O", &operation, operationModeType, &mode, &PyBytes_Type, &inParams, &ctx))
+    static const char* const kwlist[] = {"operation", "mode", "inParams", "ctx", nullptr};
+    if (!PyArg_ParseTupleAndKeywords(
+            args,
+            kwds,
+            "sO!O!|O",
+            const_cast<char**>(kwlist),
+            &operation,
+            operationModeType,
+            &mode,
+            &PyBytes_Type,
+            &inParams,
+            &ctx))
     {
         return nullptr;
     }
@@ -2252,19 +2274,19 @@ IcePy::BlobjectUpcall::exception(PyException& ex)
 }
 
 PyObject*
-IcePy::iceInvoke(PyObject* proxy, PyObject* args)
+IcePy::iceInvoke(PyObject* proxy, PyObject* args, PyObject* kwds)
 {
     Ice::ObjectPrx prx = getProxy(proxy);
     InvocationPtr i = make_shared<SyncBlobjectInvocation>(prx);
-    return i->invoke(args);
+    return i->invoke(args, kwds);
 }
 
 PyObject*
-IcePy::iceInvokeAsync(PyObject* proxy, PyObject* args)
+IcePy::iceInvokeAsync(PyObject* proxy, PyObject* args, PyObject* kwds)
 {
     Ice::ObjectPrx prx = getProxy(proxy);
     InvocationPtr i = make_shared<AsyncBlobjectInvocation>(prx, proxy);
-    return i->invoke(args);
+    return i->invoke(args, kwds);
 }
 
 PyObject*

--- a/python/modules/IcePy/Operation.h
+++ b/python/modules/IcePy/Operation.h
@@ -18,8 +18,8 @@ namespace IcePy
     extern PyTypeObject AsyncInvocationContextType;
 
     // Blobject invocations.
-    PyObject* iceInvoke(PyObject*, PyObject*);
-    PyObject* iceInvokeAsync(PyObject*, PyObject*);
+    PyObject* iceInvoke(PyObject*, PyObject*, PyObject* = nullptr);
+    PyObject* iceInvokeAsync(PyObject*, PyObject*, PyObject* = nullptr);
 
     /// Used as the callback for getConnectionAsync operation.
     class GetConnectionAsyncCallback

--- a/python/modules/IcePy/Operation.h
+++ b/python/modules/IcePy/Operation.h
@@ -18,8 +18,8 @@ namespace IcePy
     extern PyTypeObject AsyncInvocationContextType;
 
     // Blobject invocations.
-    PyObject* iceInvoke(PyObject*, PyObject*, PyObject* = nullptr);
-    PyObject* iceInvokeAsync(PyObject*, PyObject*, PyObject* = nullptr);
+    PyObject* iceInvoke(PyObject*, PyObject*, PyObject*);
+    PyObject* iceInvokeAsync(PyObject*, PyObject*, PyObject*);
 
     /// Used as the callback for getConnectionAsync operation.
     class GetConnectionAsyncCallback

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -1201,15 +1201,15 @@ proxyIceFlushBatchRequestsAsync(ProxyObject* self, PyObject* /*args*/, PyObject*
 }
 
 extern "C" PyObject*
-proxyIceInvoke(ProxyObject* self, PyObject* args)
+proxyIceInvoke(ProxyObject* self, PyObject* args, PyObject* kwds)
 {
-    return iceInvoke(reinterpret_cast<PyObject*>(self), args);
+    return iceInvoke(reinterpret_cast<PyObject*>(self), args, kwds);
 }
 
 extern "C" PyObject*
-proxyIceInvokeAsync(ProxyObject* self, PyObject* args, PyObject* /*kwds*/)
+proxyIceInvokeAsync(ProxyObject* self, PyObject* args, PyObject* kwds)
 {
-    return iceInvokeAsync(reinterpret_cast<PyObject*>(self), args);
+    return iceInvokeAsync(reinterpret_cast<PyObject*>(self), args, kwds);
 }
 
 extern "C" PyObject*
@@ -1418,7 +1418,7 @@ static PyMethodDef ProxyMethods[] = {
      PyDoc_STR("ice_flushBatchRequestsAsync() -> Awaitable[None]")},
     {"ice_invoke",
      reinterpret_cast<PyCFunction>(proxyIceInvoke),
-     METH_VARARGS,
+     METH_VARARGS | METH_KEYWORDS,
      PyDoc_STR("ice_invoke(operation: str, mode: Ice.OperationMode, inParams: bytes, ctx: dict[str, str] | None) -> "
                "tuple[bool, bytes]")},
     {"ice_invokeAsync",

--- a/python/test/Ice/blobject/Client.py
+++ b/python/test/Ice/blobject/Client.py
@@ -17,7 +17,7 @@ import Ice
 
 
 class Client(TestHelper):
-    def allTests(self, communicator: Ice.Communicator, sync: bool):
+    def allTests(self, communicator: Ice.Communicator, router: RouterI.RouterI, sync: bool):
         hello = Test.HelloPrx(communicator, f"test:{self.getTestEndpoint()}")
         hello.sayHello(False)
         hello.sayHello(False, {"_fwd": "o"})
@@ -30,6 +30,25 @@ class Client(TestHelper):
         assert isinstance(f, Ice.Future)
         ok, _ = f.result()
         test(ok)
+
+        # ice_invoke/ice_invokeAsync with the context passed as a keyword argument. The router's blobject records the
+        # context it receives, so a dropped context is caught here rather than silently ignored.
+        ok, _ = hello.ice_invoke("ice_ping", Ice.OperationMode.Normal, b"", ctx={"ctx": "sync"})
+        test(ok)
+        test(router.lastContext()["ctx"] == "sync")
+
+        f = hello.ice_invokeAsync("ice_ping", Ice.OperationMode.Normal, b"", ctx={"ctx": "async"})
+        assert isinstance(f, Ice.Future)
+        ok, _ = f.result()
+        test(ok)
+        test(router.lastContext()["ctx"] == "async")
+
+        # Every parameter can be passed by keyword.
+        ok, _ = hello.ice_invoke(
+            operation="ice_ping", mode=Ice.OperationMode.Normal, inParams=b"", ctx={"ctx": "keywords"}
+        )
+        test(ok)
+        test(router.lastContext()["ctx"] == "keywords")
         try:
             hello.raiseUE()
             test(False)
@@ -58,7 +77,7 @@ class Client(TestHelper):
             router = RouterI.RouterI(communicator, False)
             sys.stdout.write("testing async blobject... ")
             sys.stdout.flush()
-            self.allTests(communicator, False)
+            self.allTests(communicator, router, False)
             print("ok")
             router.destroy()
 
@@ -66,6 +85,6 @@ class Client(TestHelper):
             router = RouterI.RouterI(communicator, True)
             sys.stdout.write("testing sync blobject... ")
             sys.stdout.flush()
-            self.allTests(communicator, True)
+            self.allTests(communicator, router, True)
             print("ok")
             router.destroy()

--- a/python/test/Ice/blobject/RouterI.py
+++ b/python/test/Ice/blobject/RouterI.py
@@ -78,11 +78,13 @@ class BlobjectAsyncI(Ice.Blobject):
         self._queue.start()
         self._objects = {}
         self._lock = threading.Lock()
+        self._lastContext: dict[str, str] = {}
 
     @override
     def ice_invoke(self, bytes: bytes, current: Ice.Current) -> Awaitable[tuple[bool, bytes]]:
         f = Ice.Future()
         with self._lock:
+            self._lastContext = dict(current.ctx)
             proxy = self._objects[current.id]
             assert proxy is not None
             self._queue.add(BlobjectCall(proxy, f, bytes, current))
@@ -91,6 +93,10 @@ class BlobjectAsyncI(Ice.Blobject):
     def add(self, proxy: Ice.ObjectPrx):
         with self._lock:
             self._objects[proxy.ice_getIdentity()] = proxy.ice_facet("").ice_twoway().ice_router(None)
+
+    def lastContext(self) -> dict[str, str]:
+        with self._lock:
+            return self._lastContext
 
     def destroy(self):
         with self._lock:
@@ -102,10 +108,12 @@ class BlobjectI(Ice.Blobject):
     def __init__(self):
         self._objects = {}
         self._lock = threading.Lock()
+        self._lastContext: dict[str, str] = {}
 
     @override
     def ice_invoke(self, bytes: bytes, current: Ice.Current) -> tuple[bool, bytes]:
         with self._lock:
+            self._lastContext = dict(current.ctx)
             proxy = self._objects[current.id]
 
         if len(current.facet) > 0:
@@ -123,6 +131,10 @@ class BlobjectI(Ice.Blobject):
     def add(self, proxy: Ice.ObjectPrx):
         with self._lock:
             self._objects[proxy.ice_getIdentity()] = proxy.ice_facet("").ice_twoway().ice_router(None)
+
+    def lastContext(self) -> dict[str, str]:
+        with self._lock:
+            return self._lastContext
 
     def destroy(self):
         pass
@@ -157,6 +169,10 @@ class RouterI(Ice.Router):
         proxy = Ice.RouterPrx.uncheckedCast(self._adapter.addWithUUID(self))
         communicator.setDefaultRouter(proxy)
         self._adapter.activate()
+
+    def lastContext(self) -> dict[str, str]:
+        """Returns the request context of the last invocation this router's blobject received."""
+        return self._blobject.lastContext()
 
     @override
     def getClientProxy(self, current: Ice.Current) -> tuple[Ice.ObjectPrx | None, bool | None]:


### PR DESCRIPTION
Fixes #5887.

`ice_invokeAsync` was registered `METH_VARARGS | METH_KEYWORDS` but its implementation discarded `kwds` and parsed the positional tuple only, so

```python
prx.ice_invokeAsync(op, mode, inParams, ctx={"k": "v"})
```

sent the request **with no context at all** — silently dropping routing hints and session tokens. The synchronous `ice_invoke` was registered `METH_VARARGS`, so the same call raised `TypeError` instead. Both stubs declare a keyword-capable `ctx`, and the slice2py-generated proxies already accept their `context` by keyword.

This threads `kwds` from the proxy methods down to the two blobject invocations, which now parse with `PyArg_ParseTupleAndKeywords` over the keyword names the stubs already publish, and registers `ice_invoke` with `METH_KEYWORDS` so the pair behaves the same. Positional calls parse exactly as before, so the change is purely additive.

These are the first `PyArg_ParseTupleAndKeywords` calls in the extension.

### Testing

The blobject test router now records the context it receives, so a dropped context fails an assertion rather than passing silently. Verified against the unfixed extension:

```
sync  keyword ctx -> TypeError: ObjectPrx.ice_invoke() takes no keyword arguments
async keyword ctx -> delivered {}          <-- silently dropped
```

and after the fix both deliver the context. `Ice/{blobject,ami,operations,proxy,asyncio,adapterDeactivation,servantLocator}` pass; pyright and ruff are clean.