### PR TITLE
Fix MATLAB Ice.Future.fetchOutputs crash when called a second time after a failed invocation

### DIFF
--- a/changelog.d/matlab/5968.md
+++ b/changelog.d/matlab/5968.md
@@ -1,2 +1,0 @@
-- Fixed `Ice.Future.fetchOutputs`, which crashed the MATLAB process when called a second time after the first call
-  completed with an exception. As documented, any second call now raises `Ice:InvalidStateException`.

--- a/changelog.d/matlab/5968.md
+++ b/changelog.d/matlab/5968.md
@@ -1,0 +1,2 @@
+- Fixed `Ice.Future.fetchOutputs`, which crashed the MATLAB process when called a second time after the first call
+  completed with an exception. As documented, any second call now raises `Ice:InvalidStateException`.

--- a/matlab/lib/+Ice/Future.m
+++ b/matlab/lib/+Ice/Future.m
@@ -109,11 +109,14 @@ classdef Future < IceInternal.WrapperObject
             if obj.Read
                 error('Ice:InvalidStateException', 'Outputs already read');
             end
+            %
+            % Mark the outputs as read before invoking the fetch function. The fetch function deletes the
+            % underlying C++ object (clearing impl_ below), so it can only run once; arming Read here ensures a
+            % second call raises the exception above even when the first call completes exceptionally, rather
+            % than re-invoking the fetch function on a null object and crashing MATLAB.
+            %
+            obj.Read = true;
             if ~isempty(obj.fetchFunc)
-                %
-                % We assume the fetch function implementation also deletes the C++ object so that we
-                % can avoid another call into C++.
-                %
                 try
                     [varargout{1:obj.NumOutputArguments}] = obj.fetchFunc(obj);
                     obj.impl_ = [];
@@ -122,7 +125,6 @@ classdef Future < IceInternal.WrapperObject
                     rethrow(ex);
                 end
             end
-            obj.Read = true;
         end
 
         function cancel(obj)

--- a/matlab/lib/+Ice/Future.m
+++ b/matlab/lib/+Ice/Future.m
@@ -110,10 +110,8 @@ classdef Future < IceInternal.WrapperObject
                 error('Ice:InvalidStateException', 'Outputs already read');
             end
             %
-            % Mark the outputs as read before invoking the fetch function. The fetch function deletes the
-            % underlying C++ object (clearing impl_ below), so it can only run once; arming Read here ensures a
-            % second call raises the exception above even when the first call completes exceptionally, rather
-            % than re-invoking the fetch function on a null object and crashing MATLAB.
+            % The fetch function runs at most once: it deletes the underlying C++ object even when
+            % it throws. Set Read before calling it so a second call always takes the guard above.
             %
             obj.Read = true;
             if ~isempty(obj.fetchFunc)

--- a/matlab/test/Ice/ami/AllTests.m
+++ b/matlab/test/Ice/ami/AllTests.m
@@ -108,7 +108,7 @@ classdef AllTests
 
             fprintf('testing fetchOutputs after a failed invocation... ');
             % A second fetchOutputs call must raise InvalidStateException rather than crash the MATLAB
-            % process, even when the first call completed exceptionally. See issue #5968.
+            % process, even when the first call completed exceptionally.
             f = p.ice_adapterId('dummy').opAsync();
             try
                 f.fetchOutputs();

--- a/matlab/test/Ice/ami/AllTests.m
+++ b/matlab/test/Ice/ami/AllTests.m
@@ -106,6 +106,24 @@ classdef AllTests
 
             fprintf('ok\n');
 
+            fprintf('testing fetchOutputs after a failed invocation... ');
+            % A second fetchOutputs call must raise InvalidStateException rather than crash the MATLAB
+            % process, even when the first call completed exceptionally. See issue #5968.
+            f = p.ice_adapterId('dummy').opAsync();
+            try
+                f.fetchOutputs();
+                assert(false);
+            catch ex
+                assert(isa(ex, 'Ice.NoEndpointException'));
+            end
+            try
+                f.fetchOutputs();
+                assert(false);
+            catch ex
+                assert(strcmp(ex.identifier, 'Ice:InvalidStateException'));
+            end
+            fprintf('ok\n');
+
             fprintf('testing future operations... ');
 
             indirect = p.ice_adapterId('dummy');


### PR DESCRIPTION
Fixes #5968.

### Problem
`Ice.Future.fetchOutputs` is documented "Can only be called once" and guards re-entry with
`error('Ice:InvalidStateException', ...)`. But `obj.Read = true` was set only *after* the `try/catch`, so when the
first call completes exceptionally (the fetch function throws), the `catch` clears `impl_` and rethrows before `Read`
is armed — `Read` stays `false`.

A second `fetchOutputs` then passes the guard and re-invokes the fetch function while `obj.impl_ == []`. MATLAB's
`calllib` converts the empty `self` argument to a NULL pointer, and the native fetch/check entry points
(`Ice_SimpleFuture_check`, `Ice_InvocationFuture_results`/`_check`, `Ice_GetConnectionFuture_fetch`) dereference `self`
unconditionally, crashing the whole MATLAB process instead of raising the documented exception. This affects every
async API: invocations, `ice_getConnectionAsync`, `flushBatchRequestsAsync`, and `Connection.close`.

### Fix
Set `obj.Read = true` immediately after the guard, before invoking the fetch function. The fetch function runs at most
once (it deletes the underlying C++ object), so arming `Read` up front makes any second call — whether the first
succeeded or threw — raise `Ice:InvalidStateException`, exactly as documented.

### Testing
Added a regression test to the `Ice/ami` suite: it drives an indirect invocation to exceptional completion
(`Ice.NoEndpointException`), then asserts a second `fetchOutputs` raises `Ice:InvalidStateException` rather than
crashing.

Verified the fix locally with MATLAB R2025b against a freshly-built `ice` MEX: on a future that completed
exceptionally, a second `fetchOutputs` now raises `Ice:InvalidStateException` (previously a hard process crash), while
the first call still surfaces the underlying `NoEndpointException`. CI exercises the full `ami` suite. Verified the
bug and reviewed the diff with codex.