### PR TITLE
Add precondition when marshaling a fixed proxy in Swift

### DIFF
--- a/swift/src/Ice/OutputStream.swift
+++ b/swift/src/Ice/OutputStream.swift
@@ -489,8 +489,10 @@ extension OutputStream {
     /// Writes a proxy to the stream.
     ///
     /// - Parameter v: The proxy to write.
+    /// - Precondition: `v` is not a fixed proxy.
     public func write(_ v: ObjectPrx?) {
         if let prxImpl = v as? ObjectPrxI {
+            precondition(!prxImpl.ice_isFixed(), "Cannot marshal a fixed proxy")
             prxImpl.ice_write(to: self)
         } else {
             // A nil proxy is represented by an Identity with empty name and category fields.


### PR DESCRIPTION
Marshaling a fixed proxy is not supported. In the Swift mapping, doing so let the C++ `FixedProxyException` thrown by `FixedReference::streamWrite` unwind through non-throwing Swift and Objective-C++ frames — undefined behavior, in practice a crash without a usable diagnostic.

The Swift mapping already maps the other fixed-proxy misuses (`ice_adapterId`, `ice_endpoints`, `ice_router`, ...) — which throw `FixedProxyException` in C++ — to preconditions. This PR gives `OutputStream.write(ObjectPrx?)` the same treatment: `precondition(!prxImpl.ice_isFixed(), "Cannot marshal a fixed proxy")`, so the misuse now fails fast with a clear message. No signatures change.

No test: a precondition failure aborts the process, so it is not testable in-process, like the existing fixed-proxy preconditions. No changelog entry: only applications that marshal a fixed proxy — a contract violation — observe any change.

Fixes #6035

🤖 Generated with [Claude Code](https://claude.com/claude-code)