### PR TITLE
Reject routing two proxies with the same identity in Glacier2

### DIFF
--- a/changelog.d/service-glacier2/duplicate-identity-routing.md
+++ b/changelog.d/service-glacier2/duplicate-identity-routing.md
@@ -1,0 +1,3 @@
+- Fixed the routing of two different proxies with the same identity through a Glacier2 router: the router kept one
+  of them arbitrarily and could route requests to the wrong proxy. It now rejects the conflicting proxy with an
+  error.

--- a/changelog.d/service-glacier2/routing-table-duplicate-identity.md
+++ b/changelog.d/service-glacier2/routing-table-duplicate-identity.md
@@ -1,0 +1,2 @@
+- Fixed a bug in the Glacier2 routing table: registering a proxy with the same identity as an existing entry but a
+  different address had an undefined result. The router now rejects such a request.

--- a/cpp/src/Glacier2/RoutingTable.cpp
+++ b/cpp/src/Glacier2/RoutingTable.cpp
@@ -87,13 +87,26 @@ Glacier2::RoutingTable::add(
         }
         else
         {
+            auto& entry = p->second;
+
+            // Two distinct proxies with the same identity can't both be routed. We accept duplicate entries for
+            // routine concurrent registrations.
+            if (entry.proxy != proxy)
+            {
+                throw DispatchException{
+                    __FILE__,
+                    __LINE__,
+                    ReplyStatus::NotSupported,
+                    "cannot route two proxies with the same identity '" +
+                        _communicator->identityToString(proxy->ice_getIdentity()) + "'"};
+            }
+
             if (_traceLevel == 1 || _traceLevel >= 3)
             {
                 Trace out(_communicator->getLogger(), "Glacier2");
                 out << "proxy already in routing table:\n" << proxy;
             }
 
-            auto& entry = p->second;
             _queue.erase(entry.pos);
             auto q = _queue.insert(_queue.end(), p);
             entry.pos = q;

--- a/cpp/test/Glacier2/router/Client.cpp
+++ b/cpp/test/Glacier2/router/Client.cpp
@@ -477,6 +477,24 @@ CallbackClient::run(int argc, char** argv)
     }
 
     {
+        cout << "testing that adding a different proxy with an existing identity is rejected... " << flush;
+        ObjectPrx dup1(communicator, "dup:" + getTestEndpoint());
+        ObjectPrx dup2 = dup1->ice_endpoints({}); // Same identity, no endpoint.
+        router->addProxies({dup1});
+        router->addProxies({dup1}); // Adding the same proxy again is fine.
+        try
+        {
+            router->addProxies({dup2});
+            test(false);
+        }
+        catch (const DispatchException& ex)
+        {
+            test(ex.replyStatus() == ReplyStatus::NotSupported);
+        }
+        cout << "ok" << endl;
+    }
+
+    {
         cout << "pinging object with client endpoint... " << flush;
         auto baseC = communicator->stringToProxy("collocated:" + getTestEndpoint(50));
         try


### PR DESCRIPTION
When a client added a proxy to the Glacier2 routing table for an identity that was already routed, the router kept the existing entry: re-adding the exact same proxy is fine (this happens for routine concurrent registrations by the Ice client runtime), but re-adding a *different* proxy for the same identity was silently ignored, so the client was routed to the wrong endpoints with no indication of the conflict.

`RoutingTable::add` now rejects a different proxy for an already-routed identity with a `DispatchException` carrying `ReplyStatus::NotSupported`. Two distinct proxies with the same identity can't both be routed, and this indicates a bug in the client application.

Addresses item 3 of #5864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)