### PR TITLE
Reject a proxy when any endpoint matches a Glacier2 address reject rule

### DIFF
--- a/changelog.d/service-glacier2/address-filter-reject-any-endpoint.md
+++ b/changelog.d/service-glacier2/address-filter-reject-any-endpoint.md
@@ -1,0 +1,2 @@
+- Fixed a bug in the `Glacier2.Filter.Address.Reject` address filter, which did not filter multi-endpoint proxies
+  correctly.

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -488,7 +488,9 @@ namespace Glacier2
     }
 
     //
-    // A proxy validation rule encapsulating an address filter.
+    // A proxy validation rule encapsulating an address filter. An accept rule matches a proxy only when every
+    // endpoint matches it, while a reject rule matches a proxy as soon as one endpoint matches it
+    // (matchAnyEndpoint == true).
     //
     class AddressRule final : public Glacier2::ProxyRule
     {
@@ -497,11 +499,13 @@ namespace Glacier2
             CommunicatorPtr communicator,
             const vector<AddressMatcher*>& address,
             MatchesNumber* port,
-            const int traceLevel)
+            const int traceLevel,
+            bool matchAnyEndpoint)
             : _communicator(std::move(communicator)),
               _addressRules(address),
               _portMatcher(port),
-              _traceLevel(traceLevel)
+              _traceLevel(traceLevel),
+              _matchAnyEndpoint(matchAnyEndpoint)
         {
         }
 
@@ -521,38 +525,28 @@ namespace Glacier2
             {
                 return false;
             }
-            for (const auto& endpoint : endpoints)
+            if (_matchAnyEndpoint)
             {
-                string info = endpoint->toString();
-                string host;
-                if (!extractPart("-h ", info, host))
+                for (const auto& endpoint : endpoints)
                 {
-                    return false;
-                }
-                string port;
-                if (!extractPart("-p ", info, port))
-                {
-                    return false;
-                }
-
-                string::size_type pos = 0;
-                if (_portMatcher && !_portMatcher->match(port, pos))
-                {
-                    if (_traceLevel >= 3)
+                    if (matchEndpoint(endpoint))
                     {
-                        Trace out(_communicator->getLogger(), "Glacier2");
-                        out << _portMatcher->toString() << " failed to match " << port << " at pos=" << pos << "\n";
+                        return true;
                     }
-                    return false;
                 }
-
-                if (!matchAddress(host, 0, 0))
-                {
-                    return false;
-                }
+                return false;
             }
-
-            return true;
+            else
+            {
+                for (const auto& endpoint : endpoints)
+                {
+                    if (!matchEndpoint(endpoint))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
         }
 
         void dump() const
@@ -570,6 +564,35 @@ namespace Glacier2
         }
 
     private:
+        // Matches the host and port of endpoint against this rule.
+        [[nodiscard]] bool matchEndpoint(const EndpointPtr& endpoint) const
+        {
+            string info = endpoint->toString();
+            string host;
+            if (!extractPart("-h ", info, host))
+            {
+                return false;
+            }
+            string port;
+            if (!extractPart("-p ", info, port))
+            {
+                return false;
+            }
+
+            string::size_type pos = 0;
+            if (_portMatcher && !_portMatcher->match(port, pos))
+            {
+                if (_traceLevel >= 3)
+                {
+                    Trace out(_communicator->getLogger(), "Glacier2");
+                    out << _portMatcher->toString() << " failed to match " << port << " at pos=" << pos << "\n";
+                }
+                return false;
+            }
+
+            return matchAddress(host, 0, 0);
+        }
+
         // Matches host against the matchers at position index and up, starting at position pos in host. The
         // matchers must match the remainder of the host in full. When they don't, this function retries the
         // matchers that can match at a later position (the matchers created for the portion of a rule that
@@ -621,13 +644,15 @@ namespace Glacier2
         vector<AddressMatcher*> _addressRules;
         MatchesNumber* _portMatcher;
         const int _traceLevel;
+        const bool _matchAnyEndpoint;
     };
 
     static void parseProperty(
         const shared_ptr<Ice::Communicator>& communicator,
         const string& property,
         vector<ProxyRule*>& rules,
-        const int traceLevel)
+        const int traceLevel,
+        bool matchAnyEndpoint)
     {
         StartFactory startsWithFactory;
         WildCardFactory wildCardFactory;
@@ -783,7 +808,8 @@ namespace Glacier2
                         currentRuleSet.push_back(new MatchesAny);
                     }
                 }
-                allRules.push_back(new AddressRule(communicator, currentRuleSet, portMatch, traceLevel));
+                allRules.push_back(
+                    new AddressRule(communicator, currentRuleSet, portMatch, traceLevel, matchAnyEndpoint));
             }
         }
         catch (...)
@@ -859,7 +885,8 @@ Glacier2::ProxyVerifier::ProxyVerifier(CommunicatorPtr communicator)
     {
         try
         {
-            Glacier2::parseProperty(_communicator, s, _acceptRules, _traceLevel);
+            // An accept rule matches a proxy only when every endpoint matches it.
+            Glacier2::parseProperty(_communicator, s, _acceptRules, _traceLevel, false);
         }
         catch (const exception& ex)
         {
@@ -874,7 +901,8 @@ Glacier2::ProxyVerifier::ProxyVerifier(CommunicatorPtr communicator)
     {
         try
         {
-            Glacier2::parseProperty(_communicator, s, _rejectRules, _traceLevel);
+            // A reject rule matches a proxy as soon as one endpoint matches it.
+            Glacier2::parseProperty(_communicator, s, _rejectRules, _traceLevel, true);
         }
         catch (const exception& ex)
         {

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -368,6 +368,18 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                     [],
                 ),
                 (
+                    # A reject rule matches a proxy as soon as one of its endpoints matches: extra endpoints
+                    # that do not match the rule do not get the proxy accepted.
+                    "testing address filter reject rule against a multi-endpoint proxy",
+                    ("", "127.0.0.1", "", "", "", ""),
+                    [
+                        (False, "hello:tcp -h 127.0.0.1 -p 12010:tcp -h 127.0.0.2 -p 12010"),
+                        (False, "hello:tcp -h 127.0.0.2 -p 12010:tcp -h 127.0.0.1 -p 12010"),
+                        (True, "hello:tcp -h localhost -p 12010"),
+                    ],
+                    [],
+                ),
+                (
                     # A proxy with an endpoint host longer than 255 characters is rejected outright, even when
                     # no reject rule matches it: no legal host name or IP address is that long.
                     "testing address filter rejects an oversized host",


### PR DESCRIPTION
Fixes a bug in the `Glacier2.Filter.Address.Reject` address filter, which did not filter multi-endpoint proxies correctly: a reject rule now matches a proxy — and the proxy is rejected — as soon as one of its endpoints matches the rule. Accept rules keep their existing semantics: an accept rule matches a proxy only when every endpoint matches it.

`AddressRule::check` now delegates per-endpoint matching to a new `matchEndpoint` helper and aggregates the results according to the rule's mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)