### PR TITLE
Fix a deadlock in Timer::destroy() when a task destructor re-enters the timer

### DIFF
--- a/cpp/src/Ice/Timer.cpp
+++ b/cpp/src/Ice/Timer.cpp
@@ -19,6 +19,10 @@ Timer::destroy()
     {
         throw std::runtime_error("a timer task cannot destroy the timer");
     }
+    // Destroy the tasks after the lock is released and the worker joined: a task's destructor can re-enter the timer
+    // via cancel() (e.g. when it holds the last reference to a connection), which would deadlock while _mutex is held.
+    std::set<Token> tokens;
+    std::map<TimerTaskPtr, std::chrono::steady_clock::time_point> tasks;
     {
         std::lock_guard lock(_mutex);
         if (_destroyed)
@@ -26,8 +30,8 @@ Timer::destroy()
             return;
         }
         _destroyed = true;
-        _tasks.clear();
-        _tokens.clear();
+        tokens.swap(_tokens);
+        tasks.swap(_tasks);
         _condition.notify_one();
     }
     _worker.join();

--- a/cpp/test/IceUtil/timer/Client.cpp
+++ b/cpp/test/IceUtil/timer/Client.cpp
@@ -132,6 +132,27 @@ private:
 };
 using DestroyTaskPtr = std::shared_ptr<DestroyTask>;
 
+// A task whose destructor re-enters the timer by cancelling another task. This mirrors the shutdown scenario where
+// destroying a scheduled task drops the last reference to a connection, whose own destructor cancels its idle-timeout
+// task. Timer::destroy() must not run such a destructor while holding its internal lock.
+class ReentrantCancelTask final : public TimerTask
+{
+public:
+    ReentrantCancelTask(IceInternal::TimerPtr timer, TimerTaskPtr other)
+        : _timer(std::move(timer)),
+          _other(std::move(other))
+    {
+    }
+
+    ~ReentrantCancelTask() override { _timer->cancel(_other); }
+
+    void runTimerTask() override {}
+
+private:
+    const IceInternal::TimerPtr _timer;
+    const TimerTaskPtr _other;
+};
+
 class Client : public Test::TestHelper
 {
 public:
@@ -256,6 +277,21 @@ Client::run(int, char*[])
                 // Expected;
             }
         }
+    }
+    cout << "ok" << endl;
+
+    cout << "testing timer destroy with a re-entrant cancel... " << flush;
+    {
+        auto timer = make_shared<IceInternal::Timer>();
+        auto other = make_shared<TestTask>();
+        timer->schedule(other, chrono::hours(1));
+        {
+            auto reentrant = make_shared<ReentrantCancelTask>(timer, other);
+            timer->schedule(reentrant, chrono::hours(1));
+        }
+        // 'reentrant' is now referenced only by the timer. Destroying the timer runs its destructor, which cancels
+        // 'other'; this must complete without deadlocking.
+        timer->destroy();
     }
     cout << "ok" << endl;
 }


### PR DESCRIPTION
Fixes #6021.

`Timer::destroy()` cleared its task containers while holding `_mutex`. Destroying a task can run its destructor, which may re-enter the timer via `cancel()` — for example, releasing the last reference to a connection cancels that connection's idle-timeout task. Because `_mutex` is not recursive, that re-entrant `cancel()` self-deadlocks.

This swaps the containers into locals under the lock and lets them destruct after the lock is released and the worker thread is joined; a re-entrant `cancel()` then sees `_destroyed` and is a no-op. `run()` already handles the same hazard this way.

Reliably reproduced via IceStorm batch subscribers (#5964). With this fix the full IceStorm test suite and the core `Ice/timeout`, `Ice/idleTimeout`, `Ice/ami`, and `Ice/background` tests all pass.

The `Timer` API is internal (`IceInternal`) and there are no field reports, so no changelog entry.