### PR TITLE
Clean up DataStorm adapters after constructor failure

### DIFF
--- a/changelog.d/datastorm/5891.md
+++ b/changelog.d/datastorm/5891.md
@@ -1,0 +1,2 @@
+- Fixed a bug where a failed `DataStorm::Node` construction left a user-supplied communicator's default object
+  adapter set and its DataStorm object adapters alive, preventing the communicator from being reused.

--- a/changelog.d/datastorm/5891.md
+++ b/changelog.d/datastorm/5891.md
@@ -1,2 +1,2 @@
 - Fixed a bug where a failed `DataStorm::Node` construction left a user-supplied communicator's default object
-  adapter set and its DataStorm object adapters alive, preventing the communicator from being reused.
+  adapter set and its DataStorm object adapters alive.

--- a/changelog.d/datastorm/5891.md
+++ b/changelog.d/datastorm/5891.md
@@ -1,2 +1,0 @@
-- Fixed a bug where a failed `DataStorm::Node` construction left a user-supplied communicator's default object
-  adapter set and its DataStorm object adapters alive.

--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -66,10 +66,7 @@ namespace
     }
 }
 
-Instance::Instance(
-    CommunicatorPtr communicator,
-    function<void(function<void()> call)> customExecutor,
-    std::optional<Ice::SSL::ServerAuthenticationOptions> serverAuthenticationOptions)
+Instance::Instance(CommunicatorPtr communicator, function<void(function<void()> call)> customExecutor)
     : _communicator(std::move(communicator))
 {
     if (_communicator->getDefaultObjectAdapter())
@@ -94,6 +91,21 @@ Instance::Instance(
     _defaultWriterConfig.sampleCount = *_defaultReaderConfig.sampleCount;
     _defaultWriterConfig.sampleLifetime = *_defaultReaderConfig.sampleLifetime;
     _defaultWriterConfig.priority = properties->getIcePropertyAsInt("DataStorm.Topic.Priority");
+
+    _retryDelay = chrono::milliseconds(properties->getIcePropertyAsInt("DataStorm.Node.RetryDelay"));
+    _retryMultiplier = properties->getIcePropertyAsInt("DataStorm.Node.RetryMultiplier");
+    _retryCount = properties->getIcePropertyAsInt("DataStorm.Node.RetryCount");
+
+    _traceLevels = make_shared<TraceLevels>(properties, _communicator->getLogger());
+    _executor = make_shared<CallbackExecutor>(std::move(customExecutor));
+    _connectionManager = make_shared<ConnectionManager>(_executor);
+    _timer = make_shared<IceInternal::Timer>();
+}
+
+void
+Instance::init(std::optional<Ice::SSL::ServerAuthenticationOptions> serverAuthenticationOptions)
+{
+    PropertiesPtr properties = _communicator->getProperties();
 
     if (properties->getIcePropertyAsInt("DataStorm.Node.Server.Enabled") > 0)
     {
@@ -149,10 +161,6 @@ Instance::Instance(
         }
     }
 
-    _retryDelay = chrono::milliseconds(properties->getIcePropertyAsInt("DataStorm.Node.RetryDelay"));
-    _retryMultiplier = properties->getIcePropertyAsInt("DataStorm.Node.RetryMultiplier");
-    _retryCount = properties->getIcePropertyAsInt("DataStorm.Node.RetryCount");
-
     // A collocated adapter is used with a unique AdapterId to enable collocation with default servants. Proxies created
     // by this adapter will be indirect, and ObjectAdapter::isLocal will compare the adapter's AdapterId with the
     // reference's AdapterId to determine if a collocated call can be used.
@@ -165,15 +173,6 @@ Instance::Instance(
     _collocatedForwarder = make_shared<ForwarderManager>(_collocatedAdapter, "forwarders");
     _collocatedAdapter->addDefaultServant(_collocatedForwarder, "forwarders");
 
-    _executor = make_shared<CallbackExecutor>(std::move(customExecutor));
-    _connectionManager = make_shared<ConnectionManager>(_executor);
-    _timer = make_shared<IceInternal::Timer>();
-    _traceLevels = make_shared<TraceLevels>(properties, _communicator->getLogger());
-}
-
-void
-Instance::init()
-{
     auto self = shared_from_this();
 
     _topicFactory = make_shared<TopicFactoryI>(self);
@@ -268,8 +267,14 @@ Instance::destroy(bool ownsCommunicator)
     }
     else
     {
-        _adapter->destroy();
-        _collocatedAdapter->destroy();
+        if (_adapter)
+        {
+            _adapter->destroy();
+        }
+        if (_collocatedAdapter)
+        {
+            _collocatedAdapter->destroy();
+        }
         if (_multicastAdapter)
         {
             _multicastAdapter->destroy();
@@ -282,5 +287,8 @@ Instance::destroy(bool ownsCommunicator)
 
     _executor->destroy();
     _connectionManager->destroy();
-    _collocatedForwarder->destroy();
+    if (_collocatedForwarder)
+    {
+        _collocatedForwarder->destroy();
+    }
 }

--- a/cpp/src/DataStorm/Instance.h
+++ b/cpp/src/DataStorm/Instance.h
@@ -25,12 +25,9 @@ namespace DataStormI
     class Instance final : public std::enable_shared_from_this<Instance>
     {
     public:
-        Instance(
-            Ice::CommunicatorPtr communicator,
-            std::function<void(std::function<void()> call)> customExecutor,
-            std::optional<Ice::SSL::ServerAuthenticationOptions> serverAuthenticationOptions);
+        Instance(Ice::CommunicatorPtr communicator, std::function<void(std::function<void()> call)> customExecutor);
 
-        void init();
+        void init(std::optional<Ice::SSL::ServerAuthenticationOptions> serverAuthenticationOptions);
 
         [[nodiscard]] std::shared_ptr<ConnectionManager> getConnectionManager() const
         {

--- a/cpp/src/DataStorm/Node.cpp
+++ b/cpp/src/DataStorm/Node.cpp
@@ -31,11 +31,8 @@ Node::Node(NodeOptions options)
 
     try
     {
-        _instance = make_shared<DataStormI::Instance>(
-            communicator,
-            std::move(options.customExecutor),
-            std::move(options.serverAuthenticationOptions));
-        _instance->init();
+        _instance = make_shared<DataStormI::Instance>(communicator, std::move(options.customExecutor));
+        _instance->init(std::move(options.serverAuthenticationOptions));
     }
     catch (...)
     {

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -107,12 +107,49 @@ void ::Writer::run(int argc, char* argv[])
                 }
             }
 
+            // Retry properties are parsed before the DataStorm adapters are created, leaving a user-supplied
+            // communicator reusable when parsing fails.
+            {
+                Ice::CommunicatorHolder holder{Ice::initialize(makeInitData("DataStorm.Node.RetryDelay", "invalid"))};
+                try
+                {
+                    Node n11{holder.communicator()};
+                    test(false);
+                }
+                catch (const Ice::PropertyException&)
+                {
+                }
+
+                test(holder.communicator()->getDefaultObjectAdapter() == nullptr);
+                holder.communicator()->getProperties()->setProperty("DataStorm.Node.RetryDelay", "500");
+                Node n12{holder.communicator()};
+            }
+
+            // An adapter creation failure after the default adapter is set also leaves the communicator reusable.
+            // Reconstructing a node verifies that the named adapter from the failed construction was destroyed.
+            {
+                Ice::CommunicatorHolder holder{
+                    Ice::initialize(makeInitData("DataStorm.Node.Multicast.Endpoints", "invalid"))};
+                try
+                {
+                    Node n13{holder.communicator()};
+                    test(false);
+                }
+                catch (const invalid_argument&)
+                {
+                }
+
+                test(holder.communicator()->getDefaultObjectAdapter() == nullptr);
+                holder.communicator()->getProperties()->setProperty("DataStorm.Node.Multicast.Endpoints", "");
+                Node n14{holder.communicator()};
+            }
+
             // "None" is accepted as an alias for the "Never" discard policy, matching the DiscardPolicy::None
             // enumerator.
             {
                 Ice::CommunicatorHolder holder{Ice::initialize(makeInitData("DataStorm.Topic.DiscardPolicy", "None"))};
-                Node n11{holder.communicator()};
-                Topic<int, string> topic(n11, "discardPolicyAlias");
+                Node n15{holder.communicator()};
+                Topic<int, string> topic(n15, "discardPolicyAlias");
                 auto reader = makeSingleKeyReader(topic, 0);
             }
         }


### PR DESCRIPTION
## Summary
- create the DataStorm object adapters during Instance initialization so constructor failures use the existing destroy path
- parse retry and trace configuration before adapter resources are created
- make Instance destruction tolerate each partial adapter-initialization stage
- add regression coverage for retry-property and multicast-adapter failures with a user-supplied communicator

## Testing
- make -C cpp -j10 test/DataStorm/api_writer
- python3 allTests.py DataStorm/api

Fixes #5891