### PR TITLE
Parse IceGrid node and registry properties at startup

### DIFF
--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -79,6 +79,7 @@ FileIteratorI::destroy(const Ice::Current& current)
 AdminSessionI::AdminSessionI(const string& id, const shared_ptr<Database>& db, const shared_ptr<RegistryI>& registry)
     : BaseSessionI(id, "admin", db),
       _replicaName(registry->getName()),
+      _messageSizeMax(db->getCommunicator()->getProperties()->getIcePropertyAsInt("Ice.MessageSizeMax") * 1024),
       _registry(registry)
 {
 }
@@ -476,12 +477,9 @@ AdminSessionI::addFileIterator(FileReaderPrx reader, const string& filename, int
         throw FileNotAvailableException(ex.what());
     }
 
-    auto properties = reader->ice_getCommunicator()->getProperties();
-    int messageSizeMax = properties->getIcePropertyAsInt("Ice.MessageSizeMax") * 1024;
-
     auto self = static_pointer_cast<AdminSessionI>(shared_from_this());
     return Ice::uncheckedCast<FileIteratorPrx>(_servantManager->add(
-        make_shared<FileIteratorI>(self, std::move(reader), filename, offset, messageSizeMax),
+        make_shared<FileIteratorI>(self, std::move(reader), filename, offset, _messageSizeMax),
         self));
 }
 

--- a/cpp/src/IceGrid/AdminSessionI.h
+++ b/cpp/src/IceGrid/AdminSessionI.h
@@ -141,6 +141,7 @@ namespace IceGrid
         void destroyImpl(bool) final;
 
         const std::string _replicaName;
+        const int _messageSizeMax;
         std::optional<AdminPrx> _admin;
         std::map<TopicName, std::pair<Ice::ObjectPrx, bool>> _observers;
         std::shared_ptr<RegistryI> _registry;

--- a/cpp/src/IceGrid/InternalRegistryI.cpp
+++ b/cpp/src/IceGrid/InternalRegistryI.cpp
@@ -43,6 +43,7 @@ InternalRegistryI::InternalRegistryI(
     }
 
     _replicaSessionTimeout = chrono::seconds(properties->getIcePropertyAsInt("IceGrid.Registry.ReplicaSessionTimeout"));
+    _dynamicRegistration = properties->getIcePropertyAsInt("IceGrid.Registry.DynamicRegistration") > 0;
     if (_replicaSessionTimeout != 0s && _replicaSessionTimeout < 10s)
     {
         throw Ice::PropertyException{
@@ -108,7 +109,13 @@ InternalRegistryI::registerReplica(
 
     try
     {
-        auto s = ReplicaSessionI::create(_database, _wellKnownObjects, info, std::move(*prx), _replicaSessionTimeout);
+        auto s = ReplicaSessionI::create(
+            _database,
+            _wellKnownObjects,
+            info,
+            std::move(*prx),
+            _replicaSessionTimeout,
+            _dynamicRegistration);
 
         // nullptr for the connection parameter, meaning the reaper won't destroy the session if the connection is
         // closed.

--- a/cpp/src/IceGrid/InternalRegistryI.h
+++ b/cpp/src/IceGrid/InternalRegistryI.h
@@ -58,6 +58,7 @@ namespace IceGrid
         ReplicaSessionManager& _session;
         std::chrono::seconds _nodeSessionTimeout;
         std::chrono::seconds _replicaSessionTimeout;
+        bool _dynamicRegistration;
     };
 
 };

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -73,6 +73,10 @@ NodeI::NodeI(
     const_cast<string&>(_outputDir) = props->getIceProperty("IceGrid.Node.Output");
     const_cast<bool&>(_redirectErrToOut) = props->getIcePropertyAsInt("IceGrid.Node.RedirectErrToOut") > 0;
     const_cast<bool&>(_allowEndpointsOverride) = props->getIcePropertyAsInt("IceGrid.Node.AllowEndpointsOverride") > 0;
+    const_cast<chrono::seconds&>(_disableOnFailure) =
+        chrono::seconds(props->getIcePropertyAsInt("IceGrid.Node.DisableOnFailure"));
+    const_cast<bool&>(_allowRunningServersAsRoot) =
+        props->getIcePropertyAsInt("IceGrid.Node.AllowRunningServersAsRoot") > 0;
 
     //
     // Parse the properties override property.
@@ -335,6 +339,18 @@ bool
 NodeI::allowEndpointsOverride() const
 {
     return _allowEndpointsOverride;
+}
+
+chrono::seconds
+NodeI::getDisableOnFailure() const
+{
+    return _disableOnFailure;
+}
+
+bool
+NodeI::allowRunningServersAsRoot() const
+{
+    return _allowRunningServersAsRoot;
 }
 
 optional<NodeSessionPrx>

--- a/cpp/src/IceGrid/NodeI.h
+++ b/cpp/src/IceGrid/NodeI.h
@@ -113,6 +113,8 @@ namespace IceGrid
         [[nodiscard]] std::string getOutputDir() const;
         [[nodiscard]] bool getRedirectErrToOut() const;
         [[nodiscard]] bool allowEndpointsOverride() const;
+        [[nodiscard]] std::chrono::seconds getDisableOnFailure() const;
+        [[nodiscard]] bool allowRunningServersAsRoot() const;
 
         std::optional<NodeSessionPrx> registerWithRegistry(const InternalRegistryPrx&);
         void checkConsistency(const NodeSessionPrx&);
@@ -170,6 +172,8 @@ namespace IceGrid
         const bool _redirectErrToOut{false};
         const bool _allowEndpointsOverride{false};
         const int _waitTime{0};
+        const std::chrono::seconds _disableOnFailure{0};
+        const bool _allowRunningServersAsRoot{false};
         const std::string _instanceName;
         const std::optional<UserAccountMapperPrx> _userAccountMapper;
         PlatformInfo _platform;

--- a/cpp/src/IceGrid/ReplicaSessionI.cpp
+++ b/cpp/src/IceGrid/ReplicaSessionI.cpp
@@ -23,7 +23,8 @@ ReplicaSessionI::create(
     const shared_ptr<WellKnownObjectsManager>& wellKnownObjects,
     const shared_ptr<InternalReplicaInfo>& info,
     InternalRegistryPrx proxy,
-    chrono::seconds timeout)
+    chrono::seconds timeout,
+    bool dynamicRegistration)
 {
     Ice::Identity replicaSessionId{Ice::generateUUID(), ""};
     shared_ptr<ReplicaSessionI> replicaSession(new ReplicaSessionI(
@@ -32,6 +33,7 @@ ReplicaSessionI::create(
         info,
         std::move(proxy),
         timeout,
+        dynamicRegistration,
         database->getInternalAdapter()->createDirectProxy<ReplicaSessionPrx>(replicaSessionId)));
 
     try
@@ -66,6 +68,7 @@ ReplicaSessionI::ReplicaSessionI(
     const shared_ptr<InternalReplicaInfo>& info,
     InternalRegistryPrx internalRegistry,
     chrono::seconds timeout,
+    bool dynamicRegistration,
     ReplicaSessionPrx proxy)
     : _database(database),
       _wellKnownObjects(wellKnownObjects),
@@ -73,6 +76,7 @@ ReplicaSessionI::ReplicaSessionI(
       _internalRegistry(std::move(internalRegistry)),
       _info(info),
       _timeout(timeout),
+      _dynamicRegistration(dynamicRegistration),
       _proxy(std::move(proxy)),
       _timestamp(chrono::steady_clock::now())
 {
@@ -222,7 +226,7 @@ ReplicaSessionI::setAdapterDirectProxy(
     optional<Ice::ObjectPrx> proxy,
     const Ice::Current&)
 {
-    if (_database->getCommunicator()->getProperties()->getIcePropertyAsInt("IceGrid.Registry.DynamicRegistration") <= 0)
+    if (!_dynamicRegistration)
     {
         throw AdapterNotExistException();
     }

--- a/cpp/src/IceGrid/ReplicaSessionI.h
+++ b/cpp/src/IceGrid/ReplicaSessionI.h
@@ -20,7 +20,8 @@ namespace IceGrid
             const std::shared_ptr<WellKnownObjectsManager>&,
             const std::shared_ptr<InternalReplicaInfo>&,
             InternalRegistryPrx,
-            std::chrono::seconds);
+            std::chrono::seconds,
+            bool dynamicRegistration);
 
         void keepAlive(const Ice::Current&) override;
         [[nodiscard]] int getTimeout(const Ice::Current&) const override;
@@ -52,6 +53,7 @@ namespace IceGrid
             const std::shared_ptr<InternalReplicaInfo>&,
             InternalRegistryPrx,
             std::chrono::seconds,
+            bool dynamicRegistration,
             ReplicaSessionPrx);
 
         void destroyImpl(bool);
@@ -62,6 +64,7 @@ namespace IceGrid
         const InternalRegistryPrx _internalRegistry;
         const std::shared_ptr<InternalReplicaInfo> _info;
         const std::chrono::seconds _timeout;
+        const bool _dynamicRegistration;
         const ReplicaSessionPrx _proxy;
         std::optional<DatabaseObserverPrx> _observer;
         ObjectInfoSeq _replicaWellKnownObjects;

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -713,8 +713,7 @@ ServerI::ServerI(
       _id(id),
       _waitTime(wt),
       _serverDir(serversDir + "/" + id),
-      _disableOnFailure(
-          _node->getCommunicator()->getProperties()->getIcePropertyAsInt("IceGrid.Node.DisableOnFailure")),
+      _disableOnFailure(_node->getDisableOnFailure()),
       _failureTime(chrono::steady_clock::now())
 {
     assert(_node->getActivator());
@@ -2405,8 +2404,7 @@ ServerI::checkAndUpdateUser(const shared_ptr<InternalServerDescriptor>& desc, bo
             throw runtime_error("node has insufficient privileges to load server under user account '" + user + "'");
         }
 
-        if (pw->pw_uid == 0 && _node->getCommunicator()->getProperties()->getIcePropertyAsInt(
-                                   "IceGrid.Node.AllowRunningServersAsRoot") <= 0)
+        if (pw->pw_uid == 0 && !_node->allowRunningServersAsRoot())
         {
             throw runtime_error("running server as 'root' is not allowed");
         }


### PR DESCRIPTION
IceGrid parsed several configuration properties per request or per server load instead of once at startup:

- `IceGrid.Node.DisableOnFailure` was parsed every time a server was loaded on the node, and `IceGrid.Node.AllowRunningServersAsRoot` when loading a run-as-root server. Both are now parsed in the `NodeI` constructor, so an invalid value fails node startup with an error naming the property instead of failing later deployments.
- `IceGrid.Registry.DynamicRegistration` was re-parsed on every `setAdapterDirectProxy` call from a replica, even though the registry already reads it at startup. It is now parsed once in the `InternalRegistryI` constructor and injected into each `ReplicaSessionI`.
- `Ice.MessageSizeMax` was re-parsed on every admin-session `open*Log`/`openFile` request. It is now computed once per admin session.

This intentionally leaves `RegistryI::getSessionTimeout` unchanged: the operation is deprecated and rarely if ever called, so caching a value for it isn't worthwhile.

Fixed #5986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)