### PR TITLE
Bound the IceGrid Activator fork-child file-descriptor close loop

### DIFF
--- a/changelog.d/service-icegrid/5843.md
+++ b/changelog.d/service-icegrid/5843.md
@@ -1,1 +1,2 @@
-- Fixed a node-wide activation stall in the IceGrid node when running with a very large file descriptor limit (such as `LimitNOFILE=infinity` under systemd).
+- Fixed a node-wide activation stall in the IceGrid node when running with a very large file descriptor limit
+  (such as `LimitNOFILE=infinity` under systemd).

--- a/changelog.d/service-icegrid/5843.md
+++ b/changelog.d/service-icegrid/5843.md
@@ -1,1 +1,1 @@
-- Fixed a node-wide activation stall in the IceGrid node when running with an unlimited file-descriptor limit.
+- Fixed a node-wide activation stall in the IceGrid node when running with a very large file descriptor limit (such as `LimitNOFILE=infinity` under systemd).

--- a/changelog.d/service-icegrid/5843.md
+++ b/changelog.d/service-icegrid/5843.md
@@ -1,0 +1,1 @@
+- Fixed a node-wide activation stall in the IceGrid node when running with an unlimited file-descriptor limit.

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -90,12 +90,9 @@ namespace IceGrid
     }
 
     //
-    // Close every inherited file descriptor >= 3 in the fork child, keeping the
-    // two given descriptors open (the write ends of the interrupt and error
-    // pipes). This runs after setuid/setgid, so a leaked descriptor would cross
-    // a privilege boundary.
-    //
-    // Runs in the fork child, using only async-signal-safe calls.
+    // Close every inherited file descriptor >= 3, except keep1 and keep2. Runs in the fork child, using only
+    // async-signal-safe calls. maxFd bounds the fallback close loop used when close_range is unavailable. This runs
+    // after setuid/setgid, so a leaked descriptor would cross a privilege boundary.
     //
     void closeInheritedDescriptors(int keep1, int keep2, long maxFd)
     {
@@ -114,9 +111,11 @@ namespace IceGrid
         // never inverted, so the only realistic failure is the syscall being
         // unavailable (ENOSYS on an older kernel, or a seccomp EPERM), and on
         // failure it closes nothing; we fall through to the bounded loop below,
-        // so there is no need to inspect errno.
+        // so there is no need to inspect errno. Clamp the probe's start to 3 so
+        // that if both keeps landed below 3 it still cannot close stderr.
         //
-        if (syscall(SYS_close_range, static_cast<unsigned int>(hi) + 1, ~0u, 0u) == 0)
+        const unsigned int probeStart = static_cast<unsigned int>(hi + 1 > 3 ? hi + 1 : 3);
+        if (syscall(SYS_close_range, probeStart, ~0u, 0u) == 0)
         {
             if (lo > 3)
             {
@@ -777,17 +776,14 @@ Activator::activate(
     const char* pwdCStr = pwd.c_str();
 
     //
-    // Compute the last-resort descriptor-close bound before fork(), so the child
-    // has a finite bound to fall back on if it can use neither close_range nor
-    // /proc/self/fd (and so it need not call getrlimit() itself). Prefer the soft
-    // RLIMIT_NOFILE — the kernel never allocates a descriptor at or above it —
-    // capped so the loop stays bounded even under a huge or unlimited limit.
+    // Compute the fallback descriptor-close bound before fork(), so the child has a finite bound if it cannot use
+    // close_range (and doesn't need to call getrlimit() itself). Prefer the soft RLIMIT_NOFILE — the kernel never
+    // allocates a descriptor at or above it — capped so the loop stays bounded even under a huge or unlimited limit.
     //
     long maxFdToClose = 1 << 20;
     {
         rlimit fdLimit{};
-        if (getrlimit(RLIMIT_NOFILE, &fdLimit) == 0 && fdLimit.rlim_cur != RLIM_INFINITY &&
-            static_cast<long>(fdLimit.rlim_cur) < maxFdToClose)
+        if (getrlimit(RLIMIT_NOFILE, &fdLimit) == 0 && fdLimit.rlim_cur < static_cast<rlim_t>(maxFdToClose))
         {
             maxFdToClose = static_cast<long>(fdLimit.rlim_cur);
         }

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -21,6 +21,7 @@
 
 #ifndef _WIN32
 #    include <csignal>
+#    include <dirent.h>
 #    include <pwd.h> // for getpwuid
 #    include <sys/resource.h>
 #    include <sys/syscall.h>
@@ -93,9 +94,13 @@ namespace IceGrid
     // Close every inherited file descriptor >= 3 in the fork child, keeping the
     // two given descriptors open (the write ends of the interrupt and error
     // pipes). This runs after setuid/setgid, so a leaked descriptor would cross
-    // a privilege boundary. It runs in the fork child, so it uses only
-    // async-signal-safe facilities: close_range/close and the maxFd bound that
-    // the caller computed before fork().
+    // a privilege boundary.
+    //
+    // Runs in the fork child. The close_range fast path and the final bounded
+    // loop use only async-signal-safe calls; the /proc/self/fd enumeration uses
+    // opendir/readdir (which allocate), but that path runs only on Linux, where
+    // glibc keeps the allocator usable in the child after fork — as the
+    // surrounding child code, which also allocates, already relies on.
     //
     void closeInheritedDescriptors(int keep1, int keep2, long maxFd)
     {
@@ -127,9 +132,31 @@ namespace IceGrid
 #    endif
 
         //
-        // Fallback for platforms without close_range (or an older kernel that
-        // returns ENOSYS): close descriptors one by one up to maxFd, the bound
-        // the caller computed from the soft RLIMIT_NOFILE before fork().
+        // Fallback for kernels/platforms without close_range (e.g. Linux before
+        // 5.9): enumerate the descriptors that are actually open from
+        // /proc/self/fd and close them, so the child neither iterates up to a
+        // huge or unlimited limit nor leaks a descriptor above one.
+        //
+        if (DIR* dir = opendir("/proc/self/fd"))
+        {
+            const int dirFd = dirfd(dir);
+            for (dirent* entry = readdir(dir); entry != nullptr; entry = readdir(dir))
+            {
+                const int fd = atoi(entry->d_name); // "." and ".." parse to 0 and are skipped below
+                if (fd >= 3 && fd != lo && fd != hi && fd != dirFd)
+                {
+                    close(fd);
+                }
+            }
+            closedir(dir);
+            return;
+        }
+
+        //
+        // Last resort (no /proc, e.g. some minimal containers or non-Linux
+        // platforms without close_range): close descriptors one by one up to
+        // maxFd, the bound the caller computed from the soft RLIMIT_NOFILE
+        // before fork().
         //
         for (long fd = 3; fd < maxFd; ++fd)
         {
@@ -764,16 +791,17 @@ Activator::activate(
     const char* pwdCStr = pwd.c_str();
 
     //
-    // Compute the bound for closing inherited descriptors before fork(), so the
-    // child (which must stay async-signal-safe) does not call getrlimit(). A
-    // finite soft RLIMIT_NOFILE is an exact bound — the kernel never allocates a
-    // descriptor at or above it — so the child closes the whole range; if it is
-    // unlimited we fall back to a sane cap so the child cannot loop up to INT_MAX.
+    // Compute the last-resort descriptor-close bound before fork(), so the child
+    // has a finite bound to fall back on if it can use neither close_range nor
+    // /proc/self/fd (and so it need not call getrlimit() itself). Prefer the soft
+    // RLIMIT_NOFILE — the kernel never allocates a descriptor at or above it —
+    // capped so the loop stays bounded even under a huge or unlimited limit.
     //
-    long maxFdToClose = 65536;
+    long maxFdToClose = 1 << 20;
     {
         rlimit fdLimit{};
-        if (getrlimit(RLIMIT_NOFILE, &fdLimit) == 0 && fdLimit.rlim_cur != RLIM_INFINITY)
+        if (getrlimit(RLIMIT_NOFILE, &fdLimit) == 0 && fdLimit.rlim_cur != RLIM_INFINITY &&
+            static_cast<long>(fdLimit.rlim_cur) < maxFdToClose)
         {
             maxFdToClose = static_cast<long>(fdLimit.rlim_cur);
         }

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -22,6 +22,8 @@
 #ifndef _WIN32
 #    include <csignal>
 #    include <pwd.h> // for getpwuid
+#    include <sys/resource.h>
+#    include <sys/syscall.h>
 #    include <sys/wait.h>
 #    include <unistd.h>
 #else
@@ -85,6 +87,64 @@ namespace IceGrid
         // process.
         //
         _exit(EXIT_FAILURE);
+    }
+
+    //
+    // Close every inherited file descriptor >= 3 in the fork child, keeping the
+    // two given descriptors open (the write ends of the interrupt and error
+    // pipes). This runs after setuid/setgid, so a leaked descriptor would cross
+    // a privilege boundary; it must use only async-signal-safe facilities.
+    //
+    void closeInheritedDescriptors(int keep1, int keep2)
+    {
+        const int lo = keep1 < keep2 ? keep1 : keep2;
+        const int hi = keep1 < keep2 ? keep2 : keep1;
+
+#    ifdef SYS_close_range
+        //
+        // close_range (Linux 5.9+, FreeBSD 12.2+) closes a whole descriptor
+        // range in a single syscall, so the child never iterates up to a huge
+        // or unlimited RLIMIT_NOFILE. We keep lo and hi open by closing the
+        // ranges around them. Probe with the always-non-empty top range first;
+        // if the syscall exists close the lower ranges too and we are done,
+        // otherwise (e.g. an older kernel returns ENOSYS) fall through to the
+        // descriptor loop below.
+        //
+        if (syscall(SYS_close_range, static_cast<unsigned int>(hi) + 1, ~0u, 0u) == 0)
+        {
+            if (lo > 3)
+            {
+                syscall(SYS_close_range, 3u, static_cast<unsigned int>(lo) - 1, 0u);
+            }
+            if (hi > lo + 1)
+            {
+                syscall(SYS_close_range, static_cast<unsigned int>(lo) + 1, static_cast<unsigned int>(hi) - 1, 0u);
+            }
+            return;
+        }
+#    endif
+
+        //
+        // Fallback for platforms without close_range: close descriptors one by
+        // one up to the soft RLIMIT_NOFILE. The kernel does not allocate
+        // descriptors at or above that limit, so it is a suitable bound; when it
+        // is unlimited (or unavailable) we cap the loop so a single activation
+        // cannot issue billions of close() calls.
+        //
+        rlimit fdLimit{};
+        long maxFd = 65536;
+        if (getrlimit(RLIMIT_NOFILE, &fdLimit) == 0 && fdLimit.rlim_cur != RLIM_INFINITY &&
+            static_cast<long>(fdLimit.rlim_cur) < maxFd)
+        {
+            maxFd = static_cast<long>(fdLimit.rlim_cur);
+        }
+        for (long fd = 3; fd < maxFd; ++fd)
+        {
+            if (fd != lo && fd != hi)
+            {
+                close(static_cast<int>(fd));
+            }
+        }
     }
 
 #endif
@@ -792,23 +852,12 @@ Activator::activate(
         setpgid(0, 0);
 
         //
-        // Close all file descriptors, except for standard input,
-        // standard output, standard error, and the write side
-        // of the newly created pipe.
+        // Close all file descriptors, except for standard input, standard
+        // output, standard error, and the write ends of the two pipes created
+        // above: fds[1], kept open across exec so the node detects the server's
+        // termination, and errorFds[1], used to report pre-exec errors.
         //
-        int maxFd = static_cast<int>(sysconf(_SC_OPEN_MAX));
-        if (maxFd <= 0)
-        {
-            maxFd = numeric_limits<int>::max();
-        }
-
-        for (int fd = 3; fd < maxFd; ++fd)
-        {
-            if (fd != fds[1] && fd != errorFds[1])
-            {
-                close(fd);
-            }
-        }
+        closeInheritedDescriptors(fds[1], errorFds[1]);
 
         for (int i = 0; i < env.argc; i++) // NOLINT(clang-analyzer-unix.Malloc)
         {

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -21,7 +21,6 @@
 
 #ifndef _WIN32
 #    include <csignal>
-#    include <dirent.h>
 #    include <pwd.h> // for getpwuid
 #    include <sys/resource.h>
 #    include <sys/syscall.h>
@@ -96,11 +95,7 @@ namespace IceGrid
     // pipes). This runs after setuid/setgid, so a leaked descriptor would cross
     // a privilege boundary.
     //
-    // Runs in the fork child. The close_range fast path and the final bounded
-    // loop use only async-signal-safe calls; the /proc/self/fd enumeration uses
-    // opendir/readdir (which allocate), but that path runs only on Linux, where
-    // glibc keeps the allocator usable in the child after fork — as the
-    // surrounding child code, which also allocates, already relies on.
+    // Runs in the fork child, using only async-signal-safe calls.
     //
     void closeInheritedDescriptors(int keep1, int keep2, long maxFd)
     {
@@ -111,14 +106,15 @@ namespace IceGrid
         //
         // close_range (Linux 5.9+, FreeBSD 12.2+) closes a whole descriptor
         // range in a single syscall, so the child never iterates up to a huge
-        // or unlimited RLIMIT_NOFILE. We keep lo and hi open by closing the
-        // ranges around them. Probe with the always-non-empty top range first:
-        // on success, close the lower ranges too and return. The probe range is
+        // or unlimited RLIMIT_NOFILE. Every supported platform with a huge or
+        // unlimited limit has it (the minimum supported Linux distributions all
+        // ship kernel 5.10+). We keep lo and hi open by closing the ranges
+        // around them. Probe with the always-non-empty top range first: on
+        // success, close the lower ranges too and return. The probe range is
         // never inverted, so the only realistic failure is the syscall being
         // unavailable (ENOSYS on an older kernel, or a seccomp EPERM), and on
-        // failure it closes nothing; we fall through to the /proc/self/fd
-        // enumeration below, which is a complete fallback, so there is no need
-        // to inspect errno.
+        // failure it closes nothing; we fall through to the bounded loop below,
+        // so there is no need to inspect errno.
         //
         if (syscall(SYS_close_range, static_cast<unsigned int>(hi) + 1, ~0u, 0u) == 0)
         {
@@ -126,40 +122,27 @@ namespace IceGrid
             {
                 syscall(SYS_close_range, 3u, static_cast<unsigned int>(lo) - 1, 0u);
             }
-            if (hi > lo + 1)
+            //
+            // Clamp the middle range's start to 3: lo can be below 3 (the pipe
+            // write ends land at 0/1/2 only when a standard descriptor was
+            // already closed before exec), and an unclamped lo + 1 == 2 would
+            // close stderr.
+            //
+            const int mid = lo + 1 > 3 ? lo + 1 : 3;
+            if (hi - 1 >= mid)
             {
-                syscall(SYS_close_range, static_cast<unsigned int>(lo) + 1, static_cast<unsigned int>(hi) - 1, 0u);
+                syscall(SYS_close_range, static_cast<unsigned int>(mid), static_cast<unsigned int>(hi) - 1, 0u);
             }
             return;
         }
 #    endif
 
         //
-        // Fallback for kernels/platforms without close_range (e.g. Linux before
-        // 5.9): enumerate the descriptors that are actually open from
-        // /proc/self/fd and close them, so the child neither iterates up to a
-        // huge or unlimited limit nor leaks a descriptor above one.
-        //
-        if (DIR* dir = opendir("/proc/self/fd"))
-        {
-            const int dirFd = dirfd(dir);
-            for (dirent* entry = readdir(dir); entry != nullptr; entry = readdir(dir))
-            {
-                const int fd = atoi(entry->d_name); // "." and ".." parse to 0 and are skipped below
-                if (fd >= 3 && fd != lo && fd != hi && fd != dirFd)
-                {
-                    close(fd);
-                }
-            }
-            closedir(dir);
-            return;
-        }
-
-        //
-        // Last resort (no /proc, e.g. some minimal containers or non-Linux
-        // platforms without close_range): close descriptors one by one up to
-        // maxFd, the bound the caller computed from the soft RLIMIT_NOFILE
-        // before fork().
+        // Fallback when close_range is unavailable (a pre-5.9 Linux kernel
+        // outside the supported set, macOS, or a seccomp profile that rejects
+        // the syscall): close descriptors one by one up to maxFd, the bound the
+        // caller computed from the soft RLIMIT_NOFILE before fork(). These
+        // platforms have a modest limit, so the loop stays cheap.
         //
         for (long fd = 3; fd < maxFd; ++fd)
         {

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -112,10 +112,13 @@ namespace IceGrid
         // close_range (Linux 5.9+, FreeBSD 12.2+) closes a whole descriptor
         // range in a single syscall, so the child never iterates up to a huge
         // or unlimited RLIMIT_NOFILE. We keep lo and hi open by closing the
-        // ranges around them. Probe with the always-non-empty top range first;
-        // if the syscall exists close the lower ranges too and we are done,
-        // otherwise (e.g. an older kernel returns ENOSYS) fall through to the
-        // descriptor loop below.
+        // ranges around them. Probe with the always-non-empty top range first:
+        // on success, close the lower ranges too and return. The probe range is
+        // never inverted, so the only realistic failure is the syscall being
+        // unavailable (ENOSYS on an older kernel, or a seccomp EPERM), and on
+        // failure it closes nothing; we fall through to the /proc/self/fd
+        // enumeration below, which is a complete fallback, so there is no need
+        // to inspect errno.
         //
         if (syscall(SYS_close_range, static_cast<unsigned int>(hi) + 1, ~0u, 0u) == 0)
         {

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -93,9 +93,11 @@ namespace IceGrid
     // Close every inherited file descriptor >= 3 in the fork child, keeping the
     // two given descriptors open (the write ends of the interrupt and error
     // pipes). This runs after setuid/setgid, so a leaked descriptor would cross
-    // a privilege boundary; it must use only async-signal-safe facilities.
+    // a privilege boundary. It runs in the fork child, so it uses only
+    // async-signal-safe facilities: close_range/close and the maxFd bound that
+    // the caller computed before fork().
     //
-    void closeInheritedDescriptors(int keep1, int keep2)
+    void closeInheritedDescriptors(int keep1, int keep2, long maxFd)
     {
         const int lo = keep1 < keep2 ? keep1 : keep2;
         const int hi = keep1 < keep2 ? keep2 : keep1;
@@ -125,19 +127,10 @@ namespace IceGrid
 #    endif
 
         //
-        // Fallback for platforms without close_range: close descriptors one by
-        // one up to the soft RLIMIT_NOFILE. The kernel does not allocate
-        // descriptors at or above that limit, so it is a suitable bound; when it
-        // is unlimited (or unavailable) we cap the loop so a single activation
-        // cannot issue billions of close() calls.
+        // Fallback for platforms without close_range (or an older kernel that
+        // returns ENOSYS): close descriptors one by one up to maxFd, the bound
+        // the caller computed from the soft RLIMIT_NOFILE before fork().
         //
-        rlimit fdLimit{};
-        long maxFd = 65536;
-        if (getrlimit(RLIMIT_NOFILE, &fdLimit) == 0 && fdLimit.rlim_cur != RLIM_INFINITY &&
-            static_cast<long>(fdLimit.rlim_cur) < maxFd)
-        {
-            maxFd = static_cast<long>(fdLimit.rlim_cur);
-        }
         for (long fd = 3; fd < maxFd; ++fd)
         {
             if (fd != lo && fd != hi)
@@ -770,6 +763,22 @@ Activator::activate(
     //
     const char* pwdCStr = pwd.c_str();
 
+    //
+    // Compute the bound for closing inherited descriptors before fork(), so the
+    // child (which must stay async-signal-safe) does not call getrlimit(). A
+    // finite soft RLIMIT_NOFILE is an exact bound — the kernel never allocates a
+    // descriptor at or above it — so the child closes the whole range; if it is
+    // unlimited we fall back to a sane cap so the child cannot loop up to INT_MAX.
+    //
+    long maxFdToClose = 65536;
+    {
+        rlimit fdLimit{};
+        if (getrlimit(RLIMIT_NOFILE, &fdLimit) == 0 && fdLimit.rlim_cur != RLIM_INFINITY)
+        {
+            maxFdToClose = static_cast<long>(fdLimit.rlim_cur);
+        }
+    }
+
     pid_t pid = fork();
     if (pid == -1)
     {
@@ -857,7 +866,7 @@ Activator::activate(
         // above: fds[1], kept open across exec so the node detects the server's
         // termination, and errorFds[1], used to report pre-exec errors.
         //
-        closeInheritedDescriptors(fds[1], errorFds[1]);
+        closeInheritedDescriptors(fds[1], errorFds[1], maxFdToClose);
 
         for (int i = 0; i < env.argc; i++) // NOLINT(clang-analyzer-unix.Malloc)
         {

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -114,7 +114,7 @@ namespace IceGrid
         // so there is no need to inspect errno. Clamp the probe's start to 3 so
         // that if both keeps landed below 3 it still cannot close stderr.
         //
-        const unsigned int probeStart = static_cast<unsigned int>(hi + 1 > 3 ? hi + 1 : 3);
+        const auto probeStart = static_cast<unsigned int>(hi + 1 > 3 ? hi + 1 : 3);
         if (syscall(SYS_close_range, probeStart, ~0u, 0u) == 0)
         {
             if (lo > 3)


### PR DESCRIPTION
Closes #5843

In the POSIX fork child, the IceGrid `Activator` closed inherited descriptors by looping from `3` up to `sysconf(_SC_OPEN_MAX)`, with an `INT_MAX` fallback. When the soft `RLIMIT_NOFILE` is very large — e.g. a unit with systemd `LimitNOFILE=infinity`, common in containers (docker/containerd have shipped this in their service files for years) — the loop bound becomes that limit. On Linux the kernel rejects any `RLIMIT_NOFILE` above `fs.nr_open`, so the soft limit is never literally `RLIM_INFINITY`; but systemd v240+ raises `fs.nr_open` to 1,073,741,816 at boot, so `LimitNOFILE=infinity` yields an effective soft limit of ~2^30 and the child issued on the order of a billion `close()` calls before `exec` — minutes per activation. Because `activate()` holds the `Activator` mutex for its whole body and the parent blocks reading the child's error pipe until the child sets `FD_CLOEXEC` (only *after* this loop), every activate/deactivate on the node stalled with it — a per-activation hang / node-wide stall on affected deployments.

The close loop runs *after* `setuid`/`setgid`, so an inherited descriptor left open in the child would also cross a privilege boundary.

## Fix

Extracted a file-local `closeInheritedDescriptors()` helper that keeps the two preserved descriptors open — the interrupt pipe write end `fds[1]` (kept open across `exec` for server-termination detection) and the error pipe write end `errorFds[1]` (closed on `exec` via `FD_CLOEXEC`) — and closes everything else `>= 3` using the best available mechanism:

1. **`close_range(2)`** where available (`SYS_close_range` — Linux 5.9+, FreeBSD 12.2+): closes the whole range in a single syscall regardless of a huge or unlimited limit, keeping the two descriptors open by closing the sub-ranges around them (each clamped to `>= 3`). On any failure (e.g. `ENOSYS` on an older kernel, or a seccomp `EPERM`) it closes nothing and falls through to the next tier. Every supported platform that can have a huge limit has `close_range`: the minimum supported Linux distributions (RHEL 9, Debian 12, Ubuntu 24.04, Amazon Linux 2023) all ship kernel 5.10+.
2. **Bounded loop** (fallback, when `close_range` is unavailable — a pre-5.9 Linux kernel outside the supported set, macOS, or a seccomp profile that rejects the syscall): close `3..maxFd`, where `maxFd` is the soft `RLIMIT_NOFILE` (the kernel never allocates a descriptor at or above it) capped at `1 << 20`. On these platforms the limit is modest, so the loop stays cheap.

`getrlimit(RLIMIT_NOFILE)` for the fallback's bound is queried in the **parent before `fork()`** and passed into the child, so the child helper does not call it (POSIX does not require `getrlimit` to be async-signal-safe). The child helper uses only async-signal-safe calls.

An earlier revision added a `/proc/self/fd` enumeration tier between the two above (the CPython/libuv three-tier shape). It was dropped in review: it only ever executed on platforms outside the support matrix (RHEL 8, Ubuntu 20.04, whose kernels predate `close_range`), and it was the most delicate part of the helper (`opendir`/`readdir` allocating in the fork child, close-while-reading over procfs). On every supported platform `close_range` handles the whole job, and the bounded loop covers macOS and the rare seccomp case.

## Notes

- Added a `changelog.d/service-icegrid/5843.md` fragment.
- No test: reproducing the stall needs an IceGrid node with a very large `RLIMIT_NOFILE` plus activation timing — flaky and disproportionate for a fork-child fd-hygiene fix (matches the sibling Activator fix #5911, which added none).
- Compiled with the project's build flags (`-std=c++20 -Wall -Wextra -Wconversion`); both the `close_range` and bounded-loop paths build clean. Reviewed with an independent Codex cross-check.
- 3.8.3-milestoned; to be cherry-picked to `3.8`, where the `CHANGELOG-3.8.md` entry is added.
- A related but less severe occurrence of the same pattern in `cpp/src/Ice/Service.cpp` (daemonize path) is filed as #6065.
- Follow-up for `main`: nothing in the C++ tree sets `SOCK_CLOEXEC`/`O_CLOEXEC` on the descriptors it opens, which is what makes this fork-child close-loop load-bearing for security rather than just hygiene. Filed as 6072.
