### PR TITLE
Keep Communicator default accessors usable after destroy in Swift

### DIFF
--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -159,12 +159,26 @@
 
 - (nullable ICEObjectAdapter*)getDefaultObjectAdapter
 {
-    return [ICEObjectAdapter getHandle:self.communicator->getDefaultObjectAdapter()];
+    try
+    {
+        return [ICEObjectAdapter getHandle:self.communicator->getDefaultObjectAdapter()];
+    }
+    catch (const Ice::CommunicatorDestroyedException&)
+    {
+        return nil;
+    }
 }
 
 - (void)setDefaultObjectAdapter:(ICEObjectAdapter* _Nullable)adapter
 {
-    self.communicator->setDefaultObjectAdapter(adapter == nil ? nullptr : [adapter objectAdapter]);
+    try
+    {
+        self.communicator->setDefaultObjectAdapter(adapter == nil ? nullptr : [adapter objectAdapter]);
+    }
+    catch (const Ice::CommunicatorDestroyedException&)
+    {
+        // Ignored
+    }
 }
 
 - (nullable ICEImplicitContext*)getImplicitContext
@@ -196,12 +210,19 @@
 
 - (nullable ICEObjectPrx*)getDefaultRouter
 {
-    std::optional<Ice::RouterPrx> router = self.communicator->getDefaultRouter();
-    if (router)
+    try
     {
-        return [[ICEObjectPrx alloc] initWithCppObjectPrx:router.value()];
+        std::optional<Ice::RouterPrx> router = self.communicator->getDefaultRouter();
+        if (router)
+        {
+            return [[ICEObjectPrx alloc] initWithCppObjectPrx:router.value()];
+        }
+        else
+        {
+            return nil;
+        }
     }
-    else
+    catch (const Ice::CommunicatorDestroyedException&)
     {
         return nil;
     }
@@ -228,12 +249,19 @@
 
 - (nullable ICEObjectPrx*)getDefaultLocator
 {
-    std::optional<Ice::LocatorPrx> locator = self.communicator->getDefaultLocator();
-    if (locator)
+    try
     {
-        return [[ICEObjectPrx alloc] initWithCppObjectPrx:locator.value()];
+        std::optional<Ice::LocatorPrx> locator = self.communicator->getDefaultLocator();
+        if (locator)
+        {
+            return [[ICEObjectPrx alloc] initWithCppObjectPrx:locator.value()];
+        }
+        else
+        {
+            return nil;
+        }
     }
-    else
+    catch (const Ice::CommunicatorDestroyedException&)
     {
         return nil;
     }

--- a/swift/test/Ice/adapterDeactivation/AllTests.swift
+++ b/swift/test/Ice/adapterDeactivation/AllTests.swift
@@ -211,4 +211,16 @@ func allTests(_ helper: TestHelper) async throws {
             output.writeLine("ok")
         }
     }
+
+    output.write("testing default object adapter, router, and locator on a destroyed communicator... ")
+    do {
+        // The getters return nil and the setter does nothing.
+        let com = try Ice.initialize()
+        com.destroy()
+        try test(com.getDefaultObjectAdapter() == nil)
+        try test(com.getDefaultRouter() == nil)
+        try test(com.getDefaultLocator() == nil)
+        com.setDefaultObjectAdapter(nil)
+    }
+    output.writeLine("ok")
 }

--- a/swift/test/Ice/ami/AllTests.swift
+++ b/swift/test/Ice/ami/AllTests.swift
@@ -80,13 +80,6 @@ func allTests(_ helper: TestHelper, collocated: Bool = false) async throws {
             try await p2.op()
             try test(false)
         } catch is Ice.CommunicatorDestroyedException {}
-
-        // The default object adapter, router, and locator accessors remain usable on a destroyed
-        // communicator: the getters return nil and the setter does nothing.
-        try test(ic.getDefaultObjectAdapter() == nil)
-        try test(ic.getDefaultRouter() == nil)
-        try test(ic.getDefaultLocator() == nil)
-        ic.setDefaultObjectAdapter(nil)
     }
     output.writeLine("ok")
 

--- a/swift/test/Ice/ami/AllTests.swift
+++ b/swift/test/Ice/ami/AllTests.swift
@@ -80,6 +80,13 @@ func allTests(_ helper: TestHelper, collocated: Bool = false) async throws {
             try await p2.op()
             try test(false)
         } catch is Ice.CommunicatorDestroyedException {}
+
+        // The default object adapter, router, and locator accessors remain usable on a destroyed
+        // communicator: the getters return nil and the setter does nothing.
+        try test(ic.getDefaultObjectAdapter() == nil)
+        try test(ic.getDefaultRouter() == nil)
+        try test(ic.getDefaultLocator() == nil)
+        ic.setDefaultObjectAdapter(nil)
     }
     output.writeLine("ok")
 


### PR DESCRIPTION
In the Swift mapping, `getDefaultObjectAdapter`, `setDefaultObjectAdapter`, `getDefaultRouter`, and `getDefaultLocator` called C++ functions that throw `CommunicatorDestroyedException` on a destroyed communicator, with no catch in the Objective-C++ bridge and non-throwing Swift wrappers — so calling them after `destroy()` unwound a C++ exception through non-throwing frames (undefined behavior, in practice a crash).

The bridge now catches `CommunicatorDestroyedException` in these four methods: the getters return nil and the setter does nothing. This matches the mapping's existing design — `setDefaultRouter` and `setDefaultLocator` already ignore this exception. Any other exception propagates as before, and no signatures change.

The new test verifies that the accessors are usable on a destroyed communicator.

No changelog entry: only post-`destroy()` use — which previously crashed — observes any change.

Fixes #6046

🤖 Generated with [Claude Code](https://claude.com/claude-code)