### PR TITLE
Fix JS Connection.close to settle when the connection is already closed

### DIFF
--- a/changelog.d/js/5876.md
+++ b/changelog.d/js/5876.md
@@ -1,0 +1,3 @@
+- Fixed `Connection.close` to return a promise that settles even when the connection is already closed. Previously,
+  calling `close` on a connection that was already closed — for example after `abort` or after the peer closed the
+  connection — returned a promise that never settled.

--- a/js/packages/ice/src/Ice/ConnectionI.js
+++ b/js/packages/ice/src/Ice/ConnectionI.js
@@ -114,7 +114,13 @@ export class ConnectionI {
         this._exception = null;
 
         this._startPromise = null;
-        this._closed = undefined;
+
+        // Settled by finish(); returned by close(). The no-op rejection handler prevents an unhandled rejection
+        // when the connection is closed forcefully and the application never calls close().
+        this._closed = new Promise();
+        this._closed.catch(() => {});
+        this._closeRequested = false;
+
         this._finishedPromises = [];
 
         if (options.idleTimeout > 0) {
@@ -183,11 +189,13 @@ export class ConnectionI {
     }
 
     close() {
-        if (this._closed === undefined) {
-            this._closed = new Promise();
-            scheduleCloseTimeout(this);
-            if (this._asyncRequests.size === 0) {
-                this.doApplicationClose();
+        if (!this._closeRequested) {
+            this._closeRequested = true;
+            if (this._state < StateClosed) {
+                scheduleCloseTimeout(this);
+                if (this._state < StateClosing && this._asyncRequests.size === 0) {
+                    this.doApplicationClose();
+                }
             }
         }
         return this._closed;
@@ -322,7 +330,7 @@ export class ConnectionI {
                 }
                 outAsync.completedEx(ex);
 
-                if (this._closed !== undefined && this._state < StateClosing && this._asyncRequests.size === 0) {
+                if (this._closeRequested && this._state < StateClosing && this._asyncRequests.size === 0) {
                     this.doApplicationClose();
                 }
                 return; // We're done.
@@ -335,7 +343,7 @@ export class ConnectionI {
                     this._asyncRequests.delete(key);
                     outAsync.completedEx(ex);
 
-                    if (this._closed !== undefined && this._state < StateClosing && this._asyncRequests.size === 0) {
+                    if (this._closeRequested && this._state < StateClosing && this._asyncRequests.size === 0) {
                         this.doApplicationClose();
                     }
                     return; // We're done.
@@ -699,18 +707,16 @@ export class ConnectionI {
         this._writeStream.clear();
         this._writeStream.buffer.clear();
 
-        if (this._closed !== undefined) {
-            if (
-                this._exception instanceof ConnectionClosedException ||
-                this._exception instanceof CloseConnectionException ||
-                this._exception instanceof CommunicatorDestroyedException ||
-                this._exception instanceof ObjectAdapterDestroyedException
-            ) {
-                this._closed.resolve();
-            } else {
-                console.assert(this._exception !== null);
-                this._closed.reject(this._exception);
-            }
+        if (
+            this._exception instanceof ConnectionClosedException ||
+            this._exception instanceof CloseConnectionException ||
+            this._exception instanceof CommunicatorDestroyedException ||
+            this._exception instanceof ObjectAdapterDestroyedException
+        ) {
+            this._closed.resolve();
+        } else {
+            console.assert(this._exception !== null);
+            this._closed.reject(this._exception);
         }
 
         if (this._closeCallback !== null) {
@@ -1332,11 +1338,7 @@ export class ConnectionI {
                             console.assert(info.outAsync.isSent());
                         }
 
-                        if (
-                            this._closed !== undefined &&
-                            this._state < StateClosing &&
-                            this._asyncRequests.size === 0
-                        ) {
+                        if (this._closeRequested && this._state < StateClosing && this._asyncRequests.size === 0) {
                             this.doApplicationClose();
                         }
                     } else {

--- a/js/packages/test/Ice/ami/Client.ts
+++ b/js/packages/test/Ice/ami/Client.ts
@@ -298,6 +298,39 @@ export class Client extends TestHelper {
         }
         out.writeLine("ok");
 
+        out.write("testing close on an already-closed connection... ");
+        {
+            // close() on a connection the peer closed gracefully resolves.
+            const connection = await p.ice_getConnection();
+            const closed = new Promise<void>((resolve) => connection.setCloseCallback(() => resolve()));
+            await p.closeConnection();
+            await closed;
+            await connection.close();
+        }
+
+        {
+            // close() on an aborted connection rejects with the exception that closed the connection.
+            const connection = await p.ice_connectionId("close-aborted").ice_getConnection();
+            connection.abort();
+            try {
+                await connection.close();
+                test(false);
+            } catch (ex) {
+                test(ex instanceof Ice.ConnectionAbortedException);
+                test(ex.closedByApplication);
+            }
+        }
+
+        {
+            // A close() promise that is never awaited does not trigger an unhandled rejection when the
+            // connection closure was not graceful.
+            const connection = await p.ice_connectionId("close-unobserved").ice_getConnection();
+            connection.abort();
+            connection.close();
+            await Ice.Promise.delay(0); // give an unhandled rejection a chance to surface
+        }
+        out.writeLine("ok");
+
         out.write("testing bi-dir... ");
         const adapter = await communicator.createObjectAdapter("");
         const replyI = new PingReplyI();


### PR DESCRIPTION
Fixes #5876.

When `close()` was called on a connection that was already closed (after `abort()`, a peer closure, or communicator destruction), the returned promise was never settled: `finish()` — the only code that settled it — had already run.

The `_closed` promise is now created in the connection constructor and always settled by `finish()`, mirroring the C# implementation (construction-time `TaskCompletionSource` that `finish()` always completes): it resolves for graceful closures and rejects with the closure cause otherwise. `close()` just records the close request — a new `_closeRequested` flag replaces the previous `_closed === undefined` latch — triggers the graceful closure when appropriate, and returns the promise. `doApplicationClose()` is also guarded with `_state < StateClosing`, matching C++ and C#, so a `close()` during an in-progress graceful closure no longer trips the assertion in `doApplicationClose`.

The promise gets a no-op rejection handler at construction: a connection that is closed forcefully and never `close()`d by the application would otherwise produce an unhandled promise rejection, which terminates Node by default. Callers of `close()` that await the promise still observe the rejection; an unobserved `close()` is silent, like an unobserved faulted task in C#. This also fixes a pre-existing hazard where an early, unawaited `close()` produced an unhandled rejection when the connection later closed abnormally.