### PR TITLE
Avoid reattaching observers to destroyed IceStorm topics

### DIFF
--- a/changelog.d/service-icestorm/5996.md
+++ b/changelog.d/service-icestorm/5996.md
@@ -1,2 +1,0 @@
-- Fixed persistent IceStorm to keep destroyed topics out of the metrics view while they wait to be reaped. Previously,
-  updating a metrics view during this interval reattached the destroyed topic's observer.

--- a/changelog.d/service-icestorm/5996.md
+++ b/changelog.d/service-icestorm/5996.md
@@ -1,0 +1,2 @@
+- Fixed persistent IceStorm to keep destroyed topics out of the metrics view while they wait to be reaped. Previously,
+  updating a metrics view during this interval reattached the destroyed topic's observer.

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -1174,7 +1174,8 @@ TopicImpl::updateObserver()
 {
     lock_guard lock(_subscribersMutex);
 
-    if (_instance->observer())
+    // Don't reattach the observer of a topic that was destroyed but not reaped yet.
+    if (!_destroyed && _instance->observer())
     {
         _observer.attach(_instance->observer()->getTopicObserver(_name, _observer.get()));
     }

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -1161,6 +1161,8 @@ TopicImpl::observerDestroyTopic(const LogUpdate& llu)
         out << " llu: " << llu.generation << "/" << llu.iteration;
     }
     destroyInternal(llu, false);
+
+    _observer.detach();
 }
 
 Ice::ObjectPtr


### PR DESCRIPTION
## Summary

- prevent persistent IceStorm from reattaching a metrics observer to a destroyed topic while it waits to be reaped
- document the metrics lifecycle fix in the IceStorm changelog

## Testing

- make -C cpp -j8 IceStormService
- python3 allTests.py IceStorm/createOrRetrieve

Fixes #5996