### PR TITLE
Range-check the default value in Ruby and PHP getPropertyAsIntWithDefault

### DIFF
--- a/php/src/Properties.cpp
+++ b/php/src/Properties.cpp
@@ -237,7 +237,7 @@ ZEND_METHOD(Ice_Properties, getPropertyAsIntWithDefault)
     string_view propName(name, nameLen);
     if (def < INT32_MIN || def > INT32_MAX)
     {
-        invalidArgument("the value argument is out of the range of a 32-bit integer");
+        invalidArgument("the default value is out of the range of a 32-bit integer");
         RETURN_NULL();
     }
     try

--- a/php/src/Properties.cpp
+++ b/php/src/Properties.cpp
@@ -235,9 +235,13 @@ ZEND_METHOD(Ice_Properties, getPropertyAsIntWithDefault)
     assert(_this);
 
     string_view propName(name, nameLen);
+    if (def < INT32_MIN || def > INT32_MAX)
+    {
+        invalidArgument("the value argument is out of the range of a 32-bit integer");
+        RETURN_NULL();
+    }
     try
     {
-        // TODO: Range check
         int32_t val = _this->getPropertyAsIntWithDefault(propName, static_cast<int32_t>(def));
         RETURN_LONG(val);
     }

--- a/php/test/Ice/properties/Client.php
+++ b/php/test/Ice/properties/Client.php
@@ -79,6 +79,15 @@ class Client extends TestHelper
         }
         echo "ok\n";
 
+        echo "testing that an out-of-range default value throws... ";
+        $properties = Ice\createProperties();
+        try {
+            $properties->getPropertyAsIntWithDefault("Unset.Key", 99999999999);
+            test(False);
+        } catch (\InvalidArgumentException $ex) {
+        }
+        echo "ok\n";
+
         echo "testing Ice.initialize with args... ";
         $args = ["--Foo.Bar=1", "--Foo.Bar=2", "--Ice.Trace.Network=3"];
         $communicator = Ice\initialize($args);

--- a/ruby/src/IceRuby/Properties.cpp
+++ b/ruby/src/IceRuby/Properties.cpp
@@ -156,8 +156,12 @@ IceRuby_Properties_getPropertyAsIntWithDefault(VALUE self, VALUE key, VALUE def)
     {
         Ice::PropertiesPtr p = getProperties(self);
         string k = getString(key);
-        int32_t d = static_cast<int32_t>(getInteger(def));
-        int32_t v = p->getPropertyAsIntWithDefault(k, d);
+        long d = getInteger(def);
+        if (d < INT32_MIN || d > INT32_MAX)
+        {
+            throw RubyException(rb_eRangeError, "the value argument is out of the range of a 32-bit integer");
+        }
+        int32_t v = p->getPropertyAsIntWithDefault(k, static_cast<int32_t>(d));
         return INT2FIX(v);
     }
     ICE_RUBY_CATCH

--- a/ruby/src/IceRuby/Properties.cpp
+++ b/ruby/src/IceRuby/Properties.cpp
@@ -159,7 +159,7 @@ IceRuby_Properties_getPropertyAsIntWithDefault(VALUE self, VALUE key, VALUE def)
         long d = getInteger(def);
         if (d < INT32_MIN || d > INT32_MAX)
         {
-            throw RubyException(rb_eRangeError, "the value argument is out of the range of a 32-bit integer");
+            throw RubyException(rb_eRangeError, "the default value is out of the range of a 32-bit integer");
         }
         int32_t v = p->getPropertyAsIntWithDefault(k, static_cast<int32_t>(d));
         return INT2FIX(v);

--- a/ruby/test/Ice/properties/Client.rb
+++ b/ruby/test/Ice/properties/Client.rb
@@ -109,6 +109,15 @@ class Client < ::TestHelper
         end
         puts "ok"
 
+        print "testing that an out-of-range default value raises... "
+        properties = Ice.createProperties()
+        begin
+            properties.getPropertyAsIntWithDefault("Unset.Key", 99999999999)
+            test(false)
+        rescue RangeError => ex
+        end
+        puts "ok"
+
         print "testing createProperties with a defaults argument... "
         # Passing nil for the optional defaults argument must behave like omitting it (no defaults),
         # not crash. Regression test: a nil defaults argument previously bypassed the type check and


### PR DESCRIPTION
The Ruby and PHP bindings accept a wide (64-bit) integer default for `getPropertyAsIntWithDefault` and silently cast it to `int32_t`, so an out-of-range default was truncated with no error — for example `getPropertyAsIntWithDefault("Unset.Key", 99999999999)` returned `1215752191` (mod 2³²). The parsed property value is unaffected: it goes through the C++ core, which validates and throws. Only the caller-supplied default was narrowed, from accepting a wider dynamic integer and casting it down.

The bindings now range-check the default before narrowing and raise on out-of-range — `RangeError` in Ruby, `InvalidArgumentException` in PHP — matching how the property value itself is validated.

Added a regression case to the Ruby and PHP properties tests.

Fixes #6041