### PR TITLE
Fix nullability of peerCertificate in Swift SSL bridge

### DIFF
--- a/swift/src/Ice/ConnectionInfoFactory.swift
+++ b/swift/src/Ice/ConnectionInfoFactory.swift
@@ -58,7 +58,7 @@ final class ConnectionInfoFactory: ICEConnectionInfoFactory {
         WSConnectionInfo(underlying: underlying as! ConnectionInfo, headers: headers)
     }
 
-    static func createSSLConnectionInfo(_ underlying: Any, peerCertificate: SecCertificate) -> Any {
+    static func createSSLConnectionInfo(_ underlying: Any, peerCertificate: SecCertificate?) -> Any {
         return SSLConnectionInfo(
             underlying: underlying as! ConnectionInfo, peerCertificate: peerCertificate)
     }

--- a/swift/src/IceImpl/include/Connection.h
+++ b/swift/src/IceImpl/include/Connection.h
@@ -53,7 +53,7 @@ ICEIMPL_API @protocol ICEConnectionInfoFactory
 
 + (id)createWSConnectionInfo:(id)underlying headers:(NSDictionary<NSString*, NSString*>*)headers;
 
-+ (id)createSSLConnectionInfo:(id)underlying peerCertificate:(SecCertificateRef)peerCertificate;
++ (id)createSSLConnectionInfo:(id)underlying peerCertificate:(nullable SecCertificateRef)peerCertificate;
 
 + (id)createIAPConnectionInfo:(BOOL)incoming
                   adapterName:(NSString*)adapterName

--- a/swift/test/Ice/info/AllTests.swift
+++ b/swift/test/Ice/info/AllTests.swift
@@ -212,6 +212,23 @@ func allTests(_ helper: TestHelper) async throws {
             try test(ctx["ws.Sec-WebSocket-Key"] != nil)
         }
 
+        if ["ssl", "wss"].contains(helper.getTestProtocol()) {
+            // Both peers presented a certificate.
+            let sslInfo = getSSLConnectionInfo(info)!
+            try test(sslInfo.peerCertificate != nil)
+            try test(ctx["peerCertificate"] == "true")
+
+            // The server reports a nil peer certificate for a client that doesn't present one.
+            let properties = communicator.getProperties().clone()
+            properties.setProperty(key: "IceSSL.CertFile", value: "")
+            let com = try Ice.initialize(Ice.InitializationData(properties: properties))
+            defer { com.destroy() }
+            let base2 = try com.stringToProxy("test:" + helper.getTestEndpoint(num: 0))!
+            let testIntf2 = uncheckedCast(prx: base2, type: TestIntfPrx.self)
+            let ctx2 = try await testIntf2.getConnectionInfoAsContext()
+            try test(ctx2["peerCertificate"] == "false")
+        }
+
         connection = try await base.ice_datagram().ice_getConnection()!
         try connection.setBufferSize(rcvSize: 2048, sndSize: 1024)
 

--- a/swift/test/Ice/info/Server.swift
+++ b/swift/test/Ice/info/Server.swift
@@ -6,7 +6,12 @@ import TestCommon
 
 class Server: TestHelperI, @unchecked Sendable {
     override public func run(args: [String]) async throws {
-        let communicator = try initialize(args)
+        let properties = try createTestProperties(args)
+        // Accept SSL clients that don't present a certificate.
+        properties.setProperty(key: "IceSSL.VerifyPeer", value: "1")
+        var initData = Ice.InitializationData()
+        initData.properties = properties
+        let communicator = try initialize(initData)
         defer {
             communicator.destroy()
         }

--- a/swift/test/Ice/info/Server.swift
+++ b/swift/test/Ice/info/Server.swift
@@ -9,9 +9,7 @@ class Server: TestHelperI, @unchecked Sendable {
         let properties = try createTestProperties(args)
         // Accept SSL clients that don't present a certificate.
         properties.setProperty(key: "IceSSL.VerifyPeer", value: "1")
-        var initData = Ice.InitializationData()
-        initData.properties = properties
-        let communicator = try initialize(initData)
+        let communicator = try initialize(properties)
         defer {
             communicator.destroy()
         }

--- a/swift/test/Ice/info/TestI.swift
+++ b/swift/test/Ice/info/TestI.swift
@@ -24,6 +24,17 @@ func getIPConnectionInfo(_ info: Ice.ConnectionInfo) -> Ice.IPConnectionInfo? {
     return nil
 }
 
+func getSSLConnectionInfo(_ info: Ice.ConnectionInfo) -> Ice.SSLConnectionInfo? {
+    var curr: Ice.ConnectionInfo? = info
+    while curr != nil {
+        if curr is Ice.SSLConnectionInfo {
+            return curr as? Ice.SSLConnectionInfo
+        }
+        curr = curr?.underlying
+    }
+    return nil
+}
+
 final class TestI: TestIntf {
     func shutdown(current: Ice.Current) {
         current.adapter.getCommunicator().shutdown()
@@ -60,6 +71,10 @@ final class TestI: TestIntf {
             for (key, value) in wsinfo.headers {
                 ctx["ws.\(key)"] = value
             }
+        }
+
+        if let sslinfo = getSSLConnectionInfo(info) {
+            ctx["peerCertificate"] = sslinfo.peerCertificate != nil ? "true" : "false"
         }
         return ctx
     }


### PR DESCRIPTION
When the peer of an SSL connection presents no certificate, the C++ side of the Swift bridge forwards a NULL `SecCertificateRef` through a parameter declared `_Nonnull` (it sits in the header's `NS_ASSUME_NONNULL` region), and the Swift factory imports it as a non-optional `SecCertificate`. This PR annotates the bridge parameter `nullable` and makes the factory parameter `SecCertificate?`, so the chain honors its declared nullability down to the already-optional `SSLConnectionInfo.peerCertificate` property.

Contrary to the issue's description, the defect is not observable: Swift represents `Optional` of a class/CF type with the NULL pointer as `nil`, so the NULL reference stored into the optional property was already indistinguishable from `nil`. The change removes the nullability-contract violation (undefined behavior that currently happens to be benign) rather than fixing an application-visible bug — hence no CHANGELOG entry.

Also extends the `Ice/info` test: the test server now accepts SSL clients without a certificate (`IceSSL.VerifyPeer=1`) and reports the presence of the peer certificate in `getConnectionInfoAsContext`, and the client verifies both directions — a non-nil `peerCertificate` when the peer presents a certificate, and a nil one on the server side for a client that doesn't.

Fixes #5936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)