### PR TITLE
Correct OptionalFormat.Size doc comment: only enums use the Size format

### DIFF
--- a/cpp/include/Ice/StreamableTraits.h
+++ b/cpp/include/Ice/StreamableTraits.h
@@ -68,7 +68,7 @@ namespace Ice
         /// Fixed 8-byte encoding.
         F8 = 3,
 
-        /// "Size encoding" using either 1 or 5 bytes. Used by enums, class identifiers, etc.
+        /// "Size encoding" using either 1 or 5 bytes. Used by enums.
         Size = 4,
 
         /// Variable "size encoding" using either 1 or 5 bytes followed by data.

--- a/csharp/src/Ice/OptionalFormat.cs
+++ b/csharp/src/Ice/OptionalFormat.cs
@@ -32,7 +32,7 @@ public enum OptionalFormat
     F8 = 3,
 
     /// <summary>
-    /// "Size encoding" using either 1 or 5 bytes. Used by enums, class identifiers, etc.
+    /// "Size encoding" using either 1 or 5 bytes. Used by enums.
     /// </summary>
     Size = 4,
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OptionalFormat.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OptionalFormat.java
@@ -16,7 +16,7 @@ public enum OptionalFormat {
     F4(2),
     /** Fixed 8-byte encoding. */
     F8(3),
-    /** "Size encoding" using either 1 or 5 bytes. Used by enums, class identifiers, etc. */
+    /** "Size encoding" using either 1 or 5 bytes. Used by enums. */
     Size(4),
     /** Variable "size encoding" using either 1 or 5 bytes followed by data.
      *  Used by strings, fixed-size structs, and containers whose size can be computed prior to marshaling. */

--- a/js/packages/ice/src/Ice/OptionalFormat.d.ts
+++ b/js/packages/ice/src/Ice/OptionalFormat.d.ts
@@ -27,7 +27,7 @@ declare module "@zeroc/ice" {
             static readonly F8: OptionalFormat;
 
             /**
-             * "Size encoding" using either 1 or 5 bytes. Used by enums, class identifiers, etc.
+             * "Size encoding" using either 1 or 5 bytes. Used by enums.
              */
             static readonly Size: OptionalFormat;
 

--- a/swift/src/Ice/OptionalFormat.swift
+++ b/swift/src/Ice/OptionalFormat.swift
@@ -15,7 +15,7 @@ public enum OptionalFormat: UInt8 {
     /// Fixed 8-byte encoding.
     case F8 = 3
 
-    /// "Size encoding" using either 1 or 5 bytes. Used by enums, class identifiers, etc.
+    /// "Size encoding" using either 1 or 5 bytes. Used by enums.
     case Size = 4
 
     /// Variable "size encoding" using either 1 or 5 bytes followed by data.


### PR DESCRIPTION
The doc comment on the `Size` optional format read:

> "Size encoding" using either 1 or 5 bytes. Used by enums, class identifiers, etc.

Only **enums** marshal a tagged/optional member with the `Size` optional format — `Enum::getOptionalFormat()` is the only Slice type that returns `Size`, and the runtime `GetOptionalFormat` template maps only the enum category to `OptionalFormat::Size`. A "class identifier" is not a distinct, optional-markable Slice type, so the "class identifiers, etc." example is misleading.

Corrects the wording to "Used by enums." in each mapping that still carried it (C++, C#, Java, JS, Swift). MATLAB was already fixed in #5971; Python/Ruby/PHP expose no public `OptionalFormat` doc comment.

Fixes #5993