### PR TITLE
Wire IceStorm metrics in transient mode

### DIFF
--- a/changelog.d/service-icestorm/5960.md
+++ b/changelog.d/service-icestorm/5960.md
@@ -1,0 +1,4 @@
+- Fixed IceStorm metrics in transient mode. Transient topics now report the `published` and `forwarded` metrics,
+  and topic and subscriber observers are now refreshed when a metrics view changes. Previously transient topics
+  reported no topic metrics, and the subscriber metrics of transient deployments went stale after a metrics view
+  update.

--- a/changelog.d/service-icestorm/5961.md
+++ b/changelog.d/service-icestorm/5961.md
@@ -1,0 +1,2 @@
+- Fixed the `forwarded` topic metric to count forwarded events. Previously the metric was incremented once per
+  forward call, and a topic link forwards events in batches, so it undercounted the number of events.

--- a/cpp/src/IceStorm/Instrumentation.h
+++ b/cpp/src/IceStorm/Instrumentation.h
@@ -29,8 +29,8 @@ namespace IceStorm::Instrumentation
         /// Notification of an event published on the topic by a publisher.
         virtual void published() = 0;
 
-        /// Notification of an event forwared on the topic by another topic.
-        virtual void forwarded() = 0;
+        /// Notification of some events being forwarded on the topic by another topic.
+        virtual void forwarded(int count) = 0;
     };
 
     class SubscriberObserver : public virtual Ice::Instrumentation::Observer

--- a/cpp/src/IceStorm/InstrumentationI.cpp
+++ b/cpp/src/IceStorm/InstrumentationI.cpp
@@ -195,10 +195,22 @@ TopicObserverI::published()
     forEach(inc(&TopicMetrics::published));
 }
 
-void
-TopicObserverI::forwarded()
+namespace
 {
-    forEach(inc(&TopicMetrics::forwarded));
+    struct ForwardedUpdate
+    {
+        ForwardedUpdate(int countP) : count(countP) {}
+
+        void operator()(const shared_ptr<TopicMetrics>& v) { v->forwarded += count; }
+
+        int count;
+    };
+}
+
+void
+TopicObserverI::forwarded(int count)
+{
+    forEach(ForwardedUpdate(count));
 }
 
 namespace

--- a/cpp/src/IceStorm/InstrumentationI.cpp
+++ b/cpp/src/IceStorm/InstrumentationI.cpp
@@ -195,22 +195,10 @@ TopicObserverI::published()
     forEach(inc(&TopicMetrics::published));
 }
 
-namespace
-{
-    struct ForwardedUpdate
-    {
-        ForwardedUpdate(int countP) : count(countP) {}
-
-        void operator()(const shared_ptr<TopicMetrics>& v) { v->forwarded += count; }
-
-        int count;
-    };
-}
-
 void
 TopicObserverI::forwarded(int count)
 {
-    forEach(ForwardedUpdate(count));
+    forEach(add(&TopicMetrics::forwarded, count));
 }
 
 namespace

--- a/cpp/src/IceStorm/InstrumentationI.h
+++ b/cpp/src/IceStorm/InstrumentationI.h
@@ -14,7 +14,7 @@ namespace IceStorm
     {
     public:
         void published() override;
-        void forwarded() override;
+        void forwarded(int count) override;
     };
 
     class SubscriberObserverI final : public IceStorm::Instrumentation::SubscriberObserver,

--- a/cpp/src/IceStorm/Service.cpp
+++ b/cpp/src/IceStorm/Service.cpp
@@ -110,6 +110,10 @@ ServiceI::start([[maybe_unused]] const string& serviceName, const CommunicatorPt
         try
         {
             _transientManager = make_shared<TransientTopicManagerImpl>(_instance);
+            if (_instance->observer())
+            {
+                _instance->observer()->setObserverUpdater(_transientManager);
+            }
             _managerProxy = topicAdapter->add<TopicManagerPrx>(_transientManager, topicManagerId);
 
             topicAdapter->add(
@@ -367,6 +371,10 @@ ServiceI::start(
     try
     {
         _transientManager = make_shared<TransientTopicManagerImpl>(_instance);
+        if (_instance->observer())
+        {
+            _instance->observer()->setObserverUpdater(_transientManager);
+        }
         _managerProxy = topicAdapter->add<TopicManagerPrx>(_transientManager, id);
     }
     catch (const Ice::LocalException& ex)

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -948,7 +948,7 @@ TopicImpl::publish(bool forwarded, const EventDataSeq& events)
             {
                 if (forwarded)
                 {
-                    _observer->forwarded();
+                    _observer->forwarded(static_cast<int>(events.size()));
                 }
                 else
                 {

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -104,6 +104,10 @@ TransientTopicImpl::TransientTopicImpl(shared_ptr<Instance> instance, std::strin
       _name(std::move(name)),
       _id(std::move(id))
 {
+    if (_instance->observer())
+    {
+        _observer.attach(_instance->observer()->getTopicObserver(_name, nullptr));
+    }
 }
 
 string
@@ -374,6 +378,8 @@ TransientTopicImpl::destroy(const Ice::Current&)
         subscriber->destroy();
     }
     _subscribers.clear();
+
+    _observer.detach();
 }
 
 void
@@ -405,6 +411,18 @@ TransientTopicImpl::publish(bool forwarded, const EventDataSeq& events)
     vector<shared_ptr<Subscriber>> copy;
     {
         lock_guard lock(_mutex);
+
+        if (_observer)
+        {
+            if (forwarded)
+            {
+                _observer->forwarded(static_cast<int>(events.size()));
+            }
+            else
+            {
+                _observer->published();
+            }
+        }
         copy = _subscribers;
     }
 
@@ -466,5 +484,29 @@ TransientTopicImpl::shutdown()
     for (const auto& subscriber : _subscribers)
     {
         subscriber->shutdown();
+    }
+
+    _observer.detach();
+}
+
+void
+TransientTopicImpl::updateObserver()
+{
+    lock_guard lock(_mutex);
+
+    if (_instance->observer())
+    {
+        _observer.attach(_instance->observer()->getTopicObserver(_name, _observer.get()));
+    }
+}
+
+void
+TransientTopicImpl::updateSubscriberObservers()
+{
+    lock_guard lock(_mutex);
+
+    for (const auto& subscriber : _subscribers)
+    {
+        subscriber->updateObserver();
     }
 }

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -494,7 +494,8 @@ TransientTopicImpl::updateObserver()
 {
     lock_guard lock(_mutex);
 
-    if (_instance->observer())
+    // Don't reattach the observer of a topic that was destroyed but not reaped yet.
+    if (!_destroyed && _instance->observer())
     {
         _observer.attach(_instance->observer()->getTopicObserver(_name, _observer.get()));
     }

--- a/cpp/src/IceStorm/TransientTopicI.h
+++ b/cpp/src/IceStorm/TransientTopicI.h
@@ -3,7 +3,9 @@
 #ifndef ICESTORM_TRANSIENT_TOPIC_I_H
 #define ICESTORM_TRANSIENT_TOPIC_I_H
 
+#include "Ice/ObserverHelper.h"
 #include "IceStormInternal.h"
+#include "Instrumentation.h"
 
 namespace IceStorm
 {
@@ -36,6 +38,9 @@ namespace IceStorm
         [[nodiscard]] Ice::Identity id() const;
         void publish(bool, const EventDataSeq&);
 
+        void updateObserver();
+        void updateSubscriberObservers();
+
         void shutdown();
 
     private:
@@ -61,6 +66,8 @@ namespace IceStorm
         std::vector<std::shared_ptr<Subscriber>> _subscribers;
 
         bool _destroyed{false}; // Has this Topic been destroyed?
+
+        IceInternal::ObserverHelperT<IceStorm::Instrumentation::TopicObserver> _observer;
 
         mutable std::mutex _mutex;
     };

--- a/cpp/src/IceStorm/TransientTopicManagerI.cpp
+++ b/cpp/src/IceStorm/TransientTopicManagerI.cpp
@@ -117,6 +117,28 @@ TransientTopicManagerImpl::reap()
 }
 
 void
+TransientTopicManagerImpl::updateTopicObservers()
+{
+    lock_guard lock(_mutex);
+
+    for (const auto& topic : _topics)
+    {
+        topic.second->updateObserver();
+    }
+}
+
+void
+TransientTopicManagerImpl::updateSubscriberObservers()
+{
+    lock_guard lock(_mutex);
+
+    for (const auto& topic : _topics)
+    {
+        topic.second->updateSubscriberObservers();
+    }
+}
+
+void
 TransientTopicManagerImpl::shutdown()
 {
     lock_guard lock(_mutex);

--- a/cpp/src/IceStorm/TransientTopicManagerI.h
+++ b/cpp/src/IceStorm/TransientTopicManagerI.h
@@ -4,13 +4,15 @@
 #define ICESTORM_TRANSIENT_TOPIC_MANAGER_I_H
 
 #include "IceStormInternal.h"
+#include "Instrumentation.h"
 
 namespace IceStorm
 {
     class Instance;
     class TransientTopicImpl;
 
-    class TransientTopicManagerImpl final : public TopicManagerInternal
+    class TransientTopicManagerImpl final : public TopicManagerInternal,
+                                            public IceStorm::Instrumentation::ObserverUpdater
     {
     public:
         TransientTopicManagerImpl(std::shared_ptr<Instance>);
@@ -22,6 +24,10 @@ namespace IceStorm
 
         TopicDict retrieveAll(const Ice::Current&) final;
         [[nodiscard]] std::optional<IceStormElection::NodePrx> getReplicaNode(const Ice::Current&) const final;
+
+        // Observer methods.
+        void updateTopicObservers() override;
+        void updateSubscriberObservers() override;
 
         void reap();
         void shutdown();


### PR DESCRIPTION
> [!NOTE]
> Stacked on #5965 (the first two commits belong to that PR, since this change uses the new `forwarded(count)` notification). I'll rebase once #5965 merges.

Transient IceStorm reported no topic metrics and never refreshed observers:

- `TransientTopicImpl` never attached a topic observer, so transient topics reported no `published`/`forwarded` metrics.
- `TransientTopicManagerImpl` did not register an observer updater, so topic and subscriber observers were never refreshed when a metrics view changed — subscriber observers (attached at creation by the shared `Subscriber` code) went stale.

This mirrors the persistent implementation: the transient topic attaches its observer at construction, notifies it from `publish`, detaches it on destroy and shutdown, and implements `updateObserver`/`updateSubscriberObservers`; the transient topic manager implements `Instrumentation::ObserverUpdater` and is registered with `setObserverUpdater` at both construction sites in `Service.cpp` (standalone transient mode and the IceGrid-embedded instance). Registration lives in `Service.cpp` rather than a `create()` factory because the transient manager is itself the servant and already has a Slice `create` operation.

Tested with the transient variants of `IceStorm/single`, `IceStorm/federation`, and `IceStorm/createOrRetrieve` (all green).

Fixes #5960.