### PR TITLE
Remove unused self capture in Swift CtrlCHandler callback

### DIFF
--- a/swift/src/IceImpl/CtlCHandler.mm
+++ b/swift/src/IceImpl/CtlCHandler.mm
@@ -13,7 +13,7 @@
     if (callback)
     {
         self->_cppObject.setCallback(
-            [callback, self](int signal)
+            [callback](int signal)
             {
                 // This callback executes in the C++ CtrlCHandler thread.
                 // We need an autorelease pool in case the callback creates autorelease objects.


### PR DESCRIPTION
The lambda that `ICECtrlCHandler.setCallback` passes to the C++ `CtrlCHandler::setCallback` captured `self` without using it. The capture is a leftover from the one-shot `catchSignal` lambda it was copied from (#3596), which reset the callback from its body and therefore needed `self`.

Since `_cppObject` is a by-value ivar of `self` that owns the lambda, the unused capture formed a permanent retain cycle (`self → _cppObject → std::function → block → self`), leaking the `ICECtrlCHandler` and the captured Swift callback. Dropping `self` from the capture list breaks the cycle; lifetime remains sound because the lambda is owned by `_cppObject`, which cannot outlive `self`.

Fixes #6047

🤖 Generated with [Claude Code](https://claude.com/claude-code)