### PR TITLE
Make Glacier2 SessionControl::destroy idempotent

### DIFF
--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -71,24 +71,31 @@ namespace Glacier2
 
         void destroy(const Current&) final
         {
-            _sessionRouter->destroySession(
-                _connection,
-                [defaultExceptionHandler = _sessionRouter->defaultSessionDestroyExceptionHandler()](exception_ptr e)
-                {
-                    try
+            try
+            {
+                _sessionRouter->destroySession(
+                    _connection,
+                    [defaultExceptionHandler = _sessionRouter->defaultSessionDestroyExceptionHandler()](exception_ptr e)
                     {
-                        rethrow_exception(e);
-                    }
-                    catch (const Ice::ObjectNotExistException&)
-                    {
-                        // Ignored. This typically occurs when the application-provided session calls
-                        // SessionControl::destroy in its own destroy implementation.
-                    }
-                    catch (...)
-                    {
-                        defaultExceptionHandler(e);
-                    }
-                });
+                        try
+                        {
+                            rethrow_exception(e);
+                        }
+                        catch (const Ice::ObjectNotExistException&)
+                        {
+                            // Ignored. This typically occurs when the application-provided session calls
+                            // SessionControl::destroy in its own destroy implementation.
+                        }
+                        catch (...)
+                        {
+                            defaultExceptionHandler(e);
+                        }
+                    });
+            }
+            catch (const SessionNotExistException&)
+            {
+                // Ignored: the session is already destroyed. Makes this destroy idempotent.
+            }
 
             _filters->destroy();
 


### PR DESCRIPTION
Addresses item 2 of #5864.

`SessionControlI::destroy` called `SessionRouterI::destroySession` with no try/catch. When an application-initiated `SessionControl::destroy` races another teardown of the same session (the client connection closing, the client calling `Router::destroySession`, or a concurrent double-destroy), the losing dispatch finds the session entry already gone and `destroySession` throws `SessionNotExistException` — which `SessionControl::destroy` doesn't declare, so the application receives `UnknownUserException` and the filter/connection cleanup in the servant is skipped.

`SessionControlI::destroy` now catches `SessionNotExistException` and treats it as a no-op, making destroy idempotent: the race resolves silently and the local cleanup always runs.

Note the purely sequential case doesn't reach this: router-initiated teardown removes the SessionControl servant before invoking the application session's `destroyAsync`, so a `sessionControl->destroy()` call made from the session's own destroy implementation gets `ObjectNotExistException`, which the existing error handler already ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)