### PR TITLE
Return NodeSessionI load info by value

### DIFF
--- a/cpp/src/IceGrid/NodeSessionI.cpp
+++ b/cpp/src/IceGrid/NodeSessionI.cpp
@@ -214,7 +214,7 @@ NodeSessionI::getInfo() const noexcept
     return _info;
 }
 
-const LoadInfo&
+LoadInfo
 NodeSessionI::getLoadInfo() const
 {
     lock_guard lock(_mutex);

--- a/cpp/src/IceGrid/NodeSessionI.h
+++ b/cpp/src/IceGrid/NodeSessionI.h
@@ -43,7 +43,7 @@ namespace IceGrid
 
         [[nodiscard]] const NodePrx& getNode() const;
         [[nodiscard]] const std::shared_ptr<InternalNodeInfo>& getInfo() const noexcept;
-        [[nodiscard]] const LoadInfo& getLoadInfo() const;
+        [[nodiscard]] LoadInfo getLoadInfo() const;
         [[nodiscard]] NodeSessionPrx getProxy() const;
 
         [[nodiscard]] bool isDestroyed() const;


### PR DESCRIPTION
`NodeSessionI::getLoadInfo` locked `_mutex` but returned a `const LoadInfo&` to the protected `_load` member. The lock is released when the function returns, so both callers copied the three floats unlocked, racing `keepAlive`'s `_load = load` write under the mutex — the lock inside the accessor protected nothing. The accessor now copies `_load` under the lock and returns it by value.

The same bug exists on the 3.7 branch (only the lock idiom differs), hence the backport-3.7 label.

Fixes #6043

🤖 Generated with [Claude Code](https://claude.com/claude-code)