### PR TITLE
Trace routing table additions at all Glacier2.Trace.RoutingTable levels

### DIFF
--- a/cpp/src/Glacier2/RoutingTable.cpp
+++ b/cpp/src/Glacier2/RoutingTable.cpp
@@ -75,7 +75,7 @@ Glacier2::RoutingTable::add(
 
         if (p == _map.end())
         {
-            if (_traceLevel == 1 || _traceLevel >= 3)
+            if (_traceLevel >= 1)
             {
                 Trace out(_communicator->getLogger(), "Glacier2");
                 out << "adding proxy to routing table:\n" << proxy;
@@ -87,7 +87,7 @@ Glacier2::RoutingTable::add(
         }
         else
         {
-            if (_traceLevel == 1 || _traceLevel >= 3)
+            if (_traceLevel >= 1)
             {
                 Trace out(_communicator->getLogger(), "Glacier2");
                 out << "proxy already in routing table:\n" << proxy;


### PR DESCRIPTION
`Glacier2.Trace.RoutingTable=2` traced routing table evictions but silently stopped tracing additions: additions were traced at levels 1 and >= 3 only, while evictions were traced at levels >= 2. Level 2, naturally read as "level 1 plus evictions", instead dropped the addition traces.

Additions are now traced at every level >= 1, so the levels are monotonic: level 1 traces additions, level 2 adds evictions, and higher levels behave like level 2.

Addresses item 12 of #5864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)