### PR TITLE
Match Glacier2 address filter host names case-insensitively

### DIFF
--- a/changelog.d/service-glacier2/address-filter-case-insensitive.md
+++ b/changelog.d/service-glacier2/address-filter-case-insensitive.md
@@ -1,0 +1,2 @@
+- Fixed a bug in the Glacier2 address filters, `Glacier2.Filter.Address.Accept` and `Glacier2.Filter.Address.Reject`:
+  the filters compared host names case-sensitively. Host names now match regardless of case, like DNS names.

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -2,6 +2,7 @@
 
 #include "ProxyVerifier.h"
 #include "../Ice/ConsoleUtil.h"
+#include "Ice/StringUtil.h"
 
 #include <stdexcept>
 #include <string>
@@ -529,6 +530,8 @@ namespace Glacier2
                 {
                     return false;
                 }
+                // Host names are case-insensitive; the rule was folded to lower case when parsed.
+                host = toLower(host);
                 string port;
                 if (!extractPart("-p ", info, port))
                 {
@@ -675,6 +678,10 @@ namespace Glacier2
                 {
                     addr = parameter;
                 }
+
+                // Host names are case-insensitive; fold the rule to lower case and match it against the
+                // lower-cased host.
+                addr = toLower(addr);
 
                 //
                 // The addr portion can contain alphanumerics, * and

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -368,6 +368,28 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                     [],
                 ),
                 (
+                    # Host names are case-insensitive: an accept rule matches the host regardless of the case
+                    # of either the rule or the host.
+                    "testing address filter accept rule is case-insensitive",
+                    ("LocalHost", "", "", "", "", ""),
+                    [
+                        (True, "hello:tcp -h localhost -p 12010"),
+                        (True, "hello:tcp -h LOCALHOST -p 12010"),
+                        (False, "hello:tcp -h 127.0.0.1 -p 12010"),
+                    ],
+                    [],
+                ),
+                (
+                    # Same for a reject rule: a case variation of the host still matches the rule.
+                    "testing address filter reject rule is case-insensitive",
+                    ("", "badhost.example.com", "", "", "", ""),
+                    [
+                        (False, "hello:tcp -h BadHost.Example.COM -p 12010"),
+                        (True, "hello:tcp -h localhost -p 12010"),
+                    ],
+                    [],
+                ),
+                (
                     # A proxy with an endpoint host longer than 255 characters is rejected outright, even when
                     # no reject rule matches it: no legal host name or IP address is that long.
                     "testing address filter rejects an oversized host",


### PR DESCRIPTION
Fixes a bug in the Glacier2 address filters, `Glacier2.Filter.Address.Accept` and `Glacier2.Filter.Address.Reject`: the filters compared host names case-sensitively, while DNS names are case-insensitive. The rule's address portion is now folded to ASCII lower case when the filter property is parsed, and the endpoint host is folded the same way before matching. IPv4 literals and the port portion of a rule are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
