### PR TITLE
Add a bcrypt regression test for the Glacier2 Crypt permissions verifier

### DIFF
--- a/cpp/test/Glacier2/router/Client.cpp
+++ b/cpp/test/Glacier2/router/Client.cpp
@@ -8,6 +8,12 @@
 #include <random>
 #include <thread>
 
+#if defined(__GLIBC__)
+#    include <crypt.h>
+#elif defined(__FreeBSD__)
+#    include <unistd.h>
+#endif
+
 using namespace std;
 using namespace std::chrono_literals;
 using namespace Ice;
@@ -428,6 +434,50 @@ CallbackClient::run(int argc, char** argv)
         {
             cout << "ok" << endl;
         }
+    }
+
+    {
+        cout << "testing bcrypt password verification... " << flush;
+
+        // Known-answer bcrypt hash of "abc123" (cost 4); Glacier2Util.py puts the same entry in the password file.
+        const string bcryptHash = "$2b$04$cVv0r3VdmM5qjmJwUjDIne19WwQxB6Q8Py8MKRRDtcSU9Fo0ESRiK";
+#if defined(__GLIBC__) || defined(__FreeBSD__)
+        // The native crypt library supports bcrypt only in some configurations (for glibc, it comes with libxcrypt).
+        // Probe it directly: a probe through createSession would report a broken verifier as "bcrypt unsupported"
+        // and skip the very regression this test guards against.
+        struct crypt_data data;
+        data.initialized = 0;
+        const char* hashed = crypt_r("abc123", bcryptHash.c_str(), &data);
+        if (hashed != nullptr && bcryptHash == hashed)
+        {
+            router->createSession("bcryptuser", "abc123");
+            router->destroySession();
+            try
+            {
+                router->createSession("bcryptuser", "xxx");
+                test(false);
+            }
+            catch (const Glacier2::PermissionDeniedException&)
+            {
+            }
+            cout << "ok" << endl;
+        }
+        else
+        {
+            cout << "skipped (the crypt library does not support bcrypt)" << endl;
+        }
+#else
+        // bcrypt password hashes are not supported on this platform: the correct password must be denied.
+        try
+        {
+            router->createSession("bcryptuser", "abc123");
+            test(false);
+        }
+        catch (const Glacier2::PermissionDeniedException&)
+        {
+        }
+        cout << "ok" << endl;
+#endif
     }
 
     {

--- a/cpp/test/Glacier2/router/Makefile.mk
+++ b/cpp/test/Glacier2/router/Makefile.mk
@@ -3,6 +3,10 @@
 $(project)_client_sources = Client.cpp CallbackI.cpp Callback.ice
 $(project)_client_dependencies = Glacier2
 
+ifeq ($(os),Linux)
+    $(project)_client_ldflags = -lcrypt
+endif
+
 $(project)_server_sources = Server.cpp CallbackI.cpp Callback.ice
 
 tests += $(project)

--- a/scripts/Glacier2Util.py
+++ b/scripts/Glacier2Util.py
@@ -16,6 +16,11 @@ from Util import (
 
 
 class Glacier2Router(ProcessFromBinDir, ProcessIsReleaseOnly, Server):
+    # icehashpassword.py only emits sha512-crypt (Linux) and PBKDF2-sha256 (macOS/Windows), so schemes like
+    # bcrypt need pre-hashed entries. This is a known-answer bcrypt hash of "abc123" (cost 4); the
+    # Glacier2/router test authenticates against it where the native crypt library supports bcrypt.
+    hashedPasswords = {"bcryptuser": "$2b$04$cVv0r3VdmM5qjmJwUjDIne19WwQxB6Q8Py8MKRRDtcSU9Fo0ESRiK"}
+
     def __init__(self, portnum=50, passwords={"userid": "abc123"}, *args, **kargs):
         Server.__init__(
             self,
@@ -55,6 +60,9 @@ class Glacier2Router(ProcessFromBinDir, ProcessIsReleaseOnly, Server):
                             run(command, stdin=(password + "\r\n").encode("UTF-8")),
                         )
                     )
+
+                for user, hashedPassword in self.hashedPasswords.items():
+                    file.write("%s %s\n" % (user, hashedPassword))
             current.files.append(path)
 
     def getProps(self, current):


### PR DESCRIPTION
The Glacier2 Crypt permissions verifier is exercised end-to-end by the `Glacier2/router` test, but the password file is generated by `icehashpassword.py`, which only emits sha512-crypt (Linux) and PBKDF2-sha256 (macOS/Windows) — so the bcrypt verify path had no coverage, which is how #5862 went unnoticed.

- `Glacier2Util.py` now appends pre-hashed entries to the generated password file, with a pinned known-answer bcrypt entry (`bcryptuser`, `$2b$` hash of "abc123" at cost 4).
- The `Glacier2/router` test verifies it: where the platform uses the native crypt library (`__GLIBC__ || __FreeBSD__`, matching the verifier's own compile condition, so musl is excluded), the correct password must create a session and a wrong one must be denied. The skip-probe calls `crypt_r` directly with the pinned hash, so a crypt library without bcrypt support skips the assertion but a broken verifier cannot masquerade as "unsupported". On macOS and Windows, where bcrypt is not supported by design, the test asserts the correct password is denied.

The pinned hash was verified against glibc/libxcrypt (correct password reproduces the hash, wrong one doesn't), so CI runners with libxcrypt run the positive assertion rather than skipping.

Fixes #5934.

🤖 Generated with [Claude Code](https://claude.com/claude-code)