### PR TITLE
Guard Glacier2 session destroy calls against communicator destruction

### DIFF
--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -72,7 +72,7 @@ Glacier2::RouterI::destroy(function<void(exception_ptr)> error)
             catch (const NotRegisteredException&)
             {
             }
-            catch (const ObjectAdapterDeactivatedException&)
+            catch (const ObjectAdapterDestroyedException&)
             {
                 //
                 // Expected if the router has been shutdown.
@@ -80,13 +80,20 @@ Glacier2::RouterI::destroy(function<void(exception_ptr)> error)
             }
         }
 
-        if (_context.size() > 0)
+        try
         {
-            _session->destroyAsync(nullptr, std::move(error), nullptr, _context);
+            if (_context.size() > 0)
+            {
+                _session->destroyAsync(nullptr, std::move(error), nullptr, _context);
+            }
+            else
+            {
+                _session->destroyAsync(nullptr, std::move(error), nullptr);
+            }
         }
-        else
+        catch (const CommunicatorDestroyedException&)
         {
-            _session->destroyAsync(nullptr, std::move(error), nullptr);
+            // Ignored: the session is destroyed along with the communicator.
         }
     }
 

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -473,7 +473,14 @@ CreateSession::sessionCreated(optional<SessionPrx> session)
     {
         if (session)
         {
-            session->destroyAsync(nullptr); // don't wait for response
+            try
+            {
+                session->destroyAsync(nullptr); // don't wait for response
+            }
+            catch (const Ice::CommunicatorDestroyedException&)
+            {
+                // Ignored: the session is destroyed along with the communicator.
+            }
         }
         unexpectedCreateSessionException(current_exception());
         return;
@@ -963,6 +970,10 @@ SessionRouterI::sessionDestroyException(exception_ptr ex) const
         try
         {
             rethrow_exception(ex);
+        }
+        catch (const Ice::CommunicatorDestroyedException&)
+        {
+            // Expected when the router shuts down with sessions still active.
         }
         catch (const Ice::Exception& e)
         {


### PR DESCRIPTION
Addresses items 1 and 4 of #5864.

**Item 1 (remainder):** `Communicator::destroy` drains in-flight AMI completions and fires connection close callbacks; a proxy invocation made from one of those callbacks throws `CommunicatorDestroyedException` synchronously. Two Glacier2 session-destroy calls sit on such paths and were unguarded:

- `RouterI::destroy`'s `_session->destroyAsync`, reachable from the client connection's close callback and from `finishCreateSession`'s late-create teardown. The exception is now caught and ignored — the session is destroyed along with the communicator.
- `CreateSession::sessionCreated`'s cleanup `session->destroyAsync`, which runs from the session manager's AMI response callback. Same treatment, consistent with its fire-and-forget semantics.

The `createAsync` calls listed in the finding are already covered: since #5984, both `createSession` implementations run inside `authorized`'s try/catch.

Also, `sessionDestroyException` no longer traces `CommunicatorDestroyedException`: it has exactly one cause (router shutdown with sessions still active), so the trace only added noise at `Glacier2.Trace.Session=1`.

**Item 4:** `RouterI::destroy` caught `ObjectAdapterDeactivatedException` around `remove(_controlId)`, but in 3.8 `remove` throws the sibling class `ObjectAdapterDestroyedException` — the catch could never match. It now catches the correct type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)