### PR TITLE
Use the logger supplied in InitializationData over Ice.LogFile in JS

### DIFF
--- a/changelog.d/js/5878.md
+++ b/changelog.d/js/5878.md
@@ -1,0 +1,3 @@
+- Fixed the communicator to use the logger supplied in `InitializationData` even when `Ice.LogFile` is set. The
+  property previously replaced the supplied logger with a file logger, and in browsers caused communicator
+  initialization to fail.

--- a/js/packages/ice/src/Ice/InstanceExtensions.js
+++ b/js/packages/ice/src/Ice/InstanceExtensions.js
@@ -179,12 +179,15 @@ Instance.prototype.finishSetup = function (communicator) {
         );
 
         const programName = this._initData.properties.getIceProperty("Ice.ProgramName");
-        const logFile = this._initData.properties.getIceProperty("Ice.LogFile");
-        if (logFile.length > 0) {
-            if (FileLogger === null) {
-                throw new InitializationException("Ice.LogFile property is not supported in Web Browsers");
+        // Ice.LogFile is only consulted when the application didn't supply its own logger.
+        if (this._initData.logger === null) {
+            const logFile = this._initData.properties.getIceProperty("Ice.LogFile");
+            if (logFile.length > 0) {
+                if (FileLogger === null) {
+                    throw new InitializationException("Ice.LogFile property is not supported in Web Browsers");
+                }
+                this._initData.logger = new FileLogger(programName, logFile);
             }
-            this._initData.logger = new FileLogger(programName, logFile);
         }
 
         if (this._initData.logger === null) {

--- a/js/packages/ice/src/Ice/InstanceExtensions.js
+++ b/js/packages/ice/src/Ice/InstanceExtensions.js
@@ -179,7 +179,7 @@ Instance.prototype.finishSetup = function (communicator) {
         );
 
         const programName = this._initData.properties.getIceProperty("Ice.ProgramName");
-        // Ice.LogFile is only consulted when the application didn't supply its own logger.
+        // Ice.LogFile is only consulted when the application doesn't supply its own logger.
         if (this._initData.logger === null) {
             const logFile = this._initData.properties.getIceProperty("Ice.LogFile");
             if (logFile.length > 0) {

--- a/js/packages/test/Ice/properties/Client.ts
+++ b/js/packages/test/Ice/properties/Client.ts
@@ -167,6 +167,29 @@ export class Client extends TestHelper {
             }
             out.writeLine("ok");
         }
+
+        {
+            out.write("testing that the logger set in InitializationData takes precedence over Ice.LogFile... ");
+            const initData = new Ice.InitializationData();
+            initData.properties = Ice.createProperties();
+            initData.properties.setProperty("Ice.LogFile", "unused.log");
+            const logger: Ice.Logger = {
+                print: () => {},
+                trace: () => {},
+                warning: () => {},
+                error: () => {},
+                getPrefix: () => "",
+                cloneWithPrefix: (): Ice.Logger => logger,
+            };
+            initData.logger = logger;
+            const communicator = new Ice.Communicator(initData);
+            try {
+                test(communicator.getLogger() === logger);
+            } finally {
+                await communicator.destroy();
+            }
+            out.writeLine("ok");
+        }
     }
 
     async run(args: string[]) {


### PR DESCRIPTION
Fixes #5878.

`Ice.LogFile` unconditionally replaced the logger supplied in `InitializationData` with a `FileLogger`. The property is now only consulted when no logger was supplied, matching C++ (a user-provided logger always wins).

As in C++, this also means a communicator with a user-supplied logger no longer throws `InitializationException` in browsers when `Ice.LogFile` is set, since the property is never consulted.