### PR TITLE
Reject a proxy when any endpoint matches a Glacier2 address reject rule

### DIFF
--- a/changelog.d/service-glacier2/address-filter-reject-any-endpoint.md
+++ b/changelog.d/service-glacier2/address-filter-reject-any-endpoint.md
@@ -1,0 +1,3 @@
+- Fixed the Glacier2 address filter `Glacier2.Filter.Address.Reject`: a reject rule matched a proxy only when every
+  endpoint of the proxy matched the rule. A reject rule now matches—and the proxy is rejected—as soon as any endpoint
+  of the proxy matches the rule.

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -546,7 +546,8 @@ namespace Glacier2
                     return false;
                 }
 
-                if (!matchAddress(host, 0, 0))
+                vector<bool> failed(_addressRules.size() * (host.size() + 1), false);
+                if (!matchAddress(host, 0, 0, failed))
                 {
                     return false;
                 }
@@ -573,9 +574,15 @@ namespace Glacier2
         // Matches host against the matchers at position index and up, starting at position pos in host. The
         // matchers must match the remainder of the host in full. When they don't, this function retries the
         // matchers that can match at a later position (the matchers created for the portion of a rule that
-        // follows a wildcard) until every later alignment is exhausted.
-        [[nodiscard]] bool
-        matchAddress(const string& host, vector<AddressMatcher*>::size_type index, string::size_type pos) const
+        // follows a wildcard) until every later alignment is exhausted. The same (index, pos) state can be
+        // reached through many alignments of the preceding wildcards; failed is a matcher-count by
+        // (host length + 1) matrix that records failed states so each one is evaluated at most once, keeping
+        // the matching cost polynomial in the host length.
+        [[nodiscard]] bool matchAddress(
+            const string& host,
+            vector<AddressMatcher*>::size_type index,
+            string::size_type pos,
+            vector<bool>& failed) const
         {
             if (index == _addressRules.size())
             {
@@ -592,6 +599,12 @@ namespace Glacier2
                 return true;
             }
 
+            vector<bool>::size_type state = index * (host.size() + 1) + pos;
+            if (failed[state])
+            {
+                return false;
+            }
+
             AddressMatcher* rule = _addressRules[index];
             string::size_type next = pos;
             bool matched = rule->match(host, next);
@@ -602,7 +615,7 @@ namespace Glacier2
                     Trace out(_communicator->getLogger(), "Glacier2");
                     out << rule->toString() << " matched " << host << " at pos=" << next << "\n";
                 }
-                if (matchAddress(host, index + 1, next))
+                if (matchAddress(host, index + 1, next, failed))
                 {
                     return true;
                 }
@@ -614,6 +627,7 @@ namespace Glacier2
                 Trace out(_communicator->getLogger(), "Glacier2");
                 out << rule->toString() << " failed to match " << host << " at pos=" << pos << "\n";
             }
+            failed[state] = true;
             return false;
         }
 

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -488,7 +488,9 @@ namespace Glacier2
     }
 
     //
-    // A proxy validation rule encapsulating an address filter.
+    // A proxy validation rule encapsulating an address filter. An accept rule matches a proxy only when every
+    // endpoint matches it, while a reject rule matches a proxy as soon as one endpoint matches it
+    // (matchAnyEndpoint == true).
     //
     class AddressRule final : public Glacier2::ProxyRule
     {
@@ -497,11 +499,13 @@ namespace Glacier2
             CommunicatorPtr communicator,
             const vector<AddressMatcher*>& address,
             MatchesNumber* port,
-            const int traceLevel)
+            const int traceLevel,
+            bool matchAnyEndpoint)
             : _communicator(std::move(communicator)),
               _addressRules(address),
               _portMatcher(port),
-              _traceLevel(traceLevel)
+              _traceLevel(traceLevel),
+              _matchAnyEndpoint(matchAnyEndpoint)
         {
         }
 
@@ -521,39 +525,28 @@ namespace Glacier2
             {
                 return false;
             }
-            for (const auto& endpoint : endpoints)
+            if (_matchAnyEndpoint)
             {
-                string info = endpoint->toString();
-                string host;
-                if (!extractPart("-h ", info, host))
+                for (const auto& endpoint : endpoints)
                 {
-                    return false;
-                }
-                string port;
-                if (!extractPart("-p ", info, port))
-                {
-                    return false;
-                }
-
-                string::size_type pos = 0;
-                if (_portMatcher && !_portMatcher->match(port, pos))
-                {
-                    if (_traceLevel >= 3)
+                    if (matchEndpoint(endpoint))
                     {
-                        Trace out(_communicator->getLogger(), "Glacier2");
-                        out << _portMatcher->toString() << " failed to match " << port << " at pos=" << pos << "\n";
+                        return true;
                     }
-                    return false;
                 }
-
-                vector<bool> failed(_addressRules.size() * (host.size() + 1), false);
-                if (!matchAddress(host, 0, 0, failed))
-                {
-                    return false;
-                }
+                return false;
             }
-
-            return true;
+            else
+            {
+                for (const auto& endpoint : endpoints)
+                {
+                    if (!matchEndpoint(endpoint))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
         }
 
         void dump() const
@@ -571,6 +564,36 @@ namespace Glacier2
         }
 
     private:
+        // Matches the host and port of endpoint against this rule.
+        [[nodiscard]] bool matchEndpoint(const EndpointPtr& endpoint) const
+        {
+            string info = endpoint->toString();
+            string host;
+            if (!extractPart("-h ", info, host))
+            {
+                return false;
+            }
+            string port;
+            if (!extractPart("-p ", info, port))
+            {
+                return false;
+            }
+
+            string::size_type pos = 0;
+            if (_portMatcher && !_portMatcher->match(port, pos))
+            {
+                if (_traceLevel >= 3)
+                {
+                    Trace out(_communicator->getLogger(), "Glacier2");
+                    out << _portMatcher->toString() << " failed to match " << port << " at pos=" << pos << "\n";
+                }
+                return false;
+            }
+
+            vector<bool> failed(_addressRules.size() * (host.size() + 1), false);
+            return matchAddress(host, 0, 0, failed);
+        }
+
         // Matches host against the matchers at position index and up, starting at position pos in host. The
         // matchers must match the remainder of the host in full. When they don't, this function retries the
         // matchers that can match at a later position (the matchers created for the portion of a rule that
@@ -635,13 +658,15 @@ namespace Glacier2
         vector<AddressMatcher*> _addressRules;
         MatchesNumber* _portMatcher;
         const int _traceLevel;
+        const bool _matchAnyEndpoint;
     };
 
     static void parseProperty(
         const shared_ptr<Ice::Communicator>& communicator,
         const string& property,
         vector<ProxyRule*>& rules,
-        const int traceLevel)
+        const int traceLevel,
+        bool matchAnyEndpoint)
     {
         StartFactory startsWithFactory;
         WildCardFactory wildCardFactory;
@@ -797,7 +822,8 @@ namespace Glacier2
                         currentRuleSet.push_back(new MatchesAny);
                     }
                 }
-                allRules.push_back(new AddressRule(communicator, currentRuleSet, portMatch, traceLevel));
+                allRules.push_back(
+                    new AddressRule(communicator, currentRuleSet, portMatch, traceLevel, matchAnyEndpoint));
             }
         }
         catch (...)
@@ -873,7 +899,8 @@ Glacier2::ProxyVerifier::ProxyVerifier(CommunicatorPtr communicator)
     {
         try
         {
-            Glacier2::parseProperty(_communicator, s, _acceptRules, _traceLevel);
+            // An accept rule matches a proxy only when every endpoint matches it.
+            Glacier2::parseProperty(_communicator, s, _acceptRules, _traceLevel, false);
         }
         catch (const exception& ex)
         {
@@ -888,7 +915,8 @@ Glacier2::ProxyVerifier::ProxyVerifier(CommunicatorPtr communicator)
     {
         try
         {
-            Glacier2::parseProperty(_communicator, s, _rejectRules, _traceLevel);
+            // A reject rule matches a proxy as soon as one endpoint matches it.
+            Glacier2::parseProperty(_communicator, s, _rejectRules, _traceLevel, true);
         }
         catch (const exception& ex)
         {

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -368,6 +368,17 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                     [],
                 ),
                 (
+                    # A rule with many wildcard segments stays fast even when every alignment of the wildcards
+                    # has to be tried before concluding that the host does not match.
+                    "testing address filter with many wildcard segments",
+                    ("*aa*aa*aa*aa*aa*aa*aab *7.*.1", "", "", "", "", ""),
+                    [
+                        (False, "hello:tcp -h " + "a" * 255 + " -p 12010"),
+                        (True, "hello:tcp -h 127.0.0.1 -p 12010"),
+                    ],
+                    [],
+                ),
+                (
                     # A proxy with an endpoint host longer than 255 characters is rejected outright, even when
                     # no reject rule matches it: no legal host name or IP address is that long.
                     "testing address filter rejects an oversized host",

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -379,6 +379,18 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                     [],
                 ),
                 (
+                    # A reject rule matches a proxy as soon as one of its endpoints matches: extra endpoints
+                    # that do not match the rule do not get the proxy accepted.
+                    "testing address filter reject rule against a multi-endpoint proxy",
+                    ("", "127.0.0.1", "", "", "", ""),
+                    [
+                        (False, "hello:tcp -h 127.0.0.1 -p 12010:tcp -h 127.0.0.2 -p 12010"),
+                        (False, "hello:tcp -h 127.0.0.2 -p 12010:tcp -h 127.0.0.1 -p 12010"),
+                        (True, "hello:tcp -h localhost -p 12010"),
+                    ],
+                    [],
+                ),
+                (
                     # A proxy with an endpoint host longer than 255 characters is rejected outright, even when
                     # no reject rule matches it: no legal host name or IP address is that long.
                     "testing address filter rejects an oversized host",


### PR DESCRIPTION
A `Glacier2.Filter.Address.Reject` rule matched a proxy only when **every** endpoint of the proxy matched the rule, the same all-endpoints-must-match logic used for accept rules. For a reject rule this is backwards: a multi-endpoint proxy was rejected only when the rule covered all its endpoints, so a reject rule did not reliably keep out the hosts it names.

With this PR, a reject rule matches — and the proxy is rejected — as soon as any endpoint of the proxy matches the rule. Accept rules keep the existing semantics: a proxy is acceptable only when every endpoint matches.

`AddressRule::check` now delegates per-endpoint matching to a new `matchEndpoint` helper and aggregates according to the rule's mode (any-endpoint for reject, all-endpoints for accept).

Based on #5980; will rebase once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)