### PR TITLE
Fix five low-severity JS runtime findings from the API doc audit

### DIFF
--- a/js/packages/ice/src/Ice/ConnectionI.js
+++ b/js/packages/ice/src/Ice/ConnectionI.js
@@ -781,6 +781,7 @@ export class ConnectionI {
                     StateClosing,
                     new ConnectionClosedException(
                         "connection closed because it remained inactive for longer than the inactivity timeout",
+                        false,
                     ),
                 );
             }

--- a/js/packages/ice/src/Ice/EnumBase.js
+++ b/js/packages/ice/src/Ice/EnumBase.js
@@ -7,7 +7,7 @@ Object.defineProperty(OptionalFormat_Size, "value", { value: 4 });
 //
 // Ice.EnumBase
 //
-class EnumBase {
+export class EnumBase {
     constructor(name, value) {
         this._name = name;
         this._value = value;

--- a/js/packages/ice/src/Ice/LocalExceptions.js
+++ b/js/packages/ice/src/Ice/LocalExceptions.js
@@ -361,7 +361,7 @@ export class NoEndpointException extends LocalException {
     }
 
     static createMessage(arg) {
-        return arg instanceof ObjectPrx ? `$"No suitable endpoint available for proxy '${arg}'.` : arg;
+        return arg instanceof ObjectPrx ? `No suitable endpoint available for proxy '${arg}'.` : arg;
     }
 }
 

--- a/js/packages/ice/src/Ice/ObjectAdapter.js
+++ b/js/packages/ice/src/Ice/ObjectAdapter.js
@@ -310,6 +310,9 @@ export class ObjectAdapter {
     }
 
     setPublishedEndpoints(newEndpoints) {
+        if (newEndpoints.length === 0) {
+            throw new Error("the newEndpoints argument must contain at least one endpoint");
+        }
         this.checkForDestruction();
         if (this._routerInfo !== null) {
             throw new Error("can't set published endpoints on object adapter associated with a router");

--- a/js/packages/ice/src/Ice/OutputStream.js
+++ b/js/packages/ice/src/Ice/OutputStream.js
@@ -480,6 +480,7 @@ export class OutputStream {
     constructor(arg1, arg2) {
         let instance = null;
         this._encoding = null;
+        this._format = null;
 
         if (arg1 !== undefined && arg1 !== null) {
             if (arg1.constructor == Communicator) {
@@ -488,13 +489,14 @@ export class OutputStream {
                 instance = arg1;
             } else if (arg1.constructor == EncodingVersion) {
                 this._encoding = arg1;
-                if (arg2 !== null && arg2 !== undefined) {
-                    if (arg2.constructor == FormatType) {
-                        this._format = arg2;
-                    } else {
-                        throw new InitializationException("unknown argument to OutputStream constructor");
-                    }
-                }
+            } else {
+                throw new InitializationException("unknown argument to OutputStream constructor");
+            }
+        }
+
+        if (arg2 !== undefined && arg2 !== null) {
+            if (arg2.constructor == FormatType) {
+                this._format = arg2;
             } else {
                 throw new InitializationException("unknown argument to OutputStream constructor");
             }
@@ -511,12 +513,16 @@ export class OutputStream {
             if (this._encoding === null) {
                 this._encoding = instance.defaultsAndOverrides().defaultEncoding;
             }
-            this._format = instance.defaultsAndOverrides().defaultFormat;
+            if (this._format === null) {
+                this._format = instance.defaultsAndOverrides().defaultFormat;
+            }
         } else {
             if (this._encoding === null) {
                 this._encoding = Encoding_1_1;
             }
-            this._format = FormatType.CompactFormat;
+            if (this._format === null) {
+                this._format = FormatType.CompactFormat;
+            }
         }
     }
 

--- a/js/packages/test/Ice/adapterDeactivation/Client.ts
+++ b/js/packages/test/Ice/adapterDeactivation/Client.ts
@@ -57,6 +57,12 @@ export class Client extends TestHelper {
             id.name = "dummy";
             test(Ice.ArrayUtil.equals(adapter.createProxy(id).ice_getEndpoints(), prx.ice_getEndpoints()));
             test(Ice.ArrayUtil.equals(adapter.getPublishedEndpoints(), prx.ice_getEndpoints()));
+            try {
+                adapter.setPublishedEndpoints([]);
+                test(false);
+            } catch (ex) {
+                test(ex instanceof Error && ex.message.includes("at least one endpoint"));
+            }
             adapter.destroy();
             test(adapter.getPublishedEndpoints().length === 0);
 

--- a/js/packages/test/Ice/enums/Client.ts
+++ b/js/packages/test/Ice/enums/Client.ts
@@ -12,6 +12,7 @@ export class Client extends TestHelper {
         const proxy = new Test.TestIntfPrx(communicator, `test:${this.getTestEndpoint()}`);
 
         out.write("testing enum values... ");
+        test(Test.ByteEnum.benum1 instanceof Ice.EnumBase);
         test(Test.ByteEnum.benum1.value === 0);
         test(Test.ByteEnum.benum2.value === 1);
         test(Test.ByteEnum.benum3.value === Test.ByteConst1);

--- a/js/packages/test/Ice/inactivityTimeout/Client.ts
+++ b/js/packages/test/Ice/inactivityTimeout/Client.ts
@@ -27,6 +27,14 @@ async function testClientInactivityTimeout(p: Test.TestIntfPrx, helper: TestHelp
         test(connection2 == connection);
     } else {
         test(connection2 != connection);
+        // The inactivity timeout closed the connection; this closure was not initiated by the application.
+        try {
+            connection.throwException();
+            test(false);
+        } catch (ex) {
+            test(ex instanceof Ice.ConnectionClosedException);
+            test(ex.closedByApplication === false);
+        }
     }
     await connection2.close();
     output.writeLine("ok");

--- a/js/packages/test/Ice/proxy/Client.ts
+++ b/js/packages/test/Ice/proxy/Client.ts
@@ -1031,6 +1031,7 @@ export class Client extends TestHelper {
         } catch (ex) {
             if (ex instanceof Ice.NoEndpointException) {
                 test(!ssl);
+                test(ex.message.startsWith("No suitable endpoint available for proxy"));
             } else if (ex instanceof Ice.ConnectFailedException) {
                 test(ssl);
             } else {

--- a/js/packages/test/Ice/stream/Client.ts
+++ b/js/packages/test/Ice/stream/Client.ts
@@ -187,6 +187,20 @@ export class Client extends TestHelper {
         }
 
         {
+            // The format argument of the OutputStream constructor selects the class format: the sliced format
+            // writes slice headers that the compact format omits.
+            const o = new Test.OptionalClass();
+            o.bo = true;
+            const outCompact = new Ice.OutputStream(Ice.Encoding_1_1, Ice.FormatType.CompactFormat);
+            outCompact.writeValue(o);
+            outCompact.writePendingValues();
+            const outSliced = new Ice.OutputStream(Ice.Encoding_1_1, Ice.FormatType.SlicedFormat);
+            outSliced.writeValue(o);
+            outSliced.writePendingValues();
+            test(outSliced.finished().length > outCompact.finished().length);
+        }
+
+        {
             const arr = [true, false, true, false];
             let outS = new Ice.OutputStream(communicator);
             Ice.BoolSeqHelper.write(outS, arr);


### PR DESCRIPTION
Fixes #5879.

- `Ice.EnumBase` is now exported; it was `undefined` at runtime although declared in the typings.
- Removed the stray `$"` at the start of the `NoEndpointException` message.
- The `OutputStream` constructor no longer ignores its `format` argument, which was unconditionally overwritten with the default. This also restores `Ice.Default.SlicedFormat` for outgoing requests, replies, and batches, whose streams supply the default format through this constructor.
- The inactivity-timeout `ConnectionClosedException` now sets `closedByApplication` to `false` instead of leaving it `undefined`.
- `ObjectAdapter.setPublishedEndpoints` now throws when called with an empty endpoint array, as documented and as C++/C# do.