### PR TITLE
Fix JS InputStream constructor handling of ArrayBuffer and Uint8Array view arguments

### DIFF
--- a/changelog.d/js/5877.md
+++ b/changelog.d/js/5877.md
@@ -1,0 +1,3 @@
+- Fixed the `InputStream` constructor's handling of buffer arguments. An `ArrayBuffer` argument previously produced
+  an empty stream, and a `Uint8Array` view that does not span its entire underlying buffer was read from the wrong
+  byte range.

--- a/js/packages/ice/src/Ice/InputStream.d.ts
+++ b/js/packages/ice/src/Ice/InputStream.d.ts
@@ -10,18 +10,20 @@ declare module "@zeroc/ice" {
              * Constructs an InputStream using a communicator and this communicator's default encoding version.
              *
              * @param communicator The communicator to use for unmarshaling tasks.
-             * @param buffer The encoded data.
+             * @param buffer The encoded data. When a `Uint8Array` is supplied, the stream reads the exact byte
+             * range of the view.
              */
-            constructor(communicator: Communicator, buffer: Uint8Array);
+            constructor(communicator: Communicator, buffer: Uint8Array | ArrayBuffer);
 
             /**
              * Constructs an InputStream using a communicator and encoding version.
              *
              * @param communicator The communicator to use for unmarshaling tasks.
              * @param encoding The encoding version used to encode the data to be unmarshaled.
-             * @param buffer The encoded data.
+             * @param buffer The encoded data. When a `Uint8Array` is supplied, the stream reads the exact byte
+             * range of the view.
              */
-            constructor(communicator: Communicator, encoding: EncodingVersion, buffer: Uint8Array);
+            constructor(communicator: Communicator, encoding: EncodingVersion, buffer: Uint8Array | ArrayBuffer);
 
             /**
              *  Releases any data retained by encapsulations.

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -913,12 +913,18 @@ export class InputStream {
                         if (this._buf !== undefined) {
                             throw new InitializationException("duplicate buffer argument to InputStream constructor");
                         }
-                        this._buf = new Buffer(arg.bytes);
+                        this._buf = new Buffer(arg);
                     } else if (arg.constructor === Uint8Array) {
                         if (this._buf !== undefined) {
                             throw new InitializationException("duplicate buffer argument to InputStream constructor");
                         }
-                        this._buf = new Buffer(arg.buffer);
+                        // Buffer works with a whole ArrayBuffer: copy the view's range when it doesn't span its
+                        // entire underlying buffer.
+                        this._buf = new Buffer(
+                            arg.byteOffset === 0 && arg.byteLength === arg.buffer.byteLength
+                                ? arg.buffer
+                                : arg.buffer.slice(arg.byteOffset, arg.byteOffset + arg.byteLength),
+                        );
                     } else {
                         throw new InitializationException("unknown argument to InputStream constructor");
                     }

--- a/js/packages/test/Ice/stream/Client.ts
+++ b/js/packages/test/Ice/stream/Client.ts
@@ -41,6 +41,35 @@ export class Client extends TestHelper {
         }
 
         {
+            // The InputStream accepts an ArrayBuffer holding the encoded data.
+            const outS = new Ice.OutputStream(communicator);
+            outS.writeInt(0x01020304);
+            const data = outS.finished();
+            const buffer = new ArrayBuffer(data.byteLength);
+            new Uint8Array(buffer).set(data);
+            const inS = new Ice.InputStream(communicator, buffer);
+            test(inS.readInt() === 0x01020304);
+        }
+
+        {
+            // The InputStream reads from the exact range of a Uint8Array view into a larger buffer.
+            const outS = new Ice.OutputStream(communicator);
+            outS.writeInt(0x01020304);
+            const data = outS.finished();
+            const padded = new Uint8Array(data.byteLength + 8);
+            padded.fill(0xff);
+            padded.set(data, 4);
+            const inS = new Ice.InputStream(communicator, padded.subarray(4, 4 + data.byteLength));
+            test(inS.readInt() === 0x01020304);
+            try {
+                inS.readByte(); // no data remains within the view's range
+                test(false);
+            } catch (ex) {
+                test(ex instanceof Ice.MarshalException);
+            }
+        }
+
+        {
             const outS = new Ice.OutputStream(communicator);
             outS.writeBool(true);
             const data = outS.finished();


### PR DESCRIPTION
Fixes #5877.

- An `ArrayBuffer` argument was passed to `Buffer` as `arg.bytes` (undefined), producing an empty stream; the stream now wraps the `ArrayBuffer` itself (regression from #3102).
- A `Uint8Array` view was unwrapped to its entire underlying `ArrayBuffer`, ignoring `byteOffset`/`byteLength`; the stream now reads the view's exact byte range (zero-copy when the view spans its whole buffer, copying the range otherwise).

The `InputStream` TypeScript constructor overloads now accept `Uint8Array | ArrayBuffer`.

Note: the constructor's exact-constructor checks still reject `Uint8Array` subclasses such as Node's `Buffer`, although the TypeScript signature structurally admits them; that pre-existing limitation is unchanged.