### PR TITLE
Reject malformed Glacier2 filter properties at startup

### DIFF
--- a/changelog.d/service-glacier2/filter-property-unmatched-quote.md
+++ b/changelog.d/service-glacier2/filter-property-unmatched-quote.md
@@ -1,3 +1,0 @@
-- The Glacier2 router now refuses to start when a session filter property contains an unmatched quote, or when
-  `Glacier2.Filter.Category.AcceptUser` is set to a value other than 0, 1, or 2. Previously, such values were
-  silently accepted and could produce filters that did not match the intended configuration.

--- a/changelog.d/service-glacier2/filter-property-unmatched-quote.md
+++ b/changelog.d/service-glacier2/filter-property-unmatched-quote.md
@@ -1,0 +1,3 @@
+- The Glacier2 router now refuses to start when a session filter property contains an unmatched quote, or when
+  `Glacier2.Filter.Category.AcceptUser` is set to a value other than 0, 1, or 2. Previously, such values were
+  silently accepted and could produce filters that did not match the intended configuration.

--- a/cpp/src/Glacier2/Instance.cpp
+++ b/cpp/src/Glacier2/Instance.cpp
@@ -10,19 +10,20 @@ using namespace std;
 using namespace Ice;
 using namespace Glacier2;
 
-//
-// Parse a space delimited string into a sequence of strings.
-//
-
+// Parses a property whose value is a space delimited string sequence, and fails on an unmatched quote. We don't
+// use getIcePropertyAsList because it returns the default value on an unmatched quote instead of failing (it also
+// treats ',' as a delimiter, while these filter properties have always been space delimited).
 static vector<string>
-stringToStringSeq(const string& str)
+parseSpaceDelimitedProperty(const PropertiesPtr& properties, const char* propertyName)
 {
     vector<string> seq;
-    IceInternal::splitString(str, " \t", seq);
-
-    //
-    // TODO: do something about unmatched quotes
-    //
+    if (!IceInternal::splitString(properties->getIceProperty(propertyName), " \t", seq))
+    {
+        throw InitializationException(
+            __FILE__,
+            __LINE__,
+            "invalid '" + string{propertyName} + "' property: unmatched quote");
+    }
     return seq;
 }
 
@@ -52,11 +53,7 @@ stringToIdentitySeq(const string& str)
 
                     if (end == string::npos)
                     {
-                        //
-                        // TODO: should this be an unmatched quote error?
-                        //
-                        seq.push_back(stringToIdentity(str.substr(current)));
-                        break;
+                        throw invalid_argument("unmatched quote");
                     }
 
                     bool markString = true;
@@ -125,8 +122,8 @@ Glacier2::Instance::Instance(
       _serverAdapter(std::move(serverAdapter)),
       _proxyVerifier(make_shared<ProxyVerifier>(_communicator)),
       _routingTableMaxSize(_properties->getIcePropertyAsInt("Glacier2.RoutingTable.MaxSize")),
-      _filterCategories(stringToStringSeq(_properties->getIceProperty("Glacier2.Filter.Category.Accept"))),
-      _filterAdapterIds(stringToStringSeq(_properties->getIceProperty("Glacier2.Filter.AdapterId.Accept"))),
+      _filterCategories(parseSpaceDelimitedProperty(_properties, "Glacier2.Filter.Category.Accept")),
+      _filterAdapterIds(parseSpaceDelimitedProperty(_properties, "Glacier2.Filter.AdapterId.Accept")),
       _filterIdentities(parseFilterIdentities(_properties)),
       _filterAddUserMode(_properties->getIcePropertyAsInt("Glacier2.Filter.Category.AcceptUser"))
 {
@@ -136,6 +133,14 @@ Glacier2::Instance::Instance(
             __FILE__,
             __LINE__,
             "invalid value for Glacier2.RoutingTable.MaxSize: " + to_string(_routingTableMaxSize));
+    }
+
+    if (_filterAddUserMode < 0 || _filterAddUserMode > 2)
+    {
+        throw Ice::InitializationException(
+            __FILE__,
+            __LINE__,
+            "invalid value for Glacier2.Filter.Category.AcceptUser: " + to_string(_filterAddUserMode));
     }
 
     //


### PR DESCRIPTION
Addresses item 8 of #5864.

The Glacier2 session filter properties were parsed leniently, so an admin typo produced a filter that silently differed from the configuration:

- An unmatched quote in `Glacier2.Filter.Category.Accept` or `Glacier2.Filter.AdapterId.Accept` was silently accepted (`splitString`'s failure return was ignored).
- An unmatched quote in `Glacier2.Filter.Identity.Accept` produced an identity containing the opening quote character, which never matches anything.
- A `Glacier2.Filter.Category.AcceptUser` value other than 0, 1, or 2 silently disabled the feature.

The router now refuses to start in all three cases, with an error naming the property. Valid configurations parse exactly as before — this only rejects input that previously mis-parsed silently.

We keep the custom space-delimited parsing rather than switching to `getIcePropertyAsList`: it returns the default value on an unmatched quote instead of failing, and it treats ',' as a delimiter, which would change the syntax of these properties in a patch release. #6009 tracks switching to the standard list parsing in 3.9, and #6010 tracks fixing the unmatched-quote behavior of the property API itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)