### PR TITLE
Catch all exceptions in Glacier2 session creation callbacks

### DIFF
--- a/cpp/src/Glacier2/FilterManager.cpp
+++ b/cpp/src/Glacier2/FilterManager.cpp
@@ -24,7 +24,7 @@ Glacier2::FilterManager::destroy()
                 adapter->remove(_categoriesPrx->ice_getIdentity());
             }
         }
-        catch (const Exception&)
+        catch (...)
         {
         }
         try
@@ -34,7 +34,7 @@ Glacier2::FilterManager::destroy()
                 adapter->remove(_adapterIdsPrx->ice_getIdentity());
             }
         }
-        catch (const Exception&)
+        catch (...)
         {
         }
         try
@@ -44,7 +44,7 @@ Glacier2::FilterManager::destroy()
                 adapter->remove(_identitiesPrx->ice_getIdentity());
             }
         }
-        catch (const Exception&)
+        catch (...)
         {
         }
     }

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -408,16 +408,30 @@ CreateSession::CreateSession(shared_ptr<SessionRouterI> sessionRouter, string us
 void
 CreateSession::create()
 {
+    bool needAuthorize;
     try
     {
-        if (_sessionRouter->startCreateSession(shared_from_this(), _current.con))
-        {
-            authorize();
-        }
+        needAuthorize = _sessionRouter->startCreateSession(shared_from_this(), _current.con);
     }
     catch (...)
     {
+        // This CreateSession is not in _pending: just send the reply.
         finished(current_exception());
+        return;
+    }
+
+    if (needAuthorize)
+    {
+        try
+        {
+            authorize();
+        }
+        catch (...)
+        {
+            // This CreateSession owns the connection's pending-creation entry: exception() removes it and
+            // runs any queued callbacks, in addition to sending the reply.
+            exception(current_exception());
+        }
     }
 }
 

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -152,6 +152,24 @@ namespace Glacier2
                 }
                 exception(make_exception_ptr(PermissionDeniedException("internal server error")));
             }
+            catch (const std::exception& e)
+            {
+                if (_sessionRouter->sessionTraceLevel() >= 1)
+                {
+                    Warning out(_instance->logger());
+                    out << "exception while verifying permissions:\n" << e;
+                }
+                exception(make_exception_ptr(PermissionDeniedException("internal server error")));
+            }
+            catch (...)
+            {
+                if (_sessionRouter->sessionTraceLevel() >= 1)
+                {
+                    Warning out(_instance->logger());
+                    out << "exception while verifying permissions:\nunknown c++ exception";
+                }
+                exception(make_exception_ptr(PermissionDeniedException("internal server error")));
+            }
         }
 
         void authorize() override
@@ -260,6 +278,24 @@ namespace Glacier2
                 {
                     Warning out(_instance->logger());
                     out << "exception while verifying permissions:\n" << e;
+                }
+                exception(make_exception_ptr(PermissionDeniedException("internal server error")));
+            }
+            catch (const std::exception& e)
+            {
+                if (_sessionRouter->sessionTraceLevel() >= 1)
+                {
+                    Warning out(_instance->logger());
+                    out << "exception while verifying permissions:\n" << e;
+                }
+                exception(make_exception_ptr(PermissionDeniedException("internal server error")));
+            }
+            catch (...)
+            {
+                if (_sessionRouter->sessionTraceLevel() >= 1)
+                {
+                    Warning out(_instance->logger());
+                    out << "exception while verifying permissions:\nunknown c++ exception";
                 }
                 exception(make_exception_ptr(PermissionDeniedException("internal server error")));
             }
@@ -379,7 +415,7 @@ CreateSession::create()
             authorize();
         }
     }
-    catch (const Ice::Exception&)
+    catch (...)
     {
         finished(current_exception());
     }
@@ -421,7 +457,7 @@ CreateSession::authorized(bool createSession)
             sessionCreated(nullopt);
         }
     }
-    catch (const Ice::Exception&)
+    catch (...)
     {
         unexpectedCreateSessionException(current_exception());
     }
@@ -438,7 +474,7 @@ CreateSession::createException(exception_ptr ex)
     {
         exception(current_exception());
     }
-    catch (const Ice::Exception&)
+    catch (...)
     {
         unexpectedCreateSessionException(current_exception());
     }
@@ -469,7 +505,7 @@ CreateSession::sessionCreated(optional<SessionPrx> session)
                 make_shared<RouterI>(_instance, _current.con, _user, session, ident, _filterManager, Ice::Context());
         }
     }
-    catch (const Ice::Exception&)
+    catch (...)
     {
         if (session)
         {
@@ -487,7 +523,7 @@ CreateSession::sessionCreated(optional<SessionPrx> session)
         _sessionRouter->finishCreateSession(_current.con, router);
         finished(std::move(session));
     }
-    catch (const Ice::Exception&)
+    catch (...)
     {
         finished(current_exception());
     }
@@ -503,14 +539,23 @@ CreateSession::unexpectedCreateSessionException(exception_ptr ex)
 {
     if (_sessionRouter->sessionTraceLevel() >= 1)
     {
+        Trace out(_instance->logger(), "Glacier2");
+        out << "exception while creating session with session manager:\n";
         try
         {
             rethrow_exception(ex);
         }
         catch (const Ice::Exception& e)
         {
-            Trace out(_instance->logger(), "Glacier2");
-            out << "exception while creating session with session manager:\n" << e;
+            out << e;
+        }
+        catch (const std::exception& e)
+        {
+            out << e;
+        }
+        catch (...)
+        {
+            out << "unknown c++ exception";
         }
     }
     exception(make_exception_ptr(CannotCreateSessionException("internal server error")));
@@ -523,7 +568,7 @@ CreateSession::exception(exception_ptr ex)
     {
         _sessionRouter->finishCreateSession(_current.con, nullptr);
     }
-    catch (const Ice::Exception&)
+    catch (...)
     {
     }
 
@@ -535,7 +580,7 @@ CreateSession::exception(exception_ptr ex)
         {
             _instance->serverObjectAdapter()->remove(_control->ice_getIdentity());
         }
-        catch (const Exception&)
+        catch (...)
         {
         }
     }
@@ -968,6 +1013,16 @@ SessionRouterI::sessionDestroyException(exception_ptr ex) const
         {
             Trace out(_instance->logger(), "Glacier2");
             out << "exception while destroying session\n" << e;
+        }
+        catch (const std::exception& e)
+        {
+            Trace out(_instance->logger(), "Glacier2");
+            out << "exception while destroying session\n" << e;
+        }
+        catch (...)
+        {
+            Trace out(_instance->logger(), "Glacier2");
+            out << "exception while destroying session\nunknown c++ exception";
         }
     }
 }


### PR DESCRIPTION
The failure handling around Glacier2 session creation caught `Ice::Exception` only. A non-Ice exception (such as `std::bad_alloc`, or `std::runtime_error` from `std::random_device` during `RouterI` construction) thrown in these AMI callback paths escaped into the Ice runtime and was swallowed: the client never got a reply and the connection's pending-creation entry remained in place, blocking subsequent `createSession` attempts from that connection.

- `CreateSession::create`, `authorized`, `createException`, `sessionCreated`, and the cleanup catches in `CreateSession::exception` and `FilterManager::destroy` now catch all exceptions and route the failure through the existing cleanup.
- The trace-and-rethrow helpers (`unexpectedCreateSessionException`, `checkPermissionsException`, `authorizeException`, `sessionDestroyException`) now trace `Ice::Exception`, `std::exception`, and unknown exceptions instead of letting a rethrown non-Ice exception escape when tracing is enabled. The error reported to the client (`CannotCreateSessionException` / `PermissionDeniedException` with "internal server error") is unchanged.

Fixes #6004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)