### PR TITLE
Give the Ice local exceptions their type ID

### DIFF
--- a/changelog.d/python/5886.md
+++ b/changelog.d/python/5886.md
@@ -1,0 +1,3 @@
+- Fixed `ice_id()` on Ice local exceptions, such as `CommunicatorDestroyedException`. It raised `AttributeError`
+  instead of returning the exception's Slice type ID, so generic error-handling and logging code that called it
+  crashed.

--- a/python/python/Ice/LocalException.py
+++ b/python/python/Ice/LocalException.py
@@ -6,7 +6,7 @@ from .Exception import Exception as IceException
 class LocalException(IceException):
     """Base class for all Ice exceptions not defined in Slice."""
 
-    pass
+    _ice_id = "::Ice::LocalException"
 
 
 __all__ = ["LocalException"]

--- a/python/python/Ice/LocalExceptions.py
+++ b/python/python/Ice/LocalExceptions.py
@@ -21,6 +21,8 @@ class DispatchException(LocalException):
     The Ice runtime then logically re-raises this exception to the client.
     """
 
+    _ice_id = "::Ice::DispatchException"
+
     def __init__(self, replyStatus: int | None, msg: str = ""):
         if replyStatus is None or replyStatus <= ReplyStatus.UserException.value or replyStatus > 255:
             raise ValueError("the reply status must fit in a byte and be greater than ReplyStatus.UserException.value")
@@ -56,6 +58,9 @@ class RequestFailedException(DispatchException):
     """
     The base class for the 3 NotExist exceptions.
     """
+
+    # No _ice_id: like its C++ counterpart, this class does not override ice_id, so it reports
+    # "::Ice::DispatchException".
 
     def __init__(
         self, replyStatus: int, id: Identity | None = None, facet: str = "", operation: str = "", msg: str = ""
@@ -108,6 +113,8 @@ class ObjectNotExistException(RequestFailedException):
     The exception that is raised when a dispatch could not find a servant for the identity carried by the request.
     """
 
+    _ice_id = "::Ice::ObjectNotExistException"
+
     def __init__(self, id: Identity | None = None, facet: str = "", operation: str = "", msg: str = ""):
         RequestFailedException.__init__(self, ReplyStatus.ObjectNotExist.value, id, facet, operation, msg)
 
@@ -118,6 +125,8 @@ class FacetNotExistException(RequestFailedException):
     The exception that is raised when a dispatch could not find a servant for the identity + facet carried by the
     request.
     """
+
+    _ice_id = "::Ice::FacetNotExistException"
 
     def __init__(self, id: Identity | None = None, facet: str = "", operation: str = "", msg: str = ""):
         RequestFailedException.__init__(self, ReplyStatus.FacetNotExist.value, id, facet, operation, msg)
@@ -131,6 +140,8 @@ class OperationNotExistException(RequestFailedException):
     definitions newer than the server's.
     """
 
+    _ice_id = "::Ice::OperationNotExistException"
+
     def __init__(self, id: Identity | None = None, facet: str = "", operation: str = "", msg: str = ""):
         RequestFailedException.__init__(self, ReplyStatus.OperationNotExist.value, id, facet, operation, msg)
 
@@ -140,6 +151,8 @@ class UnknownException(DispatchException):
     The exception that is raised when a dispatch failed with an exception that is not a :class:`LocalException` or a
     :class:`UserException`.
     """
+
+    _ice_id = "::Ice::UnknownException"
 
     def __init__(self, msg: str, replyStatus: int = ReplyStatus.UnknownException.value):
         DispatchException.__init__(self, replyStatus, msg)
@@ -152,6 +165,8 @@ class UnknownLocalException(UnknownException):
     :class:`DispatchException`.
     """
 
+    _ice_id = "::Ice::UnknownLocalException"
+
     def __init__(self, msg: str):
         UnknownException.__init__(self, msg, ReplyStatus.UnknownLocalException.value)
 
@@ -162,6 +177,8 @@ class UnknownUserException(UnknownException):
     The exception that is raised when a client receives a :class:`UserException` that was not declared in the
     operation's exception specification.
     """
+
+    _ice_id = "::Ice::UnknownUserException"
 
     def __init__(self, msg: str):
         UnknownException.__init__(self, msg, ReplyStatus.UnknownUserException.value)
@@ -178,6 +195,8 @@ class ProtocolException(LocalException):
     The base class for exceptions related to the Ice protocol.
     """
 
+    _ice_id = "::Ice::ProtocolException"
+
 
 @final
 class CloseConnectionException(ProtocolException):
@@ -188,6 +207,8 @@ class CloseConnectionException(ProtocolException):
     connection again, and the retry limit has been reached, then this exception is propagated to the application code.
     """
 
+    _ice_id = "::Ice::CloseConnectionException"
+
 
 @final
 class DatagramLimitException(ProtocolException):
@@ -196,12 +217,16 @@ class DatagramLimitException(ProtocolException):
     maximum payload size of a UDP packet (65507 bytes).
     """
 
+    _ice_id = "::Ice::DatagramLimitException"
+
 
 @final
 class MarshalException(ProtocolException):
     """
     The exception that is raised when an error occurs during marshaling or unmarshaling.
     """
+
+    _ice_id = "::Ice::MarshalException"
 
 
 #
@@ -215,12 +240,16 @@ class TimeoutException(LocalException):
     The exception that is raised when a timeout occurs. This is the base class for all timeout exceptions.
     """
 
+    _ice_id = "::Ice::TimeoutException"
+
 
 @final
 class ConnectTimeoutException(TimeoutException):
     """
     The exception that is raised when a connection establishment times out.
     """
+
+    _ice_id = "::Ice::ConnectTimeoutException"
 
 
 @final
@@ -229,12 +258,16 @@ class CloseTimeoutException(TimeoutException):
     The exception that is raised when a graceful connection closure times out.
     """
 
+    _ice_id = "::Ice::CloseTimeoutException"
+
 
 @final
 class InvocationTimeoutException(TimeoutException):
     """
     The exception that is raised when an invocation times out.
     """
+
+    _ice_id = "::Ice::InvocationTimeoutException"
 
 
 #
@@ -248,12 +281,16 @@ class SyscallException(LocalException):
     The exception that is raised to report the failure of a system call.
     """
 
+    _ice_id = "::Ice::SyscallException"
+
 
 @final
 class DNSException(SyscallException):
     """
     The exception that is raised to report a DNS resolution failure.
     """
+
+    _ice_id = "::Ice::DNSException"
 
 
 #
@@ -267,11 +304,15 @@ class SocketException(SyscallException):
     The exception that is raised to report a socket error.
     """
 
+    _ice_id = "::Ice::SocketException"
+
 
 class ConnectFailedException(SocketException):
     """
     The exception that is raised when a connection establishment fails.
     """
+
+    _ice_id = "::Ice::ConnectFailedException"
 
 
 @final
@@ -280,12 +321,16 @@ class ConnectionLostException(SocketException):
     The exception that is raised when an established connection is lost.
     """
 
+    _ice_id = "::Ice::ConnectionLostException"
+
 
 @final
 class ConnectionRefusedException(ConnectFailedException):
     """
     The exception that is raised when the server host actively refuses a connection.
     """
+
+    _ice_id = "::Ice::ConnectionRefusedException"
 
 
 #
@@ -299,6 +344,8 @@ class AlreadyRegisteredException(LocalException):
     """
     The exception that is raised when you attempt to register an object more than once with the Ice runtime.
     """
+
+    _ice_id = "::Ice::AlreadyRegisteredException"
 
     def __init__(self, kindOfObject: str, id: str, msg: str):
         LocalException.__init__(self, msg)
@@ -337,12 +384,16 @@ class CommunicatorDestroyedException(LocalException):
     The exception that is raised when an operation fails because the communicator has been destroyed.
     """
 
+    _ice_id = "::Ice::CommunicatorDestroyedException"
+
 
 @final
 class ConnectionAbortedException(LocalException):
     """
     The exception that is raised when an operation fails because the connection has been aborted.
     """
+
+    _ice_id = "::Ice::ConnectionAbortedException"
 
     def __init__(self, closedByApplication: bool, msg: str):
         LocalException.__init__(self, msg)
@@ -359,6 +410,8 @@ class ConnectionClosedException(LocalException):
     The exception that is raised when an operation fails because the connection has been closed gracefully.
     """
 
+    _ice_id = "::Ice::ConnectionClosedException"
+
     def __init__(self, closedByApplication: bool, msg: str):
         LocalException.__init__(self, msg)
         self.__closedByApplication = closedByApplication
@@ -374,12 +427,16 @@ class FeatureNotSupportedException(LocalException):
     The exception that is raised when attempting to use an unsupported feature.
     """
 
+    _ice_id = "::Ice::FeatureNotSupportedException"
+
 
 @final
 class FixedProxyException(LocalException):
     """
     The exception that is raised when attempting to change a connection-related property on a fixed proxy.
     """
+
+    _ice_id = "::Ice::FixedProxyException"
 
 
 @final
@@ -388,11 +445,15 @@ class InitializationException(LocalException):
     The exception that is raised when communicator initialization fails.
     """
 
+    _ice_id = "::Ice::InitializationException"
+
 
 class InvocationCanceledException(LocalException):
     """
     The exception that is raised when an asynchronous invocation fails because it was canceled explicitly by the user.
     """
+
+    _ice_id = "::Ice::InvocationCanceledException"
 
 
 @final
@@ -401,12 +462,16 @@ class NoEndpointException(LocalException):
     The exception that is raised when the Ice runtime cannot find a suitable endpoint to connect to.
     """
 
+    _ice_id = "::Ice::NoEndpointException"
+
 
 @final
 class NotRegisteredException(LocalException):
     """
     The exception that is raised when attempting to find or deregister something that is not registered with Ice.
     """
+
+    _ice_id = "::Ice::NotRegisteredException"
 
     def __init__(self, kindOfObject: str, id: str, msg: str):
         LocalException.__init__(self, msg)
@@ -444,12 +509,16 @@ class ObjectAdapterDeactivatedException(LocalException):
     The exception that is raised when attempting to use an :class:`ObjectAdapter` that has been deactivated.
     """
 
+    _ice_id = "::Ice::ObjectAdapterDeactivatedException"
+
 
 @final
 class ObjectAdapterDestroyedException(LocalException):
     """
     The exception that is raised when attempting to use an :class:`ObjectAdapter` that has been destroyed.
     """
+
+    _ice_id = "::Ice::ObjectAdapterDestroyedException"
 
 
 @final
@@ -459,6 +528,8 @@ class ObjectAdapterIdInUseException(LocalException):
     :class:`Locator` implementation detects another active :class:`ObjectAdapter` with the same adapter ID.
     """
 
+    _ice_id = "::Ice::ObjectAdapterIdInUseException"
+
 
 @final
 class ParseException(LocalException):
@@ -466,12 +537,16 @@ class ParseException(LocalException):
     The exception that is raised when the parsing of a string fails.
     """
 
+    _ice_id = "::Ice::ParseException"
+
 
 @final
 class SecurityException(LocalException):
     """
     The exception that is raised when a failure occurs in the security subsystem. This includes IceSSL errors.
     """
+
+    _ice_id = "::Ice::SecurityException"
 
 
 @final
@@ -482,6 +557,8 @@ class TwowayOnlyException(LocalException):
     specification.
     """
 
+    _ice_id = "::Ice::TwowayOnlyException"
+
 
 @final
 class OnewayOnlyException(LocalException):
@@ -490,6 +567,8 @@ class OnewayOnlyException(LocalException):
     ``["oneway"]`` metadata directive) using a twoway proxy.
     """
 
+    _ice_id = "::Ice::OnewayOnlyException"
+
 
 @final
 class PropertyException(LocalException):
@@ -497,6 +576,8 @@ class PropertyException(LocalException):
     The exception that is raised when a property cannot be set or retrieved.
     For example, this exception is raised when attempting to set an unknown Ice property.
     """
+
+    _ice_id = "::Ice::PropertyException"
 
 
 __all__ = [

--- a/python/test/Ice/exceptions/AllTests.py
+++ b/python/test/Ice/exceptions/AllTests.py
@@ -2,6 +2,7 @@
 
 import array
 import sys
+from collections.abc import Iterator
 from typing import cast, override
 
 from generated.test.Ice.exceptions import Test
@@ -29,7 +30,34 @@ class ServantLocatorI(Ice.ServantLocator):
         pass
 
 
+def localExceptionClasses(cls: type[Ice.LocalException]) -> Iterator[type[Ice.LocalException]]:
+    for subclass in cls.__subclasses__():
+        yield subclass
+        yield from localExceptionClasses(subclass)
+
+
 def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.ThrowerPrx:
+    sys.stdout.write("testing ice_id on local exceptions... ")
+    sys.stdout.flush()
+
+    test(Ice.LocalException("").ice_id() == "::Ice::LocalException")
+    test(Ice.CommunicatorDestroyedException().ice_id() == "::Ice::CommunicatorDestroyedException")
+    test(Ice.ObjectNotExistException().ice_id() == "::Ice::ObjectNotExistException")
+
+    # Every local exception defines its own type ID, "::Ice::" followed by its class name, and reports it from
+    # ice_id(). Checking __dict__ rather than the resolved attribute means a class added later without a type ID
+    # fails here instead of silently inheriting its base's. Construct with __new__ to avoid constructor arguments.
+    for cls in localExceptionClasses(Ice.LocalException):
+        if cls is Ice.RequestFailedException:
+            # The one exception: like its C++ counterpart it does not override ice_id, so it reports its base's ID.
+            test("_ice_id" not in cls.__dict__)
+            test(cls.__new__(cls).ice_id() == "::Ice::DispatchException")
+        else:
+            test(cls.__dict__.get("_ice_id") == f"::Ice::{cls.__name__}")
+            test(cls.__new__(cls).ice_id() == f"::Ice::{cls.__name__}")
+
+    print("ok")
+
     sys.stdout.write("testing servant registration exceptions... ")
     sys.stdout.flush()
     communicator.getProperties().setProperty("TestAdapter1.Endpoints", "tcp -h *")


### PR DESCRIPTION
Fixes #5886.

`Ice.Exception.ice_id()` returns `self._ice_id`, but `Exception.py` only declares `_ice_id` as a class-level annotation, and slice2py emits the assignment for Slice-defined exceptions only. Nothing assigned it for the hand-written local exceptions, so `ice_id()` raised `AttributeError` on every one of them — including the `CommunicatorDestroyedException` the method's own docstring uses as its example.

This assigns `_ice_id` on `Ice.LocalException` and on the 39 classes in `LocalExceptions.py`, using the literal each C++ counterpart returns from `ice_id()`. I extracted the mapping from `cpp/src/Ice/LocalExceptions.cpp` rather than assuming the naming pattern, and confirmed all 41 definitions are exactly `"::Ice::" + <ClassName>`.

`RequestFailedException` deliberately gets **no** assignment: it is the one class in the hierarchy that does not override `ice_id()` in C++ either (verified in `cpp/include/Ice/LocalExceptions.h` — its three concrete subclasses re-declare it `final`, it does not), so it reports `"::Ice::DispatchException"`.

### Wire safety

The IcePy extension never reads `_ice_id`: `convertException` picks the Python class from the **C++** `ice_id()` string, and user-exception marshaling uses the registered `ExceptionInfo` id. So this cannot affect the wire. (`grep _ice_id python/modules/IcePy/` returns nothing.)

### Testing

`Ice/exceptions` walks every `LocalException` subclass and checks each class's **own** `__dict__` entry against `"::Ice::" + name`, rather than the resolved attribute — a class added later without a type ID would otherwise inherit its base's and pass unnoticed. Verified by deleting one assignment: a `startswith("::Ice::")` check passes, this one fails.

C++ `ice_id()` also defines `FileException` and `PluginInitializationException`, which have no Python class; they are left alone rather than invented.