### PR TITLE
Return an empty SliceInfo.typeId for compact-ID slices in Ice for .NET

### DIFF
--- a/changelog.d/csharp/5969.md
+++ b/changelog.d/csharp/5969.md
@@ -1,3 +1,3 @@
-- `Ice.SliceInfo.typeId` is now empty for a value slice decoded via a compact type ID, matching the C++, Java, and
-  Python mappings; the compact ID remains available through `Ice.SliceInfo.compactId`. Previously `typeId` held the
-  stringified compact ID.
+- `Ice.SliceInfo.typeId` is now empty for the slice of a class with a compact type ID, matching the C++, Java, and
+  Python mappings. Previously, `typeId` held the stringified compact ID. The compact ID itself remains available
+  through `Ice.SliceInfo.compactId`.

--- a/changelog.d/csharp/5969.md
+++ b/changelog.d/csharp/5969.md
@@ -1,0 +1,3 @@
+- `Ice.SliceInfo.typeId` is now empty for a value slice decoded via a compact type ID, matching the C++, Java, and
+  Python mappings; the compact ID remains available through `Ice.SliceInfo.compactId`. Previously `typeId` held the
+  stringified compact ID.

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2727,7 +2727,6 @@ public sealed class InputStream
                 b.position(end);
 
                 var info = new SliceInfo(
-                    // Empty type ID when the slice was decoded via a compact ID.
                     typeId: _current.compactId == -1 ? _current.typeId! : "",
                     compactId: _current.compactId,
                     bytes: bytes,

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2727,8 +2727,7 @@ public sealed class InputStream
                 b.position(end);
 
                 var info = new SliceInfo(
-                    // Empty type ID when the slice was decoded via a compact ID; the compact ID is carried
-                    // separately by SliceInfo.compactId (matches C++/Java/Python).
+                    // Empty type ID when the slice was decoded via a compact ID.
                     typeId: _current.compactId == -1 ? _current.typeId! : "",
                     compactId: _current.compactId,
                     bytes: bytes,

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2727,7 +2727,9 @@ public sealed class InputStream
                 b.position(end);
 
                 var info = new SliceInfo(
-                    typeId: _current.typeId!,
+                    // Empty type ID when the slice was decoded via a compact ID; the compact ID is carried
+                    // separately by SliceInfo.compactId (matches C++/Java/Python).
+                    typeId: _current.compactId == -1 ? _current.typeId! : "",
                     compactId: _current.compactId,
                     bytes: bytes,
                     hasOptionalMembers: hasOptionalMembers,

--- a/csharp/src/Ice/SlicedData.cs
+++ b/csharp/src/Ice/SlicedData.cs
@@ -13,7 +13,7 @@ public sealed record class SlicedData(SliceInfo[] slices);
 /// <summary>
 /// Encapsulates the details of a class slice with an unknown type.
 /// </summary>
-/// <param name="typeId">The Slice type ID for this slice. It's empty when the slice was decoded via a compact ID
+/// <param name="typeId">The Slice type ID for this slice. It's empty when the compact ID is set
 /// (<paramref name="compactId"/> is not -1).</param>
 /// <param name="compactId">The Slice compact type ID for this slice, or -1 if the slice has no compact ID.</param>
 /// <param name="bytes">The encoded bytes for this slice.</param>

--- a/csharp/src/Ice/SlicedData.cs
+++ b/csharp/src/Ice/SlicedData.cs
@@ -13,7 +13,8 @@ public sealed record class SlicedData(SliceInfo[] slices);
 /// <summary>
 /// Encapsulates the details of a class slice with an unknown type.
 /// </summary>
-/// <param name="typeId">The Slice type ID for this slice.</param>
+/// <param name="typeId">The Slice type ID for this slice. It's empty when the slice was decoded via a compact ID
+/// (<paramref name="compactId"/> is not -1).</param>
 /// <param name="compactId">The Slice compact type ID for this slice, or -1 if the slice has no compact ID.</param>
 /// <param name="bytes">The encoded bytes for this slice.</param>
 /// <param name="hasOptionalMembers">Whether or not the slice contains optional members.</param>


### PR DESCRIPTION
Part of #5969.

One of three companion PRs (MATLAB, C#, JavaScript) aligning `SliceInfo.typeId` for compact-ID value slices with the
C++, Java, and Python mappings.

### Problem
For a value slice decoded via a compact type ID (Ice encoding 1.1), `Ice.SliceInfo.typeId` held the **stringified
compact ID** (e.g. `"57"`), whereas C++, Java, and Python leave it **empty** and carry the compact ID only in
`SliceInfo.compactId` (C++ and Java both document *and* assert the empty behavior). This is observable to
applications inspecting `SlicedData`, e.g. in a `SliceLoader`.

### Fix
Mirror the Java reference: keep the internal stringified type ID (it is load-bearing for value-factory resolution)
and blank `typeId` **only** at the single `SliceInfo` construction site when a compact ID is present —
`csharp/src/Ice/InputStream.cs`. Also update the `SliceInfo.typeId` doc (`csharp/src/Ice/SlicedData.cs`) to state it
is empty when the slice was decoded via a compact ID, matching C++/Java.

### Testing
No new regression test. No Ice binding — including the C++/Java reference — has a test exercising a *preserved
compact-ID slice*: the only compact types in the slicing suite are client-known (fully reconstructed, no
`SlicedData`), and every "unknown preserved" server operation returns string-ID types. A true end-to-end test would
require new, coordinated cross-language `.ice` types plus a preserving operation. Verified by an adversarial
multi-agent review and an independent codex review (single construction site confirmed; factory resolution
untouched). The change is a trivial `string` ternary; a local full build is gated on first building `slice2cs`, so
CI performs the full C# compile and runs the `slicing` suites. Happy to add a coordinated cross-language regression
test as a follow-up if wanted.
