### PR TITLE
Stop using the no-op endpoint -t timeout option

### DIFF
--- a/changelog.d/service-icestorm/5979.md
+++ b/changelog.d/service-icestorm/5979.md
@@ -1,3 +1,0 @@
-- Lowered the `icestormadmin` connect timeout to 3 seconds so the tool no longer waits the full 10-second
-  default when a topic manager or the `IceStorm/Finder` object is unreachable. Set
-  `Ice.Connection.Client.ConnectTimeout` to override it.

--- a/changelog.d/service-icestorm/5979.md
+++ b/changelog.d/service-icestorm/5979.md
@@ -1,0 +1,3 @@
+- Lowered the `icestormadmin` connect timeout to 3 seconds so the tool no longer waits the full 10-second
+  default when a topic manager or the `IceStorm/Finder` object is unreachable. Set
+  `Ice.Connection.Client.ConnectTimeout` to override it.

--- a/cpp/src/IceStorm/Admin.cpp
+++ b/cpp/src/IceStorm/Admin.cpp
@@ -35,6 +35,12 @@ main(int argc, char* argv[])
 
         auto properties = Ice::createProperties(argc, argv, "IceStormAdmin");
         properties->setProperty("Ice.Warn.Endpoints", "0");
+        // Give up quickly when a topic manager or the IceStorm/Finder fallback is unreachable, instead of waiting
+        // the full default connect timeout (10s). Only lower it when the user hasn't configured it explicitly.
+        if (properties->getProperty("Ice.Connection.Client.ConnectTimeout").empty())
+        {
+            properties->setProperty("Ice.Connection.Client.ConnectTimeout", "3"); // seconds
+        }
 
         Ice::InitializationData initData{.properties = properties};
         auto communicator = Ice::initialize(std::move(initData));

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/AdapterEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/AdapterEditor.java
@@ -122,7 +122,7 @@ class AdapterEditor extends CommunicatorChildEditor {
                 + "for example:<br>"
                 + " tcp (listen on all local interfaces using a random port)<br>"
                 + " tcp -h venus.foo.com (listen on just one interface)<br>"
-                + " tcp -t 10000 (sets a timeout of 10,000 milliseconds)<br>"
+                + " tcp -p 10000 (listen on a specific port)<br>"
                 + " ssl -h venus.foo.com (accepts SSL connections instead of plain TCP)"
                 + "</html>");
 


### PR DESCRIPTION
Fixes #5979.

The endpoint `-t <timeout>` option has had no runtime effect since Ice 3.8 — it only influences connector comparison, not the connect timeout (which comes from `Ice.Connection.Client.ConnectTimeout`). We shouldn't append or advertise it ourselves. Two remaining non-test places used it:

**icestormadmin** — #5970 already dropped the bogus `-t 3000` from the `IceStorm/Finder` fallback endpoints, but that left the connect timeout at the 10s default. This restores the intended fast probe by defaulting `Ice.Connection.Client.ConnectTimeout` to 3s, so an unreachable manager/Finder fails quickly instead of hanging. The set is guarded, so a user's explicit `--Ice.Connection.Client.ConnectTimeout=…` (command line or config file) still wins.

**IceGrid GUI** — the object-adapter endpoints tooltip presented `tcp -t 10000 (sets a timeout of 10,000 milliseconds)` as a working example, which misinforms users. Replaced with `tcp -p 10000 (listen on a specific port)`.

The endpoint parsers and the `-t` round-trip in `toString()`/`options()` (including `-t infinite`) are intentional backward compatibility and stay as-is.
