### PR TITLE
Memoize failed states in Glacier2 address filter matching

### DIFF
--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -546,7 +546,8 @@ namespace Glacier2
                     return false;
                 }
 
-                if (!matchAddress(host, 0, 0))
+                vector<bool> failed(_addressRules.size() * (host.size() + 1), false);
+                if (!matchAddress(host, 0, 0, failed))
                 {
                     return false;
                 }
@@ -573,9 +574,15 @@ namespace Glacier2
         // Matches host against the matchers at position index and up, starting at position pos in host. The
         // matchers must match the remainder of the host in full. When they don't, this function retries the
         // matchers that can match at a later position (the matchers created for the portion of a rule that
-        // follows a wildcard) until every later alignment is exhausted.
-        [[nodiscard]] bool
-        matchAddress(const string& host, vector<AddressMatcher*>::size_type index, string::size_type pos) const
+        // follows a wildcard) until every later alignment is exhausted. The same (index, pos) state can be
+        // reached through many alignments of the preceding wildcards; failed is a matcher-count by
+        // (host length + 1) matrix that records failed states so each one is evaluated at most once, keeping
+        // the matching cost polynomial in the host length.
+        [[nodiscard]] bool matchAddress(
+            const string& host,
+            vector<AddressMatcher*>::size_type index,
+            string::size_type pos,
+            vector<bool>& failed) const
         {
             if (index == _addressRules.size())
             {
@@ -592,6 +599,12 @@ namespace Glacier2
                 return true;
             }
 
+            vector<bool>::size_type state = index * (host.size() + 1) + pos;
+            if (failed[state])
+            {
+                return false;
+            }
+
             AddressMatcher* rule = _addressRules[index];
             string::size_type next = pos;
             bool matched = rule->match(host, next);
@@ -602,7 +615,7 @@ namespace Glacier2
                     Trace out(_communicator->getLogger(), "Glacier2");
                     out << rule->toString() << " matched " << host << " at pos=" << next << "\n";
                 }
-                if (matchAddress(host, index + 1, next))
+                if (matchAddress(host, index + 1, next, failed))
                 {
                     return true;
                 }
@@ -614,6 +627,7 @@ namespace Glacier2
                 Trace out(_communicator->getLogger(), "Glacier2");
                 out << rule->toString() << " failed to match " << host << " at pos=" << pos << "\n";
             }
+            failed[state] = true;
             return false;
         }
 

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -368,6 +368,17 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                     [],
                 ),
                 (
+                    # A rule with many wildcard segments stays fast even when every alignment of the wildcards
+                    # has to be tried before concluding that the host does not match.
+                    "testing address filter with many wildcard segments",
+                    ("*aa*aa*aa*aa*aa*aa*aab *7.*.1", "", "", "", "", ""),
+                    [
+                        (False, "hello:tcp -h " + "a" * 255 + " -p 12010"),
+                        (True, "hello:tcp -h 127.0.0.1 -p 12010"),
+                    ],
+                    [],
+                ),
+                (
                     # A proxy with an endpoint host longer than 255 characters is rejected outright, even when
                     # no reject rule matches it: no legal host name or IP address is that long.
                     "testing address filter rejects an oversized host",


### PR DESCRIPTION
The wildcard backtracking introduced by #5897 retries each wildcard segment of an address filter rule at every later alignment of the host, so the worst-case matching cost grows exponentially with the number of wildcard segments in a rule. A slow `verify()` stalls the session's routing table and occupies a dispatch thread.

This PR records failed `(matcher index, position)` states during a host check and skips any state reached again through a different alignment of the preceding wildcards. Since each state is now evaluated at most once and hosts are capped at 255 characters, the worst-case cost is O(k·n²) for a rule with k matchers against a host of length n, with no change to the matching semantics.

The new test case exercises both outcomes through the memoized path: a 255-character host that fails a six-wildcard-segment rule only after every alignment is exhausted (previously minutes to hours of backtracking, now instant), and a host accepted by a multi-wildcard rule.

No CHANGELOG entry since the backtracking has not shipped in any release.

Fixes #5954.

🤖 Generated with [Claude Code](https://claude.com/claude-code)