### PR TITLE
Restore IceStorm batch subscriber delivery

### DIFF
--- a/changelog.d/service-icestorm/5964.md
+++ b/changelog.d/service-icestorm/5964.md
@@ -1,0 +1,4 @@
+- Restored IceStorm batch subscriber delivery, which had not worked since Ice 3.8.0. A batch oneway or batch datagram
+  subscriber's proxy was silently converted to a plain oneway or datagram proxy at subscription time, so its events
+  were delivered one at a time instead of being coalesced and flushed together every `IceStorm.Flush.Timeout`
+  milliseconds.

--- a/cpp/src/Ice/Timer.cpp
+++ b/cpp/src/Ice/Timer.cpp
@@ -19,6 +19,10 @@ Timer::destroy()
     {
         throw std::runtime_error("a timer task cannot destroy the timer");
     }
+    // Destroy the tasks after the lock is released and the worker joined: a task's destructor can re-enter the timer
+    // via cancel() (e.g. when it holds the last reference to a connection), which would deadlock while _mutex is held.
+    std::set<Token> tokens;
+    std::map<TimerTaskPtr, std::chrono::steady_clock::time_point> tasks;
     {
         std::lock_guard lock(_mutex);
         if (_destroyed)
@@ -26,8 +30,8 @@ Timer::destroy()
             return;
         }
         _destroyed = true;
-        _tasks.clear();
-        _tokens.clear();
+        tokens.swap(_tokens);
+        tasks.swap(_tasks);
         _condition.notify_one();
     }
     _worker.join();

--- a/cpp/src/IceStorm/Instance.cpp
+++ b/cpp/src/IceStorm/Instance.cpp
@@ -88,6 +88,7 @@ Instance::Instance(
         }
 
         _timer = make_shared<IceInternal::Timer>();
+        _batchFlusher = make_shared<IceInternal::Timer>();
 
         string policy = properties->getIceProperty("IceStorm.Send.QueueSizeMaxPolicy");
         if (policy == "RemoveSubscriber")
@@ -111,6 +112,16 @@ Instance::Instance(
             Ice::Warning warn(_traceLevels->logger);
             warn << "'IceStorm.Send.QueueSizeMax' value 0 is invalid; treating the send queue as unbounded";
             const_cast<int&>(_sendQueueSizeMax) = -1;
+        }
+
+        // A negative flush interval is invalid: it's used as the delay when scheduling a batch subscriber's flush on
+        // the batch flusher timer, and the timer rejects a negative delay. Fall back to the default of one second.
+        if (_flushInterval < chrono::milliseconds::zero())
+        {
+            Ice::Warning warn(_traceLevels->logger);
+            warn << "'IceStorm.Flush.Timeout' value " << _flushInterval.count()
+                 << " is invalid; using the default of 1000ms";
+            const_cast<chrono::milliseconds&>(_flushInterval) = chrono::milliseconds(1000);
         }
 
         //
@@ -205,6 +216,12 @@ Instance::timer() const
     return _timer;
 }
 
+IceInternal::TimerPtr
+Instance::batchFlusher() const
+{
+    return _batchFlusher;
+}
+
 optional<Ice::ObjectPrx>
 Instance::topicReplicaProxy() const
 {
@@ -233,6 +250,12 @@ chrono::seconds
 Instance::discardInterval() const
 {
     return _discardInterval;
+}
+
+chrono::milliseconds
+Instance::flushInterval() const
+{
+    return _flushInterval;
 }
 
 chrono::milliseconds
@@ -275,6 +298,14 @@ Instance::shutdown() noexcept
 void
 Instance::destroy() noexcept
 {
+    // Destroy the batch flusher here rather than in shutdown(): the subscribers are drained in
+    // TopicManagerImpl::shutdown(), which runs after Instance::shutdown() but before destroy(), and a pending batch
+    // flush must still be able to run during that drain.
+    if (_batchFlusher)
+    {
+        _batchFlusher->destroy();
+    }
+
     // The node instance must be cleared as the node holds the
     // replica (TopicManager) which holds the instance causing a
     // cyclic reference.

--- a/cpp/src/IceStorm/Instance.h
+++ b/cpp/src/IceStorm/Instance.h
@@ -63,12 +63,14 @@ namespace IceStorm
         [[nodiscard]] std::optional<IceStormElection::NodePrx> nodeProxy() const;
         [[nodiscard]] std::shared_ptr<TraceLevels> traceLevels() const;
         [[nodiscard]] IceInternal::TimerPtr timer() const;
+        [[nodiscard]] IceInternal::TimerPtr batchFlusher() const;
         [[nodiscard]] std::optional<Ice::ObjectPrx> topicReplicaProxy() const;
         [[nodiscard]] std::optional<Ice::ObjectPrx> publisherReplicaProxy() const;
         [[nodiscard]] std::shared_ptr<IceStorm::Instrumentation::TopicManagerObserver> observer() const;
         [[nodiscard]] std::shared_ptr<TopicReaper> topicReaper() const;
 
         [[nodiscard]] std::chrono::seconds discardInterval() const;
+        [[nodiscard]] std::chrono::milliseconds flushInterval() const;
         [[nodiscard]] std::chrono::milliseconds sendTimeout() const;
         [[nodiscard]] int sendQueueSizeMax() const;
         [[nodiscard]] SendQueueSizeMaxPolicy sendQueueSizeMaxPolicy() const;
@@ -95,6 +97,9 @@ namespace IceStorm
         std::shared_ptr<IceStormElection::NodeI> _node;
         std::shared_ptr<IceStormElection::Observers> _observers;
         IceInternal::TimerPtr _timer;
+        // A separate timer used to flush batch subscribers. Unlike _timer, it is destroyed in destroy() rather than
+        // shutdown(), so it outlives the subscriber drain in TopicManagerImpl::shutdown().
+        IceInternal::TimerPtr _batchFlusher;
         std::shared_ptr<IceStorm::Instrumentation::TopicManagerObserver> _observer;
     };
 

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -88,6 +88,29 @@ namespace
 // Each of the various Subscriber types.
 namespace
 {
+    class SubscriberBatch final : public Subscriber
+    {
+    public:
+        SubscriberBatch(
+            const shared_ptr<Instance>&,
+            const SubscriberRecord&,
+            const Ice::ObjectPrx&,
+            int,
+            Ice::ObjectPrx);
+
+        void flush() override;
+
+        // Called on the flush timer to deliver the queued events as a single batch.
+        void doFlush();
+
+    private:
+        // Called once the batch has been written to the transport.
+        void batchSent();
+
+        const Ice::ObjectPrx _obj;
+        const std::chrono::milliseconds _interval;
+    };
+
     class SubscriberOneway final : public Subscriber
     {
     public:
@@ -132,6 +155,119 @@ namespace
     private:
         const TopicLinkPrx _obj;
     };
+}
+
+SubscriberBatch::SubscriberBatch(
+    const shared_ptr<Instance>& instance,
+    const SubscriberRecord& rec,
+    const Ice::ObjectPrx& proxy,
+    int retryCount,
+    Ice::ObjectPrx obj)
+    : Subscriber(instance, rec, proxy, retryCount, 1),
+      _obj(std::move(obj)),
+      _interval(instance->flushInterval())
+{
+}
+
+void
+SubscriberBatch::flush()
+{
+    lock_guard lock(_mutex);
+
+    //
+    // If the subscriber isn't online, or there's nothing to send, we're done.
+    //
+    if (_state != SubscriberStateOnline || _events.empty())
+    {
+        return;
+    }
+
+    // Defer delivery: accumulate events and send them together when the flush timer fires. _outstanding doubles as a
+    // "flush already scheduled or in flight" guard, so at most one flush is pending at a time (_maxOutstanding is 1).
+    if (_outstanding == 0)
+    {
+        ++_outstanding;
+        auto self = static_pointer_cast<SubscriberBatch>(shared_from_this());
+        _instance->batchFlusher()->schedule([self] { self->doFlush(); }, _interval);
+    }
+}
+
+void
+SubscriberBatch::doFlush()
+{
+    lock_guard lock(_mutex);
+
+    if (_state != SubscriberStateOnline)
+    {
+        // The subscriber went offline or errored (e.g. the send queue filled up) after this flush was scheduled but
+        // before it ran: release the flush reservation and wake a waiting shutdown().
+        --_outstanding;
+        assert(_outstanding >= 0 && _outstanding < _maxOutstanding);
+        if (_events.empty() && _shutdown)
+        {
+            _condVar.notify_one();
+        }
+        return;
+    }
+
+    EventDataSeq v;
+    v.swap(_events);
+    assert(!v.empty());
+
+    if (_observer)
+    {
+        _outstandingCount = static_cast<int>(v.size());
+        _observer->outstanding(_outstandingCount);
+    }
+
+    try
+    {
+        // Queue the events on the batch proxy, then flush them to the transport as a single batch request.
+        vector<byte> dummy;
+        for (const auto& e : v)
+        {
+            _obj->ice_invoke(e.op, e.mode, e.data, dummy, e.context);
+        }
+
+        auto self = static_pointer_cast<SubscriberBatch>(shared_from_this());
+        _obj->ice_flushBatchRequestsAsync(
+            [self](exception_ptr ex) { self->error(true, ex); },
+            [self](bool) { self->batchSent(); });
+    }
+    catch (...)
+    {
+        // Catch everything, not just std::exception: a configured batch-request interceptor can throw a
+        // non-std::exception, which BatchRequestQueue rethrows. Letting it escape would leave _outstanding at 1 and
+        // hang shutdown().
+        error(true, current_exception());
+    }
+}
+
+void
+SubscriberBatch::batchSent()
+{
+    lock_guard lock(_mutex);
+
+    // The batch has been written to the transport; the flush is no longer outstanding.
+    --_outstanding;
+    assert(_outstanding >= 0 && _outstanding < _maxOutstanding);
+    if (_observer)
+    {
+        _observer->delivered(_outstandingCount);
+    }
+
+    // A successful send means the subscriber is reachable, so reset the consecutive-retry count.
+    _currentRetry = 0;
+
+    if (_events.empty() && _outstanding == 0 && _shutdown)
+    {
+        _condVar.notify_one();
+    }
+    else if (!_events.empty())
+    {
+        // More events were queued while the batch was in flight; schedule the next flush.
+        flush();
+    }
 }
 
 SubscriberOneway::SubscriberOneway(
@@ -466,17 +602,6 @@ Subscriber::create(const shared_ptr<Instance>& instance, const SubscriberRecord&
             newObj = newObj->ice_connectionCached(*value > 0);
         }
 
-        if (newObj->ice_isBatchOneway())
-        {
-            // Use Oneway in case of Batch Oneway
-            newObj = newObj->ice_oneway();
-        }
-        else if (newObj->ice_isBatchDatagram())
-        {
-            // Use Datagram in case of Batch Datagram
-            newObj = newObj->ice_datagram();
-        }
-
         shared_ptr<Subscriber> subscriber;
         if (reliability == "ordered")
         {
@@ -489,6 +614,10 @@ Subscriber::create(const shared_ptr<Instance>& instance, const SubscriberRecord&
         else if (newObj->ice_isOneway() || newObj->ice_isDatagram())
         {
             subscriber = make_shared<SubscriberOneway>(instance, rec, proxy, retryCount, newObj);
+        }
+        else if (newObj->ice_isBatchOneway() || newObj->ice_isBatchDatagram())
+        {
+            subscriber = make_shared<SubscriberBatch>(instance, rec, proxy, retryCount, newObj);
         }
         else // if(newObj->ice_isTwoway())
         {
@@ -725,6 +854,11 @@ Subscriber::error(bool dec, exception_ptr e)
     {
         hardError = false;
         what = ex.what();
+    }
+    catch (...)
+    {
+        hardError = false;
+        what = "unknown exception";
     }
 
     //

--- a/cpp/test/IceStorm/single/Subscriber.cpp
+++ b/cpp/test/IceStorm/single/Subscriber.cpp
@@ -96,6 +96,35 @@ private:
     condition_variable _condVar;
 };
 
+// A minimal servant that counts the events it receives; used to check that a batch subscriber defers delivery.
+class CountingSingleI final : public Single
+{
+public:
+    void event(int, const Current&) override
+    {
+        lock_guard<mutex> lg(_mutex);
+        ++_count;
+        _condVar.notify_all();
+    }
+
+    int count()
+    {
+        lock_guard<mutex> lg(_mutex);
+        return _count;
+    }
+
+    void waitForCount(int n)
+    {
+        unique_lock<mutex> lock(_mutex);
+        test(_condVar.wait_for(lock, 30s, [&] { return _count >= n; }));
+    }
+
+private:
+    int _count{0};
+    mutex _mutex;
+    condition_variable _condVar;
+};
+
 class Subscriber final : public Test::TestHelper
 {
 public:
@@ -246,6 +275,45 @@ Subscriber::run(int argc, char** argv)
     {
         p->waitForEvents();
     }
+
+    //
+    // Verify that a batch subscriber actually batches: its events must be coalesced and delivered together when the
+    // IceStorm.Flush.Timeout timer fires, not one at a time like a plain oneway subscriber. A plain oneway subscriber
+    // on the same topic serves as a checkpoint: once it has received every event, a batch subscriber must still have
+    // received nothing, because its events are queued until the next flush.
+    //
+    cout << "testing batch delivery ... " << flush;
+    {
+        auto batchTopic = manager->create("batch");
+
+        auto onewayCounter = make_shared<CountingSingleI>();
+        batchTopic->subscribeAndGetPublisher(IceStorm::QoS(), adapter->addWithUUID(onewayCounter)->ice_oneway());
+
+        auto batchCounter = make_shared<CountingSingleI>();
+        auto batchObject = adapter->addWithUUID(batchCounter)->ice_batchOneway();
+        batchTopic->subscribeAndGetPublisher(IceStorm::QoS(), batchObject);
+
+        const int count = 20;
+        auto publisher = uncheckedCast<SinglePrx>(batchTopic->getPublisher()->ice_twoway());
+        const auto start = chrono::steady_clock::now();
+        for (int i = 0; i < count; ++i)
+        {
+            publisher->event(i);
+        }
+
+        onewayCounter->waitForCount(count);
+        // The zero check is only meaningful while this run is still within the 1s IceStorm.Flush.Timeout window: on a
+        // slow machine the flush may already have fired. Skip the check rather than fail it.
+        if (chrono::steady_clock::now() - start < 500ms)
+        {
+            test(batchCounter->count() == 0);
+        }
+        batchCounter->waitForCount(count);
+
+        batchTopic->destroy();
+    }
+
+    cout << "ok" << endl;
 }
 
 DEFINE_TEST(Subscriber)

--- a/cpp/test/IceUtil/timer/Client.cpp
+++ b/cpp/test/IceUtil/timer/Client.cpp
@@ -132,6 +132,27 @@ private:
 };
 using DestroyTaskPtr = std::shared_ptr<DestroyTask>;
 
+// A task whose destructor re-enters the timer by cancelling another task. This mirrors the shutdown scenario where
+// destroying a scheduled task drops the last reference to a connection, whose own destructor cancels its idle-timeout
+// task. Timer::destroy() must not run such a destructor while holding its internal lock.
+class ReentrantCancelTask final : public TimerTask
+{
+public:
+    ReentrantCancelTask(IceInternal::TimerPtr timer, TimerTaskPtr other)
+        : _timer(std::move(timer)),
+          _other(std::move(other))
+    {
+    }
+
+    ~ReentrantCancelTask() override { _timer->cancel(_other); }
+
+    void runTimerTask() override {}
+
+private:
+    const IceInternal::TimerPtr _timer;
+    const TimerTaskPtr _other;
+};
+
 class Client : public Test::TestHelper
 {
 public:
@@ -256,6 +277,21 @@ Client::run(int, char*[])
                 // Expected;
             }
         }
+    }
+    cout << "ok" << endl;
+
+    cout << "testing timer destroy with a re-entrant cancel... " << flush;
+    {
+        auto timer = make_shared<IceInternal::Timer>();
+        auto other = make_shared<TestTask>();
+        timer->schedule(other, chrono::hours(1));
+        {
+            auto reentrant = make_shared<ReentrantCancelTask>(timer, other);
+            timer->schedule(reentrant, chrono::hours(1));
+        }
+        // 'reentrant' is now referenced only by the timer. Destroying the timer runs its destructor, which cancels
+        // 'other'; this must complete without deadlocking.
+        timer->destroy();
     }
     cout << "ok" << endl;
 }


### PR DESCRIPTION
Fixes #5964.

Batch oneway and batch datagram subscribers stopped being delivered in batches after the 2020 C++17 port: the subscriber's proxy was silently downgraded to a plain oneway/datagram proxy at subscription time, and the timer-driven flush was removed. Everything around the feature survived — the `IceStorm.Flush.Timeout` property, the IceGrid templates, and the `federation2` batch test — so the downgrade went unnoticed.

This reinstates `SubscriberBatch` on the current subscriber architecture: it keeps the batch proxy, accumulates events, and flushes them together every `IceStorm.Flush.Timeout` milliseconds on a dedicated instance flusher timer. The flusher is destroyed in `Instance::destroy()` (after the subscribers are drained) rather than `Instance::shutdown()`, so a pending flush can still complete during teardown. A misconfigured negative `IceStorm.Flush.Timeout` is clamped to the default with a warning.

### Includes the `Timer::destroy()` deadlock fix (also up as #6022)

Restoring batch delivery surfaced a latent core deadlock in `Timer::destroy()` — that's the first commit on this branch, and it's up for review on its own in #6022. It's included here so the batch subscriber tests don't deadlock on shutdown in CI; once #6022 merges to `main`, this branch rebases and that commit drops out.

Verified: the full IceStorm test suite (single, federation2 batch phases across all subcases, rep/stress) and the core `Ice/timeout`, `Ice/idleTimeout`, `Ice/ami`, and `Ice/background` tests all pass.