### PR TITLE
Fix broken webpack minification link in js/README.md

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -63,5 +63,5 @@ configured to drop `console.assert` via `drop_console` in [terser options].
 [esbuild]: https://esbuild.github.io/
 [esbuild-drop]: https://esbuild.github.io/api/#drop
 [@rollup/plugin-strip]: https://github.com/rollup/plugins/tree/master/packages/strip
-[webpack-js-minification]: https://docs.webpack.js.org/guides/production#javascript-minification
+[webpack-js-minification]: https://webpack.js.org/guides/production/#minification
 [terser options]: https://terser.org/docs/options/


### PR DESCRIPTION
The `js/README.md` link to webpack's JavaScript minification guide points at a non-existent `docs.webpack.js.org` subdomain and a stale anchor, so the `Check Links` CI job fails (404) on every PR:

```
Errors in js/README.md
* [404] https://docs.webpack.js.org/guides/production#javascript-minification
```

Webpack's docs live at `webpack.js.org` and the section anchor is `#minification`. Updated the link to:

```
https://webpack.js.org/guides/production/#minification
```

This link has been broken since #5326 (2026-05-12); webpack appears to have since retired the `docs.` subdomain, which is why the repo-wide link check now fails on unrelated PRs.