### PR TITLE
Destroy the IceStorm subscriber when its registration transaction fails

### DIFF
--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -626,9 +626,9 @@ Subscriber::destroy()
         {
             // Ignore
         }
-        catch (const Ice::ObjectAdapterDeactivatedException&)
+        catch (const Ice::ObjectAdapterDestroyedException&)
         {
-            // Ignore
+            // Ignore -- this can occur on shutdown.
         }
     }
 

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -564,6 +564,9 @@ TopicImpl::subscribeAndGetPublisher(QoS qos, Ice::ObjectPrx obj)
     catch (const IceDB::LMDBException& ex)
     {
         logError(_instance->communicator(), ex);
+        // The subscriber was created (and its publisher servant registered) before the transaction; remove
+        // it so a retry with the same subscriber identity is not rejected with AlreadyRegisteredException.
+        subscriber->destroy();
         throw; // will become UnknownException in caller
     }
 
@@ -1070,6 +1073,9 @@ TopicImpl::observerAddSubscriber(const LogUpdate& llu, const SubscriberRecord& r
     catch (const IceDB::LMDBException& ex)
     {
         logError(_instance->communicator(), ex);
+        // The subscriber was created (and its publisher servant registered) before the transaction; remove
+        // it so a later replica sync does not fail re-registering the same subscriber identity.
+        subscriber->destroy();
         throw; // will become UnknownException in caller
     }
 


### PR DESCRIPTION
`subscribeAndGetPublisher` and `observerAddSubscriber` registered the per-subscriber publisher servant *before* the database transaction; on a transaction failure the servant leaked, permanently blocking re-subscription of that identity. The subscriber is now destroyed on failure.

This also corrects `Subscriber::destroy` to catch the current `ObjectAdapterDestroyedException` (its catch clause had been stale since the `Deactivated`/`Destroyed` split), which the cleanup relies on to stay silent on shutdown.

Split out of #5902 so it can be reviewed and backported on its own.

Fixes #5853
