### PR TITLE
Fix three icegridadmin bugs

### DIFF
--- a/changelog.d/service-icegrid/icegridadmin-host-instance-name-crash.md
+++ b/changelog.d/service-icegrid/icegridadmin-host-instance-name-crash.md
@@ -1,0 +1,2 @@
+- Fixed a crash in `icegridadmin`: when started with `--host` and `--instanceName` and no registry could be contacted
+  on the specified host, `icegridadmin` crashed instead of reporting an error.

--- a/changelog.d/service-icegrid/icegridadmin-log-follow-retry.md
+++ b/changelog.d/service-icegrid/icegridadmin-log-follow-retry.md
@@ -1,0 +1,2 @@
+- Fixed a bug in `icegridadmin`: after a `log --follow` command failed - for example because the target server was
+  not reachable - all subsequent `log --follow` commands in the same session failed as well.

--- a/changelog.d/service-icegrid/icegridadmin-show-head.md
+++ b/changelog.d/service-icegrid/icegridadmin-show-head.md
@@ -1,0 +1,2 @@
+- Fixed a bug in `icegridadmin`: the `show` command with the `--head n` option printed the whole log file instead of
+  the first `n` lines.

--- a/cpp/src/IceGrid/Client.cpp
+++ b/cpp/src/IceGrid/Client.cpp
@@ -308,21 +308,30 @@ run(const Ice::StringSeq& args)
                 os << ":tcp -h \"" << host << "\" -p " << (port == 0 ? 4061 : port);
                 os << ":ssl -h \"" << host << "\" -p " << (port == 0 ? 4062 : port);
                 Ice::LocatorFinderPrx finder{communicator, os.str()};
+                optional<Ice::LocatorPrx> defaultLocator;
                 try
                 {
-                    communicator->setDefaultLocator(finder->getLocator());
+                    defaultLocator = finder->getLocator();
                 }
                 catch (const Ice::LocalException&)
                 {
                     // Ignore.
                 }
-                if (!instanceName.empty() &&
-                    communicator->getDefaultLocator()->ice_getIdentity().category != instanceName)
+
+                if (!defaultLocator)
                 {
-                    consoleErr << args[0] << ": registry running on '" << host << "' uses a different instance name:\n";
-                    consoleErr << communicator->getDefaultLocator()->ice_getIdentity().category << endl;
+                    consoleErr << args[0] << ": could not contact the registry running on '" << host << "'" << endl;
                     return 1;
                 }
+
+                if (!instanceName.empty() && defaultLocator->ice_getIdentity().category != instanceName)
+                {
+                    consoleErr << args[0] << ": registry running on '" << host << "' uses a different instance name:\n";
+                    consoleErr << defaultLocator->ice_getIdentity().category << endl;
+                    return 1;
+                }
+
+                communicator->setDefaultLocator(*defaultLocator);
             }
             else
             {

--- a/cpp/src/IceGrid/Parser.cpp
+++ b/cpp/src/IceGrid/Parser.cpp
@@ -2195,6 +2195,10 @@ Parser::showFile(
                     outputNewline();
                     outputString(line);
                     flushOutput();
+                    if (++i == lineCount)
+                    {
+                        break;
+                    }
                 }
             }
         }

--- a/cpp/src/IceGrid/Parser.cpp
+++ b/cpp/src/IceGrid/Parser.cpp
@@ -2327,17 +2327,27 @@ Parser::showLog(const string& id, const string& reader, bool tail, bool follow, 
 
         auto adapter = _communicator->createObjectAdapter("RemoteLoggerAdapter");
 
-        _session->ice_getConnection()->setAdapter(adapter);
-
         ostringstream os;
         os << "RemoteLogger-" << loggerCallbackCount++;
         Ice::Identity ident = {os.str(), adminCallbackTemplate->ice_getIdentity().category};
 
         auto servant = make_shared<RemoteLoggerI>();
-        auto prx = adapter->add<Ice::RemoteLoggerPrx>(servant, ident);
-        adapter->activate();
+        optional<Ice::RemoteLoggerPrx> prx;
+        try
+        {
+            _session->ice_getConnection()->setAdapter(adapter);
+            prx = adapter->add<Ice::RemoteLoggerPrx>(servant, ident);
+            adapter->activate();
 
-        loggerAdmin->attachRemoteLogger(prx, Ice::LogMessageTypeSeq(), Ice::StringSeq(), tail ? lineCount : -1);
+            loggerAdmin->attachRemoteLogger(*prx, Ice::LogMessageTypeSeq(), Ice::StringSeq(), tail ? lineCount : -1);
+        }
+        catch (...)
+        {
+            // Destroy the adapter so that the next 'log --follow' can create it again.
+            servant->destroy();
+            adapter->destroy();
+            throw;
+        }
 
         resetInterrupt();
         {
@@ -2350,7 +2360,7 @@ Parser::showLog(const string& id, const string& reader, bool tail, bool follow, 
 
         try
         {
-            loggerAdmin->detachRemoteLogger(prx);
+            loggerAdmin->detachRemoteLogger(*prx);
         }
         catch (const Ice::ObjectNotExistException&)
         {

--- a/cpp/src/IceGrid/Parser.cpp
+++ b/cpp/src/IceGrid/Parser.cpp
@@ -2190,15 +2190,18 @@ Parser::showFile(
             while (!interrupted() && !eof && i < lineCount)
             {
                 eof = it->read(maxBytes, lines);
+                // Trim the batch to the remaining line count: the terminating-newline check below looks at
+                // the last entry of the batch, so the batch must contain only the printed lines.
+                if (lines.size() > static_cast<size_t>(lineCount - i))
+                {
+                    lines.resize(static_cast<size_t>(lineCount - i));
+                }
+                i += static_cast<int>(lines.size());
                 for (const auto& line : lines)
                 {
                     outputNewline();
                     outputString(line);
                     flushOutput();
-                    if (++i == lineCount)
-                    {
-                        break;
-                    }
                 }
             }
         }


### PR DESCRIPTION
Three small, independent `icegridadmin` fixes, one commit each:

- **Crash when no registry is reachable on `--host`**: when started with `--host` and no pre-configured locator, a failed LocatorFinder lookup left the default locator unset, and with `--instanceName` the code then dereferenced the empty `std::optional` (crash). `icegridadmin` now reports `could not contact the registry running on '<host>'` and exits with status 1 — both when the lookup throws and, as defense in depth, when it returns no locator — and only sets the default locator once validated. Verified: pre-fix segfault, post-fix clean error, with and without `--instanceName`.
- **`show --head n` printed the whole file**: the line counter was never incremented and the limit was not applied within a read batch. The output now stops after `n` lines.
- **`log --follow` broke subsequent `--follow` commands after a failure**: the fixed-name `RemoteLoggerAdapter` was only destroyed after a successful attach and wait, so a setup failure (for example an unreachable target) leaked it and every later `log --follow` in the same session failed with `AlreadyRegisteredException`. Setup is now guarded and the adapter destroyed on failure; the exception still surfaces through the parser's normal error reporting. #6055 tracks modernizing this code to the default-object-adapter pattern in 3.9.

Fixes #6034
Fixes #6044
Fixes #6045

🤖 Generated with [Claude Code](https://claude.com/claude-code)