### PR TITLE
Replace a stale in-memory subscriber during replica reconciliation

### DIFF
--- a/changelog.d/service-icestorm/5852.md
+++ b/changelog.d/service-icestorm/5852.md
@@ -1,0 +1,3 @@
+- Fixed a replication bug: when a subscriber unsubscribed and re-subscribed with a different proxy or QoS while
+  a replica was out of sync, the replica kept the old subscription and could deliver events with it after
+  becoming the coordinator.

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -855,24 +855,18 @@ TopicImpl::update(const SubscriberRecordSeq& records)
                     break;
                 }
             }
-            // The subscriber doesn't exist in the incoming subscriber
-            // set so destroy it.
-            if (q == records.end())
+            // Keep the subscriber only when it exists in the incoming subscriber set with the same
+            // record, and reset its reaped status if necessary. Otherwise destroy it: it is either
+            // gone, or it re-registered with a different proxy or QoS while this replica was out of
+            // sync, and the second scan re-creates it from the incoming record so it matches the
+            // database.
+            if (q != records.end() && (*p)->record() == *q)
             {
-                (*p)->destroy();
-                p = _subscribers.erase(p);
-            }
-            else if ((*p)->record() == *q)
-            {
-                // The record is unchanged; reset the reaped status if necessary.
                 (*p)->resetIfReaped();
                 ++p;
             }
             else
             {
-                // The subscriber re-registered with a different proxy or QoS while this replica was out
-                // of sync. Destroy the stale in-memory subscriber; the second scan re-creates it from the
-                // incoming record so it matches the database.
                 (*p)->destroy();
                 p = _subscribers.erase(p);
             }

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -862,11 +862,19 @@ TopicImpl::update(const SubscriberRecordSeq& records)
                 (*p)->destroy();
                 p = _subscribers.erase(p);
             }
-            else
+            else if ((*p)->record() == *q)
             {
-                // Otherwise reset the reaped status if necessary.
+                // The record is unchanged; reset the reaped status if necessary.
                 (*p)->resetIfReaped();
                 ++p;
+            }
+            else
+            {
+                // The subscriber re-registered with a different proxy or QoS while this replica was out
+                // of sync. Destroy the stale in-memory subscriber; the second scan re-creates it from the
+                // incoming record so it matches the database.
+                (*p)->destroy();
+                p = _subscribers.erase(p);
             }
         }
     }


### PR DESCRIPTION
A replica reconciling its subscribers matched them by identity only, so a subscriber that re-registered with a different proxy or QoS while the replica was out of sync kept its stale in-memory record (and could push it cluster-wide on promotion). The in-memory subscriber is now replaced when the record differs: it is destroyed, and the second scan re-creates it from the incoming record so it matches the database.

Split out of #5902 so it can be reviewed and backported on its own.

Fixes #5852
