### PR TITLE
Fix incorrect and stale API doc comments in the Java Ice library

### DIFF
--- a/csharp/src/Ice/Value.cs
+++ b/csharp/src/Ice/Value.cs
@@ -44,7 +44,7 @@ public abstract class Value
     /// <summary>
     /// Returns the sliced data associated with this instance.
     /// </summary>
-    /// <returns>The sliced data if this value was sliced during unmarshaling, null otherwise. Unknown slices are
+    /// <returns>The sliced data if this value was sliced during unmarshaling; otherwise null. Unknown slices are
     /// preserved only when the sender uses the sliced format.</returns>
     public SlicedData? ice_getSlicedData() => _slicedData;
 

--- a/csharp/src/Ice/Value.cs
+++ b/csharp/src/Ice/Value.cs
@@ -44,7 +44,7 @@ public abstract class Value
     /// <summary>
     /// Returns the sliced data associated with this instance.
     /// </summary>
-    /// <returns>The sliced data if this value was sliced during unmarshaling; otherwise null. Unknown slices are
+    /// <returns>The sliced data if this value was sliced during unmarshaling, null otherwise. Unknown slices are
     /// preserved only when the sender uses the sliced format.</returns>
     public SlicedData? ice_getSlicedData() => _slicedData;
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -225,7 +225,7 @@ public final class Communicator implements AutoCloseable {
      *     ignored, and any SSL configuration must be done through the SSLEngineFactory. Pass null
      *     if the object adapter does not use secure endpoints, or if the ssl transport is
      *     configured through Ice.SSL configuration properties. Passing null is equivalent to
-     *     calling {@link #createObjectAdapterWithEndpoints(String, String)}.
+     *     calling {@link #createObjectAdapter(String)}.
      * @return the new object adapter
      * @throws IllegalArgumentException if the provided name is empty and sslEngineFactory is non-null
      * @see #createObjectAdapterWithEndpoints

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
@@ -33,7 +33,7 @@ public interface Connection {
      * the default object adapter of an outgoing connection is the communicator's default object adapter.
      *
      * @param adapter the object adapter to associate with this connection
-     * @throws UnsupportedOperationException Thrown when this connection is an incoming connection: you can only call
+     * @throws UnsupportedOperationException if this connection is an incoming connection: you can only call
      *     this method on outgoing (client) connections.
      * @see #getAdapter
      * @see Communicator#setDefaultObjectAdapter

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
@@ -33,6 +33,8 @@ public interface Connection {
      * the default object adapter of an outgoing connection is the communicator's default object adapter.
      *
      * @param adapter the object adapter to associate with this connection
+     * @throws UnsupportedOperationException Thrown when this connection is an incoming connection: you can only call
+     *     this method on outgoing (client) connections.
      * @see #getAdapter
      * @see Communicator#setDefaultObjectAdapter
      */

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InitializationException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InitializationException.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** The exception that is thrown when communicator initialization fails. */
+/** The exception that is thrown when a failure occurs during initialization. */
 public final class InitializationException extends LocalException {
     /**
      * Constructs an InitializationException with a message.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- * Interface to read sequence of bytes encoded using the Slice encoding and recreate the corresponding Slice types.
+ * Reads a sequence of bytes encoded using the Slice encoding and recreates the corresponding Slice types.
  *
  * @see OutputStream
  */

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/ObserverUpdater.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/ObserverUpdater.java
@@ -6,7 +6,7 @@ package com.zeroc.Ice.Instrumentation;
  * The observer updater interface. This interface is implemented by the Ice run-time and an instance of this interface
  * is provided by the Ice communicator on initialization to the {@link CommunicatorObserver} object set with the
  * communicator initialization data. The Ice communicator calls {@link CommunicatorObserver#setObserverUpdater} to
- * provide the observer updater. This interface can be used by add-ins implementing the {@link CommunicatorObserver} =
+ * provide the observer updater. This interface can be used by add-ins implementing the {@link CommunicatorObserver}
  * interface to update the observers of connections and threads.
  */
 public interface ObserverUpdater {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -401,7 +401,7 @@ public final class ObjectAdapter {
      * @param servant the servant to add
      * @param identity the identity of the Ice object that is implemented by the servant
      * @return a proxy for {@code identity}, created by this object adapter
-     * @throws AlreadyRegisteredException if a servant with the same identity is already registered.
+     * @throws AlreadyRegisteredException if a servant with the same identity and default facet is already registered.
      * @see #addFacet
      * @see #addWithUUID
      * @see #remove

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -215,7 +215,7 @@ public interface ObjectPrx {
     /**
      * Gets the per-proxy context for this proxy.
      *
-     * @return the per-proxy context, or {@code null} if the proxy does not have a per-proxy context.
+     * @return A copy of the per-proxy context. The map is empty when this proxy has no per-proxy context.
      */
     Map<String, String> ice_getContext();
 
@@ -580,7 +580,7 @@ public interface ObjectPrx {
 
     /**
      * Determines whether this proxy equals the passed object. Two proxies are equal if they are equal
-     * in all respects, that is, if their object identity, endpoints timeout settings, and so on are all equal.
+     * in all respects, that is, if their object identity, endpoints, timeout settings, and so on are all equal.
      *
      * @param r The object to compare this proxy with.
      * @return {@code true} if this proxy is equal to {@code r}, {@code false} otherwise.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
@@ -25,7 +25,7 @@ import java.util.OptionalLong;
 import java.util.TreeMap;
 
 /**
- * Interface to marshal (write) Slice types into sequence of bytes encoded using the Slice encoding.
+ * Marshals (writes) Slice types into a sequence of bytes encoded using the Slice encoding.
  *
  * @see InputStream
  */
@@ -258,7 +258,7 @@ public final class OutputStream {
         _encapsStack.encoding.ice_writeMembers(this);
     }
 
-    /** Ends the previous encapsulation. */
+    /** Ends the current encapsulation. */
     public void endEncapsulation() {
         assert (_encapsStack != null);
 
@@ -1333,8 +1333,9 @@ public final class OutputStream {
     /**
      * Writes a Slice value to the stream.
      *
-     * @param v The value to write. This method writes the index of an instance; the state of the
-     *     value is written once {@link #writePendingValues} is called.
+     * @param v The value to write. With the 1.0 encoding, this method writes an index and the state of the value is
+     *     marshaled when {@link #writePendingValues} is called; with the 1.1 encoding, the state is marshaled eagerly,
+     *     without waiting for {@link #writePendingValues}.
      */
     public void writeValue(Value v) {
         initEncaps();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManager.java
@@ -7,9 +7,9 @@ public interface PluginManager {
     /**
      * Initializes the configured plug-ins. The communicator automatically initializes the plug-ins by default, but
      * an application may need to interact directly with a plug-in prior to initialization. In this case, the
-     * application must set `Ice.InitPlugins=0` and then invoke `initializePlugins` manually. The plug-ins are
-     * initialized in the order in which they are loaded. If a plug-in throws an exception during initialization,
-     * the communicator calls {@link Plugin#destroy} on the plug-ins that have already been initialized.
+     * application must set {@code Ice.InitPlugins=0} and then invoke {@code initializePlugins} manually. The
+     * plug-ins are initialized in the order in which they are loaded. If a plug-in throws an exception during
+     * initialization, the communicator calls {@link Plugin#destroy} on the plug-ins that have already been initialized.
      *
      * @throws InitializationException if the plug-ins have already been initialized
      */

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIdentityFacetKey.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIdentityFacetKey.java
@@ -3,7 +3,7 @@
 package com.zeroc.Ice;
 
 /**
- * This class wraps a proxy to allow it to be used the key for a hashed collection.
+ * This class wraps a proxy to allow it to be used as the key for a hashed collection.
  * The {@code hashCode} and {@code equals} methods are based on the object identity and facet of the proxy.
  *
  * @see Util#proxyIdentityAndFacetCompare

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIdentityKey.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIdentityKey.java
@@ -3,7 +3,7 @@
 package com.zeroc.Ice;
 
 /**
- * This class wraps a proxy to allow it to be used the key for a hashed collection.
+ * This class wraps a proxy to allow it to be used as the key for a hashed collection.
  * The {@code hashCode} and {@code equals} methods are based on the object identity of the proxy.
  *
  * @see Util#proxyIdentityCompare

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ServantLocator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ServantLocator.java
@@ -68,7 +68,7 @@ public interface ServantLocator {
     void finished(Current curr, Object servant, java.lang.Object cookie) throws UserException;
 
     /**
-     * Notifies this servant locator that the object adapter in which it's installed is being deactivated.
+     * Notifies this servant locator that the object adapter in which it's installed is being destroyed.
      *
      * @param category the category with which this servant locator was registered
      * @see ObjectAdapter#destroy

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceInfo.java
@@ -10,7 +10,7 @@ public final class SliceInfo {
     /** The Slice compact type ID for this slice, or {@code -1} if the slice has no compact ID. */
     public final int compactId;
 
-    /** The encoded bytes for this slice, including the leading size integer. */
+    /** The encoded bytes for this slice. */
     public final byte[] bytes;
 
     /** The class instances referenced by this slice. */

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ToStringMode.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ToStringMode.java
@@ -24,8 +24,8 @@ public enum ToStringMode {
 
     /**
      * Characters with ordinal values greater than 127 are encoded as a sequence of UTF-8 bytes using octal escapes.
-     * Characters with ordinal values 127 and below are encoded as \t, \n (etc.) or an octal escape.
-     * Use this mode to generate strings compatible with Ice 3.6 and earlier.
+     * Non-printable ASCII characters with ordinal values 127 and below are encoded as \t, \n (etc.) or an octal
+     * escape. Use this mode to generate strings compatible with Ice 3.6 and earlier.
      */
     Compat(2);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ToStringMode.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ToStringMode.java
@@ -10,21 +10,21 @@ package com.zeroc.Ice;
 public enum ToStringMode {
     /**
      * Characters with ordinal values greater than 127 are kept as-is in the resulting string.
-     * Non-printable ASCII characters with ordinal values 127 and below are encoded as \\t, \\n
-     * (etc.) or \\unnnn.
+     * Non-printable ASCII characters with ordinal values 127 and below are encoded as \t, \n
+     * (etc.) or &#92;unnnn.
      */
     Unicode(0),
 
     /**
      * Characters with ordinal values greater than 127 are encoded as universal character names in the resulting string:
-     * \\unnnn for BMP characters and \\Unnnnnnnn for non-BMP characters.
-     * Non-printable ASCII characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or \\unnnn.
+     * &#92;unnnn for BMP characters and \Unnnnnnnn for non-BMP characters.
+     * Non-printable ASCII characters with ordinal values 127 and below are encoded as \t, \n (etc.) or &#92;unnnn.
      */
     ASCII(1),
 
     /**
      * Characters with ordinal values greater than 127 are encoded as a sequence of UTF-8 bytes using octal escapes.
-     * Characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or an octal escape.
+     * Characters with ordinal values 127 and below are encoded as \t, \n (etc.) or an octal escape.
      * Use this mode to generate strings compatible with Ice 3.6 and earlier.
      */
     Compat(2);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -149,7 +149,7 @@ public final class Util {
                     slash = pos;
                 } else {
                     // Extra unescaped slash found.
-                    throw new ParseException("unescaped backslash in identity string '" + s + "'");
+                    throw new ParseException("unescaped slash in identity string '" + s + "'");
                 }
             }
             pos++;
@@ -281,10 +281,10 @@ public final class Util {
     }
 
     /**
-     * Gets the per-process logger. This logger is used by all communicators that do not have their own specific logger
-     * configured at the time the communicator is created.
+     * Gets the per-process logger.
      *
      * @return The current per-process logger instance.
+     * @see #setProcessLogger
      */
     public static Logger getProcessLogger() {
         synchronized (_processLoggerMutex) {
@@ -301,8 +301,8 @@ public final class Util {
     }
 
     /**
-     * Sets the per-process logger. This logger is used by all communicators that do not have their own specific logger
-     * configured at the time the communicator is created.
+     * Sets the per-process logger. Communicators created after this call use this logger unless a logger is set in
+     * {@link InitializationData} or configured through logger properties such as {@code Ice.LogFile}.
      *
      * @param logger The new per-process logger instance.
      */

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Value.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Value.java
@@ -48,7 +48,7 @@ public abstract class Value implements Cloneable, Serializable {
     /**
      * Returns the sliced data associated with this instance.
      *
-     * @return The sliced data if this value was sliced during unmarshaling; otherwise {@code null}. Unknown slices are
+     * @return The sliced data if this value was sliced during unmarshaling, {@code null} otherwise. Unknown slices are
      *     preserved only when the sender uses the sliced format.
      */
     public SlicedData ice_getSlicedData() {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Value.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Value.java
@@ -48,8 +48,8 @@ public abstract class Value implements Cloneable, Serializable {
     /**
      * Returns the sliced data associated with this instance.
      *
-     * @return If this value has a preserved-slice base class and has been sliced during unmarshaling, this returns the
-     *     sliced data; otherwise this returns {@code null}.
+     * @return The sliced data if this value was sliced during unmarshaling; otherwise {@code null}. Unknown slices are
+     *     preserved only when the sender uses the sliced format.
      */
     public SlicedData ice_getSlicedData() {
         return _slicedData;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSConnectionInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSConnectionInfo.java
@@ -6,7 +6,10 @@ import java.util.Map;
 
 /** Provides access to the connection details of a WebSocket connection. */
 public final class WSConnectionInfo extends ConnectionInfo {
-    /** The headers from the HTTP upgrade request. */
+    /**
+     * The HTTP headers from the WebSocket upgrade handshake: the request headers for an incoming connection, and the
+     * response headers for an outgoing connection.
+     */
     public final Map<java.lang.String, java.lang.String> headers;
 
     WSConnectionInfo(ConnectionInfo underlying, Map<java.lang.String, java.lang.String> headers) {


### PR DESCRIPTION
Corrects incorrect and stale API doc comments in the **com.zeroc.ice** mapping, mirroring the C++ (#5867) and C#
(#5868) doc fixes. Found by a doc audit that compared each Java javadoc against the implementation and against the
already-merged C++/C# wording. Only the modern com.zeroc.ice mapping is covered (as with the other per-language doc
PRs).

### Incorrect documented behavior

- **`SliceInfo.bytes`** — dropped "including the leading size integer"; the captured bytes exclude the 4-byte slice
  size (re-marshaling via `writeSlicedData` would otherwise double it). **The same doc bug exists in the other
  mappings and is *not* fixed here — follow-up needed:** C++ `cpp/include/Ice/SlicedData.h:33`, C#
  `csharp/src/Ice/SlicedData.cs:18` (the `bytes` param), and JS `js/packages/ice/src/Ice/UnknownSlicedValue.d.ts`.
  Neither #5867 nor #5868 touched it.
- **`ObjectPrx.ice_getContext`** — the returned map is never `null` (a fresh, possibly empty, map).
- **`Util.getProcessLogger`/`setProcessLogger`** — property-configured loggers (`Ice.LogFile`, syslog) take
  precedence, and a default process logger is replaced per communicator, so it is not "used by all communicators
  that do not have their own specific logger".
- **`Communicator.createObjectAdapter(String, SSLEngineFactory)`** — passing `null` is equivalent to
  `createObjectAdapter(String)`, not `createObjectAdapterWithEndpoints(String, String)` (copy-paste).
- **`ServantLocator.deactivate`** — the adapter is being *destroyed*, not deactivated (locators are only notified
  from `ServantManager.destroy` ← `ObjectAdapter.destroy`).
- **`WSConnectionInfo.headers`** — request headers on an incoming connection, response headers on an outgoing one.
- **`Connection.setAdapter`** — documents that it throws `UnsupportedOperationException` on incoming connections.
- **`OutputStream.writeValue`** — the "write an index, defer the state to `writePendingValues`" behavior is 1.0-only;
  the default 1.1 encoding marshals the state eagerly.
- **`Value.ice_getSlicedData`** — dropped the stale 3.7-era "preserved-slice base class" wording; preservation is
  unconditional in the sliced format.
- **`InitializationException`** — broadened "communicator initialization fails" to "a failure occurs during
  initialization" (matches C#; it's also thrown from property/adapter/logger/SSL setup).

### Doc-quality fixes

- `InputStream`/`OutputStream` class summaries no longer call the `final class` an "Interface".
- `OutputStream.endEncapsulation` — "current" (not "previous") encapsulation.
- `ToStringMode` — escape examples render with a single backslash (`\t`, `\unnnn`), not `\\t`.
- `ObjectAdapter.add` — `@throws AlreadyRegisteredException` now says "identity **and default facet**".
- `Instrumentation.ObserverUpdater` — removed a stray `=` that rendered mid-sentence.
- `PluginManager.initializePlugins` — markdown backticks → `{@code}` (they don't render in `/** */` javadoc).
- `ObjectPrx.equals` / `ProxyIdentityKey` / `ProxyIdentityFacetKey` — grammar.
- `Util.stringToIdentity` — the exception message now says "unescaped slash" (it fires on an extra `/`, not a `\`).

### Not included (tracked separately)

- The default-servant facet-fallback **code bug** that the audit reproduced in Java is already fixed cross-mapping by
  #5915 (no doc/code change needed here).
- Coverage-gap `@throws` additions (e.g. `setProperty`, `getDefaultLocator`, `createObjectAdapter`) and the
  Instrumentation "run-time"→"runtime" / "This method is called when…" rephrasing are cross-mapping cleanups left for
  follow-up, to keep this PR consistent with the C++/C# scope.

Full findings: `API_DOC_AUDIT_JAVA-2026-07-09.md` (ice-audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

