### PR TITLE
Parse Glacier2 session filter properties at startup

### DIFF
--- a/changelog.d/service-glacier2/invalid-filter-property-fails-startup.md
+++ b/changelog.d/service-glacier2/invalid-filter-property-fails-startup.md
@@ -1,0 +1,3 @@
+- Fixed a bug where a malformed `Glacier2.Filter.Identity.Accept` or `Glacier2.Filter.Category.AcceptUser` property
+  made every session creation hang instead of failing. The router now validates these properties at startup and
+  refuses to start when one of them is invalid.

--- a/cpp/src/Glacier2/FilterManager.cpp
+++ b/cpp/src/Glacier2/FilterManager.cpp
@@ -5,99 +5,9 @@
 #include "Ice/Communicator.h"
 #include "Ice/Ice.h"
 #include "Ice/Logger.h"
-#include "Ice/Properties.h"
-#include "Ice/StringUtil.h"
 
 using namespace std;
 using namespace Ice;
-
-//
-// Parse a space delimited string into a sequence of strings.
-//
-
-static vector<string>
-stringToStringSeq(const string& str)
-{
-    vector<string> seq;
-    IceInternal::splitString(str, " \t", seq);
-
-    //
-    // TODO: do something about unmatched quotes
-    //
-    return seq;
-}
-
-static vector<Identity>
-stringToIdentitySeq(const string& str)
-{
-    vector<Identity> seq;
-    string const ws = " \t";
-
-    //
-    // Eat white space.
-    //
-    string::size_type current = str.find_first_not_of(ws, 0);
-    string::size_type end = 0;
-    while (current != string::npos)
-    {
-        switch (str[current])
-        {
-            case '"':
-            case '\'':
-            {
-                char quote = str[current];
-                end = current + 1;
-                while (true)
-                {
-                    end = str.find(quote, end);
-
-                    if (end == string::npos)
-                    {
-                        //
-                        // TODO: should this be an unmatched quote error?
-                        //
-                        seq.push_back(stringToIdentity(str.substr(current)));
-                        break;
-                    }
-
-                    bool markString = true;
-                    for (string::size_type r = end - 1; r > current && str[r] == '\\'; --r)
-                    {
-                        markString = !markString;
-                    }
-                    //
-                    // We don't want the quote so we skip that.
-                    //
-                    if (markString)
-                    {
-                        ++current;
-                        seq.push_back(stringToIdentity(str.substr(current, end - current)));
-                        break;
-                    }
-                    else
-                    {
-                        ++end;
-                    }
-                }
-                if (end != string::npos)
-                {
-                    ++end;
-                }
-                break;
-            }
-
-            default:
-            {
-                end = str.find_first_of(ws, current);
-                string::size_type len = (end == string::npos) ? string::npos : end - current;
-                seq.push_back(stringToIdentity(str.substr(current, len)));
-                break;
-            }
-        }
-        current = str.find_first_not_of(ws, end);
-    }
-    return seq;
-}
 
 Glacier2::FilterManager::~FilterManager() { destroy(); }
 
@@ -170,12 +80,11 @@ Glacier2::FilterManager::FilterManager(
 shared_ptr<Glacier2::FilterManager>
 Glacier2::FilterManager::create(shared_ptr<Instance> instance, const string& userId, bool allowAddUser)
 {
-    auto props = instance->properties();
-    vector<string> allowSeq = stringToStringSeq(props->getIceProperty("Glacier2.Filter.Category.Accept"));
+    vector<string> allowSeq = instance->filterCategories();
 
     if (allowAddUser)
     {
-        int addUserMode = props->getIcePropertyAsInt("Glacier2.Filter.Category.AcceptUser");
+        int addUserMode = instance->filterAddUserMode();
 
         if (addUserMode > 0 && !userId.empty())
         {
@@ -191,12 +100,8 @@ Glacier2::FilterManager::create(shared_ptr<Instance> instance, const string& use
     }
 
     auto categoryFilter = make_shared<Glacier2::StringSetI>(allowSeq);
-
-    auto adapterIdFilter =
-        make_shared<Glacier2::StringSetI>(stringToStringSeq(props->getIceProperty("Glacier2.Filter.AdapterId.Accept")));
-
-    auto identityFilter = make_shared<Glacier2::IdentitySetI>(
-        stringToIdentitySeq(props->getIceProperty("Glacier2.Filter.Identity.Accept")));
+    auto adapterIdFilter = make_shared<Glacier2::StringSetI>(instance->filterAdapterIds());
+    auto identityFilter = make_shared<Glacier2::IdentitySetI>(instance->filterIdentities());
 
     return make_shared<Glacier2::FilterManager>(
         std::move(instance),

--- a/cpp/src/Glacier2/Instance.cpp
+++ b/cpp/src/Glacier2/Instance.cpp
@@ -114,19 +114,6 @@ parseFilterIdentities(const PropertiesPtr& properties)
     }
 }
 
-static int
-parseFilterAddUserMode(const PropertiesPtr& properties)
-{
-    try
-    {
-        return properties->getIcePropertyAsInt("Glacier2.Filter.Category.AcceptUser");
-    }
-    catch (const std::exception& ex)
-    {
-        throw InitializationException(__FILE__, __LINE__, string{ex.what()});
-    }
-}
-
 Glacier2::Instance::Instance(
     shared_ptr<Ice::Communicator> communicator,
     Ice::ObjectAdapterPtr clientAdapter,
@@ -141,7 +128,7 @@ Glacier2::Instance::Instance(
       _filterCategories(stringToStringSeq(_properties->getIceProperty("Glacier2.Filter.Category.Accept"))),
       _filterAdapterIds(stringToStringSeq(_properties->getIceProperty("Glacier2.Filter.AdapterId.Accept"))),
       _filterIdentities(parseFilterIdentities(_properties)),
-      _filterAddUserMode(parseFilterAddUserMode(_properties))
+      _filterAddUserMode(_properties->getIcePropertyAsInt("Glacier2.Filter.Category.AcceptUser"))
 {
     if (_routingTableMaxSize < 1)
     {

--- a/cpp/src/Glacier2/Instance.cpp
+++ b/cpp/src/Glacier2/Instance.cpp
@@ -2,11 +2,130 @@
 
 #include "Instance.h"
 #include "../Ice/InstrumentationI.h"
+#include "Ice/StringUtil.h"
 #include "InstrumentationI.h"
 #include "SessionRouterI.h"
 
 using namespace std;
+using namespace Ice;
 using namespace Glacier2;
+
+//
+// Parse a space delimited string into a sequence of strings.
+//
+
+static vector<string>
+stringToStringSeq(const string& str)
+{
+    vector<string> seq;
+    IceInternal::splitString(str, " \t", seq);
+
+    //
+    // TODO: do something about unmatched quotes
+    //
+    return seq;
+}
+
+static vector<Identity>
+stringToIdentitySeq(const string& str)
+{
+    vector<Identity> seq;
+    string const ws = " \t";
+
+    //
+    // Eat white space.
+    //
+    string::size_type current = str.find_first_not_of(ws, 0);
+    string::size_type end = 0;
+    while (current != string::npos)
+    {
+        switch (str[current])
+        {
+            case '"':
+            case '\'':
+            {
+                char quote = str[current];
+                end = current + 1;
+                while (true)
+                {
+                    end = str.find(quote, end);
+
+                    if (end == string::npos)
+                    {
+                        //
+                        // TODO: should this be an unmatched quote error?
+                        //
+                        seq.push_back(stringToIdentity(str.substr(current)));
+                        break;
+                    }
+
+                    bool markString = true;
+                    for (string::size_type r = end - 1; r > current && str[r] == '\\'; --r)
+                    {
+                        markString = !markString;
+                    }
+                    //
+                    // We don't want the quote so we skip that.
+                    //
+                    if (markString)
+                    {
+                        ++current;
+                        seq.push_back(stringToIdentity(str.substr(current, end - current)));
+                        break;
+                    }
+                    else
+                    {
+                        ++end;
+                    }
+                }
+                if (end != string::npos)
+                {
+                    ++end;
+                }
+                break;
+            }
+
+            default:
+            {
+                end = str.find_first_of(ws, current);
+                string::size_type len = (end == string::npos) ? string::npos : end - current;
+                seq.push_back(stringToIdentity(str.substr(current, len)));
+                break;
+            }
+        }
+        current = str.find_first_not_of(ws, end);
+    }
+    return seq;
+}
+
+static vector<Identity>
+parseFilterIdentities(const PropertiesPtr& properties)
+{
+    try
+    {
+        return stringToIdentitySeq(properties->getIceProperty("Glacier2.Filter.Identity.Accept"));
+    }
+    catch (const std::exception& ex)
+    {
+        throw InitializationException(
+            __FILE__,
+            __LINE__,
+            "invalid 'Glacier2.Filter.Identity.Accept' property:\n" + string{ex.what()});
+    }
+}
+
+static int
+parseFilterAddUserMode(const PropertiesPtr& properties)
+{
+    try
+    {
+        return properties->getIcePropertyAsInt("Glacier2.Filter.Category.AcceptUser");
+    }
+    catch (const std::exception& ex)
+    {
+        throw InitializationException(__FILE__, __LINE__, string{ex.what()});
+    }
+}
 
 Glacier2::Instance::Instance(
     shared_ptr<Ice::Communicator> communicator,
@@ -18,7 +137,11 @@ Glacier2::Instance::Instance(
       _clientAdapter(std::move(clientAdapter)),
       _serverAdapter(std::move(serverAdapter)),
       _proxyVerifier(make_shared<ProxyVerifier>(_communicator)),
-      _routingTableMaxSize(_properties->getIcePropertyAsInt("Glacier2.RoutingTable.MaxSize"))
+      _routingTableMaxSize(_properties->getIcePropertyAsInt("Glacier2.RoutingTable.MaxSize")),
+      _filterCategories(stringToStringSeq(_properties->getIceProperty("Glacier2.Filter.Category.Accept"))),
+      _filterAdapterIds(stringToStringSeq(_properties->getIceProperty("Glacier2.Filter.AdapterId.Accept"))),
+      _filterIdentities(parseFilterIdentities(_properties)),
+      _filterAddUserMode(parseFilterAddUserMode(_properties))
 {
     if (_routingTableMaxSize < 1)
     {

--- a/cpp/src/Glacier2/Instance.h
+++ b/cpp/src/Glacier2/Instance.h
@@ -4,11 +4,15 @@
 #define GLACIER2_INSTANCE_H
 
 #include "Ice/CommunicatorF.h"
+#include "Ice/Identity.h"
 #include "Ice/ObjectAdapterF.h"
 #include "Ice/PropertiesF.h"
 #include "Instrumentation.h"
 #include "ProxyVerifier.h"
 #include "SessionRouterI.h"
+
+#include <string>
+#include <vector>
 
 namespace Glacier2
 {
@@ -27,6 +31,13 @@ namespace Glacier2
         [[nodiscard]] std::shared_ptr<SessionRouterI> sessionRouter() const { return _sessionRouter; }
         [[nodiscard]] int routingTableMaxSize() const { return _routingTableMaxSize; }
 
+        // The session filter configuration, parsed from the Glacier2.Filter.* properties. Each session
+        // seeds its own filters from these values.
+        [[nodiscard]] const std::vector<std::string>& filterCategories() const { return _filterCategories; }
+        [[nodiscard]] const std::vector<std::string>& filterAdapterIds() const { return _filterAdapterIds; }
+        [[nodiscard]] const std::vector<Ice::Identity>& filterIdentities() const { return _filterIdentities; }
+        [[nodiscard]] int filterAddUserMode() const { return _filterAddUserMode; }
+
         [[nodiscard]] const std::shared_ptr<Glacier2::Instrumentation::RouterObserver>& getObserver() const
         {
             return _observer;
@@ -44,6 +55,10 @@ namespace Glacier2
         const Ice::ObjectAdapterPtr _serverAdapter;
         const std::shared_ptr<ProxyVerifier> _proxyVerifier;
         const int _routingTableMaxSize;
+        const std::vector<std::string> _filterCategories;
+        const std::vector<std::string> _filterAdapterIds;
+        const std::vector<Ice::Identity> _filterIdentities;
+        const int _filterAddUserMode;
         std::shared_ptr<SessionRouterI> _sessionRouter;
         const std::shared_ptr<Glacier2::Instrumentation::RouterObserver> _observer;
     };

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -394,27 +394,36 @@ CreateSession::addPendingCallback(shared_ptr<CreateSession> callback)
 void
 CreateSession::authorized(bool createSession)
 {
-    //
-    // Create the filter manager now as it's required for the session control object.
-    //
-    _filterManager = createFilterManager();
+    // This function runs from an AMI response callback: an exception escaping it would be swallowed by the
+    // Ice runtime, leaving the client without a reply and the connection's pending-creation entry in place.
+    try
+    {
+        //
+        // Create the filter manager now as it's required for the session control object.
+        //
+        _filterManager = createFilterManager();
 
-    //
-    // If we have a session manager configured, we create a client-visible session object,
-    // otherwise, we return a null session proxy.
-    //
-    if (createSession)
-    {
-        if (_instance->serverObjectAdapter())
+        //
+        // If we have a session manager configured, we create a client-visible session object,
+        // otherwise, we return a null session proxy.
+        //
+        if (createSession)
         {
-            auto obj = make_shared<SessionControlI>(_sessionRouter, _current.con, _filterManager);
-            _control = _instance->serverObjectAdapter()->addWithUUID<SessionControlPrx>(obj);
+            if (_instance->serverObjectAdapter())
+            {
+                auto obj = make_shared<SessionControlI>(_sessionRouter, _current.con, _filterManager);
+                _control = _instance->serverObjectAdapter()->addWithUUID<SessionControlPrx>(obj);
+            }
+            this->createSession();
         }
-        this->createSession();
+        else
+        {
+            sessionCreated(nullopt);
+        }
     }
-    else
+    catch (const Ice::Exception&)
     {
-        sessionCreated(nullopt);
+        unexpectedCreateSessionException(current_exception());
     }
 }
 


### PR DESCRIPTION
A malformed `Glacier2.Filter.Identity.Accept` (e.g. `a/b/c`) or a non-integer `Glacier2.Filter.Category.AcceptUser` made every successful-auth `createSession` hang forever: the properties were parsed per session inside the permissions verifier's AMI response callback, the parse exception was swallowed by the Ice runtime (an `Ice.Warn.AMICallback` warning only), and the connection's pending-creation entry was never cleaned up.

With this PR, the `Instance` constructor parses all the `Glacier2.Filter.*` session filter properties once at startup and stores the parsed values; a malformed property now fails startup with an `InitializationException` naming the property, like the address filter properties. `FilterManager::create` seeds each session's filters from the pre-parsed values and no longer reads any property.

In addition, `CreateSession::authorized` now catches synchronous exceptions and funnels them through the regular failure path, since it runs from an AMI response callback where an escaping exception is swallowed by the Ice runtime. Any residual synchronous throw in this path (e.g. the server object adapter getting destroyed while a session is being created) now produces a `CannotCreateSessionException` reply and cleans up the pending-creation entry instead of wedging the connection.

Fixes #5859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)