### PR TITLE
Harden Glacier2 password file and PBKDF2 hash parsing

### DIFF
--- a/changelog.d/service-glacier2/password-file-duplicate-user.md
+++ b/changelog.d/service-glacier2/password-file-duplicate-user.md
@@ -1,0 +1,2 @@
+- Fixed a bug in the Glacier2 Crypt permissions verifier: a password file with more than one entry for the same user
+  kept the first entry and silently ignored the others. A duplicate entry now fails startup, like a malformed entry.

--- a/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
@@ -287,19 +287,24 @@ namespace
             return false; // Rounds end token not found
         }
 
-        // The rounds field is a decimal number; passlib does not produce octal or hexadecimal rounds.
-        int64_t rounds;
-        size_t roundsLength;
+        // The rounds field must contain decimal digits only; passlib does not produce a sign, whitespace, or
+        // octal or hexadecimal rounds.
         const string roundsField = p->second.substr(beg, (end - beg));
-        try
-        {
-            rounds = std::stoll(roundsField, &roundsLength, 10);
-        }
-        catch (const std::exception&)
+        if (roundsField.empty() || roundsField.find_first_not_of("0123456789") != string::npos)
         {
             return false; // Invalid rounds value
         }
-        if (roundsLength != roundsField.size() || rounds <= 0 || rounds > std::numeric_limits<uint32_t>::max())
+
+        int64_t rounds;
+        try
+        {
+            rounds = std::stoll(roundsField, nullptr, 10);
+        }
+        catch (const std::exception&)
+        {
+            return false; // Invalid rounds value (overflow)
+        }
+        if (rounds <= 0 || rounds > std::numeric_limits<uint32_t>::max())
         {
             return false; // Invalid rounds value
         }

--- a/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
@@ -8,6 +8,7 @@
 
 #include <cstring>
 #include <fstream>
+#include <limits>
 
 #if defined(__GLIBC__)
 #    include <crypt.h>
@@ -122,7 +123,14 @@ namespace
 
             hasDESStylePassword = hasDESStylePassword || (password.find('$') == string::npos && password.size() == 13);
 
-            passwords.insert(make_pair(userId, password));
+            if (!passwords.insert(make_pair(userId, password)).second)
+            {
+                throw Ice::InitializationException(
+                    __FILE__,
+                    __LINE__,
+                    "duplicate entry for user '" + userId + "' in password file '" + file + "' at line " +
+                        std::to_string(lineNumber));
+            }
         }
 
         if (hasDESStylePassword)
@@ -279,12 +287,19 @@ namespace
             return false; // Rounds end token not found
         }
 
+        // The rounds field is a decimal number; passlib does not produce octal or hexadecimal rounds.
         int64_t rounds;
+        size_t roundsLength;
+        const string roundsField = p->second.substr(beg, (end - beg));
         try
         {
-            rounds = std::stoll(p->second.substr(beg, (end - beg)), nullptr, 0);
+            rounds = std::stoll(roundsField, &roundsLength, 10);
         }
         catch (const std::exception&)
+        {
+            return false; // Invalid rounds value
+        }
+        if (roundsLength != roundsField.size() || rounds <= 0 || rounds > std::numeric_limits<uint32_t>::max())
         {
             return false; // Invalid rounds value
         }
@@ -301,7 +316,7 @@ namespace
 
         string salt = p->second.substr(beg, (end - beg));
         string checksum = p->second.substr(end + 1);
-        if (checksum.empty())
+        if (salt.empty() || checksum.empty())
         {
             return false;
         }
@@ -408,7 +423,7 @@ namespace
                 salt.c_str(),
                 static_cast<DWORD>(salt.size()),
                 CRYPT_STRING_BASE64,
-                &saltBuffer[0],
+                saltBuffer.data(),
                 &saltLength,
                 0,
                 0))
@@ -429,12 +444,12 @@ namespace
 
         DWORD status = BCryptDeriveKeyPBKDF2(
             algorithmHandle,
-            &passwordBuffer[0],
+            passwordBuffer.data(),
             static_cast<DWORD>(passwordBuffer.size()),
-            &saltBuffer[0],
+            saltBuffer.data(),
             saltLength,
-            rounds,
-            &checksumBuffer1[0],
+            static_cast<ULONGLONG>(rounds),
+            checksumBuffer1.data(),
             static_cast<DWORD>(checksumLength),
             0);
 
@@ -452,7 +467,7 @@ namespace
                 checksum.c_str(),
                 static_cast<DWORD>(checksum.size()),
                 CRYPT_STRING_BASE64,
-                &checksumBuffer2[0],
+                checksumBuffer2.data(),
                 &checksumBuffer2Length,
                 0,
                 0))


### PR DESCRIPTION
Two fixes in the Glacier2 Crypt permissions verifier:

- A password file with more than one entry for the same user kept the first entry and silently ignored the others — so appending an updated hash for an existing user (a typical rotation) left the old password in effect with no diagnostic. A duplicate entry now fails startup with an error naming the user, file, and line, like a malformed entry (#5361).

- The PBKDF2 hash parser (macOS and Windows) parsed the rounds field with `stoll(..., base 0)`, which reads a leading-zero rounds value as octal — deriving the wrong key and rejecting valid credentials — and accepted negative or partially-numeric values. The rounds field is now parsed as decimal, must be fully numeric, and must be in (0, 2^32-1]. An empty salt is rejected as malformed, and the Windows code no longer indexes empty vectors when the salt or the client-supplied password is empty (undefined behavior, assertion failure in debug builds).

Verified on macOS with an end-to-end A/B: a valid credential whose hash carries a `0100` rounds field is rejected before the fix and authenticates after it.

Addresses items 9 and 13 of #5864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)