### PR TITLE
Mark an IceStorm topic destroyed only after its transaction commits

### DIFF
--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -797,7 +797,6 @@ TopicImpl::destroy()
     {
         throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
-    _destroyed = true;
 
     auto traceLevels = _instance->traceLevels();
     if (traceLevels->topic > 0)
@@ -806,9 +805,12 @@ TopicImpl::destroy()
         out << _name << ": destroy";
     }
 
-    // destroyInternal clears out the topic content.
+    // destroyInternal clears out the topic content. Mark the topic destroyed only once its database
+    // transaction has committed, so a failed commit leaves the topic intact and still destroyable.
     LogUpdate llu = {0, 0};
-    _instance->observers()->destroyTopic(destroyInternal(llu, true), _name);
+    LogUpdate destroyLLU = destroyInternal(llu, true);
+    _destroyed = true;
+    _instance->observers()->destroyTopic(destroyLLU, _name);
 
     _observer.detach();
 }


### PR DESCRIPTION
`TopicImpl::destroy` marked the topic destroyed *before* its database transaction committed, so a failed commit left an undestroyable topic that still delivered events. `_destroyed` is now set only after `destroyInternal` commits, so a failed commit leaves the topic intact and still destroyable.

Split out of #5902 so it can be reviewed and backported on its own.

Fixes #5851
