### PR TITLE
Align Java Options.split normal-state backslash escaping with C++/C#

### DIFF
--- a/changelog.d/java/options-split-backslash.md
+++ b/changelog.d/java/options-split-backslash.md
@@ -1,0 +1,3 @@
+- Fixed a bug on Windows where a plug-in or IceBox service configured with an unquoted UNC path (such as
+  `\\server\share\plugin.jar`) was loaded from the wrong location: the path was resolved relative to the current
+  directory instead of being recognized as absolute.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
@@ -42,8 +42,7 @@ public final class Options {
                             // we don't drop backslashes from Windows path names.
                             if (i < line.length() - 1 && line.charAt(++i) != '\n') {
                                 char nextChar = line.charAt(i);
-                                // TODO: comment says we should be checking single quotes here, but we aren't?
-                                if (nextChar != ' ' && nextChar != '$' && nextChar != '\\' && nextChar != '"') {
+                                if (nextChar != ' ' && nextChar != '\'' && nextChar != '$' && nextChar != '"') {
                                     arg.append('\\');
                                 }
                                 arg.append(nextChar);

--- a/java/test/src/main/java/test/IceUtil/inputUtil/Client.java
+++ b/java/test/src/main/java/test/IceUtil/inputUtil/Client.java
@@ -103,6 +103,14 @@ public class Client extends TestHelper {
             args = Options.split("-Dir=$'C:\\\\\\cM\\x66\\146i'"); // -Dir=$'C:\\\cM\x66\146i'
             test(args.length == 1 && "-Dir=C:\\\015ffi".equals(args[0]));
             //CHECKSTYLE:ON: IllegalTokenText
+
+            // Backslash escaping in the normal (unquoted) state, matching C++ and C#: a backslash
+            // before another backslash is preserved, and a backslash before a single quote escapes
+            // the quote.
+            args = Options.split("-Dir=C:\\\\file"); // -Dir=C:\\file
+            test(args.length == 1 && "-Dir=C:\\\\file".equals(args[0])); // -Dir=C:\\file
+            args = Options.split("a\\'b"); // a\'b
+            test(args.length == 1 && "a'b".equals(args[0])); // a'b
         } catch (ParseException ex) {
             test(false);
         }


### PR DESCRIPTION
In the normal (unquoted) state, Java's `Options.split` used the wrong backslash escape set: it dropped a backslash before another backslash and kept one before a single quote — the opposite of C++ and C#. So `\\` became `\` (vs `\\`) and `\'` became `\'` (vs `'`).

The observable consequence is on Windows: an unquoted UNC path such as `\\server\share\plugin.jar` used as a plug-in or IceBox service entry point collapsed to `\server\share\plugin.jar`, failed absolute-path recognition, and was resolved relative to the working directory — so the plug-in or service loaded from the wrong location. C++ and C# preserve the `\\` and recognize the path as absolute.

The drop-set is now `{ space, ', $, " }`, matching C++ and C#. The parity test only exercised backslashes inside quotes, never the normal-state path; added unquoted `\\` and `\'` cases with C++/C# as the oracle.

Fixes #6038