### PR TITLE
Return the default list on mismatched quotes in getPropertyAsListWithDefault (C++)

### DIFF
--- a/cpp/src/Ice/Properties.cpp
+++ b/cpp/src/Ice/Properties.cpp
@@ -315,6 +315,7 @@ Ice::Properties::getPropertyAsListWithDefault(string_view key, const StringSeq& 
         {
             Warning out(getProcessLogger());
             out << "mismatched quotes in property " << key << "'s value, returning default value";
+            return value;
         }
         if (result.size() == 0)
         {

--- a/cpp/test/Ice/properties/Client.cpp
+++ b/cpp/test/Ice/properties/Client.cpp
@@ -240,6 +240,15 @@ Client::run(int, char**)
     }
 
     {
+        cout << "testing that a property value with mismatched quotes returns the default list... " << flush;
+        Ice::PropertiesPtr properties = Ice::createProperties();
+        properties->setProperty("Foo", "'foo");
+        vector<string> value = properties->getPropertyAsListWithDefault("Foo", {"default"});
+        test(value.size() == 1 && value[0] == "default");
+        cout << "ok" << endl;
+    }
+
+    {
         cout << "testing createProperties with args... " << flush;
         Ice::StringSeq args{"--Foo=Bar", "--Ice.Trace.Network=3"};
         Ice::PropertiesPtr properties = Ice::createProperties(args);


### PR DESCRIPTION
`Ice::Properties::getPropertyAsListWithDefault` returned a partially-parsed list when a property value had mismatched quotes, instead of the default — contradicting both the documentation ("If quotes are mismatched, the default list is returned.") and its own warning message ("returning default value").

`IceInternal::splitString` pushes the accumulated element before returning `false` on an unmatched quote, so for a value like `'foo` it leaves `result == ["foo"]` **and** returns `false`. The `if (result.size() == 0)` guard was then false, so the default was never substituted and the partial parse `["foo"]` was returned. The default was only used when the partial parse happened to be empty (e.g. a lone `"`).

Fix: return the default when `splitString` fails, matching the already-correct C# and Java implementations and the doc.

Affects the C++ core and every mapping that uses it for `Properties`: C++, Python, Ruby, PHP, MATLAB, Swift. (C# and Java have independent, already-correct implementations.)

Added a C++ test covering the mismatched-quotes case.

Low severity — edge case (malformed property value), no field reports. Surfaced during the #5971 review.

Fixes #5994