### PR TITLE
Make Swift Communicator.identityToString use Ice.ToStringMode

### DIFF
--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -8,6 +8,7 @@ final class CommunicatorI: LocalObject<ICECommunicator>, Communicator, @unchecke
     let classGraphDepthMax: Int32
     let traceSlicing: Bool
     let acceptClassCycles: Bool
+    let toStringMode: ToStringMode
 
     init(handle: ICECommunicator, initData: InitializationData) {
 
@@ -20,6 +21,16 @@ final class CommunicatorI: LocalObject<ICECommunicator>, Communicator, @unchecke
             acceptClassCycles = try initData.properties!.getIcePropertyAsInt("Ice.AcceptClassCycles") > 0
         } catch {
             fatalError("\(error)")
+        }
+
+        // The value was already validated by the C++ communicator.
+        switch initData.properties!.getIceProperty("Ice.ToStringMode") {
+        case "ASCII":
+            toStringMode = .ASCII
+        case "Compat":
+            toStringMode = .Compat
+        default:
+            toStringMode = .Unicode
         }
 
         super.init(handle: handle)
@@ -80,7 +91,7 @@ final class CommunicatorI: LocalObject<ICECommunicator>, Communicator, @unchecke
     }
 
     func identityToString(_ id: Identity) -> String {
-        return Ice.identityToString(id: id)
+        return Ice.identityToString(id: id, mode: toStringMode)
     }
 
     func createObjectAdapter(_ name: String) throws -> ObjectAdapter {

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -8,7 +8,6 @@ final class CommunicatorI: LocalObject<ICECommunicator>, Communicator, @unchecke
     let classGraphDepthMax: Int32
     let traceSlicing: Bool
     let acceptClassCycles: Bool
-    let toStringMode: ToStringMode
 
     init(handle: ICECommunicator, initData: InitializationData) {
 
@@ -21,16 +20,6 @@ final class CommunicatorI: LocalObject<ICECommunicator>, Communicator, @unchecke
             acceptClassCycles = try initData.properties!.getIcePropertyAsInt("Ice.AcceptClassCycles") > 0
         } catch {
             fatalError("\(error)")
-        }
-
-        // The value was already validated by the C++ communicator.
-        switch initData.properties!.getIceProperty("Ice.ToStringMode") {
-        case "ASCII":
-            toStringMode = .ASCII
-        case "Compat":
-            toStringMode = .Compat
-        default:
-            toStringMode = .Unicode
         }
 
         super.init(handle: handle)
@@ -91,7 +80,7 @@ final class CommunicatorI: LocalObject<ICECommunicator>, Communicator, @unchecke
     }
 
     func identityToString(_ id: Identity) -> String {
-        return Ice.identityToString(id: id, mode: toStringMode)
+        return handle.identityToString(name: id.name, category: id.category)
     }
 
     func createObjectAdapter(_ name: String) throws -> ObjectAdapter {

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -103,6 +103,11 @@
     }
 }
 
+- (NSString*)identityToString:(NSString*)name category:(NSString*)category
+{
+    return toNSString(self.communicator->identityToString({fromNSString(name), fromNSString(category)}));
+}
+
 - (ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError* _Nullable* _Nonnull)error
 {
     try

--- a/swift/src/IceImpl/include/Communicator.h
+++ b/swift/src/IceImpl/include/Communicator.h
@@ -25,6 +25,8 @@ ICEIMPL_API @interface ICECommunicator : ICELocalObject
                                                        property:(NSString*)property
                                                           error:(NSError* _Nullable* _Nonnull)error
     NS_SWIFT_NAME(proxyToProperty(prx:property:));
+- (NSString*)identityToString:(NSString*)name
+                     category:(NSString*)category NS_SWIFT_NAME(identityToString(name:category:));
 ;
 - (nullable ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError* _Nullable* _Nonnull)error;
 - (nullable ICEObjectAdapter*)createObjectAdapterWithEndpoints:(NSString*)name

--- a/swift/test/Ice/proxy/AllTests.swift
+++ b/swift/test/Ice/proxy/AllTests.swift
@@ -307,6 +307,15 @@ public func allTests(_ helper: TestHelper) async throws -> MyInterfacePrx {
     id2 = try Ice.stringToIdentity(communicator.identityToString(id))
     try test(id == id2)
 
+    // identityToString on a communicator uses the communicator's Ice.ToStringMode.
+    do {
+        let properties = Ice.createProperties()
+        properties.setProperty(key: "Ice.ToStringMode", value: "Compat")
+        let com = try Ice.initialize(Ice.InitializationData(properties: properties))
+        defer { com.destroy() }
+        try test(com.identityToString(id) == "\\177\\342\\202\\254/test")
+    }
+
     // More unicode character
     id = Ice.Identity(
         name: "banana \u{000E}-\u{1f34c}\u{20ac}\u{00a2}\u{0024}",


### PR DESCRIPTION
In Swift, `Communicator.identityToString` always stringified identities in Unicode mode, ignoring the communicator's `Ice.ToStringMode` property — unlike C++ and unlike Swift's own `proxyToString`, which honors it.

Fix: CommunicatorI.identityToString now delegates to C++ Communicator::identityToString through a new bridge method. Also adds a check to the `Ice/proxy` test.

Fixes #5937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)