### PR TITLE
Reject non-canonical IPv4 address forms in the Glacier2 address filters

### DIFF
--- a/changelog.d/service-glacier2/address-filter-host-forms.md
+++ b/changelog.d/service-glacier2/address-filter-host-forms.md
@@ -1,8 +1,8 @@
 - When address filters are configured (`Glacier2.Filter.Address.Accept` or `Glacier2.Filter.Address.Reject`), the
-  Glacier2 router now rejects a proxy when any of its endpoints has a host that writes an IPv4 address in an
-  alternative numeric form: for example, `0x7f000001`, `2130706433`, and `127.1` are all alternative forms of
-  `127.0.0.1`. The filter rules match the host as a string, so a host in such a form matched neither the Accept
-  nor the Reject rules written for the usual dotted-quad form.
+  Glacier2 router now rejects a proxy when any of its endpoints has a host that writes an IPv4 address in a
+  non-canonical form: for example, `0x7f000001`, `2130706433`, and `127.1` are all non-canonical forms of
+  `127.0.0.1`. The filter rules match the host as a string, so previously a host in such a form matched neither
+  the Accept nor the Reject rules written for the usual dotted-quad form.
 
 - The Glacier2 address filters now ignore the trailing dot of a fully-qualified DNS name, in the endpoint host and
   in the Accept and Reject rules alike: a rule written for `backend.example.com` matches the host

--- a/changelog.d/service-glacier2/address-filter-host-forms.md
+++ b/changelog.d/service-glacier2/address-filter-host-forms.md
@@ -1,0 +1,10 @@
+- When address filters are configured (`Glacier2.Filter.Address.Accept` or `Glacier2.Filter.Address.Reject`), the
+  Glacier2 router now rejects a proxy when any of its endpoints has a host that writes an IPv4 address in an
+  alternative numeric form: for example, `0x7f000001`, `2130706433`, and `127.1` are all alternative forms of
+  `127.0.0.1`. The filter rules match the host as a string, so a host in such a form matched neither the Accept
+  nor the Reject rules written for the usual dotted-quad form.
+
+- The Glacier2 address filters now ignore the trailing dot of a fully-qualified DNS name, in the endpoint host and
+  in the Accept and Reject rules alike: a rule written for `backend.example.com` matches the host
+  `backend.example.com.`, and vice versa. Previously, the host and the rule matched only when both spelled the
+  trailing dot the same way.

--- a/changelog.d/service-glacier2/address-filter-host-normalization.md
+++ b/changelog.d/service-glacier2/address-filter-host-normalization.md
@@ -1,0 +1,5 @@
+- Improved the Glacier2 address filters, `Glacier2.Filter.Address.Accept` and `Glacier2.Filter.Address.Reject`: the
+  filters now normalize the host of each endpoint before matching it, so that all equivalent spellings of the same
+  host match the same rules. The normalization removes the trailing dot of a fully-qualified DNS name and converts
+  IPv4 address literals to canonical dotted-quad form. Write IPv4 rules in canonical form (`127.0.0.1`): a rule
+  spelled in a non-canonical form no longer matches.

--- a/changelog.d/service-glacier2/address-filter-host-normalization.md
+++ b/changelog.d/service-glacier2/address-filter-host-normalization.md
@@ -1,5 +1,5 @@
-- Improved the Glacier2 address filters, `Glacier2.Filter.Address.Accept` and `Glacier2.Filter.Address.Reject`: the
-  filters now normalize the host of each endpoint before matching it, so that all equivalent spellings of the same
-  host match the same rules. The normalization removes the trailing dot of a fully-qualified DNS name and converts
-  IPv4 address literals to canonical dotted-quad form. Write IPv4 rules in canonical form (`127.0.0.1`): a rule
-  spelled in a non-canonical form no longer matches.
+- Improved address filtering in the Glacier2 router. The router now normalizes the host of each endpoint before
+  matching it against the `Glacier2.Filter.Address.Accept` and `Glacier2.Filter.Address.Reject` rules, so that a
+  rule matches every equivalent spelling of the host it specifies. This normalization removes the trailing dot of
+  a fully-qualified DNS name and converts IPv4 address literals to canonical dotted-quad form (for example, `0x7f.1`
+  becomes `127.0.0.1`).

--- a/changelog.d/service-glacier2/address-filter-host-normalization.md
+++ b/changelog.d/service-glacier2/address-filter-host-normalization.md
@@ -1,5 +1,0 @@
-- Improved address filtering in the Glacier2 router. The router now normalizes the host of each endpoint before
-  matching it against the `Glacier2.Filter.Address.Accept` and `Glacier2.Filter.Address.Reject` rules, so that a
-  rule matches every equivalent spelling of the host it specifies. This normalization removes the trailing dot of
-  a fully-qualified DNS name and converts IPv4 address literals to canonical dotted-quad form (for example, `0x7f.1`
-  becomes `127.0.0.1`).

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -518,7 +518,7 @@ namespace Glacier2
 
         // The leading parts are single bytes; the last part covers the remaining bytes.
         uint32_t address = 0;
-        for (vector<unsigned long>::size_type i = 0; i + 1 < parts.size(); ++i)
+        for (size_t i = 0; i + 1 < parts.size(); ++i)
         {
             if (parts[i] > 0xFF)
             {
@@ -651,7 +651,7 @@ namespace Glacier2
             {
                 host.pop_back();
             }
-            if (optional<string> canonical = canonicalIPv4Address(host))
+            else if (optional<string> canonical = canonicalIPv4Address(host))
             {
                 host = *canonical;
             }

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -500,7 +500,7 @@ namespace Glacier2
             char* end;
             errno = 0;
             unsigned long value = strtoul(p, &end, 0);
-            if (errno == ERANGE || value > 0xFFFFFFFF)
+            if (errno == ERANGE || value > UINT32_MAX)
             {
                 return nullopt;
             }

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -4,11 +4,8 @@
 #include "../Ice/ConsoleUtil.h"
 #include "Ice/StringUtil.h"
 
+#include <algorithm>
 #include <cctype>
-#include <cerrno>
-#include <cstdint>
-#include <cstdlib>
-#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -482,74 +479,95 @@ namespace Glacier2
         return true;
     }
 
-    // Parses host as an IPv4 address literal, accepting every form the resolver accepts (the inet_aton
-    // grammar): one to four '.'-separated parts, each decimal, octal (leading 0), or hexadecimal (leading 0x),
-    // with the last part supplying the remaining bytes of the address. Returns the address in canonical
-    // dotted-quad form, or nullopt when host is not an IPv4 address literal.
-    static optional<string> canonicalIPv4Address(const string& host)
+    // Splits host into its '.'-separated parts.
+    static vector<string> splitHost(const string& host)
     {
-        vector<unsigned long> parts;
-        const char* p = host.c_str();
+        vector<string> parts;
+        string::size_type start = 0;
         while (true)
         {
-            // Each part must start with a digit; strtoul alone would also accept whitespace and signs.
-            if (!isdigit(static_cast<unsigned char>(*p)))
-            {
-                return nullopt;
-            }
-            char* end;
-            errno = 0;
-            unsigned long value = strtoul(p, &end, 0);
-            if (errno == ERANGE || value > UINT32_MAX)
-            {
-                return nullopt;
-            }
-            parts.push_back(value);
-            if (*end == '\0')
+            string::size_type dot = host.find('.', start);
+            parts.push_back(host.substr(start, dot == string::npos ? string::npos : dot - start));
+            if (dot == string::npos)
             {
                 break;
             }
-            if (*end != '.' || parts.size() == 4)
-            {
-                return nullopt;
-            }
-            p = end + 1;
+            start = dot + 1;
         }
-
-        // The leading parts are single bytes; the last part covers the remaining bytes.
-        uint32_t address = 0;
-        for (size_t i = 0; i + 1 < parts.size(); ++i)
-        {
-            if (parts[i] > 0xFF)
-            {
-                return nullopt;
-            }
-            address |= static_cast<uint32_t>(parts[i]) << (8 * (3 - i));
-        }
-        unsigned long last = parts.back();
-        int lastSize = 5 - static_cast<int>(parts.size()); // in bytes
-        if (lastSize < 4 && last >= (1ul << (8 * lastSize)))
-        {
-            return nullopt;
-        }
-        address |= static_cast<uint32_t>(last);
-
-        ostringstream os;
-        os << ((address >> 24) & 0xFF) << '.' << ((address >> 16) & 0xFF) << '.' << ((address >> 8) & 0xFF) << '.'
-           << (address & 0xFF);
-        return os.str();
+        return parts;
     }
 
-    // Returns true when an endpoint of the proxy has a host longer than 255 characters. No legal host name or
-    // IP address is that long, and the bound keeps the cost of matching the address rules low.
-    static bool hasOversizedHost(const ObjectPrx& proxy)
+    // Returns true when every '.'-separated part of host is a numeral (digits, or hexadecimal digits with a
+    // 0x prefix): the host spells an IPv4 address in one of the many forms resolvers accept. This is a check
+    // on the spelling, not the value: a digit-only part covers the decimal and octal (leading zero) readings
+    // alike.
+    static bool isIPv4Numeral(const string& host)
+    {
+        for (const string& part : splitHost(host))
+        {
+            bool digitsOnly =
+                !part.empty() && all_of(part.begin(), part.end(), [](unsigned char c) { return isdigit(c) != 0; });
+            bool hex = part.size() > 2 && part[0] == '0' && (part[1] == 'x' || part[1] == 'X') &&
+                       all_of(part.begin() + 2, part.end(), [](unsigned char c) { return isxdigit(c) != 0; });
+            if (!digitsOnly && !hex)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Returns true when host is the canonical spelling of an IPv4 address: four decimal parts, each between 0
+    // and 255, with no leading zero.
+    static bool isCanonicalIPv4Spelling(const string& host)
+    {
+        vector<string> parts = splitHost(host);
+        if (parts.size() != 4)
+        {
+            return false;
+        }
+        for (const string& part : parts)
+        {
+            bool digitsOnly =
+                !part.empty() && all_of(part.begin(), part.end(), [](unsigned char c) { return isdigit(c) != 0; });
+            if (!digitsOnly || part.size() > 3 || (part.size() > 1 && part[0] == '0') || stoi(part) > 255)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Returns true when an endpoint of the proxy has a host that the address rules cannot match reliably; such
+    // a proxy is rejected outright:
+    // - A host longer than 255 characters. No legal host name or IP address is that long, and the bound keeps
+    //   the cost of matching the address rules low.
+    // - A non-canonical spelling of an IPv4 address, such as 0x7f000001, 2130706433, 0177.0.0.1, or 127.1.
+    //   The resolver accepts many aliases for the same address (with platform-dependent readings), so the
+    //   spelling would bypass rules written for the dotted quad.
+    // - An IPv4 address with a trailing dot: the resolver reads it as a DNS name, not as an address.
+    // A DNS name with a trailing dot is fine: the resolver treats 'name.' as 'name', and the matching strips
+    // the dot the same way.
+    static bool hasDisallowedHost(const ObjectPrx& proxy)
     {
         for (const auto& endpoint : proxy->ice_getEndpoints())
         {
             string host;
-            if (extractPart("-h ", endpoint->toString(), host) && host.size() > 255)
+            if (extractPart("-h ", endpoint->toString(), host))
             {
-                return true;
+                if (host.size() > 255)
+                {
+                    return true;
+                }
+                bool trailingDot = host.size() > 1 && host.back() == '.';
+                if (trailingDot)
+                {
+                    host.pop_back();
+                }
+                if (isIPv4Numeral(host) && (trailingDot || !isCanonicalIPv4Spelling(host)))
+                {
+                    return true;
+                }
             }
         }
         return false;
@@ -644,16 +662,11 @@ namespace Glacier2
             // Host names are case-insensitive; the rule was folded to lower case when parsed.
             host = toLower(host);
 
-            // Normalize the host so that a rule cannot be bypassed with an equivalent but different spelling
-            // of the same host: drop the trailing dot of a fully-qualified DNS name, and put an IPv4 address
-            // literal in canonical dotted-quad form.
+            // The resolver treats the fully-qualified name 'name.' as 'name'; strip the trailing dot so the
+            // spelling matches the rules written for 'name'.
             if (host.size() > 1 && host.back() == '.')
             {
                 host.pop_back();
-            }
-            else if (optional<string> canonical = canonicalIPv4Address(host))
-            {
-                host = *canonical;
             }
 
             string port;
@@ -801,6 +814,13 @@ namespace Glacier2
                 // Host names are case-insensitive; fold the rule to lower case and match it against the
                 // lower-cased host.
                 addr = toLower(addr);
+
+                // The trailing dot of a fully-qualified name is stripped from the host before matching; strip
+                // it from the rule the same way.
+                if (addr.size() > 1 && addr.back() == '.')
+                {
+                    addr.pop_back();
+                }
 
                 //
                 // The addr portion can contain alphanumerics, * and
@@ -1056,7 +1076,7 @@ Glacier2::ProxyVerifier::verify(const ObjectPrx& proxy)
 
     bool result = false;
 
-    if (Glacier2::hasOversizedHost(proxy))
+    if (Glacier2::hasDisallowedHost(proxy))
     {
         // Rejected regardless of the configured rules.
     }

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -4,6 +4,11 @@
 #include "../Ice/ConsoleUtil.h"
 #include "Ice/StringUtil.h"
 
+#include <cctype>
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -477,6 +482,64 @@ namespace Glacier2
         return true;
     }
 
+    // Parses host as an IPv4 address literal, accepting every form the resolver accepts (the inet_aton
+    // grammar): one to four '.'-separated parts, each decimal, octal (leading 0), or hexadecimal (leading 0x),
+    // with the last part supplying the remaining bytes of the address. Returns the address in canonical
+    // dotted-quad form, or nullopt when host is not an IPv4 address literal.
+    static optional<string> canonicalIPv4Address(const string& host)
+    {
+        vector<unsigned long> parts;
+        const char* p = host.c_str();
+        while (true)
+        {
+            // Each part must start with a digit; strtoul alone would also accept whitespace and signs.
+            if (!isdigit(static_cast<unsigned char>(*p)))
+            {
+                return nullopt;
+            }
+            char* end;
+            errno = 0;
+            unsigned long value = strtoul(p, &end, 0);
+            if (errno == ERANGE || value > 0xFFFFFFFF)
+            {
+                return nullopt;
+            }
+            parts.push_back(value);
+            if (*end == '\0')
+            {
+                break;
+            }
+            if (*end != '.' || parts.size() == 4)
+            {
+                return nullopt;
+            }
+            p = end + 1;
+        }
+
+        // The leading parts are single bytes; the last part covers the remaining bytes.
+        uint32_t address = 0;
+        for (vector<unsigned long>::size_type i = 0; i + 1 < parts.size(); ++i)
+        {
+            if (parts[i] > 0xFF)
+            {
+                return nullopt;
+            }
+            address |= static_cast<uint32_t>(parts[i]) << (8 * (3 - i));
+        }
+        unsigned long last = parts.back();
+        int lastSize = 5 - static_cast<int>(parts.size()); // in bytes
+        if (lastSize < 4 && last >= (1ul << (8 * lastSize)))
+        {
+            return nullopt;
+        }
+        address |= static_cast<uint32_t>(last);
+
+        ostringstream os;
+        os << ((address >> 24) & 0xFF) << '.' << ((address >> 16) & 0xFF) << '.' << ((address >> 8) & 0xFF) << '.'
+           << (address & 0xFF);
+        return os.str();
+    }
+
     // Returns true when an endpoint of the proxy has a host longer than 255 characters. No legal host name or
     // IP address is that long, and the bound keeps the cost of matching the address rules low.
     static bool hasOversizedHost(const ObjectPrx& proxy)
@@ -580,6 +643,19 @@ namespace Glacier2
             }
             // Host names are case-insensitive; the rule was folded to lower case when parsed.
             host = toLower(host);
+
+            // Normalize the host so that a rule cannot be bypassed with an equivalent but different spelling
+            // of the same host: drop the trailing dot of a fully-qualified DNS name, and put an IPv4 address
+            // literal in canonical dotted-quad form.
+            if (host.size() > 1 && host.back() == '.')
+            {
+                host.pop_back();
+            }
+            if (optional<string> canonical = canonicalIPv4Address(host))
+            {
+                host = *canonical;
+            }
+
             string port;
             if (!extractPart("-p ", info, port))
             {

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -518,7 +518,7 @@ namespace Glacier2
     }
 
     // Returns true when host is the canonical spelling of an IPv4 address: four decimal parts, each between 0
-    // and 255, with no leading zero.
+    // and 255, with no leading zeros.
     static bool isCanonicalIPv4Spelling(const string& host)
     {
         vector<string> parts = splitHost(host);

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -497,17 +497,17 @@ namespace Glacier2
         return parts;
     }
 
-    // Returns true when every '.'-separated part of host is a numeral (digits, or hexadecimal digits with a
-    // 0x prefix): the host spells an IPv4 address in one of the many forms resolvers accept. This is a check
-    // on the spelling, not the value: a digit-only part covers the decimal and octal (leading zero) readings
-    // alike.
+    // Returns true when every '.'-separated part of host is a numeral (digits, or a 0x prefix followed by
+    // hexadecimal digits): the host spells an IPv4 address in one of the many forms resolvers accept. This is
+    // a check on the spelling, not the value: a digit-only part covers the decimal and octal (leading zero)
+    // readings alike, and a bare 0x with no digits reads as 0.
     static bool isIPv4Numeral(const string& host)
     {
         for (const string& part : splitHost(host))
         {
             bool digitsOnly =
                 !part.empty() && all_of(part.begin(), part.end(), [](unsigned char c) { return isdigit(c) != 0; });
-            bool hex = part.size() > 2 && part[0] == '0' && (part[1] == 'x' || part[1] == 'X') &&
+            bool hex = part.size() >= 2 && part[0] == '0' && (part[1] == 'x' || part[1] == 'X') &&
                        all_of(part.begin() + 2, part.end(), [](unsigned char c) { return isxdigit(c) != 0; });
             if (!digitsOnly && !hex)
             {
@@ -538,8 +538,8 @@ namespace Glacier2
         return true;
     }
 
-    // Returns true when an endpoint of the proxy has a host that the address rules cannot match reliably; such
-    // a proxy is rejected outright:
+    // Returns true when an endpoint of the proxy has a host that the address rules cannot match reliably;
+    // when an address filter is configured, such a proxy is rejected outright:
     // - A host longer than 255 characters. No legal host name or IP address is that long, and the bound keeps
     //   the cost of matching the address rules low.
     // - A non-canonical spelling of an IPv4 address, such as 0x7f000001, 2130706433, 0177.0.0.1, or 127.1.
@@ -1008,6 +1008,7 @@ Glacier2::ProxyVerifier::ProxyVerifier(CommunicatorPtr communicator, int traceLe
     string s = _communicator->getProperties()->getIceProperty("Glacier2.Filter.Address.Accept");
     if (s != "")
     {
+        _hasAddressFilters = true;
         try
         {
             // An accept rule matches a proxy only when every endpoint matches it.
@@ -1024,6 +1025,7 @@ Glacier2::ProxyVerifier::ProxyVerifier(CommunicatorPtr communicator, int traceLe
     s = _communicator->getProperties()->getIceProperty("Glacier2.Filter.Address.Reject");
     if (s != "")
     {
+        _hasAddressFilters = true;
         try
         {
             // A reject rule matches a proxy as soon as one endpoint matches it.
@@ -1076,7 +1078,7 @@ Glacier2::ProxyVerifier::verify(const ObjectPrx& proxy)
 
     bool result = false;
 
-    if (Glacier2::hasDisallowedHost(proxy))
+    if (_hasAddressFilters && Glacier2::hasDisallowedHost(proxy))
     {
         // Rejected regardless of the configured rules.
     }

--- a/cpp/src/Glacier2/ProxyVerifier.h
+++ b/cpp/src/Glacier2/ProxyVerifier.h
@@ -39,8 +39,15 @@ namespace Glacier2
         const Ice::CommunicatorPtr _communicator;
         const int _traceLevel;
 
+        // The rules parsed from Glacier2.Filter.Address.Accept.
         std::vector<ProxyRule*> _acceptRules;
+
+        // The rules parsed from Glacier2.Filter.Address.Reject, plus a proxy length rule when
+        // Glacier2.Filter.ProxySizeMax is set.
         std::vector<ProxyRule*> _rejectRules;
+
+        // True when Glacier2.Filter.Address.Accept or Glacier2.Filter.Address.Reject is set.
+        bool _hasAddressFilters{false};
     };
 }
 #endif

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -463,8 +463,20 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                         (False, "hello:tcp -h 2130706433 -p 12010"),
                         (False, "hello:tcp -h 127.1 -p 12010"),
                         (False, "hello:tcp -h 0177.0.0.1 -p 12010"),
+                        (False, "hello:tcp -h 0x.0.0.1 -p 12010"),
                         (False, "hello:tcp -h 127.0.0.1. -p 12010"),
                         (True, "hello:tcp -h localhost -p 12010"),
+                    ],
+                    [],
+                ),
+                (
+                    # The outright rejection of non-canonical spellings applies only when an address filter is
+                    # configured: with just a size limit, the proxy is matched against no address rule, so the
+                    # spelling of the host does not matter.
+                    "testing proxy size limit alone allows non-canonical hosts",
+                    ("", "", "100", "", "", ""),
+                    [
+                        (True, "hello:tcp -h 127.1 -p 12010"),
                     ],
                     [],
                 ),

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -413,6 +413,44 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                     [],
                 ),
                 (
+                    # The host is normalized before matching: a trailing dot on a fully-qualified name and a
+                    # non-canonical spelling of an IPv4 address (octal or hexadecimal parts, fewer than four
+                    # parts, a single number) match rules written for the canonical form. The accepted proxies
+                    # also exercise the connection: the resolver accepts these spellings, which is why an
+                    # unnormalized reject rule could be bypassed with them.
+                    "testing address filter accept rule against non-canonical hosts",
+                    ("localhost 127.0.0.1", "", "", "", "", ""),
+                    [
+                        (True, "hello:tcp -h localhost. -p 12010"),
+                        (True, "hello:tcp -h 127.000.000.001 -p 12010"),
+                        (False, "hello:tcp -h localhost.example.com -p 12010"),
+                    ],
+                    [],
+                ),
+                (
+                    "testing address filter reject rule against a trailing-dot host",
+                    ("", "badhost.example.com *.internal.example.com", "", "", "", ""),
+                    [
+                        (False, "hello:tcp -h badhost.example.com. -p 12010"),
+                        (False, "hello:tcp -h db.internal.example.com. -p 12010"),
+                        (True, "hello:tcp -h 127.0.0.1 -p 12010"),
+                    ],
+                    [],
+                ),
+                (
+                    "testing address filter reject rule against non-canonical IPv4 literals",
+                    ("", "127.0.0.1", "", "", "", ""),
+                    [
+                        (False, "hello:tcp -h 127.000.000.001 -p 12010"),
+                        (False, "hello:tcp -h 0x7f000001 -p 12010"),
+                        (False, "hello:tcp -h 2130706433 -p 12010"),
+                        (False, "hello:tcp -h 127.1 -p 12010"),
+                        (False, "hello:tcp -h 127.0.0.1. -p 12010"),
+                        (True, "hello:tcp -h localhost -p 12010"),
+                    ],
+                    [],
+                ),
+                (
                     # A proxy with an endpoint host longer than 255 characters is rejected outright, even when
                     # no reject rule matches it: no legal host name or IP address is that long.
                     "testing address filter rejects an oversized host",

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -413,16 +413,18 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                     [],
                 ),
                 (
-                    # The host is normalized before matching: a trailing dot on a fully-qualified name and a
-                    # non-canonical spelling of an IPv4 address (octal or hexadecimal parts, fewer than four
-                    # parts, a single number) match rules written for the canonical form. The accepted proxies
-                    # also exercise the connection: the resolver accepts these spellings, which is why an
-                    # unnormalized reject rule could be bypassed with them.
-                    "testing address filter accept rule against non-canonical hosts",
+                    # A non-canonical spelling of an IPv4 address (octal or hexadecimal parts, leading zeros,
+                    # fewer than four parts, a single number) is rejected outright when filters are
+                    # configured: the resolver accepts these spellings as aliases for an address that
+                    # string-based rules spell differently. A DNS name keeps its meaning with a trailing dot,
+                    # so 'name.' matches the rules written for 'name'.
+                    "testing address filter against non-canonical hosts",
                     ("localhost 127.0.0.1", "", "", "", "", ""),
                     [
+                        (True, "hello:tcp -h localhost -p 12010"),
+                        (True, "hello:tcp -h 127.0.0.1 -p 12010"),
                         (True, "hello:tcp -h localhost. -p 12010"),
-                        (True, "hello:tcp -h 127.000.000.001 -p 12010"),
+                        (False, "hello:tcp -h 127.000.000.001 -p 12010"),
                         (False, "hello:tcp -h localhost.example.com -p 12010"),
                     ],
                     [],
@@ -438,6 +440,21 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                     [],
                 ),
                 (
+                    # A rule written with a trailing dot is stripped like the host, so both spellings of the
+                    # rule match both spellings of the host.
+                    "testing address filter reject rule written with a trailing dot",
+                    ("", "badhost.example.com.", "", "", "", ""),
+                    [
+                        (False, "hello:tcp -h badhost.example.com -p 12010"),
+                        (False, "hello:tcp -h badhost.example.com. -p 12010"),
+                        (True, "hello:tcp -h 127.0.0.1 -p 12010"),
+                    ],
+                    [],
+                ),
+                (
+                    # The non-canonical spellings are rejected even though none of them matches the reject
+                    # rule as a string: without the outright rejection, each would be accepted and the
+                    # resolver would connect it to the very address the rule rejects.
                     "testing address filter reject rule against non-canonical IPv4 literals",
                     ("", "127.0.0.1", "", "", "", ""),
                     [
@@ -445,6 +462,7 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                         (False, "hello:tcp -h 0x7f000001 -p 12010"),
                         (False, "hello:tcp -h 2130706433 -p 12010"),
                         (False, "hello:tcp -h 127.1 -p 12010"),
+                        (False, "hello:tcp -h 0177.0.0.1 -p 12010"),
                         (False, "hello:tcp -h 127.0.0.1. -p 12010"),
                         (True, "hello:tcp -h localhost -p 12010"),
                     ],


### PR DESCRIPTION
The Glacier2 address filters match the host of an endpoint as a string, while an IPv4 address can be written in several alternative numeric forms (octal or hexadecimal parts, leading zeros, fewer than four parts, a single 32-bit number): `0x7f000001`, `2130706433`, and `127.1` are all alternative forms of `127.0.0.1`. A host in such a form matched neither the Accept nor the Reject rules written for the dotted quad, while the connection could still reach the address the rules describe.

An earlier revision of this PR converted these forms to the canonical dotted quad before matching. That requires reproducing the platform resolver's reading of each form, which is not portable: the same literal can name different addresses on different platforms (`0177.0.0.1` reads as octal `127.0.0.1` with glibc and Winsock, and as decimal `177.0.0.1` on macOS), and the platforms' handling of out-of-range values resists characterization.

With this PR, the router instead extends the existing oversized-host check: when address filters are configured, a proxy is rejected outright — regardless of the rules — when any of its endpoints has a host that writes an IPv4 address in a form other than the plain dotted quad. The check is purely structural (is every dot-separated part a numeral, and is the whole a four-part decimal quad), so it needs no knowledge of how a given platform reads a form, and it fails closed. A canonical dotted quad and a DNS name match the rules exactly as before.

The trailing dot of a fully-qualified DNS name is dropped from the host and from the rules before matching, so `backend.example.com.` and `backend.example.com` match the same rules in either position. A trailing dot on a numeric form (`127.0.0.1.`) is rejected outright: platform resolvers treat it as a DNS name, not an address.

Behavior change: when filters are configured, an endpoint that used an alternative IPv4 form deliberately (for example `Accept=127.1` matching `-h 127.1`) is now rejected; write the rule and the endpoint as the dotted quad. IPv6 hosts are not affected; IPv6 filtering is a separate, known limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
