### PR TITLE
Fix two C# property accessor divergences

### DIFF
--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -168,7 +168,7 @@ public sealed class Properties
             {
                 return int.Parse(pv.value, CultureInfo.InvariantCulture);
             }
-            catch (FormatException)
+            catch (System.Exception ex) when (ex is System.FormatException or System.OverflowException)
             {
                 throw new PropertyException($"property '{key}' has an invalid integer value: '{pv.value}'");
             }

--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -235,10 +235,7 @@ public sealed class Properties
                     $"mismatched quotes in property {key}'s value, returning default value");
                 return value;
             }
-            else
-            {
-                return result;
-            }
+            return result.Length == 0 ? value : result;
         }
     }
 

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -225,6 +225,15 @@ public class Client : Test.TestHelper
         }
 
         {
+            Console.Out.Write("testing that a separators-only list value returns the default... ");
+            var properties = new Ice.Properties();
+            properties.setProperty("Foo", ",");
+            string[] result = properties.getPropertyAsListWithDefault("Foo", ["a", "b"]);
+            test(result.Length == 2 && result[0] == "a" && result[1] == "b");
+            Console.Out.WriteLine("ok");
+        }
+
+        {
             Console.Out.Write("testing Ice.ProgramName default... ");
             Console.Out.Flush();
             using var communicator = new Ice.Communicator();

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -210,6 +210,21 @@ public class Client : Test.TestHelper
         }
 
         {
+            Console.Out.Write("testing that reading an out-of-range value as an int throws... ");
+            var properties = new Ice.Properties();
+            properties.setProperty("Foo", "99999999999");
+            try
+            {
+                properties.getPropertyAsIntWithDefault("Foo", 0);
+                test(false);
+            }
+            catch (Ice.PropertyException)
+            {
+            }
+            Console.Out.WriteLine("ok");
+        }
+
+        {
             Console.Out.Write("testing Ice.ProgramName default... ");
             Console.Out.Flush();
             using var communicator = new Ice.Communicator();


### PR DESCRIPTION
Two small, independent C# `Properties` accessor fixes where C# diverged from the other mappings, one commit each:

- **#6032** — `getPropertyAsIntWithDefault` caught only `FormatException`, so an out-of-range value made `int.Parse` throw an uncaught `OverflowException` instead of the documented `PropertyException`. Since `OverflowException` is not a `LocalException`, it also bypassed `Instance.initialize`'s `catch (LocalException)` cleanup, leaking the partially-constructed communicator. The method now catches `OverflowException` too and converts it to a `PropertyException`, matching C++.
- **#6040** — `getPropertyAsListWithDefault` returned an empty array when a present, non-empty value parsed to an empty list (a separators-only value such as `,`), instead of returning the caller's default like C++, Java, and JS. It now returns the default.

Added regression cases to the C# properties test for both.

Fixes #6032
Fixes #6040