### PR TITLE
Fix four low-severity Swift API findings (#5938)

### DIFF
--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -4,6 +4,7 @@ import IceImpl
 
 /// Helps applications handle Ctrl+C (SIGINT) and similar signals (SIGHUP and SIGTERM). Only available on macOS.
 @available(macOS 15, *)
+@available(iOS, unavailable)
 public struct CtrlCHandler {
     private let handle = ICECtrlCHandler()
 

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -48,11 +48,12 @@ public final class InputStream {
         acceptClassCycles = (communicator as! CommunicatorI).acceptClassCycles
     }
 
-    /// Reads an encapsulation from the stream. The stream position is not advanced past the encapsulation; the
-    /// returned data includes the 6-byte encapsulation header.
+    /// Reads an encapsulation from the stream and advances the stream position past it. The returned data is a copy
+    /// that includes the 6-byte encapsulation header.
     ///
     /// - Returns: The encapsulation.
     public func readEncapsulation() throws -> (bytes: Data, encoding: EncodingVersion) {
+        let start = pos
         let sz: Int32 = try read()
         if sz < 6 {
             throw MarshalException(endOfBufferMessage)
@@ -63,9 +64,10 @@ public final class InputStream {
         }
 
         let encoding: EncodingVersion = try read()
-        try changePos(offset: -6)
+        // Advance past the remainder of the encapsulation (we've already read its 6-byte header).
+        try changePos(offset: Int(sz) - 6)
 
-        let bytes = data[pos..<pos + Int(sz)]
+        let bytes = Data(data[start..<start + Int(sz)])
         return (bytes, encoding)
     }
 

--- a/swift/src/Ice/LocalExceptions.swift
+++ b/swift/src/Ice/LocalExceptions.swift
@@ -320,6 +320,11 @@ public final class AlreadyRegisteredException: LocalException, @unchecked Sendab
 public final class CommunicatorDestroyedException: LocalException, @unchecked Sendable {}
 
 /// This exception indicates that a connection was aborted by the idle check.
+@available(
+    *, deprecated,
+    message:
+        "The Ice runtime never throws this exception; the idle check aborts the connection with ConnectionAbortedException (closedByApplication == false)."
+)
 public class ConnectionIdleException: LocalException, @unchecked Sendable {}
 
 /// This exception indicates the connection was closed forcefully.

--- a/swift/src/Ice/ObjectAdapterI.swift
+++ b/swift/src/Ice/ObjectAdapterI.swift
@@ -190,9 +190,11 @@ final class ObjectAdapterI: LocalObject<ICEObjectAdapter>, ObjectAdapter, ICEDis
         }
     }
 
-    func setLocator(_ locator: LocatorPrx?) {
+    func setLocator(_ locator: LocatorPrx?) throws {
         let l = locator as? LocatorPrxI
-        handle.setLocator(l?.handle ?? nil)
+        try autoreleasepool {
+            try handle.setLocator(l?.handle ?? nil)
+        }
     }
 
     func getLocator() -> LocatorPrx? {

--- a/swift/src/IceImpl/ObjectAdapter.mm
+++ b/swift/src/IceImpl/ObjectAdapter.mm
@@ -140,7 +140,7 @@
     }
 }
 
-- (void)setLocator:(nullable ICEObjectPrx*)locator
+- (BOOL)setLocator:(nullable ICEObjectPrx*)locator error:(NSError* _Nullable* _Nonnull)error
 {
     try
     {
@@ -150,18 +150,12 @@
             l = [locator prx];
         }
         self.objectAdapter->setLocator(Ice::uncheckedCast<Ice::LocatorPrx>(l));
+        return YES;
     }
-    catch (const Ice::ObjectAdapterDeactivatedException&)
+    catch (...)
     {
-        // ignored
-    }
-    catch (const Ice::CommunicatorDestroyedException&)
-    {
-        // ignored
-    }
-    catch (const std::exception&)
-    {
-        // unexpected but ignored nevertheless
+        *error = convertException(std::current_exception());
+        return NO;
     }
 }
 

--- a/swift/src/IceImpl/include/ObjectAdapter.h
+++ b/swift/src/IceImpl/include/ObjectAdapter.h
@@ -30,7 +30,7 @@ ICEIMPL_API @interface ICEObjectAdapter : ICELocalObject
                                      category:(NSString*)category
                                         error:(NSError* _Nullable* _Nonnull)error
     NS_SWIFT_NAME(createIndirectProxy(name:category:));
-- (void)setLocator:(ICEObjectPrx* _Nullable)locator;
+- (BOOL)setLocator:(ICEObjectPrx* _Nullable)locator error:(NSError* _Nullable* _Nonnull)error;
 - (nullable ICEObjectPrx*)getLocator;
 - (NSArray<ICEEndpoint*>*)getEndpoints;
 - (NSArray<ICEEndpoint*>*)getPublishedEndpoints;

--- a/swift/test/Ice/adapterDeactivation/AllTests.swift
+++ b/swift/test/Ice/adapterDeactivation/AllTests.swift
@@ -55,6 +55,11 @@ func allTests(_ helper: TestHelper) async throws {
         try test(!adapter.isDeactivated())
         adapter.deactivate()
         try test(adapter.isDeactivated())
+        do {
+            // setLocator on a deactivated adapter throws, matching C++ and C#.
+            try adapter.setLocator(nil)
+            try test(false)
+        } catch is Ice.ObjectAdapterDeactivatedException {}
         adapter.destroy()
     }
     output.writeLine("ok")

--- a/swift/test/Ice/stream/Client.swift
+++ b/swift/test/Ice/stream/Client.swift
@@ -584,5 +584,25 @@ public class Client: TestHelperI, @unchecked Sendable {
             } catch is Ice.MarshalException {}
         }
         writer.writeLine("ok")
+
+        writer.write("testing readEncapsulation... ")
+        do {
+            outS = Ice.OutputStream(communicator: communicator)
+            outS.startEncapsulation()
+            outS.write(Int32(42))
+            outS.endEncapsulation()
+            outS.write(Int32(0x1234))  // a marker written immediately after the encapsulation
+            let data = outS.finished()
+
+            inS = Ice.InputStream(communicator: communicator, bytes: data)
+            let (bytes, _) = try inS.readEncapsulation()
+            // The returned blob is the whole encapsulation: 4-byte size + 2-byte encoding + a 4-byte Int32 body.
+            try test(bytes.count == 10)
+            try test(bytes.startIndex == 0)  // a zero-based copy, not a shared-storage slice
+            // The stream position advanced past the encapsulation, so the trailing marker is read next.
+            let marker: Int32 = try inS.read()
+            try test(marker == 0x1234)
+        }
+        writer.writeLine("ok")
     }
 }


### PR DESCRIPTION
Fixes #5938 — the four low-severity findings from the Swift API doc audit. One commit per finding, so each can be reviewed (or dropped) independently.

### 1. `ObjectAdapter.setLocator` propagates errors
The `ObjectAdapter` protocol declares `setLocator` as `throws`, matching C++ and C#, which throw `ObjectAdapterDeactivatedException` on a deactivated adapter. But the Objective-C++ bridge caught and ignored every exception, so the Swift method could never actually throw and `setLocator` on a deactivated adapter silently succeeded. The bridge now returns the error through an `NSError**` out-parameter (mirroring `activate` and `setPublishedEndpoints`) and `ObjectAdapterI.setLocator` rethrows. All internal callers already used `try`.

### 2. `InputStream.readEncapsulation` advances the stream
It read the 6-byte encapsulation header, rewound, and returned a shared-storage slice without advancing the stream position, so a second call re-read the same bytes. C++ and C# both consume the encapsulation. It now advances past the encapsulation and returns a zero-based `Data` copy, matching the other mappings; the doc comment is corrected accordingly.

### 3. `CtrlCHandler` is unavailable off macOS
`@available(macOS 15, *)` left the struct constructible on iOS and the other Apple platforms, where the bridge is `assert(false)` — a silent no-op in release builds. Added `@available(iOS/tvOS/watchOS/visionOS, unavailable)` so the declaration enforces the "macOS only" documentation.

### 4. `ConnectionIdleException` deprecated
Nothing in the runtime or the bridge ever throws it — the idle check aborts the connection with `ConnectionAbortedException` — so catching it never matches a runtime-raised exception. Deprecated with a message pointing to the real exception. Removing it is API-breaking and left for 3.9.

### Tests
Extends `Ice/stream` (`readEncapsulation` returns the full encapsulation and advances past it) and `Ice/adapterDeactivation` (`setLocator` throws on a deactivated adapter). `Ice/stream`, `Ice/adapterDeactivation`, `Ice/location`, and `Ice/invoke` all pass.

No changelog fragment: all four are low-severity audit polish with no field reports.