### PR TITLE
Fix the IceStorm forwarded topic metric to count events

### DIFF
--- a/changelog.d/service-icestorm/5961.md
+++ b/changelog.d/service-icestorm/5961.md
@@ -1,0 +1,2 @@
+- Fixed the `forwarded` topic metric to count forwarded events. Previously the metric was incremented once per
+  forward call, and a topic link forwards events in batches, so it undercounted the number of events.

--- a/cpp/src/IceStorm/Instrumentation.h
+++ b/cpp/src/IceStorm/Instrumentation.h
@@ -29,8 +29,8 @@ namespace IceStorm::Instrumentation
         /// Notification of an event published on the topic by a publisher.
         virtual void published() = 0;
 
-        /// Notification of an event forwared on the topic by another topic.
-        virtual void forwarded() = 0;
+        /// Notification of some events being forwarded on the topic by another topic.
+        virtual void forwarded(int count) = 0;
     };
 
     class SubscriberObserver : public virtual Ice::Instrumentation::Observer

--- a/cpp/src/IceStorm/InstrumentationI.cpp
+++ b/cpp/src/IceStorm/InstrumentationI.cpp
@@ -195,10 +195,22 @@ TopicObserverI::published()
     forEach(inc(&TopicMetrics::published));
 }
 
-void
-TopicObserverI::forwarded()
+namespace
 {
-    forEach(inc(&TopicMetrics::forwarded));
+    struct ForwardedUpdate
+    {
+        ForwardedUpdate(int countP) : count(countP) {}
+
+        void operator()(const shared_ptr<TopicMetrics>& v) { v->forwarded += count; }
+
+        int count;
+    };
+}
+
+void
+TopicObserverI::forwarded(int count)
+{
+    forEach(ForwardedUpdate(count));
 }
 
 namespace

--- a/cpp/src/IceStorm/InstrumentationI.cpp
+++ b/cpp/src/IceStorm/InstrumentationI.cpp
@@ -195,22 +195,10 @@ TopicObserverI::published()
     forEach(inc(&TopicMetrics::published));
 }
 
-namespace
-{
-    struct ForwardedUpdate
-    {
-        ForwardedUpdate(int countP) : count(countP) {}
-
-        void operator()(const shared_ptr<TopicMetrics>& v) { v->forwarded += count; }
-
-        int count;
-    };
-}
-
 void
 TopicObserverI::forwarded(int count)
 {
-    forEach(ForwardedUpdate(count));
+    forEach(add(&TopicMetrics::forwarded, count));
 }
 
 namespace

--- a/cpp/src/IceStorm/InstrumentationI.h
+++ b/cpp/src/IceStorm/InstrumentationI.h
@@ -14,7 +14,7 @@ namespace IceStorm
     {
     public:
         void published() override;
-        void forwarded() override;
+        void forwarded(int count) override;
     };
 
     class SubscriberObserverI final : public IceStorm::Instrumentation::SubscriberObserver,

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -948,7 +948,7 @@ TopicImpl::publish(bool forwarded, const EventDataSeq& events)
             {
                 if (forwarded)
                 {
-                    _observer->forwarded();
+                    _observer->forwarded(static_cast<int>(events.size()));
                 }
                 else
                 {


### PR DESCRIPTION
The `TopicObserver::forwarded` notification was emitted once per forward call, but a topic link forwards events in batches, so the `forwarded` metric undercounted the number of events and contradicted its `Metrics.ice` documentation ("The number of events forwarded on the topic(s) by IceStorm topic links"). The `published` side is unaffected: the publisher servant delivers one event per invocation.

The observer now receives the event count, like the `SubscriberObserver` notifications already do. `IceStorm::Instrumentation::TopicObserver` is internal to the IceStorm service (not installed, single implementer), so the signature change has no public API impact.

Fixes #5961.