### PR TITLE
Return an empty SliceInfo.typeId for compact-ID slices in Ice for MATLAB

### DIFF
--- a/changelog.d/matlab/5969.md
+++ b/changelog.d/matlab/5969.md
@@ -1,3 +1,3 @@
-- `Ice.SliceInfo.typeId` is now empty for a value slice decoded via a compact type ID, matching the C++, Java, and
-  Python mappings; the compact ID remains available through `Ice.SliceInfo.compactId`. Previously `typeId` held the
-  stringified compact ID.
+- `Ice.SliceInfo.typeId` is now empty for the slice of a class with a compact type ID, matching the C++, Java, and
+  Python mappings. Previously, `typeId` held the stringified compact ID. The compact ID itself remains available
+  through `Ice.SliceInfo.compactId`.

--- a/changelog.d/matlab/5969.md
+++ b/changelog.d/matlab/5969.md
@@ -1,0 +1,3 @@
+- `Ice.SliceInfo.typeId` is now empty for a value slice decoded via a compact type ID, matching the C++, Java, and
+  Python mappings; the compact ID remains available through `Ice.SliceInfo.compactId`. Previously `typeId` held the
+  stringified compact ID.

--- a/matlab/lib/+Ice/SliceInfo.m
+++ b/matlab/lib/+Ice/SliceInfo.m
@@ -2,7 +2,7 @@ classdef (Sealed) SliceInfo < handle
     %SLICEINFO Encapsulates the details of a class slice with an unknown type.
     %
     %   SliceInfo Properties:
-    %     typeId - The Slice type ID for this slice.
+    %     typeId - The Slice type ID for this slice. It's empty when compactId is set (compactId ~= -1).
     %     compactId - The Slice compact type ID for this slice.
     %     bytes - The encoded bytes for this slice.
     %     hasOptionalMembers - Whether or not the slice contains optional members.
@@ -12,7 +12,7 @@ classdef (Sealed) SliceInfo < handle
     % Copyright (c) ZeroC, Inc.
 
     properties (SetAccess = immutable)
-        %TYPEID The Slice type ID for this slice.
+        %TYPEID The Slice type ID for this slice. It's empty when compactId is set (compactId ~= -1).
         %   character vector
         typeId (1, :) char
 

--- a/matlab/lib/+IceInternal/EncapsDecoder11.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder11.m
@@ -255,7 +255,14 @@ classdef (Hidden) EncapsDecoder11 < IceInternal.EncapsDecoder
                 else
                     bytes = is.getBytes(start, is.getPos() - 1);
                 end
-                info = Ice.SliceInfo(current.typeId, current.compactId, bytes, hasOptionalMembers,...
+                % When the slice was decoded via a compact type ID, the type ID is empty; the compact ID is
+                % carried separately by SliceInfo.compactId (matches C++/Java/Python).
+                if current.compactId == -1
+                    sliceTypeId = current.typeId;
+                else
+                    sliceTypeId = '';
+                end
+                info = Ice.SliceInfo(sliceTypeId, current.compactId, bytes, hasOptionalMembers,...
                     bitand(current.sliceFlags, Protocol.FLAG_IS_LAST_SLICE) > 0);
 
                 current.slices{end + 1} = info;


### PR DESCRIPTION
Part of #5969.

One of three companion PRs (MATLAB, C#, JavaScript) aligning `SliceInfo.typeId` for compact-ID value slices with the
C++, Java, and Python mappings.

### Problem
For a value slice decoded via a compact type ID (Ice encoding 1.1), `Ice.SliceInfo.typeId` held the **stringified
compact ID** (e.g. `"57"`), whereas C++, Java, and Python leave it **empty** and carry the compact ID only in
`SliceInfo.compactId` (C++ and Java both document *and* assert the empty behavior). This is observable to
applications inspecting `SlicedData`, e.g. in a `SliceLoader`.

### Fix
Mirror the Java reference: keep the internal stringified type ID (it is load-bearing for value-factory resolution)
and blank `typeId` **only** at the single `Ice.SliceInfo` construction site when a compact ID is present —
`matlab/lib/+IceInternal/EncapsDecoder11.m`. Also update the `Ice.SliceInfo.typeId` doc to state it is empty when
`compactId` is set, matching C++/Java.

### Testing
No new regression test. No Ice binding — including the C++/Java reference — has a test exercising a *preserved
compact-ID slice*: the only compact types in the slicing suite are client-known (so they are fully reconstructed,
producing no `SlicedData`), and every "unknown preserved" server operation returns string-ID types. A true
end-to-end test would require new, coordinated cross-language `.ice` types plus a preserving operation. The change
was verified by an adversarial multi-agent review and an independent codex review, both of which re-derived the
single construction site and confirmed compact-id factory resolution is untouched. Pure `.m` change (no rebuild);
CI runs the `slicing` suites. Happy to add a coordinated cross-language regression test as a follow-up if wanted.
