### PR TITLE
Drop invalid unquoted O'Reilly form from getPropertyAsList doc

### DIFF
--- a/cpp/include/Ice/Properties.h
+++ b/cpp/include/Ice/Properties.h
@@ -188,7 +188,7 @@ namespace Ice
         /// Gets a property as a list of strings. The strings must be separated by whitespace or comma. The strings in
         /// the list can contain whitespace and commas if they are enclosed in single or double quotes. If quotes are
         /// mismatched, an empty list is returned. Within single quotes or double quotes, you can escape the quote in
-        /// question with a backslash, e.g. O'Reilly can be written as O'Reilly, "O'Reilly" or 'O\'Reilly'.
+        /// question with a backslash, e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
         /// @param key The property key.
         /// @return The property value interpreted as a list of strings, or an empty list if the property is not set.
         /// @see #setProperty
@@ -197,7 +197,7 @@ namespace Ice
         /// Gets an Ice property as a list of strings. The strings must be separated by whitespace or comma. The strings
         /// in the list can contain whitespace and commas if they are enclosed in single or double quotes. If quotes are
         /// mismatched, the default list is returned. Within single quotes or double quotes, you can escape the quote
-        /// in question with a backslash, e.g. O'Reilly can be written as O'Reilly, "O'Reilly" or 'O\'Reilly'.
+        /// in question with a backslash, e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
         /// @param key The property key.
         /// @return The property value interpreted as a list of strings, or the default value if the property is not
         ///     set.
@@ -208,7 +208,7 @@ namespace Ice
         /// Gets a property as a list of strings. The strings must be separated by whitespace or comma. The strings in
         /// the list can contain whitespace and commas if they are enclosed in single or double quotes. If quotes are
         /// mismatched, the default list is returned. Within single quotes or double quotes, you can escape the quote
-        /// in question with a backslash, e.g. O'Reilly can be written as O'Reilly, "O'Reilly" or 'O\'Reilly'.
+        /// in question with a backslash, e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
         /// @param key The property key.
         /// @param value The default value to use if the property is not set.
         /// @return The property value interpreted as a list of strings, or the default value if the property is not

--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -181,7 +181,7 @@ public sealed class Properties
     /// not set, an empty list is returned. The strings in the list can contain whitespace and commas if they are
     /// enclosed in single or double quotes. If quotes are mismatched, an empty list is returned. Within single quotes
     /// or double quotes, you can escape the quote in question with a backslash, e.g. O'Reilly can be written as
-    /// O'Reilly, "O'Reilly" or 'O\'Reilly'.
+    /// "O'Reilly" or 'O\'Reilly'.
     /// </summary>
     /// <param name="key">The property key.</param>
     /// <returns>The property value interpreted as a list of strings.</returns>
@@ -193,7 +193,7 @@ public sealed class Properties
     /// not set, its default list is returned. The strings in the list can contain whitespace and commas if they are
     /// enclosed in single or double quotes. If quotes are mismatched, the default list is returned. Within single
     /// quotes or double quotes, you can escape the quote in question with a backslash, e.g. O'Reilly can be written as
-    /// O'Reilly, "O'Reilly" or 'O\'Reilly'.
+    /// "O'Reilly" or 'O\'Reilly'.
     /// </summary>
     /// <param name="key">The property key.</param>
     /// <returns>The property value interpreted as list of strings, or the default value.</returns>
@@ -210,7 +210,7 @@ public sealed class Properties
     /// not set, the default list is returned. The strings in the list can contain whitespace and commas if they are
     /// enclosed in single or double quotes. If quotes are mismatched, the default list is returned. Within single
     /// quotes or double quotes, you can escape the quote in question with a backslash, e.g. O'Reilly can be written as
-    /// O'Reilly, "O'Reilly" or 'O\'Reilly'.
+    /// "O'Reilly" or 'O\'Reilly'.
     /// </summary>
     /// <param name="key">The property key.</param>
     /// <param name="value">The default value to use if the property is not set.</param>

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -249,7 +249,7 @@ public final class Properties {
      * Gets a property as a list of strings. The strings must be separated by whitespace or comma. The strings in the
      * list can contain whitespace and commas if they are enclosed in single or double quotes. If quotes are mismatched,
      * an empty list is returned. Within single quotes or double quotes, you can escape the quote in question with
-     * a backslash, e.g. O'Reilly can be written as {@code O'Reilly}, {@code "O'Reilly"} or {@code 'O\'Reilly'}.
+     * a backslash, e.g. O'Reilly can be written as {@code "O'Reilly"} or {@code 'O\'Reilly'}.
      *
      * @param key the property key
      * @return the property value interpreted as a list of strings, or an empty list if the property is not set
@@ -263,7 +263,7 @@ public final class Properties {
      * Gets an Ice property as a list of strings. The strings must be separated by whitespace or comma. The strings in
      * the list can contain whitespace and commas if they are enclosed in single or double quotes. If quotes are
      * mismatched, the default list is returned. Within single quotes or double quotes, you can escape the quote in
-     * question with a backslash, e.g. O'Reilly can be written as {@code O'Reilly}, {@code "O'Reilly"} or
+     * question with a backslash, e.g. O'Reilly can be written as {@code "O'Reilly"} or
      * {@code 'O\'Reilly'}.
      *
      * @param key the property key
@@ -280,7 +280,7 @@ public final class Properties {
      * Gets a property as a list of strings. The strings must be separated by whitespace or comma. The strings in the
      * list can contain whitespace and commas if they are enclosed in single or double quotes. If quotes are mismatched,
      * the default list is returned. Within single quotes or double quotes, you can escape the quote in question with
-     * a backslash, e.g. O'Reilly can be written as {@code O'Reilly}, {@code "O'Reilly"} or {@code 'O\'Reilly'}.
+     * a backslash, e.g. O'Reilly can be written as {@code "O'Reilly"} or {@code 'O\'Reilly'}.
      *
      * @param key the property key
      * @param value the default value to return if the property is not set

--- a/js/packages/ice/src/Ice/Properties.d.ts
+++ b/js/packages/ice/src/Ice/Properties.d.ts
@@ -114,7 +114,7 @@ declare module "@zeroc/ice" {
              * If the property is not set, the default list is returned. The strings in the list can contain whitespace
              * and commas if they are enclosed in single or double quotes. If quotes are mismatched, the default list
              * is returned. Within single or double quotes, the respective quote character can be escaped with a
-             * backslash. For example, O'Reilly can be written as "O'Reilly", or 'O\'Reilly'.
+             * backslash. For example, O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
              *
              * @param key - The property key.
              * @param value - The default value to use if the property is not set.

--- a/js/packages/ice/src/Ice/Properties.d.ts
+++ b/js/packages/ice/src/Ice/Properties.d.ts
@@ -85,7 +85,7 @@ declare module "@zeroc/ice" {
              * Gets a property as a list of strings. The strings must be separated by whitespace or comma. The strings
              * in the list can contain whitespace and commas if they are enclosed in single or double quotes. If quotes
              * are mismatched, an empty list is returned. Within single quotes or double quotes, you can escape the
-             * quote in question with a backslash, e.g. O'Reilly can be written as O'Reilly, "O'Reilly" or 'O\'Reilly'.
+             * quote in question with a backslash, e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
              *
              * @param key - The property key.
              * @returns The property value interpreted as a list of strings, or an empty list if the property is not
@@ -98,7 +98,7 @@ declare module "@zeroc/ice" {
              * Gets an Ice property as a list of strings. The strings must be separated by whitespace or comma. The
              * strings in the list can contain whitespace and commas if they are enclosed in single or double quotes.
              * If quotes are mismatched, the default list is returned.  Within single quotes or double quotes, you can
-             * escape the quote in question with a backslash, e.g. O'Reilly can be written as O'Reilly, "O'Reilly" or
+             * escape the quote in question with a backslash, e.g. O'Reilly can be written as "O'Reilly" or
              * 'O\'Reilly'.
              *
              * @param key - The property key.
@@ -114,7 +114,7 @@ declare module "@zeroc/ice" {
              * If the property is not set, the default list is returned. The strings in the list can contain whitespace
              * and commas if they are enclosed in single or double quotes. If quotes are mismatched, the default list
              * is returned. Within single or double quotes, the respective quote character can be escaped with a
-             * backslash. For example, O'Reilly can be written as O'Reilly, "O'Reilly", or 'O\'Reilly'.
+             * backslash. For example, O'Reilly can be written as "O'Reilly", or 'O\'Reilly'.
              *
              * @param key - The property key.
              * @param value - The default value to use if the property is not set.

--- a/matlab/lib/+Ice/Properties.m
+++ b/matlab/lib/+Ice/Properties.m
@@ -209,8 +209,8 @@ classdef Properties < IceInternal.WrapperObject
             %   The strings must be separated by whitespace or comma. If the property is not set, an empty list is
             %   returned. The strings in the list can contain whitespace and commas if they are enclosed in single or
             %   double quotes. If quotes are mismatched, an empty list is returned. Within single quotes or double
-            %   quotes, you can escape the quote in question with \, e.g. O'Reilly can be written as O'Reilly,
-            %   "O'Reilly" or 'O\'Reilly'.
+            %   quotes, you can escape the quote in question with \, e.g. O'Reilly can be written as "O'Reilly" or
+            %   'O\'Reilly'.
             %
             %   Input Arguments
             %     key - The property key.
@@ -232,8 +232,8 @@ classdef Properties < IceInternal.WrapperObject
             %   The strings must be separated by whitespace or comma. If the property is not set, its default list is
             %   returned. The strings in the list can contain whitespace and commas if they are enclosed in single or
             %   double quotes. If quotes are mismatched, the default list is returned. Within single quotes or double
-            %   quotes, you can escape the quote in question with \, e.g. O'Reilly can be written as O'Reilly,
-            %   "O'Reilly" or 'O\'Reilly'.
+            %   quotes, you can escape the quote in question with \, e.g. O'Reilly can be written as "O'Reilly" or
+            %   'O\'Reilly'.
             %
             %   Throws an Ice.PropertyException if the property is not a known Ice property.
             %
@@ -257,8 +257,8 @@ classdef Properties < IceInternal.WrapperObject
             %   The strings must be separated by whitespace or comma. If the property is not set, the default value is
             %   returned. The strings in the list can contain whitespace and commas if they are enclosed in single or
             %   double quotes. If quotes are mismatched, the default list is returned. Within single quotes or double
-            %   quotes, you can escape the quote in question with \, e.g. O'Reilly can be written as O'Reilly,
-            %   "O'Reilly" or 'O\'Reilly'.
+            %   quotes, you can escape the quote in question with \, e.g. O'Reilly can be written as "O'Reilly" or
+            %   'O\'Reilly'.
             %
             %   Input Arguments
             %     key - The property key.

--- a/python/python/Ice/Properties.py
+++ b/python/python/Ice/Properties.py
@@ -197,7 +197,7 @@ class Properties:
         The strings must be separated by whitespace or comma. The strings in the list can contain whitespace and commas
         if they are enclosed in single or double quotes. If quotes are mismatched, an empty list is returned.
         Within single quotes or double quotes, you can escape the quote in question with a backslash,
-        e.g. O'Reilly can be written as O'Reilly, "O'Reilly" or 'O\'Reilly'.
+        e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
 
         Parameters
         ----------
@@ -218,7 +218,7 @@ class Properties:
         The strings must be separated by whitespace or comma. The strings in the list can contain whitespace and commas
         if they are enclosed in single or double quotes. If quotes are mismatched, the default list is returned.
         Within single quotes or double quotes, you can escape the quote in question with a backslash,
-        e.g. O'Reilly can be written as O'Reilly, "O'Reilly" or 'O\'Reilly'.
+        e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
 
         Parameters
         ----------
@@ -244,7 +244,7 @@ class Properties:
         The strings must be separated by whitespace or comma. The strings in the list can contain whitespace and commas
         if they are enclosed in single or double quotes. If quotes are mismatched, the default list is returned.
         Within single quotes or double quotes, you can escape the quote in question with a backslash,
-        e.g. O'Reilly can be written as O'Reilly, "O'Reilly" or 'O\'Reilly'.
+        e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
 
         Parameters
         ----------

--- a/python/python/Ice/Properties.py
+++ b/python/python/Ice/Properties.py
@@ -197,7 +197,7 @@ class Properties:
         The strings must be separated by whitespace or comma. The strings in the list can contain whitespace and commas
         if they are enclosed in single or double quotes. If quotes are mismatched, an empty list is returned.
         Within single quotes or double quotes, you can escape the quote in question with a backslash,
-        e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
+        e.g. O'Reilly can be written as "O'Reilly" or 'O\\'Reilly'.
 
         Parameters
         ----------
@@ -218,7 +218,7 @@ class Properties:
         The strings must be separated by whitespace or comma. The strings in the list can contain whitespace and commas
         if they are enclosed in single or double quotes. If quotes are mismatched, the default list is returned.
         Within single quotes or double quotes, you can escape the quote in question with a backslash,
-        e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
+        e.g. O'Reilly can be written as "O'Reilly" or 'O\\'Reilly'.
 
         Parameters
         ----------
@@ -244,7 +244,7 @@ class Properties:
         The strings must be separated by whitespace or comma. The strings in the list can contain whitespace and commas
         if they are enclosed in single or double quotes. If quotes are mismatched, the default list is returned.
         Within single quotes or double quotes, you can escape the quote in question with a backslash,
-        e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
+        e.g. O'Reilly can be written as "O'Reilly" or 'O\\'Reilly'.
 
         Parameters
         ----------

--- a/swift/src/Ice/Properties.swift
+++ b/swift/src/Ice/Properties.swift
@@ -56,7 +56,7 @@ public protocol Properties: AnyObject {
     /// Gets a property as a list of strings. The strings must be separated by whitespace or comma. The strings in
     /// the list can contain whitespace and commas if they are enclosed in single or double quotes. If quotes are
     /// mismatched, an empty list is returned. Within single quotes or double quotes, you can escape the quote in
-    /// question with a backslash, e.g. O'Reilly can be written as O'Reilly, "O'Reilly" or 'O\'Reilly'.
+    /// question with a backslash, e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
     ///
     /// - Parameter key: The property key.
     /// - Returns: The property value interpreted as a list of strings, or an empty list if the property is not set.
@@ -65,7 +65,7 @@ public protocol Properties: AnyObject {
     /// Gets an Ice property as a list of strings. The strings must be separated by whitespace or comma. The strings in
     /// the list can contain whitespace and commas if they are enclosed in single or double quotes. If quotes are
     /// mismatched, the default list is returned. Within single quotes or double quotes, you can escape the quote in
-    /// question with a backslash, e.g. O'Reilly can be written as O'Reilly, "O'Reilly" or 'O\'Reilly'.
+    /// question with a backslash, e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
     ///
     /// - Parameter key: The property key.
     /// - Returns: The property value interpreted as a list of strings, or the default value if the property is not
@@ -76,7 +76,7 @@ public protocol Properties: AnyObject {
     /// Gets a property as a list of strings. The strings must be separated by whitespace or comma. The strings in
     /// the list can contain whitespace and commas if they are enclosed in single or double quotes. If quotes are
     /// mismatched, the default list is returned. Within single quotes or double quotes, you can escape the quote in
-    /// question with a backslash, e.g. O'Reilly can be written as O'Reilly, "O'Reilly" or 'O\'Reilly'.
+    /// question with a backslash, e.g. O'Reilly can be written as "O'Reilly" or 'O\'Reilly'.
     ///
     /// - Parameters:
     ///   - key: The property key.


### PR DESCRIPTION
The `getPropertyAsList` / `getPropertyAsListWithDefault` doc comment listed a bare, unquoted `O'Reilly` as one of three valid ways to write the value. That form is wrong: `IceInternal::splitString` (`cpp/src/Ice/StringUtil.cpp:647-650`) treats the apostrophe as an opening quote, so it is dropped and the trailing unmatched quote fails the parse — bare `O'Reilly` yields `OReilly`, not `O'Reilly`. Only the quoted forms `"O'Reilly"` and `'O\'Reilly'` are valid.

This drops the bare form from the example in every mapping's `Properties` doc (C++, C#, Java, JS, Python, Swift, MATLAB). Ruby and PHP have no public `Properties` doc comment. The MATLAB comment wrapped mid-list, so its two lines are reflowed to stay within the column limit.

Doc-comment-only change; no behavior change.

Fixes #5995