### PR TITLE
Warn on an invalid Ice.RetryIntervals value in C++, C#, and Java

### DIFF
--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -1262,20 +1262,26 @@ IceInternal::Instance::initialize(const Ice::CommunicatorPtr& communicator)
                 istringstream value(retryValue);
 
                 int v;
-                if (!(value >> v) || !value.eof())
-                {
-                    v = 0;
-                }
+                bool parsed = static_cast<bool>(value >> v) && value.eof();
 
                 //
                 // If -1 is the first value, no retry and wait intervals.
                 //
-                if (v == -1 && _retryIntervals.empty())
+                if (parsed && v == -1 && _retryIntervals.empty())
                 {
                     break;
                 }
 
-                _retryIntervals.push_back(v > 0 ? v : 0);
+                // Any value that is not a non-negative integer (or the leading -1 handled above) is invalid and
+                // treated as 0.
+                if (!parsed || v < 0)
+                {
+                    Warning out(_initData.logger);
+                    out << "invalid value '" << retryValue << "' in property Ice.RetryIntervals, assuming 0";
+                    v = 0;
+                }
+
+                _retryIntervals.push_back(v);
             }
         }
 

--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -819,26 +819,38 @@ public sealed class Instance
                 for (int i = 0; i < retryValues.Length; i++)
                 {
                     int v;
+                    bool parsed;
 
                     try
                     {
                         v = int.Parse(retryValues[i], CultureInfo.InvariantCulture);
+                        parsed = true;
                     }
-                    catch (System.FormatException)
+                    catch (System.Exception ex) when (ex is System.FormatException or System.OverflowException)
                     {
                         v = 0;
+                        parsed = false;
                     }
 
                     //
                     // If -1 is the first value, no retry and wait intervals.
                     //
-                    if (i == 0 && v == -1)
+                    if (parsed && i == 0 && v == -1)
                     {
                         retryIntervals = [];
                         break;
                     }
 
-                    retryIntervals[i] = v > 0 ? v : 0;
+                    // Any value that is not a non-negative integer (or the leading -1 handled above) is
+                    // invalid and treated as 0.
+                    if (!parsed || v < 0)
+                    {
+                        _initData.logger.warning(
+                            $"invalid value '{retryValues[i]}' in property Ice.RetryIntervals, assuming 0");
+                        v = 0;
+                    }
+
+                    retryIntervals[i] = v;
                 }
             }
 

--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -818,19 +818,8 @@ public sealed class Instance
 
                 for (int i = 0; i < retryValues.Length; i++)
                 {
-                    int v;
-                    bool parsed;
-
-                    try
-                    {
-                        v = int.Parse(retryValues[i], CultureInfo.InvariantCulture);
-                        parsed = true;
-                    }
-                    catch (System.Exception ex) when (ex is System.FormatException or System.OverflowException)
-                    {
-                        v = 0;
-                        parsed = false;
-                    }
+                    bool parsed =
+                        int.TryParse(retryValues[i], NumberStyles.Integer, CultureInfo.InvariantCulture, out int v);
 
                     //
                     // If -1 is the first value, no retry and wait intervals.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -739,20 +739,33 @@ public final class Instance {
 
                 for (int i = 0; i < arr.length; i++) {
                     int v;
+                    boolean parsed;
 
                     try {
                         v = Integer.parseInt(arr[i]);
+                        parsed = true;
                     } catch (NumberFormatException ex) {
                         v = 0;
+                        parsed = false;
                     }
 
                     // If -1 is the first value, no retry and wait intervals.
-                    if (i == 0 && v == -1) {
+                    if (parsed && i == 0 && v == -1) {
                         _retryIntervals = new int[0];
                         break;
                     }
 
-                    _retryIntervals[i] = v > 0 ? v : 0;
+                    // Any value that is not a non-negative integer (or the leading -1 handled above) is
+                    // invalid and treated as 0.
+                    if (!parsed || v < 0) {
+                        _initData.logger.warning(
+                                "invalid value '"
+                                        + arr[i]
+                                        + "' in property Ice.RetryIntervals, assuming 0");
+                        v = 0;
+                    }
+
+                    _retryIntervals[i] = v;
                 }
             }
             _cacheMessageBuffers = properties.getIcePropertyAsInt("Ice.CacheMessageBuffers");

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -759,9 +759,9 @@ public final class Instance {
                     // invalid and treated as 0.
                     if (!parsed || v < 0) {
                         _initData.logger.warning(
-                                "invalid value '"
-                                        + arr[i]
-                                        + "' in property Ice.RetryIntervals, assuming 0");
+                            "invalid value '"
+                                + arr[i]
+                                + "' in property Ice.RetryIntervals, assuming 0");
                         v = 0;
                     }
 


### PR DESCRIPTION
C++, C#, and Java silently coerced an invalid `Ice.RetryIntervals` token to `0` ("retry immediately"), so a malformed configuration value was indistinguishable from an intentional `0` and gave no diagnostic. They now log a warning when coercing, while leaving a legitimate `0` and the leading `-1` (no retries) silent.

"Invalid" now uniformly covers a non-integer token, an out-of-range value, and an unexpected negative value (any negative other than the leading `-1` sentinel — previously clamped to `0` with no warning). The C# change additionally coerces an out-of-range value to `0` like C++ and Java, instead of letting `int.Parse`'s `OverflowException` escape.

JS is unchanged: it continues to reject an invalid value with a `ParseException` at startup. Unifying the four mappings on that stricter reject-at-startup contract is a documented-behavior change tracked for 3.9 in #6058.

Fixes #6042