### PR TITLE
Return an empty SliceInfo.typeId for compact-ID slices in Ice for JavaScript

### DIFF
--- a/changelog.d/js/5969.md
+++ b/changelog.d/js/5969.md
@@ -1,0 +1,3 @@
+- `Ice.SliceInfo.typeId` is now empty for a value slice decoded via a compact type ID, matching the C++, Java, and
+  Python mappings; the compact ID remains available through `Ice.SliceInfo.compactId`. Previously `typeId` held the
+  stringified compact ID.

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -625,7 +625,9 @@ class EncapsDecoder11 extends EncapsDecoder {
         // Preserve this slice.
         //
         const info = new SliceInfo();
-        info.typeId = this._current.typeId;
+        // When the slice was decoded via a compact type ID, expose an empty type ID; the compact ID is
+        // carried separately by info.compactId (matches C++/Java/Python).
+        info.typeId = this._current.compactId === -1 ? this._current.typeId : "";
         info.compactId = this._current.compactId;
         info.hasOptionalMembers = (this._current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) !== 0;
         info.isLastSlice = (this._current.sliceFlags & Protocol.FLAG_IS_LAST_SLICE) !== 0;

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -625,8 +625,7 @@ class EncapsDecoder11 extends EncapsDecoder {
         // Preserve this slice.
         //
         const info = new SliceInfo();
-        // When the slice was decoded via a compact type ID, expose an empty type ID; the compact ID is
-        // carried separately by info.compactId (matches C++/Java/Python).
+        // When the slice was decoded via a compact type ID, expose an empty type ID.
         info.typeId = this._current.compactId === -1 ? this._current.typeId : "";
         info.compactId = this._current.compactId;
         info.hasOptionalMembers = (this._current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) !== 0;

--- a/js/packages/ice/src/Ice/UnknownSlicedValue.d.ts
+++ b/js/packages/ice/src/Ice/UnknownSlicedValue.d.ts
@@ -7,7 +7,7 @@ declare module "@zeroc/ice" {
          */
         class SliceInfo {
             /**
-             * The Slice type ID for this slice.
+             * The Slice type ID for this slice. It's empty when the compact ID is set (compactId !== -1).
              */
             typeId: string;
 

--- a/js/packages/ice/src/Ice/UnknownSlicedValue.js
+++ b/js/packages/ice/src/Ice/UnknownSlicedValue.js
@@ -5,7 +5,7 @@ import { Value } from "./Value.js";
 export class SliceInfo {
     constructor() {
         //
-        // The Slice type ID for this slice.
+        // The Slice type ID for this slice. It's empty when the compact ID is set (compactId !== -1).
         //
         this.typeId = "";
 


### PR DESCRIPTION
Part of #5969.

One of three companion PRs (MATLAB, C#, JavaScript) aligning `SliceInfo.typeId` for compact-ID value slices with the
C++, Java, and Python mappings.

### Problem
For a value slice decoded via a compact type ID (Ice encoding 1.1), `Ice.SliceInfo.typeId` held the **stringified
compact ID** (e.g. `"57"`), whereas C++, Java, and Python leave it **empty** and carry the compact ID only in
`SliceInfo.compactId` (C++ and Java both document *and* assert the empty behavior). This is observable to
applications inspecting `SlicedData`, e.g. in a `SliceLoader`.

### Fix
Mirror the Java reference: keep the internal stringified type ID (it is load-bearing for value-factory resolution)
and blank `typeId` **only** at the single `SliceInfo` construction site when a compact ID is present —
`js/packages/ice/src/Ice/InputStream.js`. Also update the `SliceInfo.typeId` doc
(`js/packages/ice/src/Ice/UnknownSlicedValue.js` and `.d.ts`) to state it is empty when the compact ID is set,
matching C++/Java.

### Testing
No new regression test. No Ice binding — including the C++/Java reference — has a test exercising a *preserved
compact-ID slice*: the only compact types in the slicing suite are client-known (fully reconstructed, no
`SlicedData`), and every "unknown preserved" server operation returns string-ID types. A true end-to-end test would
require new, coordinated cross-language `.ice` types plus a preserving operation (note: JS generated compact-id
classes auto-register into the global default slice loader, which further complicates a local unit test). Verified
by an adversarial multi-agent review and an independent codex review (single construction site confirmed; factory
resolution untouched); the changed files pass `node --check`. CI builds the package and runs the `slicing` suites.
Happy to add a coordinated cross-language regression test as a follow-up if wanted.
