### PR TITLE
Fix incorrect and stale API doc comments in the MATLAB Ice library

### DIFF
--- a/matlab/lib/+Ice/+SSL/ConnectionInfo.m
+++ b/matlab/lib/+Ice/+SSL/ConnectionInfo.m
@@ -2,7 +2,8 @@ classdef (Sealed) ConnectionInfo < Ice.ConnectionInfo
     %CONNECTIONINFO Provides access to the connection details of an SSL connection.
     %
     %   ConnectionInfo Properties:
-    %     peerCertificate - The peer certificate.
+    %     peerCertificate - The peer certificate encoded in PEM format, or an empty character vector if the peer did
+    %       not provide a certificate.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -14,7 +15,8 @@ classdef (Sealed) ConnectionInfo < Ice.ConnectionInfo
         end
     end
     properties (SetAccess = immutable)
-        %PEERCERTIFICATE The peer certificate.
+        %PEERCERTIFICATE The peer certificate encoded in PEM format, or an empty character vector if the peer did not
+        %   provide a certificate.
         %   character vector
         peerCertificate (1, :) char
     end

--- a/matlab/lib/+Ice/AlreadyRegisteredException.m
+++ b/matlab/lib/+Ice/AlreadyRegisteredException.m
@@ -3,17 +3,17 @@ classdef (Sealed) AlreadyRegisteredException < Ice.LocalException
     %   the Ice runtime.
     %
     %   AlreadyRegisteredException Properties:
-    %     kindOfObject - The kind of object that could not be removed.
-    %     id - The ID (or name) of the object that is registered already.
+    %     kindOfObject - The kind of object that is already registered.
+    %     id - The ID (or name) of the object that is already registered.
 
     % Copyright (c) ZeroC, Inc.
 
     properties
-        %KINDOFOBJECT The kind of object that could not be removed.
+        %KINDOFOBJECT The kind of object that is already registered.
         %   character vector
         kindOfObject (1, :) char = ''
 
-        %ID The ID (or name) of the object that is registered already.
+        %ID The ID (or name) of the object that is already registered.
         %   character vector
         id (1, :) char = ''
     end

--- a/matlab/lib/+Ice/ClassSliceLoader.m
+++ b/matlab/lib/+Ice/ClassSliceLoader.m
@@ -2,14 +2,16 @@ classdef (Sealed) ClassSliceLoader < Ice.SliceLoader
     %CLASSSLICELOADER Implements Ice.SliceLoader using meta classes.
     %
     %   ClassSliceLoader Methods:
-    %     ClassSliceLoader - Constructs a ClassSliceLoader from one or more meta classes.
+    %     ClassSliceLoader - Constructs a ClassSliceLoader from meta classes of generated classes or exceptions.
     %     newInstance - Creates a class or exception instance from a Slice type ID.
 
     % Copyright (c) ZeroC, Inc.
 
     methods
         function obj = ClassSliceLoader(metaclass)
-            %CLASSSLICELOADER Constructs a ClassSliceLoader from one or more meta classes.
+            %CLASSSLICELOADER Constructs a ClassSliceLoader from meta classes of generated classes or exceptions.
+            %   Errors with identifier 'Ice:ArgumentException' when a metaclass does not correspond to a generated
+            %   class or exception.
             %
             %   Input Arguments (Repeating)
             %     metaclass - The meta class of a generated class or exception.
@@ -42,6 +44,8 @@ classdef (Sealed) ClassSliceLoader < Ice.SliceLoader
         end
 
         function r = newInstance(obj, typeId)
+            %NEWINSTANCE Creates a class or exception instance from a Slice type ID.
+            %   See also Ice.SliceLoader.newInstance.
             arguments
                 obj (1, 1) Ice.ClassSliceLoader
                 typeId (1, :) char

--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -118,7 +118,7 @@ classdef Communicator < IceInternal.WrapperObject
             %
             %   Input Arguments
             %     str - The stringified proxy to convert into a proxy.
-            %       character vector | string scalar
+            %       character vector
             %
             %   Output Arguments
             %     r - The proxy, or an empty array if str is an empty string.

--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -14,7 +14,7 @@ classdef Communicator < IceInternal.WrapperObject
     %     getImplicitContext - Gets the implicit context associated with this communicator.
     %     getLogger - Gets the logger for this communicator.
     %     getProperties - Gets the Ice properties for this communicator.
-    %     identityToString - Convert an identity into a string.
+    %     identityToString - Converts an identity into a string.
     %     propertyToProxy - Converts a set of proxy properties into a proxy.
     %     proxyToProperty - Converts a proxy to a set of proxy properties.
     %     proxyToString - Converts a proxy into a string.
@@ -41,9 +41,10 @@ classdef Communicator < IceInternal.WrapperObject
             %
             %   Input Name-Value Arguments
             %     Properties - Properties object used to initialize the communicator properties. If args is non-empty,
-            %       any reserved properties specified in args override these properties.
+            %       any Ice options in args (arguments starting with -- and one of the reserved prefixes, such as Ice
+            %       or IceSSL) override these properties.
             %       Ice.Properties scalar
-            %     SliceLoader - Slice loader used to load Slice classes and exceptions.
+            %     SliceLoader - The Slice loader, used to unmarshal Slice classes and exceptions.
             %       Ice.SliceLoader scalar
             %
             %   Output Arguments
@@ -113,9 +114,11 @@ classdef Communicator < IceInternal.WrapperObject
             %STRINGTOPROXY Converts a stringified proxy into a proxy.
             %   Deprecated: Use the constructor of your proxy class instead.
             %
+            %   Throws an Ice.ParseException if str is not a valid proxy string.
+            %
             %   Input Arguments
             %     str - The stringified proxy to convert into a proxy.
-            %       character vector
+            %       character vector | string scalar
             %
             %   Output Arguments
             %     r - The proxy, or an empty array if str is an empty string.
@@ -170,7 +173,7 @@ classdef Communicator < IceInternal.WrapperObject
             %       character vector
             %
             %   Output Arguments
-            %     r - The proxy.
+            %     r - The proxy, or an empty array if the property is not set.
             %       Ice.ObjectPrx scalar | empty array of Ice.ObjectPrx
 
             arguments
@@ -212,7 +215,7 @@ classdef Communicator < IceInternal.WrapperObject
         end
 
         function r = identityToString(obj, id)
-            %IDENTITYTOSTRING Convert an identity into a string.
+            %IDENTITYTOSTRING Converts an identity into a string.
             %
             %   Input Arguments
             %     id - The identity to convert into a string.
@@ -304,7 +307,8 @@ classdef Communicator < IceInternal.WrapperObject
 
         function setDefaultRouter(obj, proxy)
             %SETDEFAULTROUTER Sets a default router for this communicator.
-            %   All newly created proxies will use this default router.
+            %   All newly created proxies will use this default router. This method has no effect on existing proxies.
+            %   Pass an empty array to remove the default router.
             %
             %   Input Arguments
             %     proxy - The default router to use for this communicator.
@@ -343,7 +347,8 @@ classdef Communicator < IceInternal.WrapperObject
 
         function setDefaultLocator(obj, proxy)
             %SETDEFAULTLOCATOR Sets a default locator for this communicator.
-            %   All newly created proxies will use this default locator.
+            %   All newly created proxies will use this default locator. This method has no effect on existing
+            %   proxies. Pass an empty array to remove the default locator.
             %
             %   Input Arguments
             %     proxy - The default locator to use for this communicator.
@@ -389,7 +394,7 @@ classdef Communicator < IceInternal.WrapperObject
             %       Ice.CompressBatch scalar
             %
             %   Output Arguments
-            %     r - A future that will be completed when the invocation completes.
+            %     r - A future that completes when all batch requests have been sent.
             %       Ice.Future scalar
 
             arguments

--- a/matlab/lib/+Ice/CompositeSliceLoader.m
+++ b/matlab/lib/+Ice/CompositeSliceLoader.m
@@ -1,5 +1,6 @@
 classdef (Sealed) CompositeSliceLoader < Ice.SliceLoader
     %COMPOSITESLICELOADER Implements Ice.SliceLoader by combining multiple Slice loaders.
+    %   The loaders are consulted in the order they were added; the first non-empty result is returned.
     %
     %   CompositeSliceLoader Methods:
     %     CompositeSliceLoader - Constructs a new CompositeSliceLoader.
@@ -41,6 +42,8 @@ classdef (Sealed) CompositeSliceLoader < Ice.SliceLoader
         end
 
         function r = newInstance(obj, typeId)
+            %NEWINSTANCE Creates a class or exception instance from a Slice type ID.
+            %   See also Ice.SliceLoader.newInstance.
             arguments
                 obj (1, 1) Ice.CompositeSliceLoader
                 typeId (1, :) char

--- a/matlab/lib/+Ice/Connection.m
+++ b/matlab/lib/+Ice/Connection.m
@@ -3,17 +3,19 @@ classdef Connection < IceInternal.WrapperObject
     %
     %   Connection Methods:
     %     abort - Aborts this connection.
-    %     close - Closes the connection gracefully after waiting for all outstanding invocations to complete.
-    %     createProxy - Creates a proxy that uses this connection.
+    %     close - Starts a graceful closure of this connection once all outstanding invocations have completed.
+    %     createProxy - Creates a special proxy (a "fixed proxy") that always uses this connection.
+    %     disableInactivityCheck - Disables the inactivity check on this connection.
     %     eq - Compares this connection with another Connection for equality.
     %     flushBatchRequests - Flushes any pending batch requests for this connection.
     %     flushBatchRequestsAsync - An asynchronous flushBatchRequests.
     %     getEndpoint - Gets the endpoint from which this connection was created.
-    %     getInfo - Gets the connection information for this connection.
-    %     setBufferSize - Sets the buffer sizes for this connection.
-    %     throwException - Manually throws an exception to indicate that the connection is lost.
-    %     toString - Gets a description of this connection.
-    %     type - Gets the type of this connection.
+    %     getInfo - Returns the connection information.
+    %     setBufferSize - Sets the size of the receive and send buffers.
+    %     throwException - Throws the exception that provides the reason for the closure of this connection.
+    %     toString - Returns a description of the connection as human readable text, suitable for logging or error
+    %       messages.
+    %     type - Returns the connection type.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -27,7 +29,10 @@ classdef Connection < IceInternal.WrapperObject
     methods
         function r = eq(obj, other)
             %EQ Compares this connection with another Connection for equality.
-            %   See also eq.
+            %
+            %   Output Arguments
+            %     r - True if both objects refer to the same connection, false otherwise.
+            %       logical scalar
 
             if isempty(other) || ~isa(other, 'Ice.Connection')
                 r = false;
@@ -49,10 +54,12 @@ classdef Connection < IceInternal.WrapperObject
         end
 
         function f = close(obj)
-            %CLOSE Closes the connection gracefully after waiting for all outstanding invocations to complete.
+            %CLOSE Starts a graceful closure of this connection once all outstanding invocations have completed.
             %
             %   Output Arguments
-            %     f - A future that completes when the connection is closed.
+            %     f - A future that completes when the connection closure completes. If closing takes longer than the
+            %       configured close timeout, the connection is aborted with an Ice.CloseTimeoutException and the
+            %       future completes with this exception.
             %       Ice.Future scalar
 
             arguments
@@ -65,14 +72,14 @@ classdef Connection < IceInternal.WrapperObject
         end
 
         function r = createProxy(obj, id)
-            %CREATEPROXY Creates a special proxy that always uses this connection.
+            %CREATEPROXY Creates a special proxy (a "fixed proxy") that always uses this connection.
             %
             %   Input Arguments
-            %     id - The identity for which a proxy is to be created.
+            %     id - The identity of the target object.
             %       Ice.Identity scalar
             %
             %   Output Arguments
-            %     r - A proxy that matches the given identity and uses this connection.
+            %     r - A fixed proxy with the provided identity.
             %       Ice.ObjectPrx scalar
 
             arguments
@@ -85,7 +92,7 @@ classdef Connection < IceInternal.WrapperObject
         end
 
         function disableInactivityCheck(obj)
-            %DISABLEINACTIVITYCHECK Disables the inactivity check for this connection.
+            %DISABLEINACTIVITYCHECK Disables the inactivity check on this connection.
 
             arguments
                 obj (1, 1) Ice.Connection
@@ -148,7 +155,7 @@ classdef Connection < IceInternal.WrapperObject
         end
 
         function r = type(obj)
-            %TYPE Returns the connection type. This corresponds to the endpoint type, i.e., "tcp", "udp", etc.
+            %TYPE Returns the connection type. This corresponds to the endpoint type, such as "tcp", "udp", etc.
             %
             %   Output Arguments
             %     r - The type of the connection.
@@ -162,7 +169,7 @@ classdef Connection < IceInternal.WrapperObject
 
         function r = toString(obj)
             %TOSTRING Returns a description of the connection as human readable text, suitable for logging or error
-            %   messages.
+            %   messages. This method remains usable after the connection is closed or aborted.
             %
             %   Output Arguments
             %     r - The description of the connection as human readable text.
@@ -175,7 +182,8 @@ classdef Connection < IceInternal.WrapperObject
         end
 
         function r = getInfo(obj)
-            %GETINFO Returns the connection information.
+            %GETINFO Returns the connection information. If the connection is closed, this method throws the exception
+            %   that caused the closure.
             %
             %   Output Arguments
             %     r - The connection information.
@@ -189,12 +197,12 @@ classdef Connection < IceInternal.WrapperObject
         end
 
         function setBufferSize(obj, rcvSize, sndSize)
-            %SETBUFFERSIZE Sets the connection buffer receive/send size.
+            %SETBUFFERSIZE Sets the size of the receive and send buffers.
             %
             %   Input Arguments
-            %     rcvSize - The connection receive buffer size.
+            %     rcvSize - The size of the receive buffer.
             %       int32 scalar
-            %     sndSize - The connection send buffer size.
+            %     sndSize - The size of the send buffer.
             %       int32 scalar
 
             arguments
@@ -206,10 +214,11 @@ classdef Connection < IceInternal.WrapperObject
         end
 
         function throwException(obj)
-            %THROWEXCEPTION Throws an exception indicating the reason for connection closure.
-            %   For example, CloseConnectionException is thrown if the connection was closed gracefully, whereas
-            %   ConnectionAbortedException/ConnectionClosedException are thrown if the connection was manually closed by
-            %   the application. This method does nothing if the connection is not yet closed.
+            %THROWEXCEPTION Throws the exception that provides the reason for the closure of this connection.
+            %   This method does nothing if the connection is not yet closing or closed. For example, this method
+            %   throws Ice.CloseConnectionException when the connection was closed gracefully by the peer,
+            %   Ice.ConnectionClosedException when the connection was closed gracefully by the application, and
+            %   Ice.ConnectionAbortedException when the connection was aborted with abort.
 
             arguments
                 obj (1, 1) Ice.Connection

--- a/matlab/lib/+Ice/ConnectionAbortedException.m
+++ b/matlab/lib/+Ice/ConnectionAbortedException.m
@@ -3,13 +3,14 @@ classdef ConnectionAbortedException < Ice.LocalException
     %   aborted.
     %
     %   ConnectionAbortedException Properties:
-    %     closedByApplication - True if the connection was closed by the application, false if it was closed by the Ice runtime.
+    %     closedByApplication - True if the connection was aborted by the application, false if it was aborted by the
+    %       Ice runtime.
 
     % Copyright (c) ZeroC, Inc.
 
     properties
-        %CLOSEDBYAPPLICATION True if the connection was closed by the application, false if it was closed by the Ice
-        %   runtime.
+        %CLOSEDBYAPPLICATION True if the connection was aborted by the application, false if it was aborted by the
+        %   Ice runtime.
         %   logical scalar
         closedByApplication (1, 1) logical = false
     end

--- a/matlab/lib/+Ice/Endpoint.m
+++ b/matlab/lib/+Ice/Endpoint.m
@@ -19,7 +19,10 @@ classdef Endpoint < IceInternal.WrapperObject
         function r = eq(obj, other)
             %EQ Compares this Endpoint with another Endpoint for equality.
             %
-            %   See also eq.
+            %   Output Arguments
+            %     r - True if both objects refer to the same endpoint, false otherwise.
+            %       logical scalar
+
             if isempty(other) || ~isa(other, 'Ice.Endpoint')
                 r = false;
             else
@@ -34,7 +37,7 @@ classdef Endpoint < IceInternal.WrapperObject
             %TOSTRING Returns a string representation of the endpoint.
             %
             %   Output Arguments
-            %     The string representation of the endpoint.
+            %     r - The string representation of the endpoint.
             %       character vector
 
             arguments

--- a/matlab/lib/+Ice/EndpointInfo.m
+++ b/matlab/lib/+Ice/EndpointInfo.m
@@ -7,8 +7,8 @@ classdef EndpointInfo
     %
     %   EndpointInfo Methods:
     %     type - Returns the type of the endpoint.
-    %     datagram - Returns true if this endpoint is a datagram endpoint.
-    %     secure - Returns true if this endpoint is a secure endpoint.
+    %     datagram - Returns true if this endpoint's transport is a datagram transport (namely, UDP).
+    %     secure - Returns true if this endpoint's transport uses SSL.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -31,7 +31,7 @@ classdef EndpointInfo
         end
 
         function r = datagram(obj)
-            %DATAGRAM Returns true if this endpoint is a datagram endpoint.
+            %DATAGRAM Returns true if this endpoint's transport is a datagram transport (namely, UDP).
             %
             %   Output Arguments
             %     r - True for a datagram endpoint.
@@ -48,7 +48,7 @@ classdef EndpointInfo
         end
 
         function r = secure(obj)
-            %SECURE Returns true if this endpoint is a secure endpoint.
+            %SECURE Returns true if this endpoint's transport uses SSL.
             %
             %   Output Arguments
             %     r - True for a secure endpoint.

--- a/matlab/lib/+Ice/EndpointSelectionType.m
+++ b/matlab/lib/+Ice/EndpointSelectionType.m
@@ -1,18 +1,17 @@
 classdef EndpointSelectionType < uint8
-    %ENDPOINTSELECTIONTYPE Determines the order in which the Ice run time uses the endpoints in a proxy when
-    %   establishing a connection.
+    %ENDPOINTSELECTIONTYPE Determines how the Ice runtime sorts proxy endpoints when establishing a connection.
     %
     %   EndpointSelectionType Properties:
-    %     Random - Random causes the endpoints to be arranged in a random order.
-    %     Ordered - Ordered forces the Ice run time to use the endpoints in the order they appeared in the proxy.
+    %     Random - The Ice runtime shuffles the endpoints in a random order.
+    %     Ordered - The Ice runtime uses the endpoints in the order they appear in the proxy.
 
     % Copyright (c) ZeroC, Inc.
 
     enumeration
-        %RANDOM Random causes the endpoints to be arranged in a random order.
+        %RANDOM The Ice runtime shuffles the endpoints in a random order.
         Random (0)
 
-        %ORDERED Ordered forces the Ice run time to use the endpoints in the order they appeared in the proxy.
+        %ORDERED The Ice runtime uses the endpoints in the order they appear in the proxy.
         Ordered (1)
     end
     methods (Static)

--- a/matlab/lib/+Ice/Exception.m
+++ b/matlab/lib/+Ice/Exception.m
@@ -1,5 +1,5 @@
 classdef (Abstract) Exception < MException
-    %EXCEPTION Base class for all Ice exceptions.
+    %EXCEPTION Abstract base class for all Ice exceptions.
 
     % Copyright (c) ZeroC, Inc.
 end

--- a/matlab/lib/+Ice/FacetNotExistException.m
+++ b/matlab/lib/+Ice/FacetNotExistException.m
@@ -1,5 +1,5 @@
 classdef (Sealed) FacetNotExistException < Ice.RequestFailedException
-    %FACETNOTEXISTEXCEPTION The exception that is thrown when a dispatch cannot find a servant for the identity +
+    %FACETNOTEXISTEXCEPTION The exception that is thrown when a dispatch could not find a servant for the identity +
     %   facet carried by the request.
 
     % Copyright (c) ZeroC, Inc.

--- a/matlab/lib/+Ice/FormatType.m
+++ b/matlab/lib/+Ice/FormatType.m
@@ -1,18 +1,20 @@
 classdef FormatType < uint8
-    %FORMATTYPE This enumeration describes the possible formats for classes and exceptions.
+    %FORMATTYPE Specifies the format for marshaling classes and exceptions with the Slice 1.1 encoding.
     %
     %   FormatType Properties:
-    %     CompactFormat - A minimal format that eliminates the possibility for slicing unrecognized types.
-    %     SlicedFormat - Allow slicing and preserve slices for unknown types.
+    %     CompactFormat - Favors compactness, but does not support slicing-off unknown slices during unmarshaling.
+    %     SlicedFormat - Allows slicing-off unknown slices during unmarshaling, at the cost of some extra space in the
+    %       marshaled data.
 
     % Copyright (c) ZeroC, Inc.
 
     % Don't use an enumeration as comparing enumerators with integral values is significantly slower.
     properties (Constant)
-        %COMPACTFORMAT A minimal format that eliminates the possibility for slicing unrecognized types.
+        %COMPACTFORMAT Favors compactness, but does not support slicing-off unknown slices during unmarshaling.
         CompactFormat = uint8(0)
 
-        %SLICEDFORMAT Allow slicing and preserve slices for unknown types.
+        %SLICEDFORMAT Allows slicing-off unknown slices during unmarshaling, at the cost of some extra space in the
+        %   marshaled data.
         SlicedFormat = uint8(1)
     end
 end

--- a/matlab/lib/+Ice/Future.m
+++ b/matlab/lib/+Ice/Future.m
@@ -9,7 +9,7 @@ classdef Future < IceInternal.WrapperObject
     %     State - The current state of the future.
     %
     %   Future Methods:
-    %     cancel - If the invocation is still pending, calling this method instructs the local Ice runtime to ignore its results.
+    %     cancel - Cancels this invocation locally if it is still pending.
     %     fetchOutputs - Blocks until the invocation completes and then returns the results or throws an exception.
     %     wait - Blocks until the invocation reaches a certain state, or a timeout expires.
 
@@ -34,6 +34,8 @@ classdef Future < IceInternal.WrapperObject
         Read (1, 1) logical = false
 
         %STATE The current state of the future. Its initial value is 'running' and its final value is 'finished'.
+        %   The 'sent' state is only reported for twoway invocations; other futures transition directly from 'running'
+        %   to 'finished'.
         %   'running' | 'sent' | 'finished'
         State (1, :) char = 'running'
     end
@@ -76,7 +78,7 @@ classdef Future < IceInternal.WrapperObject
             %     state - If provided, wait blocks until the future reaches the given state. If not provided, wait
             %     blocks until the state is 'finished'. Note that the future enters the 'finished' state when completed
             %     successfully or exceptionally.
-            %     'running' | 'sent' | 'finished' | empty array (default)
+            %     'running' | 'sent' | 'finished'
             %   timeout - If provided, wait blocks up to the given number of seconds while waiting for the future to
             %     reach the desired state. If the timeout is negative or not provided, wait blocks indefinitely.
             %     double | empty array (default)
@@ -126,8 +128,9 @@ classdef Future < IceInternal.WrapperObject
         end
 
         function cancel(obj)
-            %CANCEL If the invocation is still pending, calling this method instructs the local Ice runtime to ignore
-            %   its results.
+            %CANCEL Cancels this invocation locally if it is still pending. The future then completes with an
+            %   Ice.InvocationCanceledException. Cancellation has no effect on the request if it was already sent to
+            %   the server.
 
             if ~isempty(obj.impl_)
                 obj.iceCall('cancel');

--- a/matlab/lib/+Ice/Future.m
+++ b/matlab/lib/+Ice/Future.m
@@ -33,9 +33,8 @@ classdef Future < IceInternal.WrapperObject
         %   logical scalar
         Read (1, 1) logical = false
 
-        %STATE The current state of the future. Its initial value is 'running' and its final value is 'finished'.
-        %   The 'sent' state is only reported for twoway invocations; other futures transition directly from 'running'
-        %   to 'finished'.
+        %STATE The current state of the future. Its final value is 'finished'.
+        %   The 'sent' state is only reported for twoway invocations.
         %   'running' | 'sent' | 'finished'
         State (1, :) char = 'running'
     end

--- a/matlab/lib/+Ice/IPEndpointInfo.m
+++ b/matlab/lib/+Ice/IPEndpointInfo.m
@@ -1,5 +1,5 @@
 classdef IPEndpointInfo < Ice.EndpointInfo
-    %IPENDPOINTINFO Provides access to the address details of a IP endpoint.
+    %IPENDPOINTINFO Provides access to the address details of an IP endpoint.
     %
     %   IPEndpointInfo Properties:
     %     host - The host or address configured with the endpoint.

--- a/matlab/lib/+Ice/ImplicitContext.m
+++ b/matlab/lib/+Ice/ImplicitContext.m
@@ -15,10 +15,10 @@ classdef ImplicitContext < IceInternal.WrapperObject
     end
     methods
         function r = getContext(obj)
-            %GETCONTEXT Gets a copy of the underlying context.
+            %GETCONTEXT Gets a copy of the request context.
             %
             %   Output Arguments
-            %     r - A copy of the underlying context.
+            %     r - A copy of the request context.
             %       dictionary(string, string) scalar
 
             arguments
@@ -28,7 +28,7 @@ classdef ImplicitContext < IceInternal.WrapperObject
         end
 
         function setContext(obj, newContext)
-            %SETCONTEXT Sets the underlying context.
+            %SETCONTEXT Sets the request context.
             %
             %   Input Arguments
             %     newContext - The new context.
@@ -42,7 +42,7 @@ classdef ImplicitContext < IceInternal.WrapperObject
         end
 
         function r = containsKey(obj, key)
-            %CONTAINSKEY Checks if this key has an associated value in the underlying context.
+            %CONTAINSKEY Checks if this key has an associated value in the request context.
             %
             %   Input Arguments
             %     key - The key.
@@ -60,7 +60,7 @@ classdef ImplicitContext < IceInternal.WrapperObject
         end
 
         function r = get(obj, key)
-            %GET Gets the value associated with the given key in the underlying context. Returns an empty string if no
+            %GET Gets the value associated with the given key in the request context. Returns an empty string if no
             %   value is associated with the key.
             %
             %   See also containsKey.
@@ -81,7 +81,7 @@ classdef ImplicitContext < IceInternal.WrapperObject
         end
 
         function r = put(obj, key, value)
-            %PUT Creates or updates a key/value entry in the underlying context.
+            %PUT Creates or updates a key/value entry in the request context.
             %
             %   Input Arguments
             %     key - The key.
@@ -102,7 +102,7 @@ classdef ImplicitContext < IceInternal.WrapperObject
         end
 
         function r = remove(obj, key)
-            %REMOVE Removes the entry for the given key in the underlying context. Returns an empty array if there is
+            %REMOVE Removes the entry for the given key in the request context. Returns an empty string if there is
             %   no entry for the key.
             %
             %   Input Arguments

--- a/matlab/lib/+Ice/InitializationData.m
+++ b/matlab/lib/+Ice/InitializationData.m
@@ -10,14 +10,23 @@ classdef (Sealed) InitializationData
     % Copyright (c) ZeroC, Inc.
 
     properties
-        Properties (1, 1) Ice.Properties = Ice.Properties() % The properties of the communicator.
-        SliceLoader (1, 1) Ice.SliceLoader = IceInternal.DefaultSliceLoader.Instance % The Slice loader.
+        %PROPERTIES The properties of the communicator.
+        %   Ice.Properties scalar
+        Properties (1, 1) Ice.Properties = Ice.Properties()
+
+        %SLICELOADER The Slice loader, used to unmarshal Slice classes and exceptions.
+        %   Ice.SliceLoader scalar
+        SliceLoader (1, 1) Ice.SliceLoader = IceInternal.DefaultSliceLoader.Instance
     end
     properties (Dependent, Hidden)
         properties_ (1, 1) Ice.Properties % Deprecated: Use Properties instead.
     end
     methods
         function obj = InitializationData(options)
+            %INITIALIZATIONDATA Constructs an InitializationData from name-value arguments.
+            %
+            %   Examples
+            %     initData = Ice.InitializationData(Properties = props);
             arguments
                 options.?Ice.InitializationData
             end

--- a/matlab/lib/+Ice/InitializationException.m
+++ b/matlab/lib/+Ice/InitializationException.m
@@ -1,5 +1,5 @@
 classdef (Sealed) InitializationException < Ice.LocalException
-    %INITIALIZATIONEXCEPTION The exception that is thrown when communicator initialization fails.
+    %INITIALIZATIONEXCEPTION The exception that is thrown when a failure occurs during initialization.
 
     % Copyright (c) ZeroC, Inc.
 end

--- a/matlab/lib/+Ice/LocalException.m
+++ b/matlab/lib/+Ice/LocalException.m
@@ -1,5 +1,8 @@
 classdef LocalException < Ice.Exception
     %LOCALEXCEPTION Base class for all Ice exceptions not defined in Slice.
+    %   The identifier of an Ice.LocalException is 'Ice:<Name>Exception' (for example 'Ice:TimeoutException'). Ice
+    %   local exceptions that do not have a corresponding MATLAB class are reported as instances of this class; their
+    %   identifier carries the underlying exception name.
 
     % Copyright (c) ZeroC, Inc.
 

--- a/matlab/lib/+Ice/Logger.m
+++ b/matlab/lib/+Ice/Logger.m
@@ -2,9 +2,9 @@ classdef Logger < IceInternal.WrapperObject
     %LOGGER Represents Ice's abstraction for logging and tracing.
     %
     %   Logger Methods:
-    %     cloneWithPrefix - Creates a new logger with a different prefix.
+    %     cloneWithPrefix - Returns a clone of the logger with a new prefix.
     %     error - Logs an error message.
-    %     getPrefix - Gets the prefix for this logger.
+    %     getPrefix - Returns this logger's prefix.
     %     print - Prints a message.
     %     trace - Logs a trace message.
     %     warning - Logs a warning message.
@@ -20,7 +20,7 @@ classdef Logger < IceInternal.WrapperObject
     methods
         function print(obj, message)
             %PRINT Prints a message. The message is printed literally, without any decorations such as executable name
-            %   or time stamp.
+            %   or timestamp.
             %
             %   Input Arguments
             %     message - The message to log.

--- a/matlab/lib/+Ice/NotRegisteredException.m
+++ b/matlab/lib/+Ice/NotRegisteredException.m
@@ -1,5 +1,6 @@
 classdef NotRegisteredException < Ice.LocalException
-    %NOTREGISTEREDEXCEPTION An attempt was made to find or deregister something that is not registered with Ice.
+    %NOTREGISTEREDEXCEPTION The exception that is thrown when attempting to find or deregister something that is not
+    %   registered with Ice.
     %
     %   NotRegisteredException Properties:
     %     kindOfObject - The kind of object that is not registered.

--- a/matlab/lib/+Ice/ObjectNotExistException.m
+++ b/matlab/lib/+Ice/ObjectNotExistException.m
@@ -1,6 +1,6 @@
 classdef (Sealed) ObjectNotExistException < Ice.RequestFailedException
-    %OBJECTNOTEXISTEXCEPTION This exception is raised if an object does not exist on the server, that is, if no
-    %   facets with the given identity exist.
+    %OBJECTNOTEXISTEXCEPTION The exception that is thrown when a dispatch could not find a servant for the identity
+    %   carried by the request.
 
     % Copyright (c) ZeroC, Inc.
 end

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -12,6 +12,8 @@ classdef ObjectPrx < IceInternal.WrapperObject
     %         character vector
     %
     %   ObjectPrx Methods:
+    %     checkedCast - Creates an Ice.ObjectPrx from an existing proxy after confirming the target object's type
+    %       via a remote invocation.
     %     disp - Displays this proxy as a string.
     %     eq - Compares this proxy with another ObjectPrx for equality.
     %     ice_adapterId - Returns a proxy that is identical to this proxy, except for the adapter ID.
@@ -69,11 +71,9 @@ classdef ObjectPrx < IceInternal.WrapperObject
     %     ice_ping - Tests whether the target object of this proxy can be reached.
     %     ice_pingAsync - An asynchronous ice_ping.
     %     ice_router - Returns a proxy that is identical to this proxy, except for the router.
+    %     ice_staticId - Returns the Slice type ID associated with this type.
     %     ice_toString - Creates a stringified version of this proxy.
     %     ice_twoway - Returns a proxy that is identical to this proxy, but uses twoway invocations.
-    %     checkedCast - Creates an Ice.ObjectPrx from an existing proxy after confirming the target object's type
-    %       via a remote invocation.
-    %     ice_staticId - Returns the Slice type ID associated with this type.
     %     uncheckedCast - Creates a new Ice.ObjectPrx from an existing proxy without any validation.
 
     % Copyright (c) ZeroC, Inc.

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -8,7 +8,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
     %     Input Arguments
     %       communicator - The associated communicator.
     %         Ice.Communicator scalar
-    %       proxyString - A stringified proxy, such as 'name:tcp -p localhost -p 4061'.
+    %       proxyString - A stringified proxy, such as 'name:tcp -h localhost -p 4061'.
     %         character vector
     %
     %   ObjectPrx Methods:
@@ -17,7 +17,8 @@ classdef ObjectPrx < IceInternal.WrapperObject
     %     ice_adapterId - Returns a proxy that is identical to this proxy, except for the adapter ID.
     %     ice_batchDatagram - Returns a proxy that is identical to this proxy, but uses batch datagram invocations.
     %     ice_batchOneway - Returns a proxy that is identical to this proxy, but uses batch oneway invocations.
-    %     ice_compress - Returns a proxy that is identical to this proxy, except for compression.
+    %     ice_compress - Returns a proxy that is identical to this proxy, except for its compression setting, which
+    %       overrides the compression setting from the proxy endpoints.
     %     ice_connectionCached - Returns a proxy that is identical to this proxy, except for connection caching.
     %     ice_connectionId - Returns a proxy that is identical to this proxy, except for its connection ID.
     %     ice_context - Returns a proxy that is identical to this proxy, except for the per-proxy context.
@@ -26,18 +27,19 @@ classdef ObjectPrx < IceInternal.WrapperObject
     %     ice_endpointSelection - Returns a proxy that is identical to this proxy, except for the endpoint selection policy.
     %     ice_endpoints - Returns a proxy that is identical to this proxy, except for the endpoints.
     %     ice_facet - Returns a proxy that is identical to this proxy, except for the facet.
-    %     ice_fixed - Obtains a proxy that is identical to this proxy, except it's a fixed proxy bound to the given connection.
-    %     ice_flushBatchRequests - Flushes any pending batched requests for this communicator.
+    %     ice_fixed - Returns a proxy that is identical to this proxy, except it's a fixed proxy bound to the given
+    %       connection.
+    %     ice_flushBatchRequests - Flushes any pending batched requests for this proxy.
     %     ice_flushBatchRequestsAsync - An asynchronous ice_flushBatchRequests.
     %     ice_getAdapterId - Returns the adapter ID for this proxy.
     %     ice_getCachedConnection - Returns the cached Connection for this proxy.
     %     ice_getCommunicator - Gets the communicator that created this proxy.
-    %     ice_getCompress - Obtains the compression override setting of this proxy.
+    %     ice_getCompress - Returns the compression override setting of this proxy.
     %     ice_getConnection - Returns the Connection for this proxy.
     %     ice_getConnectionAsync - An asynchronous ice_getConnection.
-    %     ice_getConnectionId - Returns the connection id of this proxy.
+    %     ice_getConnectionId - Returns the connection ID of this proxy.
     %     ice_getContext - Returns the per-proxy context for this proxy.
-    %     ice_getEncodingVersion - Returns the encoding version used to marshal requests parameters.
+    %     ice_getEncodingVersion - Returns the encoding version used to marshal request parameters.
     %     ice_getEndpoints - Returns the endpoints used by this proxy.
     %     ice_getEndpointSelection - Returns how this proxy selects endpoints (randomly or ordered).
     %     ice_getFacet - Returns the facet for this proxy.
@@ -50,7 +52,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
     %     ice_idAsync - An asynchronous ice_id.
     %     ice_identity - Returns a proxy that is identical to this proxy, except for the identity.
     %     ice_ids - Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
-    %     ice_idsAsync - Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
+    %     ice_idsAsync - An asynchronous ice_ids.
     %     ice_invocationTimeout - Returns a proxy that is identical to this proxy, except for the invocation timeout.
     %     ice_isA - Tests whether this object supports a specific Slice interface.
     %     ice_isAAsync - An asynchronous ice_isA.
@@ -69,6 +71,10 @@ classdef ObjectPrx < IceInternal.WrapperObject
     %     ice_router - Returns a proxy that is identical to this proxy, except for the router.
     %     ice_toString - Creates a stringified version of this proxy.
     %     ice_twoway - Returns a proxy that is identical to this proxy, but uses twoway invocations.
+    %     checkedCast - Creates an Ice.ObjectPrx from an existing proxy after confirming the target object's type
+    %       via a remote invocation.
+    %     ice_staticId - Returns the Slice type ID associated with this type.
+    %     uncheckedCast - Creates a new Ice.ObjectPrx from an existing proxy without any validation.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -79,7 +85,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %   Input Arguments
             %     communicator - The associated communicator.
             %       Ice.Communicator scalar
-            %     proxyString - A stringified proxy, such as 'name:tcp -p localhost -p 4061'.
+            %     proxyString - A stringified proxy, such as 'name:tcp -h localhost -p 4061'.
             %       character vector
             %
             %   Output Arguments
@@ -130,8 +136,13 @@ classdef ObjectPrx < IceInternal.WrapperObject
 
         function r = eq(obj, other)
             %EQ Compares this proxy with another ObjectPrx for equality.
+            %   Two proxies are equal when all their settings (identity, facet, endpoints, and other proxy options)
+            %   are identical. To compare only the target object identities, use Ice.proxyIdentityCompare.
             %
-            %   See also eq.
+            %   Output Arguments
+            %     r - True if the proxies are equal, false otherwise.
+            %       logical scalar
+
             if isempty(other) || ~isa(other, 'Ice.ObjectPrx')
                 r = false;
             else
@@ -200,7 +211,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %       unconfigured dictionary (default) | dictionary(string, string) scalar
             %
             %   Output Arguments
-            %     future - A future that will be completed with the result of the invocation.
+            %     r - A future that will be completed when the invocation completes.
             %       Ice.Future scalar
             %
             %   See also ice_ping, Ice.Future.
@@ -431,7 +442,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %ICE_GETFACET Returns the facet for this proxy.
             %
             %   Output Arguments
-            %     r - The facet for this proxy.
+            %     r - The facet for this proxy. If the proxy uses the default facet, r is the empty string.
             %       character vector
 
             arguments
@@ -703,7 +714,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getEncodingVersion(obj)
-            %ICE_GETENCODINGVERSION Returns the encoding version used to marshal requests parameters.
+            %ICE_GETENCODINGVERSION Returns the encoding version used to marshal request parameters.
             %
             %   Output Arguments
             %      r - The encoding version.
@@ -739,7 +750,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %ICE_GETROUTER Returns the router for this proxy.
             %
             %   Output Arguments
-            %      r - The router for the proxy.
+            %      r - The router for this proxy, or an empty array if no router is configured.
             %        Ice.RouterPrx scalar | empty array of Ice.RouterPrx
 
             arguments
@@ -781,7 +792,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %ICE_GETLOCATOR Returns the locator for this proxy.
             %
             %   Output Arguments
-            %      r - The locator for the proxy.
+            %      r - The locator for this proxy, or an empty array if no locator is configured.
             %        Ice.LocatorPrx scalar | empty array of Ice.LocatorPrx
 
             arguments
@@ -950,7 +961,8 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_compress(obj, b)
-            %ICE_COMPRESS Returns a proxy that is identical to this proxy, except for compression.
+            %ICE_COMPRESS Returns a proxy that is identical to this proxy, except for its compression setting, which
+            %   overrides the compression setting from the proxy endpoints.
             %
             %   Input Arguments
             %     b - True enables compression for the new proxy; false disables compression.
@@ -973,7 +985,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getCompress(obj)
-            %ICE_GETCOMPRESS Obtains the compression override setting of this proxy.
+            %ICE_GETCOMPRESS Returns the compression override setting of this proxy.
             %
             %   Output Arguments
             %     r - The compression override setting. If Ice.Unset is returned, no override is set. Otherwise,
@@ -992,7 +1004,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_fixed(obj, connection)
-            %ICE_FIXED Obtains a proxy that is identical to this proxy, except it's a fixed proxy bound to the
+            %ICE_FIXED Returns a proxy that is identical to this proxy, except it's a fixed proxy bound to the
             %   given connection.
             %
             %   Input Arguments
@@ -1088,7 +1100,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function ice_flushBatchRequests(obj)
-            %ICE_FLUSHBATCHREQUESTS Flushes any pending batched requests for this communicator.
+            %ICE_FLUSHBATCHREQUESTS Flushes any pending batched requests for this proxy.
             %   The call blocks until the flush is complete.
 
             arguments
@@ -1098,10 +1110,10 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_flushBatchRequestsAsync(obj)
-            %ICE_FLUSHBATCHREQUESTSASYNC Flushes asynchronously any pending batched requests for this communicator.
+            %ICE_FLUSHBATCHREQUESTSASYNC Flushes any pending batched requests for this proxy asynchronously.
             %
             %   Output Arguments
-            %     r - A future that will be completed when the invocation completes.
+            %     r - A future that completes when all batch requests have been sent.
             %       Ice.Future scalar
 
             arguments
@@ -1264,12 +1276,18 @@ classdef ObjectPrx < IceInternal.WrapperObject
 
     methods (Static)
         function r = ice_staticId()
+            %ICE_STATICID Returns the Slice type ID associated with this type.
+            %
+            %   Output Arguments
+            %     r - The Slice type ID ('::Ice::Object').
+            %       character vector
+
             r = '::Ice::Object';
         end
 
         function r = checkedCast(p, varargin)
-            %CHECKEDCAST Creates a proxy from an existing proxy after contacting the server to check if the target
-            %   object implements pseudo-Slice interface Ice::Object.
+            %CHECKEDCAST Creates an Ice.ObjectPrx from an existing proxy after confirming the target object's type
+            %   via a remote invocation.
             %
             %   Input Arguments
             %     p - The source proxy.
@@ -1280,8 +1298,8 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %       dictionary(string, string) scalar
             %
             %   Output Arguments
-            %     r - A new Ice.ObjectPrx scalar if the target object implements Slice interface
-            %       ::Ice::Object; otherwise, an empty array of Ice.ObjectPrx.
+            %     r - A new Ice.ObjectPrx scalar if the target object implements Slice interface ::Ice::Object; an
+            %       empty array of Ice.ObjectPrx if it does not, or when p is an empty array.
             %
             arguments
                 p Ice.ObjectPrx {mustBeScalarOrEmpty}
@@ -1294,6 +1312,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
 
         function r = uncheckedCast(p, varargin)
             %UNCHECKEDCAST Creates a new Ice.ObjectPrx from an existing proxy without any validation.
+            %   This is a purely local operation: it does not contact the server.
             %
             %   Input Arguments
             %     p - The source proxy.

--- a/matlab/lib/+Ice/OpaqueEndpointInfo.m
+++ b/matlab/lib/+Ice/OpaqueEndpointInfo.m
@@ -20,6 +20,8 @@ classdef (Sealed) OpaqueEndpointInfo < Ice.EndpointInfo
     end
     methods
         function r = type(obj)
+            %TYPE Returns the type of the endpoint.
+
             r = obj.type_;
         end
     end

--- a/matlab/lib/+Ice/OperationNotExistException.m
+++ b/matlab/lib/+Ice/OperationNotExistException.m
@@ -1,6 +1,7 @@
 classdef (Sealed) OperationNotExistException < Ice.RequestFailedException
-    %OPERATIONNOTEXISTEXCEPTION This exception is raised if an operation for a given object does not exist on the
-    %   server. Typically this is caused by either the client or the server using an outdated Slice specification.
+    %OPERATIONNOTEXISTEXCEPTION The exception that is thrown when a dispatch could not find the operation carried by
+    %   the request on the target servant. This is typically due to a mismatch in the Slice definitions, such as the
+    %   client using Slice definitions newer than the server's.
 
     % Copyright (c) ZeroC, Inc.
 end

--- a/matlab/lib/+Ice/OptionalFormat.m
+++ b/matlab/lib/+Ice/OptionalFormat.m
@@ -8,10 +8,12 @@ classdef OptionalFormat < uint8
     %     F2 - Fixed-length format (2 bytes).
     %     F4 - Fixed-length format (4 bytes).
     %     F8 - Fixed-length format (8 bytes).
-    %     Size - Variable-length format with size.
-    %     VSize - Variable-length format with variable size.
-    %     FSize - Fixed-length format with size.
-    %     Class - Class format.
+    %     Size - Size encoding using either 1 or 5 bytes. Used by enums, class identifiers, etc.
+    %     VSize - Size encoding using either 1 or 5 bytes followed by data. Used by strings, fixed-size structs, and
+    %       containers whose size can be computed prior to marshaling.
+    %     FSize - Fixed size encoding using 4 bytes followed by data. Used by variable-size structs and containers
+    %       whose size cannot be computed prior to marshaling.
+    %     Class - Class instance; no longer supported (as of Ice 3.8).
 
     % Copyright (c) ZeroC, Inc.
 
@@ -29,16 +31,18 @@ classdef OptionalFormat < uint8
         %F8 Fixed-length format (8 bytes).
         F8 = uint8(3)
 
-        %SIZE Variable-length format with size.
+        %SIZE Size encoding using either 1 or 5 bytes. Used by enums, class identifiers, etc.
         Size = uint8(4)
 
-        %VSIZE Variable-length format with variable size.
+        %VSIZE Size encoding using either 1 or 5 bytes followed by data. Used by strings, fixed-size structs, and
+        %   containers whose size can be computed prior to marshaling.
         VSize = uint8(5)
 
-        %FSIZE Fixed-length format with size.
+        %FSIZE Fixed size encoding using 4 bytes followed by data. Used by variable-size structs and containers whose
+        %   size cannot be computed prior to marshaling.
         FSize = uint8(6)
 
-        %CLASS Class format, no longer supported as of Ice 3.8.
+        %CLASS Class instance; no longer supported (as of Ice 3.8).
         Class = uint8(7)
     end
 end

--- a/matlab/lib/+Ice/OptionalFormat.m
+++ b/matlab/lib/+Ice/OptionalFormat.m
@@ -8,7 +8,7 @@ classdef OptionalFormat < uint8
     %     F2 - Fixed-length format (2 bytes).
     %     F4 - Fixed-length format (4 bytes).
     %     F8 - Fixed-length format (8 bytes).
-    %     Size - Size encoding using either 1 or 5 bytes. Used by enums, class identifiers, etc.
+    %     Size - Size encoding using either 1 or 5 bytes. Used by enums.
     %     VSize - Size encoding using either 1 or 5 bytes followed by data. Used by strings, fixed-size structs, and
     %       containers whose size can be computed prior to marshaling.
     %     FSize - Fixed size encoding using 4 bytes followed by data. Used by variable-size structs and containers
@@ -31,7 +31,7 @@ classdef OptionalFormat < uint8
         %F8 Fixed-length format (8 bytes).
         F8 = uint8(3)
 
-        %SIZE Size encoding using either 1 or 5 bytes. Used by enums, class identifiers, etc.
+        %SIZE Size encoding using either 1 or 5 bytes. Used by enums.
         Size = uint8(4)
 
         %VSIZE Size encoding using either 1 or 5 bytes followed by data. Used by strings, fixed-size structs, and

--- a/matlab/lib/+Ice/Properties.m
+++ b/matlab/lib/+Ice/Properties.m
@@ -1,7 +1,7 @@
 classdef Properties < IceInternal.WrapperObject
     %PROPERTIES Represents a set of properties used to configure Ice and Ice-based applications.
     %   A property is a key/value pair, where both the key and the value are strings. By convention, property keys
-    %   should have the form `application-name>[.category[.sub-category]].name`.
+    %   should have the form `application-name[.category[.sub-category]].name`.
     %
     %   Ice.Properties Methods:
     %     Properties - Constructs a new property set.
@@ -35,10 +35,13 @@ classdef Properties < IceInternal.WrapperObject
             %     [properties, remArgs] = Ice.Properties(args, defaults)
             %
             %   Input Arguments
-            %     args - A command-line argument vector, possibly containing options to set properties. If the
-            %       command-line options include an --Ice.Config option, the corresponding configuration file is parsed.
-            %       If the same property is set in a configuration file and in the argument vector, the argument vector
-            %       takes precedence.
+            %     args - The command-line arguments. The constructor parses arguments starting with -- and one of the
+            %       reserved prefixes (Ice, IceSSL, etc.) as properties. If there is an argument starting with
+            %       --Ice.Config, the constructor loads the specified configuration file. When the same property is
+            %       set in a configuration file and through a command-line argument, the command-line setting takes
+            %       precedence. When there is no --Ice.Config argument and Ice.Config is not already set (for example
+            %       via defaults), the constructor loads the configuration files specified by the ICE_CONFIG
+            %       environment variable.
             %       empty string array (default) | string array | cell array of character vectors
             %     defaults - A property set used to initialize the default state of the new property set. Settings in
             %       configuration files and the argument vector override these defaults.
@@ -91,6 +94,8 @@ classdef Properties < IceInternal.WrapperObject
         function r = getIceProperty(obj, key)
             %GETICEPROPERTY Gets an Ice property by key. If the property is not set, its default value is returned.
             %
+            %   Throws an Ice.PropertyException if the property is not a known Ice property.
+            %
             %   Input Arguments
             %     key - The property key.
             %       character vector
@@ -131,6 +136,8 @@ classdef Properties < IceInternal.WrapperObject
         function r = getPropertyAsInt(obj, key)
             %GETPROPERTYASINT Gets a property as an integer. If the property is not set, 0 is returned.
             %
+            %   Throws an Ice.PropertyException if the property value is not a valid integer.
+            %
             %   Input Arguments
             %     key - The property key.
             %       character vector
@@ -152,6 +159,9 @@ classdef Properties < IceInternal.WrapperObject
             %GETICEPROPERTYASINT Gets an Ice property as an integer. If the property is not set, its default value is
             %   returned.
             %
+            %   Throws an Ice.PropertyException if the property is not a known Ice property or the value is not a
+            %   valid integer.
+            %
             %   Input Arguments
             %     key - The property key.
             %       character vector
@@ -171,6 +181,8 @@ classdef Properties < IceInternal.WrapperObject
         function r = getPropertyAsIntWithDefault(obj, key, def)
             %GETPROPERTYASINTWITHDEFAULT Gets a property as an integer. If the property is not set, the given default
             %   value is returned.
+            %
+            %   Throws an Ice.PropertyException if the property value is not a valid integer.
             %
             %   Input Arguments
             %     key - The property key.
@@ -217,11 +229,13 @@ classdef Properties < IceInternal.WrapperObject
 
         function r = getIcePropertyAsList(obj, key)
             %GETICEPROPERTYASLIST Gets an Ice property as a list of strings.
-             %  The strings must be separated by whitespace or comma. If the property is not set, an empty list is
+            %   The strings must be separated by whitespace or comma. If the property is not set, its default list is
             %   returned. The strings in the list can contain whitespace and commas if they are enclosed in single or
-            %   double quotes. If quotes are mismatched, an empty list is returned. Within single quotes or double
+            %   double quotes. If quotes are mismatched, the default list is returned. Within single quotes or double
             %   quotes, you can escape the quote in question with \, e.g. O'Reilly can be written as O'Reilly,
             %   "O'Reilly" or 'O\'Reilly'.
+            %
+            %   Throws an Ice.PropertyException if the property is not a known Ice property.
             %
             %   Input Arguments
             %     key - The property key.
@@ -242,7 +256,7 @@ classdef Properties < IceInternal.WrapperObject
             %GETPROPERTYASLISTWITHDEFAULT Gets a property as a list of strings.
             %   The strings must be separated by whitespace or comma. If the property is not set, the default value is
             %   returned. The strings in the list can contain whitespace and commas if they are enclosed in single or
-            %   double quotes. If quotes are mismatched, an empty list is returned. Within single quotes or double
+            %   double quotes. If quotes are mismatched, the default list is returned. Within single quotes or double
             %   quotes, you can escape the quote in question with \, e.g. O'Reilly can be written as O'Reilly,
             %   "O'Reilly" or 'O\'Reilly'.
             %
@@ -265,7 +279,7 @@ classdef Properties < IceInternal.WrapperObject
         end
 
         function r = getPropertiesForPrefix(obj, prefix)
-            %GETPROPERTIESFORPREFIX Gets all properties whose keys begins with prefix. If prefix is an empty string,
+            %GETPROPERTIESFORPREFIX Gets all properties whose keys begin with prefix. If prefix is an empty string,
             %   then all properties are returned.
             %
             %   Input Arguments
@@ -350,15 +364,15 @@ classdef Properties < IceInternal.WrapperObject
 
         function r = parseIceCommandLineOptions(obj, options)
             %PARSEICECOMMANDLINEOPTIONS Converts a sequence of command-line options into properties. All options that
-            %   begin with one of the following prefixes are converted into properties: "--Ice", "--IceBox",
-            %   "--IceGrid", "--IceSSL", "--IceStorm", and "--Glacier2".
+            %   start with one of the reserved Ice prefixes (--Ice, --IceSSL, etc.) are converted into properties.
             %
             %   Input Arguments
             %     options - The command-line options.
             %       string array | cell array of character vectors
             %
             %   Output Arguments
-            %     r - The command-line options that do not start with one of the listed prefixes, in their original order.
+            %     r - The command-line options that do not start with one of the reserved prefixes, in their original
+            %       order.
             %       string array
 
             arguments

--- a/matlab/lib/+Ice/RequestFailedException.m
+++ b/matlab/lib/+Ice/RequestFailedException.m
@@ -10,7 +10,7 @@ classdef RequestFailedException < Ice.DispatchException
 
     properties
         %ID The identity of the Ice Object to which the request was sent.
-        %   Ice.Identity scalar
+        %   Ice.Identity scalar (empty if not set)
         id (1, :) Ice.Identity = Ice.Identity.empty
 
         %FACET The facet to which the request was sent.

--- a/matlab/lib/+Ice/SliceInfo.m
+++ b/matlab/lib/+Ice/SliceInfo.m
@@ -3,7 +3,7 @@ classdef (Sealed) SliceInfo < handle
     %
     %   SliceInfo Properties:
     %     typeId - The Slice type ID for this slice.
-    %     compactId - The Slice compact type ID for this slice.
+    %     compactId - The Slice compact type ID for this slice, or -1 if the slice has no compact ID.
     %     bytes - The encoded bytes for this slice.
     %     hasOptionalMembers - Whether or not the slice contains optional members.
     %     isLastSlice - Whether or not this is the last slice.
@@ -16,7 +16,7 @@ classdef (Sealed) SliceInfo < handle
         %   character vector
         typeId (1, :) char
 
-        %COMPACTID The Slice compact type ID for this slice.
+        %COMPACTID The Slice compact type ID for this slice, or -1 if the slice has no compact ID.
         %   int32 scalar
         compactId (1, 1) int32
 

--- a/matlab/lib/+Ice/SliceLoader.m
+++ b/matlab/lib/+Ice/SliceLoader.m
@@ -4,6 +4,8 @@ classdef (Abstract) SliceLoader < handle
     %   SliceLoader Methods:
     %     newInstance - Creates a class or exception instance from a Slice type ID.
 
+    % Copyright (c) ZeroC, Inc.
+
     methods (Abstract)
         %NEWINSTANCE Creates a class or exception instance from a Slice type ID.
         %
@@ -11,10 +13,10 @@ classdef (Abstract) SliceLoader < handle
         %     typeId - The Slice type ID or compact ID.
         %       character vector
         %
-        %    Output Arguments
-        %      r - The new class instance or exception instance, or an empty array if the implementation cannot find a
-        %        class or exception for typeId.
-        %        Ice.Value | Ice.UserException | empty array
+        %   Output Arguments
+        %     r - The new class instance or exception instance, or an empty array if the implementation cannot find a
+        %       class or exception for typeId.
+        %       Ice.Value | Ice.UserException | empty array
         r = newInstance(obj, typeId)
     end
 end

--- a/matlab/lib/+Ice/SlicedData.m
+++ b/matlab/lib/+Ice/SlicedData.m
@@ -8,7 +8,7 @@ classdef (Sealed) SlicedData < handle
 
     properties (SetAccess = immutable)
         %SLICES The details of each slice, in order of most-derived to least-derived.
-        %   cell array of SliceInfo objects
+        %   cell array of Ice.SliceInfo objects
         slices (1, :) cell
     end
     methods (Hidden)

--- a/matlab/lib/+Ice/TCPConnectionInfo.m
+++ b/matlab/lib/+Ice/TCPConnectionInfo.m
@@ -2,8 +2,8 @@ classdef (Sealed) TCPConnectionInfo < Ice.IPConnectionInfo
     %TCPCONNECTIONINFO Provides access to the connection details of a TCP connection.
     %
     %   TCPConnectionInfo Properties:
-    %     rcvSize - The connection buffer receive size.
-    %     sndSize - The connection buffer send size.
+    %     rcvSize - The size of the receive buffer.
+    %     sndSize - The size of the send buffer.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -17,11 +17,11 @@ classdef (Sealed) TCPConnectionInfo < Ice.IPConnectionInfo
         end
     end
     properties (SetAccess = immutable)
-        %RCVSIZE The connection buffer receive size.
+        %RCVSIZE The size of the receive buffer.
         %   int32 scalar
         rcvSize (1, 1) int32
 
-        %SNDSIZE The connection buffer send size.
+        %SNDSIZE The size of the send buffer.
         %   int32 scalar
         sndSize (1, 1) int32
     end

--- a/matlab/lib/+Ice/TCPEndpointInfo.m
+++ b/matlab/lib/+Ice/TCPEndpointInfo.m
@@ -3,7 +3,7 @@ classdef (Sealed) TCPEndpointInfo < Ice.IPEndpointInfo
     %
     %   TCPEndpointInfo Methods:
     %     type - Returns the type of the endpoint.
-    %     secure - Returns true if this endpoint is a secure endpoint.
+    %     secure - Returns true if this endpoint's transport uses SSL.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -17,10 +17,14 @@ classdef (Sealed) TCPEndpointInfo < Ice.IPEndpointInfo
     end
     methods
         function r = type(obj)
+            %TYPE Returns the type of the endpoint.
+
             r = obj.type_;
         end
 
         function r = secure(obj)
+            %SECURE Returns true if this endpoint's transport uses SSL.
+
             r = obj.secure_;
         end
     end

--- a/matlab/lib/+Ice/ToStringMode.m
+++ b/matlab/lib/+Ice/ToStringMode.m
@@ -12,17 +12,17 @@ classdef ToStringMode < uint8
 
     enumeration
         %UNICODE Characters with ordinal values greater than 127 are kept as-is in the resulting string. Non-printable
-        %   ASCII characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or \\unnnn.
+        %   ASCII characters with ordinal values 127 and below are encoded as \t, \n (etc.) or \unnnn.
         Unicode (0)
 
         %ASCII Characters with ordinal values greater than 127 are encoded as universal character names in the resulting
-        %   string: \\unnnn for BMP characters and \\Unnnnnnnn for non-BMP characters. Non-printable ASCII characters
-        %   with ordinal values 127 and below are encoded as \\t, \\n (etc.) or \\unnnn.
+        %   string: \unnnn for BMP characters and \Unnnnnnnn for non-BMP characters. Non-printable ASCII characters
+        %   with ordinal values 127 and below are encoded as \t, \n (etc.) or \unnnn.
         ASCII (1)
 
         %COMPAT Characters with ordinal values greater than 127 are encoded as a sequence of UTF-8 bytes using octal
-        %   escapes. Characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or an octal escape.
-        %   Use this mode to generate strings compatible with Ice 3.6 and earlier.
+        %   escapes. Non-printable ASCII characters with ordinal values 127 and below are encoded as \t, \n (etc.) or
+        %   an octal escape. Use this mode to generate strings compatible with Ice 3.6 and earlier.
         Compat (2)
     end
 end

--- a/matlab/lib/+Ice/UDPConnectionInfo.m
+++ b/matlab/lib/+Ice/UDPConnectionInfo.m
@@ -4,8 +4,8 @@ classdef (Sealed) UDPConnectionInfo < Ice.IPConnectionInfo
     %   UDPConnectionInfo Properties:
     %     mcastAddress - The multicast address.
     %     mcastPort - The multicast port.
-    %     rcvSize - The connection buffer receive size.
-    %     sndSize - The connection buffer send size.
+    %     rcvSize - The size of the receive buffer.
+    %     sndSize - The size of the send buffer.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -29,11 +29,11 @@ classdef (Sealed) UDPConnectionInfo < Ice.IPConnectionInfo
         %   int32 scalar
         mcastPort (1, 1) int32
 
-        %RCVSIZE The connection buffer receive size.
+        %RCVSIZE The size of the receive buffer.
         %   int32 scalar
         rcvSize (1, 1) int32
 
-        %SNDSIZE The connection buffer send size.
+        %SNDSIZE The size of the send buffer.
         %   int32 scalar
         sndSize (1, 1) int32
     end

--- a/matlab/lib/+Ice/UDPEndpointInfo.m
+++ b/matlab/lib/+Ice/UDPEndpointInfo.m
@@ -7,7 +7,7 @@ classdef (Sealed) UDPEndpointInfo < Ice.IPEndpointInfo
     %
     %   UDPEndpointInfo Methods:
     %     type - Returns the type of the endpoint.
-    %     datagram - Returns true if this endpoint is a datagram endpoint.
+    %     datagram - Returns true if this endpoint's transport is a datagram transport (namely, UDP).
 
     % Copyright (c) ZeroC, Inc.
 
@@ -21,10 +21,14 @@ classdef (Sealed) UDPEndpointInfo < Ice.IPEndpointInfo
     end
     methods
         function r = type(~)
+            %TYPE Returns the type of the endpoint.
+
             r = Ice.UDPEndpointType.value;
         end
 
         function r = datagram(~)
+            %DATAGRAM Returns true if this endpoint's transport is a datagram transport (namely, UDP).
+
             r = true;
         end
     end

--- a/matlab/lib/+Ice/UnknownException.m
+++ b/matlab/lib/+Ice/UnknownException.m
@@ -1,7 +1,6 @@
 classdef UnknownException < Ice.DispatchException
-    %UNKNOWNEXCEPTION
-    %   The exception that is thrown when a dispatch failed with an exception that is not a LocalException or a
-    %   UserException.
+    %UNKNOWNEXCEPTION The exception that is thrown when a dispatch failed with an exception that is not a
+    %   LocalException or a UserException.
 
     % Copyright (c) ZeroC, Inc.
 end

--- a/matlab/lib/+Ice/UnknownLocalException.m
+++ b/matlab/lib/+Ice/UnknownLocalException.m
@@ -1,6 +1,6 @@
 classdef (Sealed) UnknownLocalException < Ice.UnknownException
-    %UNKNOWNLOCALEXCEPTION
-    %   The exception that is thrown when a dispatch failed with a LocalException that is not a DispatchException.
+    %UNKNOWNLOCALEXCEPTION The exception that is thrown when a dispatch failed with a LocalException that is not a
+    %   DispatchException.
 
     % Copyright (c) ZeroC, Inc.
 end

--- a/matlab/lib/+Ice/UnknownSlicedValue.m
+++ b/matlab/lib/+Ice/UnknownSlicedValue.m
@@ -2,7 +2,7 @@ classdef UnknownSlicedValue < Ice.Value
     %UNKNOWNSLICEDVALUE Represents an instance of an unknown class.
     %
     %   UnknownSlicedValue Methods:
-    %     ice_id - Returns the Slice type ID associated with this instance.
+    %     ice_id - Returns the Slice type ID of the unknown most-derived class (the type ID of the first slice).
 
     % Copyright (c) ZeroC, Inc.
 
@@ -13,6 +13,11 @@ classdef UnknownSlicedValue < Ice.Value
     end
     methods
         function id = ice_id(obj)
+            %ICE_ID Returns the Slice type ID of the unknown most-derived class (the type ID of the first slice).
+            %
+            %   Output Arguments
+            %     id - The Slice type ID.
+            %       character vector
             id = obj.unknownTypeId;
         end
     end

--- a/matlab/lib/+Ice/UnknownSlicedValue.m
+++ b/matlab/lib/+Ice/UnknownSlicedValue.m
@@ -2,7 +2,8 @@ classdef UnknownSlicedValue < Ice.Value
     %UNKNOWNSLICEDVALUE Represents an instance of an unknown class.
     %
     %   UnknownSlicedValue Methods:
-    %     ice_id - Returns the Slice type ID of the unknown most-derived class (the type ID of the first slice).
+    %     ice_id - Returns the Slice type ID of this unknown value's most-derived slice, or a compact ID
+    %       formatted as a decimal string when that slice was encoded with a compact ID.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -13,10 +14,11 @@ classdef UnknownSlicedValue < Ice.Value
     end
     methods
         function id = ice_id(obj)
-            %ICE_ID Returns the Slice type ID of the unknown most-derived class (the type ID of the first slice).
+            %ICE_ID Returns the Slice type ID of this unknown value's most-derived slice. When that slice was
+            %   encoded with a compact ID, the return value is the compact ID formatted as a decimal string.
             %
             %   Output Arguments
-            %     id - The Slice type ID.
+            %     id - The Slice type ID, or a compact ID formatted as a decimal string.
             %       character vector
             id = obj.unknownTypeId;
         end

--- a/matlab/lib/+Ice/UnknownUserException.m
+++ b/matlab/lib/+Ice/UnknownUserException.m
@@ -1,7 +1,6 @@
 classdef (Sealed) UnknownUserException < Ice.UnknownException
-    %UNKNOWNUSEREXCEPTION
-    %   The exception that is thrown when a client receives a UserException that was not declared in the operation's
-    %   exception specification.
+    %UNKNOWNUSEREXCEPTION The exception that is thrown when a client receives a UserException that was not declared
+    %   in the operation's exception specification.
 
     % Copyright (c) ZeroC, Inc.
 

--- a/matlab/lib/+Ice/Unset.m
+++ b/matlab/lib/+Ice/Unset.m
@@ -1,6 +1,6 @@
 function r = Unset()
-    %UNSET This function returns a singleton instance that we use as a sentinel value to indicate an unset optional
-    %   value.
+    %UNSET Returns the sentinel value used to indicate an unset optional value.
+    %   Compare a value against Ice.Unset with == or ~= to determine whether an optional value is set.
     %
     %   Output Arguments
     %     r - The unset sentinel value.

--- a/matlab/lib/+Ice/UserException.m
+++ b/matlab/lib/+Ice/UserException.m
@@ -2,12 +2,12 @@ classdef (Abstract) UserException < Ice.Exception
     %USEREXCEPTION Abstract base class for all Ice exceptions defined in Slice.
     %
     %   UserException Methods:
-    %     ice_id - Returns the Slice type ID associated with this instance.
+    %     ice_id - Gets the Slice type ID of the most-derived class supported by this object.
 
     % Copyright (c) ZeroC, Inc.
 
     methods (Abstract)
-        %ICE_ID Returns the Slice type ID associated with this instance.
+        %ICE_ID Gets the Slice type ID of the most-derived class supported by this object.
         %
         %   Output Arguments
         %     id - The Slice type ID.

--- a/matlab/lib/+Ice/Value.m
+++ b/matlab/lib/+Ice/Value.m
@@ -7,7 +7,7 @@ classdef (Abstract) Value < matlab.mixin.Copyable
     %     ice_id - Gets the Slice type ID of the most-derived class supported by this object.
     %     ice_postUnmarshal - Ice invokes this method after unmarshaling the fields of this object.
     %     ice_preMarshal - Ice invokes this method prior to marshaling the fields of this object.
-    %     ice_staticId - Gets the Slice type ID of this type.
+    %     ice_staticId - Returns the Slice type ID associated with this type.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -62,10 +62,10 @@ classdef (Abstract) Value < matlab.mixin.Copyable
     end
     methods (Static)
         function id = ice_staticId()
-            %ICE_STATICID Gets the Slice type ID of this type.
+            %ICE_STATICID Returns the Slice type ID associated with this type.
             %
             %   Output Arguments
-            %     id - The return value is always '::Ice::Object'.
+            %     id - The Slice type ID ('::Ice::Object').
             %       character vector
             id = '::Ice::Object';
         end

--- a/matlab/lib/+Ice/Value.m
+++ b/matlab/lib/+Ice/Value.m
@@ -3,9 +3,11 @@ classdef (Abstract) Value < matlab.mixin.Copyable
     %
     %   Value Methods:
     %     Value - Constructs a new Value instance.
-    %     ice_getSlicedData - Gets the sliced data if this object has a preserved-slice base class and has been sliced during unmarshaling.
+    %     ice_getSlicedData - Gets the sliced data if this value was sliced during unmarshaling.
+    %     ice_id - Gets the Slice type ID of the most-derived class supported by this object.
     %     ice_postUnmarshal - Ice invokes this method after unmarshaling the fields of this object.
     %     ice_preMarshal - Ice invokes this method prior to marshaling the fields of this object.
+    %     ice_staticId - Gets the Slice type ID of this type.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -32,21 +34,26 @@ classdef (Abstract) Value < matlab.mixin.Copyable
 
         function ice_preMarshal(~)
             %ICE_PREMARSHAL Ice invokes this method prior to marshaling the fields of this object. This allows a
-            %   subclass to override this method in order to validate its fields.
+            %   subclass to override this method in order to update or validate its fields before marshaling.
         end
 
         function ice_postUnmarshal(~)
             %ICE_POSTUNMARSHAL Ice invokes this method after unmarshaling the fields of this object. This allows a
-            %   subclass to override this method in order to perform additional initialization.
+            %   subclass to override this method in order to update or validate its fields after unmarshaling.
         end
 
         function r = ice_getSlicedData(obj)
-            %ICE_GETSLICEDDATA Returns the sliced-off data of this object.
+            %ICE_GETSLICEDDATA Gets the sliced data associated with this instance.
+            %
+            %   Output Arguments
+            %     r - The sliced data if this value was sliced during unmarshaling, or an empty array if the value was
+            %       not sliced. Unknown slices are preserved only when the sender uses the sliced format.
+            %       Ice.SlicedData scalar | empty array of Ice.SlicedData
             r = obj.iceSlicedData_;
         end
     end
     methods (Abstract)
-        %ICE_ID Returns the Slice type ID associated with this instance.
+        %ICE_ID Gets the Slice type ID of the most-derived class supported by this object.
         %
         %   Output Arguments
         %     id - The Slice type ID.
@@ -55,6 +62,11 @@ classdef (Abstract) Value < matlab.mixin.Copyable
     end
     methods (Static)
         function id = ice_staticId()
+            %ICE_STATICID Gets the Slice type ID of this type.
+            %
+            %   Output Arguments
+            %     id - The return value is always '::Ice::Object'.
+            %       character vector
             id = '::Ice::Object';
         end
     end

--- a/matlab/lib/+Ice/WSConnectionInfo.m
+++ b/matlab/lib/+Ice/WSConnectionInfo.m
@@ -2,7 +2,8 @@ classdef (Sealed) WSConnectionInfo < Ice.ConnectionInfo
     %WSCONNECTIONINFO Provides access to the connection details of a WebSocket connection.
     %
     %   WSConnectionInfo Properties:
-    %     headers - The headers from the HTTP upgrade request.
+    %     headers - The HTTP headers from the WebSocket upgrade handshake. Since MATLAB connections are always
+    %       outgoing, these are the HTTP response headers.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -14,7 +15,8 @@ classdef (Sealed) WSConnectionInfo < Ice.ConnectionInfo
         end
     end
     properties (SetAccess = immutable)
-        %HEADERS The headers from the HTTP upgrade request.
+        %HEADERS The HTTP headers from the WebSocket upgrade handshake. Since MATLAB connections are always outgoing,
+        %   these are the HTTP response headers.
         %   dictionary(string, string)
         headers (1, 1) dictionary {Ice.mustBeStringStringDictionary} = configureDictionary('string', 'string')
     end

--- a/matlab/lib/+Ice/identityToString.m
+++ b/matlab/lib/+Ice/identityToString.m
@@ -4,8 +4,8 @@ function r = identityToString(id, mode)
     %   Input Arguments
     %     id - The object identity to convert.
     %       Ice.Identity scalar
-    %     mode - Specifies how non-printable ASCII characters are escaped in the result. Defaults to
-    %       Ice.ToStringMode.Unicode.
+    %     mode - Specifies how to handle non-ASCII characters and non-printable ASCII characters in the result.
+    %       Defaults to Ice.ToStringMode.Unicode.
     %       Ice.ToStringMode scalar
     %
     %   Output Arguments

--- a/matlab/lib/+Ice/initialize.m
+++ b/matlab/lib/+Ice/initialize.m
@@ -3,7 +3,7 @@ function communicator = initialize(varargin)
     %   This function is provided for backwards compatibility. New code should call the Ice.Communicator
     %   constructor directly.
     %
-    %   Examples:
+    %   Examples
     %     communicator = Ice.initialize()
     %     communicator = Ice.initialize(args)
     %     communicator = Ice.initialize(initData)

--- a/matlab/lib/+Ice/intVersion.m
+++ b/matlab/lib/+Ice/intVersion.m
@@ -1,7 +1,8 @@
 function r = intVersion()
     %INTVERSION Returns the Ice version as an integer in the form AABBCC, where AA indicates the major version, BB
     %   indicates the minor version, and CC indicates the patch level. For example, for Ice 3.9.1, the returned
-    %   value is 30901.
+    %   value is 30901. For pre-releases, CC encodes the pre-release instead of the patch level. For example, for
+    %   Ice 3.9.0-alpha.0, the returned value is 30950.
     %
     %   Output Arguments
     %     r - The Ice version

--- a/matlab/lib/+Ice/mustBeStringStringDictionary.m
+++ b/matlab/lib/+Ice/mustBeStringStringDictionary.m
@@ -1,5 +1,5 @@
 function mustBeStringStringDictionary(dict)
-    %MUSTBESTRINGSTRINGDICTIONARY Verify dict is a string-string dictionary.
+    %MUSTBESTRINGSTRINGDICTIONARY Verifies that dict is a string-to-string dictionary.
     %
     %   Input Arguments
     %     dict - The dictionary to check.

--- a/matlab/lib/+Ice/proxyIdentityAndFacetCompare.m
+++ b/matlab/lib/+Ice/proxyIdentityAndFacetCompare.m
@@ -9,8 +9,9 @@ function r = proxyIdentityAndFacetCompare(lhs, rhs)
     %
     %   Output Arguments
     %     r - -1 if the identity and facet in lhs compares less than the identity and facet in rhs; 0 if the
-    %       identities and facets compare equal; 1, otherwise.
-    %       int32 scalar
+    %       identities and facets compare equal; 1, otherwise. An empty proxy compares less than any non-empty
+    %       proxy; two empty proxies compare equal.
+    %       double scalar
 
     % Copyright (c) ZeroC, Inc.
 

--- a/matlab/lib/+Ice/proxyIdentityCompare.m
+++ b/matlab/lib/+Ice/proxyIdentityCompare.m
@@ -9,8 +9,8 @@ function r = proxyIdentityCompare(lhs, rhs)
     %
     %   Output Arguments
     %     r - -1 if the identity in lhs compares less than the identity in rhs; 0 if the identities compare equal;
-    %       1, otherwise.
-    %       int32 scalar
+    %       1, otherwise. An empty proxy compares less than any non-empty proxy; two empty proxies compare equal.
+    %       double scalar
 
     % Copyright (c) ZeroC, Inc.
 

--- a/matlab/lib/+Ice/stringVersion.m
+++ b/matlab/lib/+Ice/stringVersion.m
@@ -1,6 +1,6 @@
 function r = stringVersion()
     %STRINGVERSION Returns the Ice version in the form A.B.C, where A indicates the major version, B indicates the
-    %   minor version, and C indicates the patch level.
+    %   minor version, and C indicates the patch level, with an optional pre-release suffix, e.g. '3.9.0-alpha.0'.
     %
     %   Output Arguments
     %     r - The Ice version.


### PR DESCRIPTION
Fixes incorrect and stale help text in the MATLAB Ice library, found during the MATLAB API doc review (follow-up to #5867/#5868/#5883/#5893/#5933/#5941). Documentation-only — every changed line is a comment line (the two `InitializationData` property declarations only lost their trailing inline comments, moved into block-style docs). The code bugs found by the same review are tracked in #5967/#5968 and deliberately not fixed here.

Incorrect claims corrected (many are the same stale pre-#5867 patterns fixed in the other mappings):

- `OptionalFormat` — the `Size`/`VSize`/`FSize` descriptions were garbled to the point of stating the inverse (`FSize` "Fixed-length format with size" actually marks variable-length data preceded by a fixed 4-byte size); all three now mirror `StreamableTraits.h`, and the `Class` summary line matches its own property comment ("no longer supported").
- `ObjectPrx.ice_flushBatchRequests`/`Async` claimed to flush "for this **communicator**" — the implementation is the per-proxy flush (×3 spots incl. the methods list).
- The constructor example `'name:tcp -p localhost -p 4061'` was an invalid proxy string ("localhost" parses as the port and throws `ParseException`); now `-h localhost` (×2).
- `Ice.Properties` constructor — documents the reserved-prefix arg-parsing scope and the real `ICE_CONFIG` condition (used when there is no `--Ice.Config` argument and `Ice.Config` is not already set). Note: unlike C++'s default constructor, the no-arg `Ice.Properties()` goes through the same path and honors `ICE_CONFIG`.
- `getIcePropertyAsList` — unset returns the property's **default list**, not "an empty list"; mismatched quotes → "the default list" (here and in `getPropertyAsListWithDefault`); the `getIceProperty*`/`getPropertyAsInt*` family now documents the `Ice.PropertyException` throws that the C++ reference documents.
- `parseIceCommandLineOptions` listed 6 prefixes as exhaustive; the implementation recognizes 16 — now uses the reference's non-exhaustive formulation.
- `AlreadyRegisteredException.kindOfObject` said "could not be **removed**" — it is an add/registration conflict ("is already registered").
- `Connection.close` was described as a blocking call — it starts a graceful closure and returns a future; the close-timeout abort (`CloseTimeoutException`) is now documented. `throwException` — "not yet **closing** or closed", corrected exception examples (peer close vs application close vs abort), and a truthful methods-list entry. `Future.cancel` — pre-3.8 AsyncResult wording replaced (local cancel, `InvocationCanceledException`, no effect once sent); the `'sent'` state is documented as twoway-only.
- `WSConnectionInfo.headers` — MATLAB connections are always outgoing, so these are the HTTP **response** headers of the upgrade handshake, not the request headers.
- `Value.ice_getSlicedData` — drops the stale "preserved-slice base class" wording and documents the real contract (empty array when not sliced; unknown slices preserved only with the sliced format). `FormatType` — Slice 1.1-only scope + corrected Compact/Sliced descriptions.
- `ToStringMode` — doubled backslashes rendered literally in `help` (`\\t` → `\t` etc.), and `Compat` gains the missing "Non-printable" qualification — this is the MATLAB part of #5955.
- Plus: `identityToString` mode description (non-ASCII handling), `intVersion`/`stringVersion` pre-release forms (30950 / `3.9.0-alpha.0`), `ConnectionAbortedException` "closed"→"aborted" copy-paste, stale `ObjectNotExist`/`OperationNotExist` wording, compare functions' `int32`→`double` output type + empty-proxy ordering, `checkedCast`/`uncheckedCast` (purely-local remark, empty-input case), empty-return cases (`propertyToProxy`, `ice_getRouter`/`ice_getLocator`, `ice_getFacet`, `setDefaultRouter`/`Locator` clearing), `stringToProxy` `ParseException`, `getInfo`-on-closed rethrow + `toString` remains-usable, SSL `peerCertificate` PEM/empty note, `SliceInfo.compactId` -1 case, `CompositeSliceLoader` consultation order, the `Ice:<Name>Exception` identifier convention + `Ice.LocalException` fallback role, methods-list drift (`disableInactivityCheck`, `checkedCast`/`uncheckedCast`/`ice_staticId`, `ice_id`/`ice_staticId`), help on undocumented public overrides (endpoint-info `type`/`secure`/`datagram`, `newInstance`, `UnknownSlicedValue.ice_id`), and markup/consistency fixes (the mapping's only "Ice run time" occurrences, verb alignment, self-referential "See also eq", missing copyright in `SliceLoader.m`, indentation).

Deliberately excluded: the `SliceInfo.typeId` doc (pending the #5969 MATLAB+C# vs C++/Python code-vs-doc decision), `InputStream`/`OutputStream` per-method docs (H1-only state is deliberate per #4141 — worth a maintainer decision before documenting ~120 methods), `(Sealed)` on the three C++-`final` leaf exceptions and the public `OutputStream.buf` property (code changes), and error-contract notes where the C++ reference is itself silent.

Full findings: `API_DOC_AUDIT_MATLAB-2026-07-13.md` (ice-audit). All Medium+ findings were adversarially re-verified against the implementation and cross-checked with codex (8 CONFIRMED, 1 PARTIAL); the MATLAB code analyzer runs in CI (doc comments are analyzer-neutral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
