### PR TITLE
Evict replicas whose initialization fails during an IceStorm election

### DIFF
--- a/changelog.d/service-icestorm/5849.md
+++ b/changelog.d/service-icestorm/5849.md
@@ -1,5 +1,5 @@
-- Fixed a highly available IceStorm availability issue: when a replica stayed reachable but persistently failed to
-  apply the initial replica state (for example on a local database write error), every election failed and the
-  whole group kept cycling through recovery, so no replica served requests. The coordinator now evicts a replica
+- Fixed an availability issue in a replicated IceStorm deployment: when a replica stayed reachable but persistently
+  failed to apply the initial replica state (for example on a local database write error), every election failed and
+  the whole group kept cycling through recovery, so no replica served requests. The coordinator now evicts a replica
   whose initialization fails and completes the election as long as a majority of the replicas succeeds, as it
   already did for failures during replicated updates.

--- a/changelog.d/service-icestorm/5849.md
+++ b/changelog.d/service-icestorm/5849.md
@@ -1,0 +1,5 @@
+- Fixed a highly available IceStorm availability issue: when a replica stayed reachable but persistently failed to
+  apply the initial replica state (for example on a local database write error), every election failed and the
+  whole group kept cycling through recovery, so no replica served requests. The coordinator now evicts a replica
+  whose initialization fails and completes the election as long as a majority of the replicas succeeds, as it
+  already did for failures during replicated updates.

--- a/cpp/src/IceStorm/Observers.cpp
+++ b/cpp/src/IceStorm/Observers.cpp
@@ -96,26 +96,52 @@ Observers::init(const set<GroupNodeInfo>& slaves, const LogUpdate& llu, const To
                 Ice::Trace out(_traceLevels->logger, _traceLevels->replicationCat);
                 out << "error calling init on " << slave.id << ", exception: " << ex;
             }
-            throw;
+
+            lock_guard<mutex> reapedLock(_reapedMutex);
+            _reaped.push_back(slave.id);
         }
     }
 
-    for (auto& o : observers)
+    // Like the replicated update operations (see wait()), the initialization proceeds as long as a majority of the
+    // slaves succeeds: a slave whose init fails is evicted and reported as reaped, and the node removes it from the
+    // group on its next check(). Failing the whole initialization instead would make every election fail when a
+    // single reachable replica persistently cannot apply the initial state (for example on a local database write
+    // error), keeping the group from ever reaching the normal state.
+    auto p = observers.begin();
+    while (p != observers.end())
     {
         try
         {
-            o.future.get();
+            p->future.get();
         }
         catch (const Ice::Exception& ex)
         {
             if (_traceLevels->replication > 0)
             {
                 Ice::Trace out(_traceLevels->logger, _traceLevels->replicationCat);
-                out << "init on " << o.id << " failed with exception " << ex;
+                out << "init on " << p->id << " failed with exception " << ex;
             }
-            throw;
+            int id = p->id;
+            p = observers.erase(p);
+
+            lock_guard<mutex> reapedLock(_reapedMutex);
+            _reaped.push_back(id);
+            continue;
         }
+        ++p;
     }
+
+    // If we don't have the majority of observers we raise.
+    if (observers.size() < _majority)
+    {
+        if (_traceLevels->replication > 0)
+        {
+            Ice::Trace out(_traceLevels->logger, _traceLevels->replicationCat);
+            out << "number of observers '" << observers.size() << "' is less than the majority '" << _majority << "'";
+        }
+        throw Ice::UnknownException(__FILE__, __LINE__, "too few observers");
+    }
+
     _observers = std::move(observers);
 }
 


### PR DESCRIPTION
`Observers::init` rethrew on the first slave whose `observerInit` failed, which made the coordinator's `initMaster` fail and triggered `recovery()`. A replica that stays reachable (it keeps answering election RPCs) but persistently fails to apply the initial replica state — e.g. a local database write error such as LMDB `MDB_MAP_FULL` while reads still work — therefore made every election fail: the coordinator recovered and re-invited the broken replica each round, the group never reached the Normal state, and since `startCachedRead` waits for Normal, even reads hung on every replica. One node's disk problem became a cluster-wide outage.

`Observers::init` now mirrors what `Observers::wait` already does for failures during replicated updates: a slave whose initialization fails (either sending `initAsync` or completing it) is evicted and reported as reaped, and the election completes as long as a majority of the observers succeeds; below majority it still throws and the coordinator recovers. The node's next `check()` drains the reaped ids and removes those slaves from the group, exactly as for a mid-update eviction.

Two design points worth calling out for review:

- **The evicted replica still receives `ready()`** (it remains in `mergeContinue`'s `tmpSet`) and transitions to Normal without the initial content, so it resumes serving from its stale, un-applied state — entering Normal simply ungates the local cached-read paths (`startCachedRead` waits only for Normal; nothing validates the served generation against applied state). This matches the existing semantics for a slave evicted by `wait()` mid-update. It does **not**, however, keep the group quiescent: `ready()` never cancels the slave's repeated `TimeoutTask`, so once the coordinator's next `check()` reaps it from `_up`, its `areYouThere` poll returns false, it runs `recovery()` and becomes self-coordinated, and the coordinator's merge scan pulls the whole group into a fresh election — where its init fails and it is evicted again. The permanent outage therefore becomes a healthy group punctuated by periodic brief re-elections. Keeping the replica in `ready()` versus excluding it only changes what it does during each window (serving stale cached state versus blocking while stuck in Reorganization), not the churn itself. Eliminating the churn would need invite suppression/backoff for a known-broken replica — filed as a follow-up (#6012).
- **Cold start**: the full-participation gate in `mergeContinue` runs before `initMaster`, so with an eviction during init a cold-start cluster can reach Normal with N−1 slaves. Latest-data selection is unaffected — the evicted replica did participate in the election and its LLU was considered in the max-LLU computation; it only failed to apply the new state.

Tested with `IceStorm/rep1` (replicated) and `IceStorm/single` (all green). No new test: injecting a persistent local write failure into one replica isn't feasible in the existing harness, and the healthy-path election behavior is covered by `rep1`.

Fixes #5849.
