### PR TITLE
Use sizeof(s) as the read count in pipe-draining loops

### DIFF
--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -1513,7 +1513,7 @@ Ice::Service::runDaemon(int argc, char* argv[], InitializationData initData)
             ssize_t rs;
             char s[16];
             string message;
-            while ((rs = read(fds[0], &s, 16)) > 0)
+            while ((rs = read(fds[0], s, sizeof(s))) > 0)
             {
                 message.append(s, static_cast<size_t>(rs));
             }

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -868,7 +868,7 @@ Activator::activate(
         string message;
 
         // We keep the Activator mutex locked for the whole activate.
-        while ((rs = read(errorFds[0], &s, 16)) > 0) // NOLINT(clang-analyzer-unix.BlockInCriticalSection)
+        while ((rs = read(errorFds[0], s, sizeof(s))) > 0) // NOLINT(clang-analyzer-unix.BlockInCriticalSection)
         {
             message.append(s, static_cast<size_t>(rs));
         }
@@ -1349,7 +1349,7 @@ Activator::terminationListener()
                 //
                 while (true)
                 {
-                    rs = read(fd, &s, 16); // NOLINT(clang-analyzer-unix.BlockInCriticalSection)
+                    rs = read(fd, s, sizeof(s)); // NOLINT(clang-analyzer-unix.BlockInCriticalSection)
                     if (rs > 0)
                     {
                         message.append(s, static_cast<size_t>(rs));


### PR DESCRIPTION
The POSIX pipe-draining loops in the IceGrid Activator and in `Ice::Service` read into a `char s[16]` buffer using a separate bare `16` literal as the `read()` count. This PR ties the count to the buffer with `sizeof(s)`, so the two can't drift apart, and replaces the unconventional `&s` argument with `s`.

No behavior change.

Fixes #5917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)