### PR TITLE
Throw MarshalException on a null getLinkProxy result in IceStorm link()

### DIFF
--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -618,7 +618,12 @@ TopicImpl::link(const TopicPrx& topic, int cost)
 {
     auto internal = Ice::uncheckedCast<TopicInternalPrx>(topic);
     optional<TopicLinkPrx> link = internal->getLinkProxy();
-    assert(link);
+    if (!link)
+    {
+        // A conforming peer always returns a non-null TopicLink; a null result would be dereferenced when
+        // constructing the SubscriberLink.
+        throw Ice::MarshalException{__FILE__, __LINE__, "getLinkProxy returned a null proxy"};
+    }
 
     auto traceLevels = _instance->traceLevels();
     if (traceLevels->topic > 0)

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -620,8 +620,8 @@ TopicImpl::link(const TopicPrx& topic, int cost)
     optional<TopicLinkPrx> link = internal->getLinkProxy();
     if (!link)
     {
-        // A conforming peer always returns a non-null TopicLink; a null result would be dereferenced when
-        // constructing the SubscriberLink.
+        // Defense in depth: getLinkProxy never returns a null proxy. Once proxies can be declared
+        // non-null in Slice (#5209), this check will be performed automatically during unmarshaling.
         throw Ice::MarshalException{__FILE__, __LINE__, "getLinkProxy returned a null proxy"};
     }
 

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -231,8 +231,8 @@ TransientTopicImpl::link(optional<TopicPrx> topic, int cost, const Ice::Current&
     auto link = internal->getLinkProxy();
     if (!link)
     {
-        // A conforming peer always returns a non-null TopicLink; a null result would be dereferenced when
-        // constructing the SubscriberLink.
+        // Defense in depth: getLinkProxy never returns a null proxy. Once proxies can be declared
+        // non-null in Slice (#5209), this check will be performed automatically during unmarshaling.
         throw Ice::MarshalException{__FILE__, __LINE__, "getLinkProxy returned a null proxy"};
     }
 

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -229,6 +229,12 @@ TransientTopicImpl::link(optional<TopicPrx> topic, int cost, const Ice::Current&
     checkNotNull(topic, __FILE__, __LINE__, current);
     auto internal = Ice::uncheckedCast<TopicInternalPrx>(*topic);
     auto link = internal->getLinkProxy();
+    if (!link)
+    {
+        // A conforming peer always returns a non-null TopicLink; a null result would be dereferenced when
+        // constructing the SubscriberLink.
+        throw Ice::MarshalException{__FILE__, __LINE__, "getLinkProxy returned a null proxy"};
+    }
 
     auto traceLevels = _instance->traceLevels();
     if (traceLevels->topic > 0)


### PR DESCRIPTION
Fixes an assert-only / unchecked null-proxy dereference in IceStorm topic linking.

`getLinkProxy` is expected to return the topic's non-null `TopicLink` proxy. Both `link()` implementations let a null result from a non-conforming peer flow into the `SubscriberLink` constructor, which dereferences it (`rec.obj->ice_invocationTimeout(...)`) — undefined behavior in release builds:

- **Persistent** `TopicImpl::link` — guarded only by `assert(link)`, which is elided under `NDEBUG`.
- **Transient** `TransientTopicImpl::link` — no check at all.

Both paths now check the result and throw `Ice::MarshalException`, matching Ice's own `throwNullProxyMarshalException` handling of an unexpected null proxy. Only reachable against a non-conforming/malicious peer; the normal non-null path is unchanged.

Reviewed with an independent Codex pass (data-flow trace to the `SubscriberLink` deref, exception hierarchy, and a search confirming these are the only two `getLinkProxy` consumers).

Closes #5957