### PR TITLE
Document that the Glacier2 routing table keeps the first proxy registered for an identity

### DIFF
--- a/cpp/src/Glacier2/RoutingTable.cpp
+++ b/cpp/src/Glacier2/RoutingTable.cpp
@@ -87,6 +87,8 @@ Glacier2::RoutingTable::add(
         }
         else
         {
+            // We tolerate duplicate registrations and keep the first proxy: two objects with the same identity
+            // are the same object.
             if (_traceLevel >= 1)
             {
                 Trace out(_communicator->getLogger(), "Glacier2");


### PR DESCRIPTION
When a proxy is added to the Glacier2 routing table and its identity is already routed, the router keeps the existing entry: duplicate registrations are tolerated and the first proxy wins, even when the new proxy is different. This is intended behavior — in the Ice object model, two objects with the same identity are the same object — so this PR documents it with a comment.

#6005 tracks revisiting this behavior (see also the closed PR #5991).

🤖 Generated with [Claude Code](https://claude.com/claude-code)