### PR TITLE
Contain exceptions thrown by Connection::close callbacks

### DIFF
--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -62,7 +62,8 @@ namespace Ice
         /// @remark The response and exception callbacks may be called synchronously (from the calling thread); in
         /// particular, this occurs when you call `close` on a connection that is already closed. The implementation
         /// always calls one of the two callbacks once; it never calls both. If closing the connection takes longer than
-        /// the configured close timeout, the connection is aborted with a CloseTimeoutException.
+        /// the configured close timeout, the connection is aborted with a CloseTimeoutException. The response and
+        /// exception callbacks must not throw any exception.
         virtual void
         close(std::function<void()> response, std::function<void(std::exception_ptr)> exception) noexcept = 0;
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -552,14 +552,14 @@ Ice::ConnectionI::close(function<void()> response, function<void(std::exception_
         {
             if (response)
             {
-                response();
+                executeCallback(response);
             }
         }
         else
         {
             if (exception)
             {
-                exception(closeException);
+                executeCallback([&] { exception(closeException); });
             }
         }
     }
@@ -776,7 +776,9 @@ Ice::ConnectionI::setCloseCallback(CloseCallback callback)
             if (callback)
             {
                 auto self = shared_from_this();
-                _threadPool->execute([self, callback = std::move(callback)]() { self->closeCallback(callback); }, self);
+                _threadPool->execute(
+                    [self, callback = std::move(callback)]() { self->executeCallback(callback); },
+                    self);
             }
         }
         else
@@ -795,11 +797,17 @@ Ice::ConnectionI::disableInactivityCheck() noexcept
 }
 
 void
-Ice::ConnectionI::closeCallback(const CloseCallback& callback)
+Ice::ConnectionI::executeCallback(const CloseCallback& callback) noexcept
+{
+    executeCallback([self = shared_from_this(), &callback] { callback(self); });
+}
+
+void
+Ice::ConnectionI::executeCallback(const std::function<void()>& callback) noexcept
 {
     try
     {
-        callback(shared_from_this());
+        callback();
     }
     catch (const std::exception& ex)
     {
@@ -1779,14 +1787,14 @@ Ice::ConnectionI::finish(bool close)
             {
                 if (pair.first)
                 {
-                    pair.first();
+                    executeCallback(pair.first);
                 }
             }
             else
             {
                 if (pair.second)
                 {
-                    pair.second(_exception);
+                    executeCallback([this, &pair] { pair.second(_exception); });
                 }
             }
         }
@@ -1795,7 +1803,7 @@ Ice::ConnectionI::finish(bool close)
 
     if (_closeCallback)
     {
-        closeCallback(_closeCallback);
+        executeCallback(_closeCallback);
         _closeCallback = nullptr;
     }
 

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -218,7 +218,9 @@ namespace Ice
             InputStream& messageStream);
         void finish(bool);
 
-        void closeCallback(const CloseCallback&);
+        // Executes a callback provided by the application, catching and logging any exception it throws.
+        void executeCallback(const CloseCallback& callback) noexcept;
+        void executeCallback(const std::function<void()>& callback) noexcept;
 
         /// Aborts the connection with a ConnectionAbortedException if the connection is active and did not receive
         /// a byte for some time. See the IdleTimeoutTransceiverDecorator.

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1247,31 +1247,44 @@ allTests(TestHelper* helper, bool collocated)
                 TestIntfPrx p2(ich.communicator(), p->ice_toString());
 
                 auto con = p2->ice_getConnection();
-                promise<void> closed;
-                con->setCloseCallback([&closed](const ConnectionPtr&) { closed.set_value(); });
 
-                promise<void> first;
-                con->close(
-                    [&first]
+                vector<string> order;
+                mutex orderMutex;
+                auto record = [&](const char* event)
+                {
+                    lock_guard<mutex> lock(orderMutex);
+                    order.emplace_back(event);
+                };
+
+                promise<void> closed;
+                con->setCloseCallback(
+                    [&](const ConnectionPtr&)
                     {
-                        first.set_value();
+                        record("closed");
+                        closed.set_value();
+                    });
+
+                // Keeps the connection open until both close calls below have queued their callbacks.
+                auto sleepFuture = p2->sleepAsync(100);
+
+                con->close(
+                    [&]
+                    {
+                        record("first");
                         throw std::runtime_error("from response callback");
                     },
-                    [&first](exception_ptr)
+                    [&](exception_ptr)
                     {
-                        first.set_value();
+                        record("first");
                         throw std::runtime_error("from exception callback");
                     });
-                promise<void> second;
-                con->close(
-                    [&second] { second.set_value(); },
-                    [&second](exception_ptr ex) { second.set_exception(ex); });
+                con->close([&] { record("second"); }, [&](exception_ptr) { record("second"); });
 
-                first.get_future().get();
-                second.get_future().get();
+                sleepFuture.get();
                 // The close callback runs after the close response callbacks: reaching it shows that the throwing
                 // callback did not interrupt the connection's finalization.
                 closed.get_future().get();
+                test((order == vector<string>{"first", "second", "closed"}));
 
                 // On an already-closed connection, the response callback runs synchronously from this thread; the
                 // exception must not escape close, which is noexcept.

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1223,6 +1223,62 @@ allTests(TestHelper* helper, bool collocated)
             }
             cout << "ok" << endl;
 
+            cout << "testing connection close with a throwing callback... " << flush;
+            {
+                // The callbacks passed to close must not throw. When one throws anyway, the connection must still
+                // invoke the other close callbacks and finish. The thrown exceptions are logged as errors; this
+                // communicator's logger swallows them to keep the test output clean.
+                class SwallowLogger final : public Ice::Logger
+                {
+                public:
+                    void print(const string&) override {}
+                    void trace(const string&, const string&) override {}
+                    void warning(const string&) override {}
+                    void error(const string&) override {}
+                    string getPrefix() override { return ""; }
+                    Ice::LoggerPtr cloneWithPrefix(string) override { return make_shared<SwallowLogger>(); }
+                };
+
+                InitializationData initData;
+                initData.properties = communicator->getProperties()->clone();
+                initData.logger = make_shared<SwallowLogger>();
+                installTransport(initData);
+                Ice::CommunicatorHolder ich(initialize(initData));
+                TestIntfPrx p2(ich.communicator(), p->ice_toString());
+
+                auto con = p2->ice_getConnection();
+                promise<void> closed;
+                con->setCloseCallback([&closed](const ConnectionPtr&) { closed.set_value(); });
+
+                promise<void> first;
+                con->close(
+                    [&first]
+                    {
+                        first.set_value();
+                        throw std::runtime_error("from response callback");
+                    },
+                    [&first](exception_ptr)
+                    {
+                        first.set_value();
+                        throw std::runtime_error("from exception callback");
+                    });
+                promise<void> second;
+                con->close(
+                    [&second] { second.set_value(); },
+                    [&second](exception_ptr ex) { second.set_exception(ex); });
+
+                first.get_future().get();
+                second.get_future().get();
+                // The close callback runs after the close response callbacks: reaching it shows that the throwing
+                // callback did not interrupt the connection's finalization.
+                closed.get_future().get();
+
+                // On an already-closed connection, the response callback runs synchronously from this thread; the
+                // exception must not escape close, which is noexcept.
+                con->close([] { throw std::runtime_error("from response callback"); }, nullptr);
+            }
+            cout << "ok" << endl;
+
             cout << "testing connection abort... " << flush;
             {
                 //


### PR DESCRIPTION
The response and exception callbacks passed to the callback-based `Connection::close` overload must not throw — this PR documents that requirement in the API reference. It is a doc clarification plus hardening, not a bug fix: before and after, throwing from these callbacks is a contract violation.

Ice now also handles a violation gracefully instead of catastrophically. Previously, a throwing callback escaped the `noexcept` `close` on the synchronous already-closed path (`std::terminate`), and on the finalization path it prevented the remaining close callbacks from running and the connection from ever reaching `StateFinished`, hanging `Communicator::destroy`. Both paths now route the callbacks through the same catch-and-log guard that the `setCloseCallback` family already used (`ConnectionI::closeCallback`, renamed to an `executeCallback` overload) — matching the established AMI convention where throwing callbacks are caught and logged.

The new test verifies both paths: a throwing callback during an asynchronous close does not prevent the other close callbacks from running or the connection from finishing, and a throwing callback invoked synchronously on an already-closed connection does not terminate the process.

No changelog entry: only applications that violate the documented contract observe any change.

Fixes #6033

🤖 Generated with [Claude Code](https://claude.com/claude-code)