### PR TITLE
Restore SessionNotExistException from Glacier2 refreshSession

### DIFF
--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -746,6 +746,24 @@ SessionRouterI::destroySessionAsync(function<void()> response, function<void(exc
 }
 
 void
+SessionRouterI::refreshSessionAsync(
+    function<void()> response,
+    function<void(exception_ptr)> exception,
+    const Current& current)
+{
+    // This operation is deprecated and no longer refreshes the session, but it still reports whether the caller
+    // has a session with this router.
+    if (getRouter(current.con, current.id, false))
+    {
+        response();
+    }
+    else
+    {
+        exception(make_exception_ptr(SessionNotExistException()));
+    }
+}
+
+void
 SessionRouterI::destroySession(const ConnectionPtr& connection, function<void(exception_ptr)> error)
 {
     shared_ptr<RouterI> router;

--- a/cpp/src/Glacier2/SessionRouterI.h
+++ b/cpp/src/Glacier2/SessionRouterI.h
@@ -105,10 +105,7 @@ namespace Glacier2
         void refreshSessionAsync(
             std::function<void()> response,
             std::function<void(std::exception_ptr)>,
-            const Ice::Current&) final
-        {
-            response();
-        }
+            const Ice::Current&) final;
 
         void destroySessionAsync(
             std::function<void()> response,

--- a/slice/Glacier2/Router.ice
+++ b/slice/Glacier2/Router.ice
@@ -71,7 +71,7 @@ module Glacier2
 
         /// Keeps the session with this router alive.
         /// @throws SessionNotExistException Thrown when no session exists for the caller (client).
-        ["deprecated:As of Ice 3.8, this operation does nothing."]
+        ["deprecated:As of Ice 3.8, this operation no longer keeps the session alive; it only verifies that the session exists."]
         void refreshSession()
             throws SessionNotExistException;
 


### PR DESCRIPTION
The deprecated `Glacier2::Router::refreshSession` operation is documented (and declared) to throw `SessionNotExistException` when the caller has no session, but the 3.8 implementation stubbed it to always succeed. A legacy client that uses `refreshSession` to detect whether its session is still alive was therefore always told "alive", even with no session.

`refreshSession` still does not keep the session alive (that is now connection-based), but it once again reports whether the caller has a session: it resolves the session from the caller's connection and, when none exists, completes with `SessionNotExistException`. This matches the pre-3.8 behavior. The deprecation comment is updated accordingly.

Addresses item 10 of #5864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)