### PR TITLE
Use compact type ID for unknownTypeId in Python, Ruby, and PHP

### DIFF
--- a/cpp/include/Ice/SlicedData.h
+++ b/cpp/include/Ice/SlicedData.h
@@ -93,11 +93,13 @@ namespace Ice
     {
     public:
         /// Constructs the placeholder instance.
-        /// @param unknownTypeId The Slice type ID of the unknown value.
+        /// @param unknownTypeId The Slice type ID of the unknown value, or the string form of the compact type ID
+        /// (for example, "1") when the most-derived slice was marshaled with a compact type ID.
         UnknownSlicedValue(std::string unknownTypeId) noexcept;
 
         /// Returns the Slice type ID associated with this instance.
-        /// @return The type ID supplied to the constructor.
+        /// @return The type ID supplied to the constructor. It's the string form of the compact type ID (for
+        /// example, "1") when the most-derived slice was marshaled with a compact type ID.
         [[nodiscard]] const char* ice_id() const noexcept final;
 
         /// Clones this object.

--- a/csharp/src/Ice/UnknownSlicedValue.cs
+++ b/csharp/src/Ice/UnknownSlicedValue.cs
@@ -12,13 +12,15 @@ public sealed class UnknownSlicedValue : Value
     /// <summary>
     /// Initializes a new instance of the <see cref="UnknownSlicedValue" /> class.
     /// </summary>
-    /// <param name="unknownTypeId">The Slice type ID of the unknown value.</param>
+    /// <param name="unknownTypeId">The Slice type ID of the unknown value, or the string form of the compact type
+    /// ID (for example, "1") when the most-derived slice was marshaled with a compact type ID.</param>
     public UnknownSlicedValue(string unknownTypeId) => _unknownTypeId = unknownTypeId;
 
     /// <summary>
     /// Returns the Slice type ID associated with this instance.
     /// </summary>
-    /// <returns>The type ID supplied to the constructor.</returns>
+    /// <returns>The type ID supplied to the constructor. It's the string form of the compact type ID (for example,
+    /// "1") when the most-derived slice was marshaled with a compact type ID.</returns>
     public override string ice_id() => _unknownTypeId;
 
     private readonly string _unknownTypeId;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UnknownSlicedValue.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UnknownSlicedValue.java
@@ -7,7 +7,9 @@ public final class UnknownSlicedValue extends Value {
     /**
      * Constructs the placeholder instance.
      *
-     * @param unknownTypeId the Slice type ID of the unknown value
+     * @param unknownTypeId the Slice type ID of the unknown value, or the string form of the
+     *     compact type ID (for example, "1") when the most-derived slice was marshaled with a
+     *     compact type ID
      */
     public UnknownSlicedValue(String unknownTypeId) {
         _unknownTypeId = unknownTypeId;
@@ -16,7 +18,8 @@ public final class UnknownSlicedValue extends Value {
     /**
      * Returns the Slice type ID associated with this instance.
      *
-     * @return the type ID supplied to the constructor
+     * @return the type ID supplied to the constructor; it's the string form of the compact type ID
+     *     (for example, "1") when the most-derived slice was marshaled with a compact type ID
      */
     @Override
     public String ice_id() {

--- a/js/packages/ice/src/Ice/UnknownSlicedValue.d.ts
+++ b/js/packages/ice/src/Ice/UnknownSlicedValue.d.ts
@@ -54,14 +54,16 @@ declare module "@zeroc/ice" {
             /**
              * Constructs an unknown sliced value.
              *
-             * @param unknownTypeId The Slice type ID of the unknown class.
+             * @param unknownTypeId The Slice type ID of the unknown class, or the string form of the compact type
+             * ID (for example, "1") when the most-derived slice was marshaled with a compact type ID.
              */
             constructor(unknownTypeId: string);
 
             /**
              * Returns the Slice type ID associated with this object.
              *
-             * @returns The Slice type ID.
+             * @returns The type ID supplied to the constructor. It's the string form of the compact type ID (for
+             * example, "1") when the most-derived slice was marshaled with a compact type ID.
              */
             ice_id(): string;
         }

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -2978,7 +2978,8 @@ IcePHP::ValueReader::_iceRead(Ice::InputStream* is)
         {
             assert(!_slicedData->slices.empty());
 
-            const string typeId = _slicedData->slices[0]->typeId;
+            const Ice::SliceInfoPtr& sliceInfo = _slicedData->slices[0];
+            const string typeId = sliceInfo->typeId.empty() ? std::to_string(sliceInfo->compactId) : sliceInfo->typeId;
             zval zv;
             AutoDestroy typeIdDestroyer(&zv);
             ZVAL_STRINGL(&zv, typeId.c_str(), static_cast<int>(typeId.size()));

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -3011,7 +3011,9 @@ IcePy::ValueReader::_iceRead(Ice::InputStream* is)
         {
             assert(!_slicedData->slices.empty());
 
-            PyObjectHandle typeId{createString(_slicedData->slices[0]->typeId)};
+            const Ice::SliceInfoPtr& sliceInfo = _slicedData->slices[0];
+            PyObjectHandle typeId{
+                createString(sliceInfo->typeId.empty() ? std::to_string(sliceInfo->compactId) : sliceInfo->typeId)};
             if (!typeId.get() || PyObject_SetAttrString(_object.get(), "unknownTypeId", typeId.get()) < 0)
             {
                 assert(PyErr_Occurred());

--- a/python/python/Ice/UnknownSlicedValue.py
+++ b/python/python/Ice/UnknownSlicedValue.py
@@ -15,8 +15,8 @@ class UnknownSlicedValue(Value):
     Attributes
     ----------
     unknownTypeId : str
-        The Slice type ID of the unknown value; empty when the most-derived slice was marshaled with a compact
-        type ID.
+        The Slice type ID of the unknown value, or the string form of the compact type ID (for example, ``"1"``)
+        when the most-derived slice was marshaled with a compact type ID.
     """
 
     _ice_type = None  # Will be set after class definition
@@ -29,7 +29,8 @@ class UnknownSlicedValue(Value):
         Returns
         -------
         str
-            The Slice type ID of the unknown value.
+            The Slice type ID of the unknown value, or the string form of the compact type ID (for example,
+            ``"1"``) when the most-derived slice was marshaled with a compact type ID.
         """
         return self.unknownTypeId
 

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -2553,7 +2553,9 @@ IceRuby::ValueReader::_iceRead(Ice::InputStream* is)
         {
             assert(!_slicedData->slices.empty());
 
-            volatile VALUE typeId = createString(_slicedData->slices[0]->typeId);
+            const Ice::SliceInfoPtr& sliceInfo = _slicedData->slices[0];
+            volatile VALUE typeId =
+                createString(sliceInfo->typeId.empty() ? std::to_string(sliceInfo->compactId) : sliceInfo->typeId);
             callRuby(rb_iv_set, _object, "@unknownTypeId", typeId);
         }
     }

--- a/swift/src/Ice/UnknownSlicedValue.swift
+++ b/swift/src/Ice/UnknownSlicedValue.swift
@@ -14,7 +14,8 @@ public final class UnknownSlicedValue: Value {
 
     /// Returns the Slice type ID associated with this instance.
     ///
-    /// - Returns: The type ID supplied to the constructor.
+    /// - Returns: The type ID supplied to the initializer. It's the string form of the compact type ID
+    ///   (for example, `"1"`) when the most-derived slice was marshaled with a compact type ID.
     override public func ice_id() -> String {
         return unknownTypeId
     }


### PR DESCRIPTION
When the most-derived slice of an unknown class instance was marshaled with a compact type ID, `UnknownSlicedValue.unknownTypeId` (and `ice_id()`) was the empty string in Python, Ruby, and PHP, while all other mappings return the string form of the compact ID (e.g. `"1"`). These three mappings now fall back to the string form of `slices[0].compactId` when `slices[0].typeId` is empty, matching the other languages. PHP had the same copied idiom even though #5916 only lists Python and Ruby.

This value is informational only — re-marshaling uses the preserved `SlicedData`, which keeps `compactId` per slice — so there is no wire impact.

Also updates the `UnknownSlicedValue` constructor and `ice_id` doc-comments in C++, C#, Java, JavaScript, Swift, and Python to state that the ID is the string form of the compact type ID when the most-derived slice was marshaled with one (the Swift and MATLAB implementations already behave this way; MATLAB already documents it, and Ruby and PHP define these classes without doc-comments).

Verified end-to-end: a server returning a class with compact type ID 1, unknown to the client and marshaled in the sliced format, now yields `ice_id() == "1"` in Python, Ruby, and PHP clients (previously `""`).

Fixes #5916.

🤖 Generated with [Claude Code](https://claude.com/claude-code)