### PR TITLE
Count Glacier2 forwarded requests when they are forwarded

### DIFF
--- a/cpp/src/Glacier2/Blobject.cpp
+++ b/cpp/src/Glacier2/Blobject.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 #include "Blobject.h"
+#include "ForwardObserver.h"
 #include "Instrumentation.h"
 #include "SessionRouterI.h"
 
@@ -17,9 +18,14 @@ namespace
     constexpr string_view clientTraceRequest = "Glacier2.Client.Trace.Request";
 }
 
-Glacier2::Blobject::Blobject(shared_ptr<Instance> instance, ConnectionPtr reverseConnection, Context context)
+Glacier2::Blobject::Blobject(
+    shared_ptr<Instance> instance,
+    shared_ptr<ForwardObserver> forwardObserver,
+    ConnectionPtr reverseConnection,
+    Context context)
     : _instance(std::move(instance)),
       _reverseConnection(std::move(reverseConnection)),
+      _forwardObserver(std::move(forwardObserver)),
       _forwardContext(
           _reverseConnection ? _instance->properties()->getIcePropertyAsInt(serverForwardContext) > 0
                              : _instance->properties()->getIcePropertyAsInt(clientForwardContext) > 0),
@@ -38,6 +44,9 @@ Glacier2::Blobject::invoke(
     function<void(exception_ptr)> exception, // NOLINT(performance-unnecessary-value-param)
     const Current& current)
 {
+    // A client blobject has no reverse connection.
+    _forwardObserver->forwarded(_reverseConnection == nullptr);
+
     //
     // Set the correct facet on the proxy.
     //

--- a/cpp/src/Glacier2/Blobject.h
+++ b/cpp/src/Glacier2/Blobject.h
@@ -8,10 +8,12 @@
 
 namespace Glacier2
 {
+    class ForwardObserver;
+
     class Blobject : public Ice::BlobjectArrayAsync, public std::enable_shared_from_this<Blobject>
     {
     public:
-        Blobject(std::shared_ptr<Instance>, Ice::ConnectionPtr, Ice::Context);
+        Blobject(std::shared_ptr<Instance>, std::shared_ptr<ForwardObserver>, Ice::ConnectionPtr, Ice::Context);
 
     protected:
         void invoke(
@@ -25,6 +27,7 @@ namespace Glacier2
         const Ice::ConnectionPtr _reverseConnection;
 
     private:
+        const std::shared_ptr<ForwardObserver> _forwardObserver;
         const bool _forwardContext;
         const int _requestTraceLevel;
         const Ice::Context _context;

--- a/cpp/src/Glacier2/ClientBlobject.cpp
+++ b/cpp/src/Glacier2/ClientBlobject.cpp
@@ -14,10 +14,9 @@ Glacier2::ClientBlobject::ClientBlobject(
     shared_ptr<Instance> instance,
     shared_ptr<FilterManager> filters,
     const Ice::Context& sslContext,
-    shared_ptr<RoutingTable> routingTable)
-    :
-
-      Glacier2::Blobject(std::move(instance), nullptr, sslContext),
+    shared_ptr<RoutingTable> routingTable,
+    shared_ptr<ForwardObserver> forwardObserver)
+    : Glacier2::Blobject(std::move(instance), std::move(forwardObserver), nullptr, sslContext),
       _routingTable(std::move(routingTable)),
       _filters(std::move(filters)),
       _rejectTraceLevel(_instance->properties()->getIcePropertyAsInt("Glacier2.Client.Trace.Reject"))

--- a/cpp/src/Glacier2/ClientBlobject.h
+++ b/cpp/src/Glacier2/ClientBlobject.h
@@ -10,6 +10,7 @@ namespace Glacier2
 {
     class FilterManager;
     class RoutingTable;
+    class ForwardObserver;
 
     class ClientBlobject final : public Glacier2::Blobject
     {
@@ -18,7 +19,8 @@ namespace Glacier2
             std::shared_ptr<Instance>,
             std::shared_ptr<FilterManager>,
             const Ice::Context&,
-            std::shared_ptr<RoutingTable>);
+            std::shared_ptr<RoutingTable>,
+            std::shared_ptr<ForwardObserver>);
 
         void ice_invokeAsync(
             std::pair<const std::byte*, const std::byte*> inEncaps,

--- a/cpp/src/Glacier2/ForwardObserver.h
+++ b/cpp/src/Glacier2/ForwardObserver.h
@@ -1,0 +1,40 @@
+// Copyright (c) ZeroC, Inc.
+
+#ifndef GLACIER2_FORWARD_OBSERVER_H
+#define GLACIER2_FORWARD_OBSERVER_H
+
+#include "Instrumentation.h"
+
+#include <memory>
+#include <mutex>
+
+namespace Glacier2
+{
+    // A thread-safe holder for the session observer, used to report forwarded requests. The RouterI and its
+    // blobjects share this object, so it stays valid and consistently synchronized while a request is being
+    // forwarded, even if the session is destroyed concurrently.
+    class ForwardObserver final
+    {
+    public:
+        void update(std::shared_ptr<Instrumentation::SessionObserver> observer)
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _observer = std::move(observer);
+        }
+
+        void forwarded(bool client)
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_observer)
+            {
+                _observer->forwarded(client);
+            }
+        }
+
+    private:
+        std::shared_ptr<Instrumentation::SessionObserver> _observer;
+        std::mutex _mutex;
+    };
+}
+
+#endif

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -2,6 +2,7 @@
 
 #include "RouterI.h"
 #include "FilterManager.h"
+#include "ForwardObserver.h"
 #include "Glacier2/Session.h"
 #include "RoutingTable.h"
 
@@ -20,11 +21,13 @@ Glacier2::RouterI::RouterI(
     shared_ptr<FilterManager> filters,
     const Context& context)
     : _instance(std::move(instance)),
+      _forwardObserver(make_shared<ForwardObserver>()),
       _routingTable(make_shared<RoutingTable>(
           _instance->communicator(),
           _instance->proxyVerifier(),
           _instance->routingTableMaxSize())),
-      _clientBlobject(make_shared<ClientBlobject>(_instance, std::move(filters), context, _routingTable)),
+      _clientBlobject(
+          make_shared<ClientBlobject>(_instance, std::move(filters), context, _routingTable, _forwardObserver)),
       _connection(std::move(connection)),
       _userId(std::move(userId)),
       _session(std::move(session)),
@@ -46,7 +49,7 @@ Glacier2::RouterI::RouterI(
         const_cast<optional<ObjectPrx>&>(_serverProxy) = _instance->serverObjectAdapter()->createProxy(ident);
 
         auto& serverBlobject = const_cast<shared_ptr<ServerBlobject>&>(_serverBlobject);
-        serverBlobject = make_shared<ServerBlobject>(_instance, _connection);
+        serverBlobject = make_shared<ServerBlobject>(_instance, _forwardObserver, _connection);
     }
 
     if (_instance->getObserver())
@@ -162,31 +165,19 @@ Glacier2::RouterI::getACMTimeout(const Current&) const
 shared_ptr<ClientBlobject>
 Glacier2::RouterI::getClientBlobject() const
 {
-    // Can only be called with the SessionRouterI mutex locked
-    if (_observer)
-    {
-        _observer->forwarded(true);
-    }
     return _clientBlobject;
 }
 
 shared_ptr<ServerBlobject>
 Glacier2::RouterI::getServerBlobject() const
 {
-    // Can only be called with the SessionRouterI mutex locked
-    if (_observer)
-    {
-        _observer->forwarded(false);
-    }
     return _serverBlobject;
 }
 
 void
 Glacier2::RouterI::updateObserver(const shared_ptr<Glacier2::Instrumentation::RouterObserver>& observer)
 {
-    // Can only be called with the SessionRouterI mutex locked
-
-    _observer = _routingTable->updateObserver(observer, _userId, _connection);
+    _forwardObserver->update(_routingTable->updateObserver(observer, _userId, _connection));
 }
 
 string

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -94,6 +94,9 @@ Glacier2::RouterI::destroy(function<void(exception_ptr)> error)
     }
 
     _routingTable->destroy();
+
+    // Requests forwarded after this point are no longer counted in the session metrics.
+    _forwardObserver->update(nullptr);
 }
 
 optional<ObjectPrx>

--- a/cpp/src/Glacier2/RouterI.h
+++ b/cpp/src/Glacier2/RouterI.h
@@ -13,6 +13,7 @@ namespace Glacier2
     class RoutingTable;
     class RouterI;
     class FilterManager;
+    class ForwardObserver;
 
     class RouterI final : public Router
     {
@@ -60,6 +61,7 @@ namespace Glacier2
 
     private:
         const std::shared_ptr<Instance> _instance;
+        const std::shared_ptr<ForwardObserver> _forwardObserver;
         const std::shared_ptr<RoutingTable> _routingTable;
         const std::optional<Ice::ObjectPrx> _serverProxy;
         const std::shared_ptr<ClientBlobject> _clientBlobject;
@@ -69,8 +71,6 @@ namespace Glacier2
         const std::optional<SessionPrx> _session;
         const Ice::Identity _controlId;
         const Ice::Context _context;
-
-        std::shared_ptr<Glacier2::Instrumentation::SessionObserver> _observer;
     };
 }
 

--- a/cpp/src/Glacier2/ServerBlobject.cpp
+++ b/cpp/src/Glacier2/ServerBlobject.cpp
@@ -6,8 +6,11 @@ using namespace std;
 using namespace Ice;
 using namespace Glacier2;
 
-Glacier2::ServerBlobject::ServerBlobject(shared_ptr<Instance> instance, ConnectionPtr connection)
-    : Glacier2::Blobject(std::move(instance), std::move(connection), Ice::Context())
+Glacier2::ServerBlobject::ServerBlobject(
+    shared_ptr<Instance> instance,
+    shared_ptr<ForwardObserver> forwardObserver,
+    ConnectionPtr connection)
+    : Glacier2::Blobject(std::move(instance), std::move(forwardObserver), std::move(connection), Ice::Context())
 {
 }
 

--- a/cpp/src/Glacier2/ServerBlobject.h
+++ b/cpp/src/Glacier2/ServerBlobject.h
@@ -7,10 +7,12 @@
 
 namespace Glacier2
 {
+    class ForwardObserver;
+
     class ServerBlobject final : public Glacier2::Blobject
     {
     public:
-        ServerBlobject(std::shared_ptr<Instance>, Ice::ConnectionPtr);
+        ServerBlobject(std::shared_ptr<Instance>, std::shared_ptr<ForwardObserver>, Ice::ConnectionPtr);
 
         void ice_invokeAsync(
             std::pair<const std::byte*, const std::byte*> inEncaps,


### PR DESCRIPTION
The Glacier2 `forwardedClient` session metric counted a client request at servant-locate time, before `ClientBlobject` applies its category/identity/adapter-id filters and looks up the routing table. A request later rejected by a filter or missing from the routing table was therefore counted as forwarded even though it was not.

The forwarded count now happens in `Blobject::invoke`, i.e. when the request is actually forwarded, after all the rejection checks have passed. The server side already forwarded every located request, so its count is unchanged.

The session observer is now held by a small shared, self-locked `ForwardObserver` owned by `RouterI` and shared with its blobjects, instead of a mutable `RouterI` member protected by the `SessionRouterI` mutex. This removes the metrics side-effect from `getClientBlobject`/`getServerBlobject` and keeps the observer valid while a request is being forwarded.

Addresses item 11 of #5864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)