### PR TITLE
Fix loading the wrong config file with adjacent --Ice.Config arguments (C#, Java)

### DIFF
--- a/changelog.d/csharp/config-args-adjacent.md
+++ b/changelog.d/csharp/config-args-adjacent.md
@@ -1,0 +1,2 @@
+- Fixed a bug where specifying the `--Ice.Config` command-line option more than once loaded the wrong configuration
+  file: Ice loaded the first file instead of the last.

--- a/changelog.d/java/config-args-adjacent.md
+++ b/changelog.d/java/config-args-adjacent.md
@@ -1,0 +1,2 @@
+- Fixed a bug where specifying the `--Ice.Config` command-line option more than once loaded the wrong configuration
+  file: Ice loaded the first file instead of the last.

--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -621,28 +621,26 @@ public sealed class Properties
     private void loadArgs(ref string[] args)
     {
         bool loadConfigFiles = false;
+        List<string> remainingArgs = [];
 
-        for (int i = 0; i < args.Length; i++)
+        foreach (string arg in args)
         {
-            if (args[i].StartsWith("--Ice.Config", StringComparison.Ordinal))
+            if (arg.StartsWith("--Ice.Config", StringComparison.Ordinal))
             {
-                string line = args[i];
+                string line = arg;
                 if (!line.Contains('=', StringComparison.Ordinal))
                 {
                     line += "=1";
                 }
                 parseLine(line[2..]);
                 loadConfigFiles = true;
-
-                string[] arr = new string[args.Length - 1];
-                Array.Copy(args, 0, arr, 0, i);
-                if (i < args.Length - 1)
-                {
-                    Array.Copy(args, i + 1, arr, i, args.Length - i - 1);
-                }
-                args = arr;
+            }
+            else
+            {
+                remainingArgs.Add(arg);
             }
         }
+        args = [.. remainingArgs];
 
         if (!loadConfigFiles)
         {

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -43,6 +43,21 @@ public class Client : Test.TestHelper
             Console.Out.WriteLine("ok");
         }
 
+        //
+        // Two separate --Ice.Config arguments: the last one wins, like C++.
+        //
+        {
+            Console.Out.Write("testing using Ice.Config with adjacent command-line arguments... ");
+            Console.Out.Flush();
+            string[] args1 = ["--Ice.Config=config/config.1", "--Ice.Config=config/config.2"];
+            var properties = new Ice.Properties(ref args1);
+            test(properties.getIceProperty("Ice.Config") == "config/config.2");
+            test(properties.getProperty("Config1").Length == 0);
+            test(properties.getProperty("Config2") == "Config2");
+            test(args1.Length == 0);
+            Console.Out.WriteLine("ok");
+        }
+
         {
             Console.Out.Write("testing configuration file escapes... ");
             Console.Out.Flush();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -590,24 +590,21 @@ public final class Properties {
 
     private void loadArgs(String[] args, List<String> remainingArgs) {
         boolean loadConfigFiles = false;
+        List<String> filteredArgs = new ArrayList<>();
 
-        for (int i = 0; i < args.length; i++) {
-            if (args[i].startsWith("--Ice.Config")) {
-                String line = args[i];
+        for (String arg : args) {
+            if (arg.startsWith("--Ice.Config")) {
+                String line = arg;
                 if (line.indexOf('=') == -1) {
                     line += "=1";
                 }
                 parseLine(line.substring(2));
                 loadConfigFiles = true;
-
-                String[] arr = new String[args.length - 1];
-                System.arraycopy(args, 0, arr, 0, i);
-                if (i < args.length - 1) {
-                    System.arraycopy(args, i + 1, arr, i, args.length - i - 1);
-                }
-                args = arr;
+            } else {
+                filteredArgs.add(arg);
             }
         }
+        args = filteredArgs.toArray(new String[0]);
 
         if (!loadConfigFiles) {
             // If Ice.Config is not set, load from ICE_CONFIG (if set)

--- a/java/test/src/main/java/test/Ice/properties/Client.java
+++ b/java/test/src/main/java/test/Ice/properties/Client.java
@@ -8,6 +8,9 @@ import com.zeroc.Ice.PropertyException;
 
 import test.TestHelper;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Client extends TestHelper {
     public static void test(boolean b) {
         if (!b) {
@@ -39,6 +42,22 @@ public class Client extends TestHelper {
             test("Config1".equals(properties.getProperty("Config1")));
             test("Config2".equals(properties.getProperty("Config2")));
             test("Config3".equals(properties.getProperty("Config3")));
+            System.out.println("ok");
+        }
+
+        //
+        // Two separate --Ice.Config arguments: the last one wins, like C++.
+        //
+        {
+            System.out.print("testing using Ice.Config with adjacent command-line arguments... ");
+            String[] args1 =
+                new String[]{"--Ice.Config=config/config.1", "--Ice.Config=config/config.2"};
+            List<String> remainingArgs = new ArrayList<>();
+            Properties properties = new Properties(args1, remainingArgs);
+            test("config/config.2".equals(properties.getIceProperty("Ice.Config")));
+            test(properties.getProperty("Config1").isEmpty());
+            test("Config2".equals(properties.getProperty("Config2")));
+            test(remainingArgs.isEmpty());
             System.out.println("ok");
         }
 


### PR DESCRIPTION
When two `--Ice.Config` options were passed as adjacent command-line arguments (e.g. `--Ice.Config=a.cfg --Ice.Config=b.cfg`), the C# and Java runtimes loaded `a.cfg` but set the `Ice.Config` property to `b.cfg` — so the loaded values and the property disagreed, and the second file was never loaded. C++ loads the last file, as expected.

The cause was a forward loop in `loadArgs` that removed the current element from the argument array and then incremented the index, skipping the element that shifted into the freed slot. `loadArgs` now builds a fresh list of the non-`--Ice.Config` arguments — mirroring C++ `loadArgs` and the sibling `parseCommandLineOptions` — so the last file wins.

Added a regression case to the C# and Java properties tests: two adjacent `--Ice.Config` arguments load the second file's values, not the first, and the arguments are consumed.

Fixes #6031