### PR TITLE
Fix incorrect and stale API doc comments in the Swift Ice library

### DIFF
--- a/swift/src/Ice/Communicator.swift
+++ b/swift/src/Ice/Communicator.swift
@@ -26,7 +26,8 @@ public protocol Communicator: AnyObject, Sendable {
     func waitForShutdown()
 
     /// Waits asynchronously until this communicator is shut down.
-    /// If the communicator is already shut down, this call returns immediately.
+    /// The continuation is usually resumed by a dedicated background thread; it can also be resumed by the current
+    /// thread when the shutdown has already completed.
     func shutdownCompleted() async
 
     /// Checks whether or not ``shutdown()`` was called on this communicator.
@@ -53,6 +54,7 @@ public protocol Communicator: AnyObject, Sendable {
     ///
     /// - Parameter property: The base property name.
     /// - Returns: The proxy, or `nil` if the property is not set.
+    /// - Throws: ``ParseException`` if the property value is not a valid proxy string.
     func propertyToProxy(_ property: String) throws -> ObjectPrx?
 
     /// Converts a proxy into a set of proxy properties.
@@ -61,6 +63,7 @@ public protocol Communicator: AnyObject, Sendable {
     ///   - proxy: The proxy.
     ///   - property: The base property name.
     /// - Returns: The property set.
+    /// - Precondition: `proxy` must not be a fixed proxy.
     func proxyToProperty(proxy: ObjectPrx, property: String) -> PropertyDict
 
     /// Converts an identity into a string.

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -280,7 +280,7 @@ final class CommunicatorI: LocalObject<ICECommunicator>, Communicator, @unchecke
 }
 
 extension Communicator {
-    /// Initialize the configured plug-ins. The communicator automatically initializes
+    /// Initializes the configured plug-ins. The communicator automatically initializes
     /// the plug-ins by default, but an application may need to interact directly with
     /// a plug-in prior to initialization. In this case, the application must set
     /// `Ice.InitPlugins=0` and then invoke `initializePlugins` manually. The plug-ins are
@@ -288,8 +288,7 @@ extension Communicator {
     /// during initialization, the communicator invokes destroy on the plug-ins that have
     /// already been initialized.
     ///
-    /// - Throws: Raised if the plug-ins have already been
-    ///           initialized.
+    /// - Throws: ``InitializationException`` if the plug-ins have already been initialized.
     public func initializePlugins() throws {
         try autoreleasepool {
             try (self as! CommunicatorI).handle.initializePlugins()

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -20,7 +20,7 @@ public enum CompressBatch: UInt8 {
 
 /// An `Ice.InputStream` extension to read `CompressBatch` enumerated values from the stream.
 extension InputStream {
-    /// Read an enumerated value.
+    /// Reads an enumerated value.
     ///
     /// - Returns: The enumerated value.
     public func read() throws -> CompressBatch {
@@ -31,7 +31,7 @@ extension InputStream {
         return val
     }
 
-    /// Read an optional enumerated value from the stream.
+    /// Reads an optional enumerated value from the stream.
     ///
     /// - Parameter tag: The numeric tag associated with the value.
     /// - Returns: The enumerated value.
@@ -69,9 +69,8 @@ extension OutputStream {
 public typealias HeaderDict = [String: String]
 
 /// The callback function given to ``Connection/setCloseCallback(_:)``.
-/// This callback is called by the connection when the connection is closed.
-///
-/// - Parameter _: The connection that was closed. It's never `nil`.
+/// This callback is called by the connection when the connection is closed. Its argument is the connection that
+/// was closed; it's never `nil`.
 public typealias CloseCallback = (Connection?) -> Void
 
 /// Represents a connection that uses the Ice protocol.
@@ -81,12 +80,14 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
 
     /// Closes this connection gracefully once all outstanding invocations have completed. If closing the connection
     /// takes longer than the configured close timeout, the connection is aborted with a ``CloseTimeoutException``.
+    /// If the connection was lost or aborted, awaiting the result rethrows the exception that caused the closure.
     func close() async throws
 
     /// Creates a special proxy (a "fixed proxy") that always uses this connection.
     ///
     /// - Parameter id: The identity of the target object.
     /// - Returns: A fixed proxy with the provided identity.
+    /// - Precondition: `id.name` must not be empty.
     func createProxy(_ id: Identity) throws -> ObjectPrx
 
     /// Associates an object adapter with this connection. When a connection receives a request, it dispatches this
@@ -96,6 +97,8 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
     /// the default object adapter of an outgoing connection is the communicator's default object adapter.
     ///
     /// - Parameter adapter: The object adapter to associate with this connection.
+    /// - Throws: A ``LocalException`` when this connection is an incoming connection: you can only call this method
+    ///   on outgoing (client) connections.
     func setAdapter(_ adapter: ObjectAdapter?) throws
 
     /// Gets the object adapter associated with this connection.
@@ -151,7 +154,7 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
     /// Throws an exception that provides the reason for the closure of this connection. For example,
     /// this method throws ``CloseConnectionException`` when the connection was closed gracefully by the peer;
     /// it throws ``ConnectionAbortedException`` when the connection is aborted with ``abort()``.
-    /// This method does nothing if the connection is not yet closed.
+    /// This method does nothing if the connection is not yet closing or closed.
     func throwException() throws
 }
 
@@ -235,7 +238,7 @@ public final class TCPConnectionInfo: IPConnectionInfo {
 
 /// Provides access to the connection details of an SSL connection.
 public final class SSLConnectionInfo: ConnectionInfo {
-    /// The certificate chain.
+    /// The peer certificate, or `nil` if the peer did not provide one.
     public let peerCertificate: SecCertificate?
 
     internal init(underlying: ConnectionInfo, peerCertificate: SecCertificate?) {
@@ -277,7 +280,8 @@ public final class UDPConnectionInfo: IPConnectionInfo {
 
 /// Provides access to the connection details of a WebSocket connection.
 public final class WSConnectionInfo: ConnectionInfo {
-    /// The headers from the HTTP upgrade request.
+    /// The HTTP headers from the WebSocket upgrade handshake: the request headers for an incoming connection,
+    /// and the response headers for an outgoing connection.
     public let headers: HeaderDict
 
     internal init(underlying: ConnectionInfo, headers: HeaderDict) {

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -151,10 +151,11 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
     ///   - sndSize: The size of the send buffer.
     func setBufferSize(rcvSize: Int32, sndSize: Int32) throws
 
-    /// Throws an exception that provides the reason for the closure of this connection. For example,
-    /// this method throws ``CloseConnectionException`` when the connection was closed gracefully by the peer;
-    /// it throws ``ConnectionAbortedException`` when the connection is aborted with ``abort()``.
+    /// Throws an exception that provides the reason for the closure of this connection.
     /// This method does nothing if the connection is not yet closing or closed.
+    ///
+    /// - Throws: ``CloseConnectionException`` when the connection was closed gracefully by the peer;
+    ///   ``ConnectionAbortedException`` when the connection was aborted, for example with ``abort()``.
     func throwException() throws
 }
 

--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -8,7 +8,7 @@ public struct CtrlCHandler {
     private let handle = ICECtrlCHandler()
 
     /// Creates a CtrlCHandler. Only one instance of this struct can exist in a program at any point in time.
-    /// This instance must be created before starting any thread.
+    /// This instance must be created before starting any thread. Creating a second instance terminates the program.
     public init() {}
 
     /// Sets the signal callback. If there was a previous callback, it is replaced.

--- a/swift/src/Ice/Endpoint.swift
+++ b/swift/src/Ice/Endpoint.swift
@@ -12,7 +12,7 @@ public protocol Endpoint: AnyObject, CustomStringConvertible {
 
     /// Returns this endpoint's information.
     ///
-    /// - Returns: This endpoint's information class.
+    /// - Returns: The endpoint information, or `nil` when no information class is available for this endpoint type.
     func getInfo() -> EndpointInfo?
 }
 
@@ -20,7 +20,7 @@ public typealias EndpointSeq = [Endpoint]
 
 /// Base class for the endpoint info classes.
 open class EndpointInfo {
-    /// The information of the underlying endpoint or nil if there's no underlying endpoint.
+    /// The information of the underlying endpoint or `nil` if there's no underlying endpoint.
     public let underlying: EndpointInfo?
 
     /// Specifies whether or not compression should be used if available when using this endpoint.

--- a/swift/src/Ice/EndpointI.swift
+++ b/swift/src/Ice/EndpointI.swift
@@ -17,10 +17,12 @@ final class EndpointI: LocalObject<ICEEndpoint>, Endpoint {
     }
 }
 
+/// Returns `true` when the two endpoints are not equal (the negation of `==`), `false` otherwise.
 public func != (lhs: Endpoint?, rhs: Endpoint?) -> Bool {
     return !(lhs == rhs)
 }
 
+/// Returns `true` when the two endpoints are equal (same transport, parameters, and address), `false` otherwise.
 public func == (lhs: Endpoint?, rhs: Endpoint?) -> Bool {
     if lhs === rhs {
         return true

--- a/swift/src/Ice/EndpointSelectionType.swift
+++ b/swift/src/Ice/EndpointSelectionType.swift
@@ -17,7 +17,7 @@ public enum EndpointSelectionType: UInt8 {
 
 /// An `Ice.InputStream` extension to read `EndpointSelectionType` enumerated values from the stream.
 extension InputStream {
-    /// Read an enumerated value.
+    /// Reads an enumerated value.
     ///
     /// - Returns: The enumerated value.
     public func read() throws -> EndpointSelectionType {
@@ -28,7 +28,7 @@ extension InputStream {
         return val
     }
 
-    /// Read an optional enumerated value from the stream.
+    /// Reads an optional enumerated value from the stream.
     ///
     /// - Parameter tag: The numeric tag associated with the value.
     /// - Returns: The enumerated value.

--- a/swift/src/Ice/ImplicitContext.swift
+++ b/swift/src/Ice/ImplicitContext.swift
@@ -39,13 +39,13 @@ public protocol ImplicitContext: AnyObject {
     /// - Parameters:
     ///   - key: The key.
     ///   - value: The value.
-    /// - Returns: The previous value associated with the key, if any.
+    /// - Returns: The previous value associated with the key, or the empty string if the key had no previous value.
     @discardableResult
     func put(key: String, value: String) -> String
 
     /// Removes the entry for the specified key in the request context.
     ///
     /// - Parameter key: The key.
-    /// - Returns: The value associated with the key, if any.
+    /// - Returns: The value associated with the key, or the empty string if the key was not present.
     func remove(_ key: String) -> String
 }

--- a/swift/src/Ice/IncomingRequest.swift
+++ b/swift/src/Ice/IncomingRequest.swift
@@ -13,7 +13,7 @@ public struct IncomingRequest {
     /// - Parameters:
     ///   - current: The Current object for the request.
     ///   - inputStream: The input stream buffer over the incoming Ice protocol request message. The stream is
-    ///   positioned at the beginning of the request header - the next data to read is the identity of the target.
+    ///   positioned at the beginning of the encapsulation carrying the in-parameters.
     public init(current: Current, inputStream: InputStream) {
         self.current = current
         self.inputStream = inputStream

--- a/swift/src/Ice/Initialize.swift
+++ b/swift/src/Ice/Initialize.swift
@@ -115,7 +115,9 @@ public func createProperties() -> Properties {
     return PropertiesI(handle: ICEUtil.createProperties())
 }
 
-/// Creates a property set initialized from an argument array.
+/// Creates a property set initialized from an argument array. This function loads configuration files named by the
+/// `Ice.Config` property set through `args` or, when no `Ice.Config` property is set at all, by the `ICE_CONFIG`
+/// environment variable.
 ///
 /// - Parameters:
 ///   - args: A command-line argument array, possibly containing options to set properties. If the
@@ -137,7 +139,9 @@ public func createProperties(_ args: [String], defaults: Properties? = nil) thro
     }
 }
 
-/// Creates a property set initialized from an argument array.
+/// Creates a property set initialized from an argument array. This function loads configuration files named by the
+/// `Ice.Config` property set through `args` or, when no `Ice.Config` property is set at all, by the `ICE_CONFIG`
+/// environment variable.
 ///
 /// - Parameters:
 ///   - args: A command-line argument array, possibly containing options to set properties. If the
@@ -167,23 +171,28 @@ public func createProperties(_ args: inout [String], defaults: Properties? = nil
     }
 }
 
-/// Returns the Ice version as an integer in the form AABBCC, where AA
-/// indicates the major version, BB indicates the minor version, and CC
-/// indicates the patch level. For example, for Ice 3.9.1, the returned
-/// value is 30901.
+/// The Ice version as an integer in the form AABBCC, where AA indicates the major version, BB indicates the minor
+/// version, and CC indicates the patch level. For example, for Ice 3.9.1, the value is 30901.
+/// For pre-releases, CC encodes the pre-release instead of the patch version. For example, for Ice 3.9.0-alpha.0
+/// the value is 30950.
 public let intVersion: Int = 30950
 
-/// The Ice version in the form A.B.C, where A indicates the major version,
-/// B indicates the minor version, and C indicates the patch level.
+/// The Ice version in the form `A.B.C`, where A indicates the major version, B indicates the minor version, and C
+/// indicates the patch level, with an optional pre-release suffix, e.g. `3.9.0-alpha.0`.
 public let stringVersion: String = "3.9.0-alpha.0"
 
+/// Identifies encoding version 1.0.
 public let Encoding_1_0 = EncodingVersion(major: 1, minor: 0)
+
+/// Identifies encoding version 1.1.
 public let Encoding_1_1 = EncodingVersion(major: 1, minor: 1)
 
 /// Converts a stringified identity into an `Identity`.
 ///
 /// - Parameter string: The stringified identity.
 /// - Returns: An `Identity` containing the name and category components.
+/// - Throws: ``ParseException`` if `string` cannot be converted to an identity; a ``LocalException`` if the
+///   identity has an empty name.
 public func stringToIdentity(_ string: String) throws -> Identity {
     guard factoriesRegistered else {
         fatalError("Unable to initialize Ice")
@@ -202,6 +211,7 @@ public func stringToIdentity(_ string: String) throws -> Identity {
 ///   - id: The object identity to convert.
 ///   - mode: Specifies how to handle non-ASCII characters and non-printable ASCII characters.
 /// - Returns: The stringified identity.
+/// - Precondition: `id.name` must not be empty.
 public func identityToString(id: Identity, mode: ToStringMode = .Unicode) -> String {
     precondition(!id.name.isEmpty, "Invalid identity with an empty name")
     return ICEUtil.identityToString(name: id.name, category: id.category, mode: mode.rawValue)

--- a/swift/src/Ice/Initialize.swift
+++ b/swift/src/Ice/Initialize.swift
@@ -116,8 +116,8 @@ public func createProperties() -> Properties {
 }
 
 /// Creates a property set initialized from an argument array. This function loads configuration files named by the
-/// `Ice.Config` property set through `args` or, when no `Ice.Config` property is set at all, by the `ICE_CONFIG`
-/// environment variable.
+/// `Ice.Config` property set through `args`, or by the `ICE_CONFIG` environment variable when `Ice.Config` is not
+/// set, is empty, or is set to `1` (the value a bare `--Ice.Config` option becomes).
 ///
 /// - Parameters:
 ///   - args: A command-line argument array, possibly containing options to set properties. If the
@@ -140,8 +140,8 @@ public func createProperties(_ args: [String], defaults: Properties? = nil) thro
 }
 
 /// Creates a property set initialized from an argument array. This function loads configuration files named by the
-/// `Ice.Config` property set through `args` or, when no `Ice.Config` property is set at all, by the `ICE_CONFIG`
-/// environment variable.
+/// `Ice.Config` property set through `args`, or by the `ICE_CONFIG` environment variable when `Ice.Config` is not
+/// set, is empty, or is set to `1` (the value a bare `--Ice.Config` option becomes).
 ///
 /// - Parameters:
 ///   - args: A command-line argument array, possibly containing options to set properties. If the

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -48,7 +48,8 @@ public final class InputStream {
         acceptClassCycles = (communicator as! CommunicatorI).acceptClassCycles
     }
 
-    /// Reads an encapsulation from the stream.
+    /// Reads an encapsulation from the stream. The stream position is not advanced past the encapsulation; the
+    /// returned data includes the 6-byte encapsulation header.
     ///
     /// - Returns: The encapsulation.
     public func readEncapsulation() throws -> (bytes: Data, encoding: EncodingVersion) {
@@ -101,7 +102,7 @@ public final class InputStream {
         return encoding
     }
 
-    /// Ends the previous encapsulation.
+    /// Ends the current encapsulation.
     public func endEncapsulation() throws {
         if !encaps.encoding_1_0 {
             try skipOptionals()
@@ -175,9 +176,10 @@ public final class InputStream {
     }
 
     /// Indicates that unmarshaling is complete, except for any class instances. The application must call this method
-    /// only if the stream actually contains class instances. Calling `readPendingValues` triggers the
-    /// calls to consumers provided with {@link #readValue} to inform the application that unmarshaling of an instance
-    /// is complete.
+    /// only if the stream actually contains class instances. With the 1.0 encoding, calling `readPendingValues`
+    /// triggers the calls to consumers provided to the class-read methods (`read(cb:)` and `read(_:cb:)`) to inform
+    /// the application that unmarshaling of an instance is complete; with the 1.1 encoding, the consumers are called
+    /// while the instance is read and this method does nothing.
     public func readPendingValues() throws {
         if encaps.decoder != nil {
             try encaps.decoder.readPendingValues()
@@ -294,7 +296,8 @@ public final class InputStream {
 
     /// Marks the end of a class instance.
     ///
-    /// - Returns: A SlicedData object containing the preserved slices for unknown types.
+    /// - Returns: A SlicedData object containing the preserved slices for unknown types, or `nil` when the instance
+    ///   has no preserved slices.
     @discardableResult
     public func endValue() throws -> SlicedData? {
         precondition(encaps.decoder != nil)

--- a/swift/src/Ice/LocalExceptions.swift
+++ b/swift/src/Ice/LocalExceptions.swift
@@ -20,7 +20,7 @@ public class DispatchException: LocalException, @unchecked Sendable {
     ///   - message: The exception message.
     ///   - file: The file where the exception was thrown.
     ///   - line: The line where the exception was thrown.
-    /// - Precondition: `replyStatus` must be greater than `ReplyStatus.userException.rawValue`.
+    /// - Precondition: `replyStatus` must be greater than `ReplyStatus.userException`.
     public init(
         replyStatus: UInt8, message: String? = nil, file: String = #fileID, line: Int32 = #line
     ) {

--- a/swift/src/Ice/LocalExceptions.swift
+++ b/swift/src/Ice/LocalExceptions.swift
@@ -16,10 +16,11 @@ public class DispatchException: LocalException, @unchecked Sendable {
     /// Creates a DispatchException.
     ///
     /// - Parameters:
-    ///   - replyStatus: The reply status raw value. It may not correspond to a valid ``ReplyStatus`` enum value.
+    ///   - replyStatus: The reply status raw value.
     ///   - message: The exception message.
     ///   - file: The file where the exception was thrown.
     ///   - line: The line where the exception was thrown.
+    /// - Precondition: `replyStatus` must be greater than `ReplyStatus.userException.rawValue`.
     public init(
         replyStatus: UInt8, message: String? = nil, file: String = #fileID, line: Int32 = #line
     ) {
@@ -279,12 +280,10 @@ public final class ConnectionLostException: SocketException, @unchecked Sendable
 // Other leaf local exceptions in alphabetical order.
 //
 
-/// An attempt was made to register something more than once with the Ice run time. This exception is thrown if an
-/// attempt is made to register a servant, servant locator, facet,  plug-in, or object adapter more than once for the
-// same ID.
+/// The exception that is thrown when you attempt to register an object more than once with the Ice runtime.
 public final class AlreadyRegisteredException: LocalException, @unchecked Sendable {
-    /// The kind of object that could not be removed: "servant", "facet", "object", "default servant",
-    /// "servant locator", "plugin", "object adapter", "object adapter with router", "replica group".
+    /// The kind of object that is already registered: "servant", "facet", "default servant",
+    /// "servant locator", "plugin", "object adapter", "object adapter with router".
     public let kindOfObject: String
 
     /// The ID (or name) of the object that is registered already.

--- a/swift/src/Ice/NativePropertiesAdmin.swift
+++ b/swift/src/Ice/NativePropertiesAdmin.swift
@@ -2,11 +2,9 @@
 
 import IceImpl
 
-/// Closure called when the communicator's properties have been updated.
-///
-/// - Parameter: `PropertyDict` A dictionary containing the properties that were added,
-///   changed, or removed. Removed properties are denoted by an entry whose value is an
-///   empty string.
+/// A callback invoked when the communicator's properties are updated; it receives a `PropertyDict` containing the
+/// properties that were added, changed, or removed. Removed properties are denoted by an entry whose value is an
+/// empty string.
 public typealias PropertiesAdminUpdateCallback = (PropertyDict) -> Void
 
 /// Closure used to remove a ``PropertiesAdminUpdateCallback``.

--- a/swift/src/Ice/ObjectAdapter.swift
+++ b/swift/src/Ice/ObjectAdapter.swift
@@ -65,7 +65,7 @@ public protocol ObjectAdapter: AnyObject, Sendable {
 
     /// Adds a middleware to the dispatch pipeline of this object adapter.
     /// Middleware are executed in the order they are added.
-    /// All middleware must be installed before the first dispatch and execute in the order they are installed.
+    /// All middleware must be installed before the first dispatch.
     ///
     /// - Parameter middlewareFactory: The middleware factory that creates the new middleware when this object adapter
     ///   creates its dispatch pipeline. A middleware factory is a function that takes a dispatcher (the next element
@@ -103,16 +103,18 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     ///
     /// - Parameter servant: The servant to add.
     /// - Returns: A proxy with the generated UUID identity created by this object adapter.
+    /// - Throws: `ObjectAdapterDestroyedException` when the object adapter has been destroyed.
     @discardableResult
     func addWithUUID(_ servant: Dispatcher) throws -> ObjectPrx
 
     /// Adds a servant to this object adapter's Active Servant Map (ASM), using an automatically generated UUID as its
-    /// identity.  Also specifies a facet.
+    /// identity. Also specifies a facet.
     ///
     /// - Parameters:
     ///   - servant: The servant to add.
     ///   - facet: The facet of the Ice object that is implemented by the servant.
     /// - Returns: A proxy with the generated UUID identity and specified facet created by this object adapter.
+    /// - Throws: `ObjectAdapterDestroyedException` when the object adapter has been destroyed.
     @discardableResult
     func addFacetWithUUID(servant: Dispatcher, facet: String) throws -> ObjectPrx
 
@@ -196,14 +198,14 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     func findAllFacets(_ id: Identity) -> FacetMap
 
     /// Looks up a servant in this object adapter's Active Servant Map or among the default servants, given a proxy.
-    /// This operation does not attempt to locate a servant using servant locators.
+    /// This method does not attempt to locate a servant using servant locators.
     ///
     /// - Parameter proxy: The proxy that provides the identity and facet to search.
     /// - Returns: The servant that matches the identity and facet carried by `proxy`,
     ///   or nil if no such servant has been found.
     func findByProxy(_ proxy: ObjectPrx) -> Dispatcher?
 
-    /// Adds a ``ServantLocator``` to this object adapter for a specific category.
+    /// Adds a ``ServantLocator`` to this object adapter for a specific category.
     ///
     /// - Parameters:
     ///   - locator: The servant locator to add.

--- a/swift/src/Ice/OptionalFormat.swift
+++ b/swift/src/Ice/OptionalFormat.swift
@@ -23,7 +23,7 @@ public enum OptionalFormat: UInt8 {
     case VSize = 5
 
     /// Fixed "size encoding" using 4 bytes followed by data.
-    /// Used by variable-size structs and containers whose sizes can't be computed prior to unmarshaling.
+    /// Used by variable-size structs and containers whose sizes can't be computed prior to marshaling.
     case FSize = 6
 
     /// Class instance. No longer supported.

--- a/swift/src/Ice/OutgoingResponse.swift
+++ b/swift/src/Ice/OutgoingResponse.swift
@@ -6,7 +6,7 @@ import Foundation
 public struct OutgoingResponse {
     /// The exception ID of the response.
     /// It's nil when ``replyStatus`` is `ok` or `userException`. Otherwise, this ID is the value returned by `ice_id` for
-    /// Ice local exceptions. For other exceptions, this ID is the full name of the exception's type.
+    /// Ice local exceptions. For other errors, this ID is the name of the error's type.
     public let exceptionId: String?
 
     /// The full details of the exception marshaled into the response.

--- a/swift/src/Ice/OutputStream.swift
+++ b/swift/src/Ice/OutputStream.swift
@@ -44,16 +44,18 @@ public final class OutputStream {
         self.init(encoding: encoding, format: defaultsAndOverrides.defaultFormat)
     }
 
-    /// Writes the start of an encapsulation to the stream.
+    /// Writes the start of an encapsulation to the stream. A stream supports a single encapsulation: starting a
+    /// second encapsulation, nested or sequential, is a programming error (precondition failure).
     public func startEncapsulation() {
         startEncapsulation(encoding: encoding, format: nil)
     }
 
-    /// Writes the start of an encapsulation to the stream.
+    /// Writes the start of an encapsulation to the stream. A stream supports a single encapsulation: starting a
+    /// second encapsulation, nested or sequential, is a programming error (precondition failure).
     ///
     /// - Parameters:
     ///   - encoding: The encoding version of the encapsulation.
-    ///   - format: Specify the compact or sliced format.
+    ///   - format: Specify the compact or sliced format. When `nil`, the stream's default class format is used.
     public func startEncapsulation(encoding: EncodingVersion, format: FormatType?) {
         precondition(encaps == nil, "Nested or sequential encapsulations are not supported")
         encaps = Encaps(encoding: encoding, format: format, start: data.count)
@@ -61,7 +63,7 @@ public final class OutputStream {
         write(encaps.encoding)
     }
 
-    /// Ends the previous encapsulation.
+    /// Ends the current encapsulation.
     public func endEncapsulation() {
         // Size includes size and version.
         let start = encaps.start
@@ -101,7 +103,8 @@ public final class OutputStream {
 
     /// Marks the start of a class instance.
     ///
-    /// - Parameter data: Preserved slices for this instance, or nil.
+    /// - Parameter data: Preserved slices for this instance, or nil. These slices are marshaled with the instance
+    ///   only when this stream uses the sliced format; otherwise they are ignored.
     public func startValue(data: SlicedData?) {
         precondition(encaps.encoder != nil)
         encaps.encoder.startInstance(type: .ValueSlice, data: data)
@@ -142,7 +145,8 @@ public final class OutputStream {
         }
     }
 
-    /// Writes the state of Slice classes whose index was previously written with writeValue() to the stream.
+    /// Encodes the state of class instances whose insertion was delayed by a previous call to `write(_ v: Value?)`.
+    /// This method must be called only once; with the 1.1 encoding it does nothing (the state is marshaled eagerly).
     public func writePendingValues() {
         if encaps != nil, encaps.encoder != nil {
             encaps.encoder.writePendingValues()
@@ -444,7 +448,7 @@ extension OutputStream {
         data.append(bytes)
     }
 
-    /// Writes a string to the stream.
+    /// Writes an optional string to the stream.
     ///
     /// - Parameters:
     ///   - tag: The tag of the optional field or parameter.

--- a/swift/src/Ice/Properties.swift
+++ b/swift/src/Ice/Properties.swift
@@ -5,6 +5,8 @@ import Foundation
 /// Represents a set of properties used to configure Ice and Ice-based applications. A property is a key/value pair,
 /// where both the key and the value are strings. By convention, property keys should have the form
 /// `application-name[.category[.sub-category]].name`.
+///
+/// This protocol is thread-safe: multiple threads can safely read and write the properties.
 public protocol Properties: AnyObject {
     /// Gets a property by key.
     ///
@@ -16,7 +18,7 @@ public protocol Properties: AnyObject {
     ///
     /// - Parameter key: The property key.
     /// - Returns: The property value, or the default value for this property if the property is not set.
-    /// - Throws: ``PropertyException`` when the property is not a known Ice property.
+    /// - Note: Using a key that is not a known Ice property terminates the program.
     func getIceProperty(_ key: String) -> String
 
     /// Gets a property by key.
@@ -68,7 +70,7 @@ public protocol Properties: AnyObject {
     /// - Parameter key: The property key.
     /// - Returns: The property value interpreted as a list of strings, or the default value if the property is not
     ///   set.
-    /// - Throws: `PropertyException` when the property is not a known Ice property.
+    /// - Note: Using a key that is not a known Ice property terminates the program.
     func getIcePropertyAsList(_ key: String) -> StringSeq
 
     /// Gets a property as a list of strings. The strings must be separated by whitespace or comma. The strings in
@@ -94,6 +96,7 @@ public protocol Properties: AnyObject {
     /// - Parameters:
     ///   - key: The property key.
     ///   - value: The property value.
+    /// - Note: Setting an unknown property in a reserved Ice prefix (`Ice`, `IceSSL`, etc.) terminates the program.
     func setProperty(key: String, value: String)
 
     /// Gets a sequence of command-line options that is equivalent to this property set. Each element of the returned

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -80,7 +80,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject, Sendable {
 
     /// Gets the invocation timeout of this proxy.
     ///
-    /// - Returns: The invocation timeout value.
+    /// - Returns: The invocation timeout value (in milliseconds).
     func ice_getInvocationTimeout() -> Int32
 
     /// Creates a proxy that is identical to this proxy, except for the invocation timeout.
@@ -292,7 +292,8 @@ public func checkedCast(
 ///   - prx: The source proxy.
 ///   - type: The type of the new proxy.
 ///   - facet: The optional facet for the new proxy.
-/// - Returns: A new proxy with the specified facet.
+/// - Returns: A proxy with the requested type and, when `facet` is provided, the specified facet. This is a purely
+///   local operation.
 public func uncheckedCast(
     prx: Ice.ObjectPrx,
     type _: ObjectPrx.Protocol,
@@ -308,10 +309,14 @@ public func ice_staticId(_: ObjectPrx.Protocol) -> String {
     return ObjectTraits.staticId
 }
 
+/// Returns `true` when the two proxies do not have identical settings (identity, facet, endpoints, context, and
+/// all other proxy options), `false` otherwise.
 public func != (lhs: ObjectPrx?, rhs: ObjectPrx?) -> Bool {
     return !(lhs == rhs)
 }
 
+/// Returns `true` when the two proxies have identical settings (identity, facet, endpoints, context, and all other
+/// proxy options), `false` otherwise.
 public func == (lhs: ObjectPrx?, rhs: ObjectPrx?) -> Bool {
     if lhs === rhs {
         return true
@@ -332,7 +337,7 @@ extension ObjectPrx {
         return self as! ObjectPrxI
     }
 
-    /// Sends ping request to the target object.
+    /// Tests whether the target object of this proxy can be reached.
     ///
     /// - Parameter context: The optional context dictionary for the invocation.
     public func ice_ping(context: Context? = nil) async throws {
@@ -347,7 +352,8 @@ extension ObjectPrx {
     /// - Parameters:
     ///   - id: The type ID of the Slice interface to test against.
     ///   - context: The optional context dictionary for the invocation.
-    /// - Returns: The result of the invocation.
+    /// - Returns: `true` if the target object implements the Slice interface specified by `id` or implements a
+    ///   derived interface, `false` otherwise.
     public func ice_isA(id: String, context: Context? = nil) async throws -> Bool {
         return try await _impl._invoke(
             operation: "ice_isA",
@@ -362,7 +368,7 @@ extension ObjectPrx {
     /// Returns the Slice type ID of the most-derived interface supported by the target object of this proxy.
     ///
     /// - Parameter context: The optional context dictionary for the invocation.
-    /// - Returns: `String` The result of the invocation.
+    /// - Returns: The Slice type ID of the most-derived interface supported by the target object.
     public func ice_id(context: Context? = nil) async throws -> String {
         return try await _impl._invoke(
             operation: "ice_id",
@@ -374,7 +380,7 @@ extension ObjectPrx {
     /// Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
     ///
     /// - Parameter context: The optional context dictionary for the invocation.
-    /// - Returns: The result of the invocation.
+    /// - Returns: The Slice type IDs of the interfaces supported by the target object, in alphabetical order.
     public func ice_ids(context: Context? = nil) async throws -> StringSeq {
         return try await _impl._invoke(
             operation: "ice_ids",
@@ -390,7 +396,9 @@ extension ObjectPrx {
     ///   - mode: The operation mode (normal or idempotent).
     ///   - inEncaps: The encoded in-parameters for the operation.
     ///   - context: The context dictionary for the invocation.
-    /// - Returns: The result of the invocation.
+    /// - Returns: `ok` is `true` if the operation completed successfully, `false` if it completed with a user
+    ///   exception; `outEncaps` contains the encoded results (or the encoded user exception when `ok` is false).
+    ///   For oneway and batch proxies, `ok` is always `true` and `outEncaps` is empty.
     public func ice_invoke(
         operation: String,
         mode: OperationMode,
@@ -453,7 +461,8 @@ extension ObjectPrx {
     /// Returns the connection for this proxy. If the proxy does not yet have an established connection,
     /// it first attempts to create a connection.
     ///
-    /// - Returns: The result of the invocation.
+    /// - Returns: The connection for this proxy, or `nil` when the proxy uses collocation optimization and
+    ///   communicates with a collocated object adapter.
     public func ice_getConnection() async throws -> Connection? {
         return try await withCheckedThrowingContinuation { continuation in
             self._impl.handle.ice_getConnection(

--- a/swift/src/Ice/ServantLocator.swift
+++ b/swift/src/Ice/ServantLocator.swift
@@ -35,7 +35,7 @@ public protocol ServantLocator: Sendable {
     ///   an exception, the exception thrown by `finished` prevails and is marshaled back to the client.
     func finished(curr: Current, servant: Dispatcher, cookie: AnyObject?) throws
 
-    /// Notifies this servant locator that the object adapter in which it's installed is being deactivated.
+    /// Notifies this servant locator that the object adapter in which it's installed is being destroyed.
     ///
     /// - Parameter category: The category with which this servant locator was registered.
     func deactivate(_ category: String)

--- a/swift/src/Ice/SliceInfo.swift
+++ b/swift/src/Ice/SliceInfo.swift
@@ -10,7 +10,7 @@ public struct SliceInfo {
     /// The Slice compact type ID for this slice, or `-1` if the slice has no compact ID.
     public let compactId: Int32
 
-    /// The encoded bytes for this slice, including the leading size integer.
+    /// The encoded bytes for this slice, excluding the slice header.
     public let bytes: Data
 
     /// The class instances referenced by this slice.

--- a/swift/src/Ice/ToStringMode.swift
+++ b/swift/src/Ice/ToStringMode.swift
@@ -16,8 +16,8 @@ public enum ToStringMode: UInt8 {
     case ASCII = 1
 
     /// Characters with ordinal values greater than 127 are encoded as a sequence of UTF-8 bytes using octal escapes.
-    /// Characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or an octal escape. Use this mode
-    /// to generate strings compatible with Ice 3.6 and earlier.
+    /// Non-printable ASCII characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or an octal
+    /// escape. Use this mode to generate strings compatible with Ice 3.6 and earlier.
     case Compat = 2
 
     public init() {

--- a/swift/src/Ice/Value.swift
+++ b/swift/src/Ice/Value.swift
@@ -30,8 +30,8 @@ open class Value {
 
     /// Gets the sliced data associated with this instance.
     ///
-    /// - Returns: The sliced data if the value has a preserved-slice base class and has been sliced during
-    /// unmarshaling of the value, `nil` otherwise.
+    /// - Returns: The sliced data if this value was sliced during unmarshaling, `nil` otherwise. Unknown slices
+    /// are preserved only when the sender uses the sliced format.
     open func ice_getSlicedData() -> SlicedData? {
         return slicedData
     }


### PR DESCRIPTION
Fixes incorrect and stale DocC comments in the Swift Ice library, found during the Swift API doc review (follow-up to #5867/#5868/#5883/#5893). Documentation-only — no declaration or code changes; the runtime bugs found by the same review are tracked in #5936-#5938 and deliberately not fixed here.

Incorrect claims corrected (many are the same stale pre-#5867 patterns fixed in the other mappings):

- `Communicator.shutdownCompleted()` — "returns immediately when already shut down" replaced with the corrected resumption-threading wording; `ServantLocator.deactivate` is called on adapter *destroy*; WS `headers` are the *response* headers on outgoing connections; `Connection.throwException` also throws while *closing*; `setAdapter` documents the `LocalException` on incoming connections; `SSLConnectionInfo.peerCertificate` is a single peer certificate (the `nil` wording documents the field's contract — the currently-impossible nil crossing is bug #5936); `ToStringMode.Compat` escapes only *non-printable* ASCII; `OptionalFormat.FSize` "prior to marshaling"; `endEncapsulation` ends the *current* encapsulation (both streams); `writePendingValues`/`readPendingValues` describe the 1.0-only deferral and reference the real Swift APIs (the old text pointed at a nonexistent `writeValue()` and a Javadoc `{@link #readValue}`); `ice_getSlicedData` drops the stale "preserved-slice base class"; `SliceInfo.bytes` excludes the slice header; `IncomingRequest` is positioned at the in-parameters encapsulation (the old sentence was a C# copy-paste); `OutgoingResponse.exceptionId` is the *name* of the error's type, not a "full name"; `intVersion`/`stringVersion` document the pre-release forms.
- `AlreadyRegisteredException` was triply wrong: the class doc was physically truncated by a `//` line (DocC rendered "…more than once for the"), `kindOfObject` said "could not be **removed**", and the kind list included "object"/"replica group" which nothing produces — now the 7 actual kinds.
- Trap/terminate realities documented per the #5894 pattern: `getIceProperty`/`getIcePropertyAsList` no longer carry `- Throws:` tags on non-throwing functions — a note states that an unknown Ice property terminates the program (the bridge deliberately doesn't catch); `setProperty` documents the same for unknown reserved-prefix properties; preconditions documented on `identityToString`, `Connection.createProxy`, `proxyToProperty` (fixed proxies), `DispatchException.init`, and `CtrlCHandler.init` (second instance terminates).
- Missing/vague docs: the proxy `- Returns: The result of the invocation.` batch now states the real semantics (`ice_isA` true-if-implements, `ice_ids` alphabetical, `ice_invoke`'s `ok`/`outEncaps` tuple incl. oneway/batch, `ice_getConnection` nil for collocation); `ice_getInvocationTimeout` "(in milliseconds)"; `uncheckedCast` purely-local remark; `==`/`!=` documented for proxies and endpoints; `stringToProxy`/`propertyToProxy`/`stringToIdentity`/`addWithUUID`/`addFacetWithUUID`/`initializePlugins` Throws named; `Encoding_1_0`/`Encoding_1_1` documented; `Endpoint.getInfo()`/`endValue()` nil cases; `readEncapsulation` documents that the position is not advanced and the 6-byte header is included (today's behavior; a change is tracked in #5938); single-encapsulation restriction documented on both `startEncapsulation` overloads; `ImplicitContext.put`/`remove` empty-string convention; `Properties` thread-safety remark; `createProperties` Ice.Config/ICE_CONFIG loading conditions; `close()` rethrow note.
- Markup/consistency: stray third backtick breaking the ``ServantLocator`` link, malformed `- Parameter:` on the properties-update callback typealias, `CloseCallback` parameter prose, "Ice run time"→"runtime", imperative "Read an…"→"Reads an…", double spaces, redundant middleware sentence.

Deliberately excluded: the `addDefaultServant`/`find`/`findFacet` lookup-order docs (correct once #5915 merges), `setLocator` docs (#5938 owns the impl decision), and the `getPropertyAsList` mismatched-quotes sentences (pending the cross-mapping code-vs-doc decision). One codex-audit flag declined: `ice_ping`'s "tests whether the target object can be reached" is the corrected C++ reference wording — the oneway/batch nuance applies identically in C++ and should be refined there first if desired.

Verified with the CI-identical `swift format` check (in-place format produces no diff) and `swift format lint --strict`: clean. All changes were codex-audited against the Swift implementation, the ObjC++ bridge, and the C++ core; the three valid flags (createProperties ICE_CONFIG nuance, readPendingValues 1.1 qualification, sequential-encapsulation precondition) are incorporated.
