### PR TITLE
Fix icestormadmin error reporting when no topic manager is reachable

### DIFF
--- a/changelog.d/service-icestorm/5962.md
+++ b/changelog.d/service-icestorm/5962.md
@@ -1,0 +1,4 @@
+- Improved the `icestormadmin` diagnostics when no topic manager can be reached. Without any configuration the
+  tool now prints `no manager proxies configured` instead of failing with a raw endpoint parse error, and when
+  `IceStormAdmin.Host` or `IceStormAdmin.Port` is set, a missing port, a malformed value, and an unreachable
+  `IceStorm/Finder` object are now each reported as such.

--- a/changelog.d/service-icestorm/5962.md
+++ b/changelog.d/service-icestorm/5962.md
@@ -1,4 +1,5 @@
-- Improved the `icestormadmin` diagnostics when no topic manager can be reached. Without any configuration the
-  tool now prints `no manager proxies configured` instead of failing with a raw endpoint parse error, and when
-  `IceStormAdmin.Host` or `IceStormAdmin.Port` is set, a missing port, a malformed value, and an unreachable
-  `IceStorm/Finder` object are now each reported as such.
+- Fixed `icestormadmin` to report `no manager proxies configured` when it runs without any configuration.
+  Previously, it failed with a cryptic endpoint parse error.
+- Improved the `icestormadmin` error messages when `IceStormAdmin.Host` or `IceStormAdmin.Port` is set: a missing
+  port, an invalid host or port value, and an unreachable `IceStorm/Finder` object are now reported as distinct
+  errors.

--- a/cpp/src/IceStorm/Admin.cpp
+++ b/cpp/src/IceStorm/Admin.cpp
@@ -156,20 +156,37 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
         string host = properties->getIceProperty("IceStormAdmin.Host");
         string port = properties->getIceProperty("IceStormAdmin.Port");
 
-        const int timeout = 3000; // 3s connection timeout.
-        ostringstream os;
-        os << "IceStorm/Finder";
-        os << ":tcp" << (host.empty() ? "" : (" -h \"" + host + "\"")) << " -p " << port << " -t " << timeout;
-        os << ":ssl" << (host.empty() ? "" : (" -h \"" + host + "\"")) << " -p " << port << " -t " << timeout;
+        if (!host.empty() || !port.empty())
+        {
+            // The IceStorm/Finder fallback is configured. A host alone is not sufficient to build the Finder
+            // endpoints: the port is required, it has no default.
+            if (port.empty())
+            {
+                consoleErr << args[0] << ": IceStormAdmin.Host is set but IceStormAdmin.Port is not" << endl;
+                return 1;
+            }
 
-        IceStorm::FinderPrx finder{communicator, os.str()};
-        try
-        {
-            defaultManager = finder->getTopicManager();
-        }
-        catch (const Ice::LocalException&)
-        {
-            // Ignore.
+            const int timeout = 3000; // 3s connection timeout.
+            ostringstream os;
+            os << "IceStorm/Finder";
+            os << ":tcp" << (host.empty() ? "" : (" -h \"" + host + "\"")) << " -p " << port << " -t " << timeout;
+            os << ":ssl" << (host.empty() ? "" : (" -h \"" + host + "\"")) << " -p " << port << " -t " << timeout;
+
+            try
+            {
+                IceStorm::FinderPrx finder{communicator, os.str()};
+                defaultManager = finder->getTopicManager();
+            }
+            catch (const Ice::ParseException&)
+            {
+                consoleErr << args[0] << ": invalid IceStormAdmin.Host or IceStormAdmin.Port value" << endl;
+                return 1;
+            }
+            catch (const Ice::LocalException& ex)
+            {
+                consoleErr << args[0] << ": could not contact the IceStorm/Finder object:" << endl << ex << endl;
+                return 1;
+            }
         }
     }
 

--- a/cpp/src/IceStorm/Admin.cpp
+++ b/cpp/src/IceStorm/Admin.cpp
@@ -166,11 +166,10 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
                 return 1;
             }
 
-            const int timeout = 3000; // 3s connection timeout.
             ostringstream os;
             os << "IceStorm/Finder";
-            os << ":tcp" << (host.empty() ? "" : (" -h \"" + host + "\"")) << " -p " << port << " -t " << timeout;
-            os << ":ssl" << (host.empty() ? "" : (" -h \"" + host + "\"")) << " -p " << port << " -t " << timeout;
+            os << ":tcp" << (host.empty() ? "" : (" -h \"" + host + "\"")) << " -p " << port;
+            os << ":ssl" << (host.empty() ? "" : (" -h \"" + host + "\"")) << " -p " << port;
 
             try
             {


### PR DESCRIPTION
Without any configuration, `icestormadmin` built the `IceStorm/Finder` fallback proxy with an empty `IceStormAdmin.Port` (the property has no default) and constructed it outside the try block, so the tool died with a raw endpoint parse error — `no argument provided for -p option in endpoint ''tcp  -p -t 3000''` — instead of the intended `no manager proxies configured` message.

The tool now distinguishes the failure modes instead of reporting them all as "no manager proxies configured": that message is reserved for a truly unconfigured run, while a partially configured or unreachable Finder gets a specific error (the unreachable case follows `icegridadmin`'s "could not contact the default locator" pattern). The exit code is unchanged (1) in all cases.

Verified against a local build:

| Invocation | Before | After |
|---|---|---|
| no configuration | `no argument provided for -p option in endpoint ''tcp  -p -t 3000''` | `no manager proxies configured` |
| `--IceStormAdmin.Host=localhost` only | same parse error (empty port) | `IceStormAdmin.Host is set but IceStormAdmin.Port is not` |
| `--IceStormAdmin.Port=abc` | `invalid port value 'abc' in endpoint ''tcp  -p abc -t 3000''` | `invalid IceStormAdmin.Host or IceStormAdmin.Port value` |
| `--IceStormAdmin.Port=39999` (nothing listening) | `no manager proxies configured` (after the 3s timeouts, misleading) | `could not contact the IceStorm/Finder object:` + the connection exception |

Fixes #5962.