### PR TITLE
Reject invalid groups in Glacier2 address filter rules at startup

### DIFF
--- a/changelog.d/service-glacier2/address-filter-rule-validation.md
+++ b/changelog.d/service-glacier2/address-filter-rule-validation.md
@@ -1,0 +1,3 @@
+- Improved the validation of the Glacier2 address filter rules: a rule with an inverted numeric range (such as
+  `[5-1]`) or with a stray `[` inside a group was accepted and then silently did not match the hosts it appears to
+  describe.

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -67,6 +67,10 @@ namespace Glacier2
                             throw invalid_argument("expected number");
                         }
                         r.end = value;
+                        if (r.end < r.start)
+                        {
+                            throw invalid_argument("range lower bound is greater than its upper bound");
+                        }
                         ws(istr);
                         if (!istr.eof())
                         {
@@ -733,6 +737,10 @@ namespace Glacier2
                         }
                         else if (addr[current] == '[')
                         {
+                            if (inGroup)
+                            {
+                                throw invalid_argument("unexpected '[' in group");
+                            }
                             // ??? what does it mean if current == mark?
                             if (current != mark)
                             {


### PR DESCRIPTION
The Glacier2 address filter rule parser accepted two malformed group constructs and built rules that silently did not match the hosts they appear to describe:

- an inverted numeric range, such as `[5-1]`, produced a range that never matches (it fails closed, with no diagnostic);
- a stray `[` inside a group, as in `a[1[2]`, mis-parsed the group into a literal-string match (a stray `*` in a group was already rejected).

Both now fail router startup with an `InitializationException` naming the property, like the other address filter validation errors.

Addresses item 7 of #5864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)