### PR TITLE
Fix DataStorm session-creation race that left a one-sided connected session

### DIFF
--- a/changelog.d/datastorm/6039.md
+++ b/changelog.d/datastorm/6039.md
@@ -1,7 +1,2 @@
-- Fixed a race in DataStorm session establishment that could permanently disconnect a reader from a writer after a
-  connection loss. The publisher-side session was marked connected before the subscriber acknowledged the session
-  confirmation, so concurrent session creation attempts failed with `AlreadyConnected` and exhausted the subscriber's
-  session retry budget; the publisher then kept a session connected to a peer session that no longer existed and
-  rejected every subsequent session creation attempt from that peer. The publisher-side session is now marked
-  connected only once the subscriber acknowledges the confirmation, and a destroyed session no longer schedules
-  reconnection attempts.
+- Fixed a race in DataStorm session establishment that could leave a reader permanently
+  disconnected from a writer after a connection loss.

--- a/changelog.d/datastorm/6039.md
+++ b/changelog.d/datastorm/6039.md
@@ -1,0 +1,7 @@
+- Fixed a race in DataStorm session establishment that could permanently disconnect a reader from a writer after a
+  connection loss. The publisher-side session was marked connected before the subscriber acknowledged the session
+  confirmation, so concurrent session creation attempts failed with `AlreadyConnected` and exhausted the subscriber's
+  session retry budget; the publisher then kept a session connected to a peer session that no longer existed and
+  rejected every subsequent session creation attempt from that peer. The publisher-side session is now marked
+  connected only once the subscriber acknowledges the confirmation, and a destroyed session no longer schedules
+  reconnection attempts.

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -249,16 +249,30 @@ NodeI::createSessionAsync(
 
                 try
                 {
-                    // Must be called before connected
+                    // The confirmation response is this session's send barrier: the subscriber connects its session
+                    // before sending the response, so everything this session sends once the response arrives - the
+                    // initial topic announcements and any forwarded samples - is processed by a connected subscriber
+                    // session.
+                    //
+                    // Mark the session as connected only once the subscriber acknowledges the confirmation. A
+                    // session marked connected earlier rejects concurrent session creation requests with
+                    // AlreadyConnected and, if the subscriber never processes the confirmation, remains connected
+                    // to a peer session that no longer exists, rejecting all future session creation requests from
+                    // this peer.
                     s->confirmCreateSessionAsync(
                         self->_proxy,
                         uncheckedCast<PublisherSessionPrx>(session->getProxy()),
-                        nullptr,
+                        [session, subscriberSession, connection, instance]
+                        {
+                            // Session::connected informs the subscriber session of all the topic writers in the
+                            // current node.
+                            session->connected(
+                                *subscriberSession,
+                                connection,
+                                instance->getTopicFactory()->getTopicWriters());
+                        },
                         [self, subscriber, session](auto ex)
                         { self->retryPublisherSessionCreation(*subscriber, session, ex); });
-
-                    // Session::connected informs the subscriber session of all the topic writers in the current node.
-                    session->connected(*subscriberSession, connection, instance->getTopicFactory()->getTopicWriters());
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
@@ -343,7 +357,6 @@ NodeI::confirmCreateSessionAsync(
         exception(make_exception_ptr(SessionCreationException{SessionCreationError::AlreadyConnected}));
         return;
     }
-    response();
 
     // If the publisher session is hosted on a relay, current.con represents the connection to the relay.
     // Otherwise, it represents the connection to the publisher node. In both cases, a fixed proxy is used
@@ -354,8 +367,15 @@ NodeI::confirmCreateSessionAsync(
     }
     // else collocated call.
 
-    // Session::connected informs the publisher session of all the topic readers in the current node.
+    // Session::connected informs the publisher session of all the topic readers in the current node. The publisher
+    // session is not connected yet - it connects when the confirmation response arrives - so it drops this initial
+    // announcement; the attachment is instead driven by the publisher's own topic announcement, sent once connected.
     session->connected(*publisherSession, current.con, instance->getTopicFactory()->getTopicReaders());
+
+    // Send the response only after this session is connected: the response is the publisher's send barrier. The
+    // publisher marks its session connected and starts announcing topics and forwarding samples only after this node
+    // acknowledges the confirmation.
+    response();
 }
 
 void

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -690,6 +690,14 @@ bool
 SessionI::retryImpl(NodePrx node, exception_ptr exception)
 {
     // Called with the session mutex locked.
+
+    // A callback from an earlier session creation attempt can run after the session was destroyed; don't schedule a
+    // retry task for a destroyed session.
+    if (_destroyed)
+    {
+        return false;
+    }
+
     if (exception)
     {
         // Don't retry if we are shutting down.


### PR DESCRIPTION
Fixes #6039.

`NodeI::createSessionAsync` marked the publisher-side session connected immediately after issuing
`confirmCreateSession`, without waiting for the subscriber to acknowledge it. Concurrent session creation requests
were then rejected with `AlreadyConnected`; each rejection canceled the subscriber's pending retry timer and consumed
a retry slot, so the retry budget could be exhausted within milliseconds, before any timer fired. If the subscriber
destroyed its session before processing the confirmation, the confirmation returned `SessionNotFound` while the
publisher kept a connected session for a peer session that no longer existed — rejecting every subsequent session
creation request from that peer until the connection closed. See the issue for the full trace-level analysis.

Changes:

- Mark the publisher session connected only in the `confirmCreateSession` success callback.
- In `confirmCreateSessionAsync`, connect the subscriber session before sending the response. The confirmation
  response is now the publisher's send barrier: everything the publisher session sends once the response arrives is
  processed by a connected subscriber session. Previously this relied on same-connection FIFO ordering of the
  confirmation request; the ordering contract is now documented in the code. The subscriber's initial topic
  announcement is dropped by the not-yet-connected publisher; the attachment is driven by the publisher's own
  post-acknowledgment announcement.
- Ignore retry requests for already-destroyed sessions in `SessionI::retryImpl`.

No wire or Slice changes; the fix is compatible with 3.8.x peers. Relays forward the confirmation response
end-to-end (`NodeForwarder::confirmCreateSessionAsync` passes the dispatch callbacks through to the target node), so
the barrier holds across relayed topologies.

Verification:

- Reproduced red→green locally by delaying the confirmation send by 18 s (longer than the full retry backoff):
  unfixed, a two-node repro hangs with the exact CI trace signature (retry exhaustion → destroyed session →
  `SessionNotFound` on the confirmation); fixed, it completes.
- All `cpp/test/DataStorm` suites pass.

Not addressed here (deferred to the planned session retry-policy rework): retry slots are still consumed per error
callback rather than per attempt, and concurrent creation attempts are not serialized or generation-tagged — with a
multi-threaded client thread pool (non-default), reordered duplicate-confirmation callbacks could still consume
retry slots.
