### PR TITLE
Reset the oneway subscriber retry counter on a successful send

### DIFF
--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -207,9 +207,15 @@ SubscriberOneway::flush()
             {
                 ++_outstanding;
             }
-            else if (_observer)
+            else
             {
-                _observer->delivered(1);
+                // The event was delivered synchronously, so the subscriber is reachable: reset the
+                // consecutive-retry count as the twoway subscriber does on a successful reply.
+                _currentRetry = 0;
+                if (_observer)
+                {
+                    _observer->delivered(1);
+                }
             }
         }
         catch (const std::exception&)
@@ -233,6 +239,9 @@ SubscriberOneway::sentAsynchronously()
     // Decrement the _outstanding count.
     --_outstanding;
     assert(_outstanding >= 0 && _outstanding < _maxOutstanding);
+    // The event was delivered, so the subscriber is reachable: reset the consecutive-retry count as the
+    // twoway subscriber does on a successful reply.
+    _currentRetry = 0;
     if (_observer)
     {
         _observer->delivered(1);


### PR DESCRIPTION
Oneway and datagram subscribers never reset their consecutive-retry counter on a successful send — only the twoway completion path did — so retries accumulated over the subscription's lifetime and eventually removed healthy subscribers. Reset the counter on a successful oneway send (synchronous delivery in `flush` and the async `sentAsynchronously` path), matching the twoway subscriber.

Split out of #5902 so it can be reviewed and backported on its own.

Fixes #5854
