### PR TITLE
Accept any callable in Connection.setCloseCallback

### DIFF
--- a/changelog.d/python/5889.md
+++ b/changelog.d/python/5889.md
@@ -1,0 +1,3 @@
+- Fixed `Connection.setCloseCallback` to accept any callable. It previously rejected everything except plain functions
+  and lambdas, so passing a bound method, a `functools.partial`, a callable instance or a builtin function raised
+  `ValueError`. Passing a non-callable now raises `TypeError`, like the other Ice callback setters.

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -142,15 +142,15 @@ Awaitable[None]
     A future that becomes available when the flush completes.)";
 
     constexpr const char* connectionSetCloseCallback_doc =
-        R"(setCloseCallback(callback: Callable[[Connection], None]) -> None
+        R"(setCloseCallback(callback: Callable[[Connection], None] | None) -> None
 
 Sets a close callback on the connection. The callback is called by the connection when it's closed.
 The callback is called from the Ice thread pool associated with the connection.
 
 Parameters
 ----------
-callback : Callable[[Connection], None]
-    The close callback callable.)";
+callback : Callable[[Connection], None] | None
+    The close callback callable, or None to remove the current callback.)";
 
     constexpr const char* connectionType_doc = R"(type() -> str
 
@@ -598,10 +598,9 @@ connectionSetCloseCallback(ConnectionObject* self, PyObject* args)
         return nullptr;
     }
 
-    PyObject* callbackType = lookupType("types.FunctionType");
-    if (cb != Py_None && !PyObject_IsInstance(cb, callbackType))
+    if (cb != Py_None && !PyCallable_Check(cb))
     {
-        PyErr_Format(PyExc_ValueError, "callback must be None or a function");
+        PyErr_Format(PyExc_TypeError, "callback must be None or a callable");
         return nullptr;
     }
 

--- a/python/python/IcePy-stubs/__init__.pyi
+++ b/python/python/IcePy-stubs/__init__.pyi
@@ -209,15 +209,15 @@ class Connection:
         """
         ...
 
-    def setCloseCallback(self, callback: Callable[[Connection], None]) -> None:
+    def setCloseCallback(self, callback: Callable[[Connection], None] | None) -> None:
         """
         Sets a close callback on the connection. The callback is called by the connection when it's closed.
         The callback is called from the Ice thread pool associated with the connection.
 
         Parameters
         ----------
-        callback : Callable[[Connection], None]
-            The close callback callable.
+        callback : Callable[[Connection], None] | None
+            The close callback callable, or ``None`` to remove the current callback.
         """
         ...
 

--- a/python/test/Ice/ami/AllTests.py
+++ b/python/test/Ice/ami/AllTests.py
@@ -1,5 +1,6 @@
 # Copyright (c) ZeroC, Inc.
 
+import functools
 import random
 import sys
 import threading
@@ -22,6 +23,16 @@ class PingReplyI(Test.PingReply):
 
     def checkReceived(self):
         return self._received
+
+
+class CloseCallbackI:
+    """A close callback that is neither a plain function nor a lambda: a bound method and a callable instance."""
+
+    def closed(self, connection: Ice.Connection) -> None:
+        pass
+
+    def __call__(self, connection: Ice.Connection) -> None:
+        pass
 
 
 class CallbackBase:
@@ -150,6 +161,18 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator, collocated: boo
         p = p.ice_connectionId("CloseGracefully")  # Start with a new connection.
         con = p.ice_getConnection()
         assert con is not None
+
+        # setCloseCallback accepts any callable, and None to clear the callback.
+        con.setCloseCallback(functools.partial(lambda c, x: None, x=1))
+        con.setCloseCallback(CloseCallbackI().closed)  # a bound method
+        con.setCloseCallback(CloseCallbackI())  # a callable instance
+        con.setCloseCallback(None)
+        try:
+            con.setCloseCallback(42)  # type: ignore[arg-type]
+            test(False)
+        except TypeError:
+            pass
+
         cb = CallbackBase()
         con.setCloseCallback(lambda c: cb.called())
         f = p.startDispatchAsync()


### PR DESCRIPTION
Fixes #5889.

> [!IMPORTANT]
> Please merge **after** #5927. Widening the accepted callable types makes a callable instance with a `__del__` a direct trigger for the pre-existing `setCloseCallback` deadlock fixed there (#5926).

`setCloseCallback` gated its argument with an `isinstance` check against `types.FunctionType`, which only plain functions and lambdas satisfy. A bound method — the most natural callback in object-oriented code — plus `functools.partial` objects, callable instances and builtin functions were all rejected with `ValueError`, even though C++ accepts any invocable and the wrapper only ever calls the object.

It now gates with `PyCallable_Check`. This was the **last** `types.FunctionType` check in the extension; every other callback setter (`PropertiesAdmin`, `Executor`, `Thread`, `BatchRequestInterceptor`, `Communicator`, `Types`, `PySliceLoader`) already used `PyCallable_Check`, so the family is finally uniform — including its `TypeError` for a non-callable.

The stub and docstring also omitted the accepted `None`, which clears the callback.

### Compatibility

Widening a type check cannot break a call that previously worked. The only observable change for incorrect code is `ValueError` becoming `TypeError`, which matches the sibling setters; no test or caller depended on it (the suite's only `setCloseCallback` call passes a lambda).

`CloseCallbackWrapper` takes a strong reference via `Py_NewRef`, so accepting temporaries such as bound methods and `functools.partial` objects is safe — but dropping that reference is what exposes #5926, hence the merge order above.

### Testing

`Ice/ami` now asserts that a bound method, a `functools.partial`, a callable instance and `None` are all accepted, and that a non-callable raises `TypeError`. Verified all four forms are rejected with `ValueError` against the unfixed extension.