### PR TITLE
Fix the SliceInfo.bytes doc comment in C++, C#, JS, and MATLAB

### DIFF
--- a/cpp/include/Ice/SlicedData.h
+++ b/cpp/include/Ice/SlicedData.h
@@ -30,7 +30,7 @@ namespace Ice
         /// The Slice compact type ID for this slice, or `-1` if the slice has no compact ID.
         const int compactId;
 
-        /// The encoded bytes for this slice, including the leading size integer.
+        /// The encoded bytes for this slice.
         const std::vector<std::byte> bytes;
 
         /// The class instances referenced by this slice.

--- a/csharp/src/Ice/SlicedData.cs
+++ b/csharp/src/Ice/SlicedData.cs
@@ -15,7 +15,7 @@ public sealed record class SlicedData(SliceInfo[] slices);
 /// </summary>
 /// <param name="typeId">The Slice type ID for this slice.</param>
 /// <param name="compactId">The Slice compact type ID for this slice, or -1 if the slice has no compact ID.</param>
-/// <param name="bytes">The encoded bytes for this slice, including the leading size integer.</param>
+/// <param name="bytes">The encoded bytes for this slice.</param>
 /// <param name="hasOptionalMembers">Whether or not the slice contains optional members.</param>
 /// <param name="isLastSlice">Whether or not this is the last slice.</param>
 public sealed record class SliceInfo(

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -82,7 +82,7 @@ public sealed class Util
                     //
                     // Extra unescaped slash found.
                     //
-                    throw new ParseException($"unescaped backslash in identity string '{s}'");
+                    throw new ParseException($"unescaped slash in identity string '{s}'");
                 }
             }
             pos++;

--- a/js/packages/ice/src/Ice/UnknownSlicedValue.d.ts
+++ b/js/packages/ice/src/Ice/UnknownSlicedValue.d.ts
@@ -17,7 +17,7 @@ declare module "@zeroc/ice" {
             compactId: number;
 
             /**
-             * The encoded bytes for this slice, including the leading size integer.
+             * The encoded bytes for this slice.
              */
             bytes: Uint8Array;
 

--- a/js/packages/ice/src/Ice/UnknownSlicedValue.js
+++ b/js/packages/ice/src/Ice/UnknownSlicedValue.js
@@ -15,7 +15,7 @@ export class SliceInfo {
         this.compactId = -1;
 
         //
-        // The encoded bytes for this slice, including the leading size integer.
+        // The encoded bytes for this slice.
         //
         this.bytes = [];
 

--- a/matlab/lib/+Ice/SliceInfo.m
+++ b/matlab/lib/+Ice/SliceInfo.m
@@ -4,7 +4,7 @@ classdef (Sealed) SliceInfo < handle
     %   SliceInfo Properties:
     %     typeId - The Slice type ID for this slice.
     %     compactId - The Slice compact type ID for this slice.
-    %     bytes - The encoded bytes for this slice, including the leading size integer.
+    %     bytes - The encoded bytes for this slice.
     %     hasOptionalMembers - Whether or not the slice contains optional members.
     %     isLastSlice - Whether or not this is the last slice.
     %     instances - The class instances referenced by this slice.
@@ -20,7 +20,7 @@ classdef (Sealed) SliceInfo < handle
         %   int32 scalar
         compactId (1, 1) int32
 
-        %BYTES The encoded bytes for this slice, including the leading size integer.
+        %BYTES The encoded bytes for this slice.
         %   uint8 vector
         bytes (1, :) uint8
 


### PR DESCRIPTION
The doc comment for `SliceInfo.bytes` claims the encoded bytes include the leading size integer, but every stream implementation captures the slice bytes after the size was consumed (`skipSlice` skips `sliceSize - 4` from the capture start).

Follow-up to the review discussion in #5933 (fix all languages): Java is fixed by #5933, Python by #5893, and Swift by #5941; this PR fixes the remaining mappings (C++, C#, JS, MATLAB).

Also fixes the C# `stringToIdentity` exception message for an extra unescaped `/`: it named the wrong character ("unescaped backslash"), unlike C++ ("unescaped '/' in identity") and the fixed Java message (#5933 review discussion).