### PR TITLE
Negotiate a DataStorm protocol epoch for correct reader initialization

### DIFF
--- a/changelog.d/datastorm/5819.md
+++ b/changelog.d/datastorm/5819.md
@@ -1,0 +1,10 @@
+- Fixed a bug in DataStorm where the initialization samples for a late-joining reader could be lost or delivered to
+  the wrong reader. A writer covering several keys, or several readers of the same writer, produces one initialization
+  batch per key and per reader; the receiver marked every attached reader initialized on the first batch and dropped
+  the rest, so a multi-key or any-key late reader lost all but one key's samples. The receiver now routes each writer's
+  batches to the readers that subscribe to their keys. Two DataStorm nodes running this release also negotiate a new
+  protocol epoch during session establishment and initialize each reader element by exact address, which removes the
+  remaining ambiguity when several readers subscribe to the same key with different sample filters. The negotiation is
+  backward compatible: a node still establishes epoch-0 sessions with Ice 3.8.0-3.8.2 peers and applies the
+  receiver-side fix on them. Set `DataStorm.Node.MinProtocolEpoch=1` to require the new epoch and refuse sessions with
+  older peers, and `DataStorm.Node.MaxProtocolEpoch` to cap the epoch a node advertises.

--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -399,6 +399,8 @@
 
     <section name="DataStorm" opt-in="false">
         <property name="Node.ConnectTo" languages="cpp" />
+        <property name="Node.MaxProtocolEpoch" default="1" languages="cpp" />
+        <property name="Node.MinProtocolEpoch" default="0" languages="cpp" />
         <property name="Node.Multicast" class="ObjectAdapter" languages="cpp" />
         <property name="Node.Multicast.Enabled" default="1" languages="cpp" />
         <property name="Node.Multicast.Proxy" class="Proxy" languages="cpp" />

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -10,6 +10,18 @@
 
 module DataStormContract
 {
+    /// The DataStorm protocol epoch implemented by this node.
+    ///
+    /// During session establishment, each node advertises the highest epoch it supports (capped by
+    /// `DataStorm.Node.MaxProtocolEpoch`), and the two peers use the lowest of the two advertised values as the
+    /// session epoch. A node rejects a session whose negotiated epoch is below its `DataStorm.Node.MinProtocolEpoch`.
+    ///
+    /// - Epoch 0 is the original protocol used by Ice 3.8.0 through 3.8.2. Reader initialization is delivered with
+    ///   {@link Session::initSamples}, whose envelope identifies only the writer element.
+    /// - Epoch 1 adds {@link Session::initializeReaders}, which delivers each reader's initialization addressed to the
+    ///   exact reader element and merged across its keys.
+    const int CurrentProtocolEpoch = 1;
+
     /// Defines policies for clearing the data sample history of a reader in response to sample events.
     /// @see DataSample
     enum ClearHistoryPolicy
@@ -72,6 +84,26 @@ module DataStormContract
         DataSampleSeq samples;
     }
     sequence<DataSamples> DataSamplesSeq;
+
+    /// Represents the complete initialization of a single reader element by a single writer element. Used with protocol
+    /// epoch 1 and later.
+    ///
+    /// Unlike {@link DataSamples}, which carries only the writer element id and is delivered per key, a
+    /// `ReaderInitialization` names both the writer and the exact reader element it initializes, and its samples are
+    /// the merged result across all of that reader's keys.
+    ["cpp:custom-print"]
+    struct ReaderInitialization
+    {
+        /// The remote writer element that produced these samples.
+        long writerId;
+
+        /// The local reader element that must receive these samples.
+        long readerId;
+
+        /// The samples for this writer-reader pair, ordered by increasing sample id and deduplicated by id.
+        DataSampleSeq samples;
+    }
+    sequence<ReaderInitialization> ReaderInitializationSeq;
 
     /// Provides metadata about an element, such as a key, filter, or tag.
     ["cpp:custom-print"]
@@ -363,11 +395,29 @@ module DataStormContract
         /// @param elements A sequence of element identifiers representing the keys or filters to detach.
         void detachElements(long topicId, Ice::LongSeq elements);
 
-        /// Initializes the subscriber with the publisher queued samples for a topic during session establishment.
+        /// Initializes the subscriber with the publisher queued samples for a topic during session establishment. Used
+        /// with protocol epoch 0. Epoch 1 and later use {@link initializeReaders}, which addresses each reader element
+        /// exactly instead of relying on the receiver to route per-key batches by the writer element id.
         ///
         /// @param topicId The unique identifier for the topic.
         /// @param samples A sequence of {@link DataSamples} containing the queued samples to initialize the subscriber.
         void initSamples(long topicId, DataSamplesSeq samples);
+
+        /// Initializes reader elements with the publisher's queued samples during session establishment, addressing
+        /// each reader element exactly. Used with protocol epoch 1 and later; epoch 0 sessions use {@link initSamples}.
+        ///
+        /// The publisher builds one {@link ReaderInitialization} per (writer element, reader element) pair in an
+        /// initialization round. For each entry, it applies the reader element's key set and sample filter, then merges
+        /// the selected per-key histories, deduplicates them by sample id, and orders them by increasing sample id. An
+        /// entry with an empty `samples` sequence is still sent: it marks the reader element initialized and enables the
+        /// subsequent live sample delivery for that writer-reader pair.
+        ///
+        /// The receiver initializes only the reader element named by `readerId` and delivers the merged sequence to it
+        /// in a single call.
+        ///
+        /// @param topicId The unique identifier for the topic.
+        /// @param initializations The per-reader initialization entries for this round.
+        void initializeReaders(long topicId, ReaderInitializationSeq initializations);
 
         /// Notifies the peer that the session is being disconnected.
         ///
@@ -429,9 +479,11 @@ module DataStormContract
         /// reader for which this node has a corresponding topic writer.
         ///
         /// @param publisher The publisher node initiating the session. The proxy is never null.
+        /// @param protocolEpoch The highest DataStorm protocol epoch the publisher node supports. When not set, the
+        /// publisher is an Ice 3.8.0-3.8.2 node and epoch 0 is assumed. See {@link CurrentProtocolEpoch}.
         /// @throws SessionCreationException Thrown when the session cannot be created.
         /// @see Lookup::announceTopicReader
-        void initiateCreateSession(Node* publisher) throws SessionCreationException;
+        void initiateCreateSession(Node* publisher, optional(1) int protocolEpoch) throws SessionCreationException;
 
         /// Initiates the creation of a subscriber session with a node. The subscriber node sends this request to a
         /// publisher node in one of the following scenarios:
@@ -446,16 +498,21 @@ module DataStormContract
         /// @param subscriber The subscriber node initiating the session. This proxy is never null.
         /// @param session The subscriber session being created. This proxy is never null.
         /// @param fromRelay Indicates whether the session is being created from a relay node.
+        /// @param protocolEpoch The highest DataStorm protocol epoch the subscriber node supports. When not set, the
+        /// subscriber is an Ice 3.8.0-3.8.2 node and epoch 0 is assumed. See {@link CurrentProtocolEpoch}.
         /// @throws SessionCreationException Thrown when the session cannot be created.
-        void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay)
+        void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay, optional(1) int protocolEpoch)
             throws SessionCreationException;
 
         /// Confirm the creation of a publisher session with a node.
         ///
         /// @param publisher The publisher node confirming the session. The proxy is never null.
         /// @param session The publisher session being confirmed. The proxy is never null.
+        /// @param protocolEpoch The highest DataStorm protocol epoch the publisher node supports. When not set, the
+        /// publisher is an Ice 3.8.0-3.8.2 node and epoch 0 is assumed. See {@link CurrentProtocolEpoch}.
         /// @throws SessionCreationException Thrown when the session cannot be created.
-        void confirmCreateSession(Node* publisher, PublisherSession* session) throws SessionCreationException;
+        void confirmCreateSession(Node* publisher, PublisherSession* session, optional(1) int protocolEpoch)
+            throws SessionCreationException;
     }
 
     /// The lookup interface is used by DataStorm nodes to announce their topic readers and writers to other connected

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -154,7 +154,7 @@ DataElementI::attach(
     SessionPrx prx,
     const ElementDataAck& data,
     const chrono::time_point<chrono::system_clock>& now,
-    DataSamplesSeq& samples)
+    ReaderInitializationSeq& batches)
 {
     // Called with the topic and session from TopicI::attachElementsAck locked.
     shared_ptr<Filter> sampleFilter;
@@ -178,10 +178,12 @@ DataElementI::attach(
         name = os.str();
     }
 
-    // Attach a key or filter. If the attachment is successful, compute the queued samples to send to the peer.
-    // - If this data element is a data reader, the computed samples will be empty.
-    // - If this data element is a data writer, the computed samples will contain the samples to send to the peer
-    //   based on the peer reader configuration.
+    // Attach a key or filter. If the attachment is successful, compute the queued samples to send to the peer, tagged
+    // with the peer reader element (data.id) so the caller can address them.
+    // - If this data element is a data reader, the computed batch is empty.
+    // - If this data element is a data writer, the computed batch contains this key's samples to send to the peer based
+    //   on the peer reader configuration. A multi-key reader produces one batch per key here; the caller merges the
+    //   batches sharing a (writer, reader) pair when the session uses protocol epoch 1.
     if ((id > 0 &&
          attachKey(topicId, data.id, key, sampleFilter, session, std::move(prx), facet, id, name, priority)) ||
         (id < 0 &&
@@ -189,7 +191,9 @@ DataElementI::attach(
     {
         auto q = data.lastIds.find(_id);
         int64_t lastId = q != data.lastIds.end() ? q->second : 0;
-        samples.push_back(getSamples(key, sampleFilter, data.config, lastId, now));
+        DataSamples batch = getSamples(key, sampleFilter, data.config, lastId, now);
+        batches.push_back(
+            ReaderInitialization{.writerId = batch.id, .readerId = data.id, .samples = std::move(batch.samples)});
     }
 
     auto samplesI =

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -192,8 +192,9 @@ namespace DataStormI
         /// @param data The acknowledgment data associated with the remote element, describing its configuration or
         /// state.
         /// @param now The timestamp indicating when the attachment was requested.
-        /// @param samples Output parameter filled with the data samples in the publisher's queue. This parameter is
-        /// always empty when the method is called on the subscriber side.
+        /// @param batches Output parameter appended with this key's samples from the publisher's queue, tagged with the
+        /// peer reader element id (`data.id`) so the caller can address them. The appended batch is empty when the
+        /// method is called on the subscriber side, since a reader has no samples to send.
         /// @return A function that initializes the reader with the prepared samples:
         /// - For a publisher, this method always returns a `nullptr` function.
         /// - For a subscriber, this method returns a function that initializes the reader with samples provided by the
@@ -207,7 +208,7 @@ namespace DataStormI
             DataStormContract::SessionPrx prx,
             const DataStormContract::ElementDataAck& data,
             const std::chrono::time_point<std::chrono::system_clock>& now,
-            DataStormContract::DataSamplesSeq& samples);
+            DataStormContract::ReaderInitializationSeq& batches);
 
         [[nodiscard]] bool attachKey(
             std::int64_t,
@@ -283,6 +284,10 @@ namespace DataStormI
             const std::string&,
             const std::chrono::time_point<std::chrono::system_clock>&,
             bool);
+
+        /// Determines whether this element subscribes to the given key. Reader elements override this to match against
+        /// their keys or filter; the default suits writer elements, which never receive initialization samples.
+        [[nodiscard]] virtual bool matchKey(const std::shared_ptr<Key>&) const { return true; }
 
         [[nodiscard]] virtual std::string toString() const = 0;
 
@@ -371,7 +376,9 @@ namespace DataStormI
             std::function<void(const std::shared_ptr<Sample>&)>) override;
 
     protected:
-        [[nodiscard]] virtual bool matchKey(const std::shared_ptr<Key>&) const = 0;
+        // Re-declared pure so every concrete reader must implement key matching, even though the base DataElementI
+        // provides a default for writer elements.
+        [[nodiscard]] bool matchKey(const std::shared_ptr<Key>&) const override = 0;
         [[nodiscard]] bool addConnectedKey(const std::shared_ptr<Key>&, const std::shared_ptr<Subscriber>&) override;
 
         // Returns true if the given sample priority is lower than the highest priority among the connected publishers

--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -96,6 +96,26 @@ Instance::Instance(CommunicatorPtr communicator, function<void(function<void()> 
     _retryMultiplier = properties->getIcePropertyAsInt("DataStorm.Node.RetryMultiplier");
     _retryCount = properties->getIcePropertyAsInt("DataStorm.Node.RetryCount");
 
+    // The advertised epoch must name an epoch this build implements, and the accepted floor must not exceed it
+    // (otherwise the node could never accept any session it negotiates). An out-of-range value is a misconfiguration,
+    // so reject it rather than silently coerce it.
+    _maxProtocolEpoch = properties->getIcePropertyAsInt("DataStorm.Node.MaxProtocolEpoch");
+    if (_maxProtocolEpoch < 0 || _maxProtocolEpoch > DataStormContract::CurrentProtocolEpoch)
+    {
+        ostringstream os;
+        os << "invalid value for property 'DataStorm.Node.MaxProtocolEpoch': " << _maxProtocolEpoch
+           << " is not in the range [0, " << DataStormContract::CurrentProtocolEpoch << "]";
+        throw invalid_argument(os.str());
+    }
+    _minProtocolEpoch = properties->getIcePropertyAsInt("DataStorm.Node.MinProtocolEpoch");
+    if (_minProtocolEpoch < 0 || _minProtocolEpoch > _maxProtocolEpoch)
+    {
+        ostringstream os;
+        os << "invalid value for property 'DataStorm.Node.MinProtocolEpoch': " << _minProtocolEpoch
+           << " is not in the range [0, " << _maxProtocolEpoch << "]";
+        throw invalid_argument(os.str());
+    }
+
     _traceLevels = make_shared<TraceLevels>(properties, _communicator->getLogger());
     _executor = make_shared<CallbackExecutor>(std::move(customExecutor));
     _connectionManager = make_shared<ConnectionManager>(_executor);

--- a/cpp/src/DataStorm/Instance.h
+++ b/cpp/src/DataStorm/Instance.h
@@ -102,6 +102,14 @@ namespace DataStormI
 
         [[nodiscard]] int getRetryCount() const { return _retryCount; }
 
+        // The highest DataStorm protocol epoch this node advertises during session establishment, from
+        // DataStorm.Node.MaxProtocolEpoch (validated to be in [0, CurrentProtocolEpoch]).
+        [[nodiscard]] int getMaxProtocolEpoch() const { return _maxProtocolEpoch; }
+
+        // The lowest DataStorm protocol epoch this node accepts; a session whose negotiated epoch is below this value
+        // is rejected. From DataStorm.Node.MinProtocolEpoch.
+        [[nodiscard]] int getMinProtocolEpoch() const { return _minProtocolEpoch; }
+
         void shutdown();
         [[nodiscard]] bool isShutdown() const;
         void checkShutdown() const;
@@ -157,6 +165,8 @@ namespace DataStormI
         std::chrono::milliseconds _retryDelay;
         int _retryMultiplier;
         int _retryCount;
+        int _maxProtocolEpoch;
+        int _minProtocolEpoch;
         DataStorm::ReaderConfig _defaultReaderConfig;
         DataStorm::WriterConfig _defaultWriterConfig;
 

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -42,6 +42,21 @@ namespace
         shared_ptr<NodeI> _node;
         shared_ptr<CallbackExecutor> _executor;
     };
+
+    // Builds the exception used to reject a session whose negotiated protocol epoch is below this node's minimum. A
+    // NotSupported dispatch exception is understood by every Ice version, including the 3.8.0-3.8.2 nodes that predate
+    // the epoch handshake; adding a new SessionCreationError enumerator instead would make an old peer report a marshal
+    // failure rather than the intended reason. The exception must be delivered through the dispatch exception
+    // continuation: throwing it from a NodeI try block would let the generic catch convert it to
+    // SessionCreationError::Internal, losing the reply status and message.
+    exception_ptr makeIncompatibleEpochException(int negotiatedEpoch, int minEpoch)
+    {
+        ostringstream os;
+        os << "the DataStorm session was rejected because the negotiated protocol epoch " << negotiatedEpoch
+           << " is below the required minimum " << minEpoch
+           << "; upgrade the peer node (and any relay on the path) or lower DataStorm.Node.MinProtocolEpoch";
+        return make_exception_ptr(DispatchException{__FILE__, __LINE__, ReplyStatus::NotSupported, os.str()});
+    }
 }
 
 NodeI::NodeI(const shared_ptr<Instance>& instance, std::string name)
@@ -143,9 +158,21 @@ NodeI::destroy(bool ownsCommunicator)
     _publisherSessions.clear();
 }
 
+optional<int>
+NodeI::negotiateProtocolEpoch(const shared_ptr<Instance>& instance, optional<int32_t> peerEpoch) const
+{
+    int negotiated = min(instance->getMaxProtocolEpoch(), peerEpoch.value_or(0));
+    if (negotiated < instance->getMinProtocolEpoch())
+    {
+        return nullopt;
+    }
+    return negotiated;
+}
+
 void
 NodeI::initiateCreateSessionAsync(
     optional<NodePrx> publisher,
+    optional<int32_t> protocolEpoch,
     function<void()> response,
     function<void(std::exception_ptr)> exception,
     const Current& current)
@@ -153,6 +180,23 @@ NodeI::initiateCreateSessionAsync(
     try
     {
         checkNotNull(publisher, __FILE__, __LINE__, current);
+
+        // The instance class owns this object, so it is guaranteed to be available.
+        auto instance = _instance.lock();
+        assert(instance);
+
+        // Reject an incompatible publisher before creating any session state. The subscriber session also negotiates in
+        // confirmCreateSession, where the publisher re-sends its epoch, so this early check only avoids the extra
+        // round-trip of building the session and having it rejected there; it is not the sole enforcement point (a
+        // subscriber-initiated session skips this operation and is rejected in confirmCreateSession).
+        if (!negotiateProtocolEpoch(instance, protocolEpoch))
+        {
+            exception(makeIncompatibleEpochException(
+                min(instance->getMaxProtocolEpoch(), protocolEpoch.value_or(0)),
+                instance->getMinProtocolEpoch()));
+            return;
+        }
+
         // Create a session with the given publisher.
         createPublisherSession(*publisher, current.con, nullptr);
         response();
@@ -182,6 +226,7 @@ NodeI::createSessionAsync(
     optional<NodePrx> subscriber,
     optional<SubscriberSessionPrx> subscriberSession,
     bool fromRelay,
+    optional<int32_t> protocolEpoch,
     function<void()> response,
     function<void(exception_ptr)> exception,
     const Current& current)
@@ -192,6 +237,18 @@ NodeI::createSessionAsync(
     // The instance class owns this object, so it is guaranteed to be available.
     auto instance = _instance.lock();
     assert(instance);
+
+    // Negotiate the protocol epoch before creating any session state, so an incompatible peer is rejected before a
+    // oneway session proxy is connected. Reject through the exception continuation rather than throwing, so the
+    // NotSupported reply status survives to the peer.
+    auto protocolEpochOrReject = negotiateProtocolEpoch(instance, protocolEpoch);
+    if (!protocolEpochOrReject)
+    {
+        exception(makeIncompatibleEpochException(
+            min(instance->getMaxProtocolEpoch(), protocolEpoch.value_or(0)),
+            instance->getMinProtocolEpoch()));
+        return;
+    }
 
     shared_ptr<PublisherSessionI> session;
     try
@@ -220,6 +277,14 @@ NodeI::createSessionAsync(
 
         unique_lock<mutex> lock(_mutex);
         session = createPublisherSessionServant(*subscriber);
+        session->setProtocolEpoch(*protocolEpochOrReject);
+        if (*protocolEpochOrReject == 0 && instance->getMaxProtocolEpoch() > 0 && traceLevels->session > 0)
+        {
+            Trace out(traceLevels->logger, traceLevels->sessionCat);
+            out << "publisher session with '" << *subscriber
+                << "' established at protocol epoch 0; the peer does not support epoch "
+                << instance->getMaxProtocolEpoch();
+        }
         s->ice_getConnectionAsync(
             [=, self = shared_from_this()](const auto& connection) mutable
             {
@@ -262,6 +327,7 @@ NodeI::createSessionAsync(
                     s->confirmCreateSessionAsync(
                         self->_proxy,
                         uncheckedCast<PublisherSessionPrx>(session->getProxy()),
+                        instance->getMaxProtocolEpoch(),
                         [session, subscriberSession, connection, instance]
                         {
                             // Session::connected informs the subscriber session of all the topic writers in the
@@ -315,6 +381,7 @@ void
 NodeI::confirmCreateSessionAsync(
     optional<NodePrx> publisher,
     optional<PublisherSessionPrx> publisherSession,
+    optional<int32_t> protocolEpoch,
     function<void()> response,
     function<void(exception_ptr)> exception,
     const Current& current)
@@ -358,6 +425,25 @@ NodeI::confirmCreateSessionAsync(
         return;
     }
 
+    // Negotiate the protocol epoch before connecting the subscriber session. Rejecting here, before connected() and
+    // before the response, keeps an incompatible peer from ever reaching a connected session: the publisher only
+    // connects its own session in the confirmCreateSession response callback, which now receives this rejection.
+    auto protocolEpochOrReject = negotiateProtocolEpoch(instance, protocolEpoch);
+    if (!protocolEpochOrReject)
+    {
+        exception(makeIncompatibleEpochException(
+            min(instance->getMaxProtocolEpoch(), protocolEpoch.value_or(0)),
+            instance->getMinProtocolEpoch()));
+        return;
+    }
+    session->setProtocolEpoch(*protocolEpochOrReject);
+    if (*protocolEpochOrReject == 0 && instance->getMaxProtocolEpoch() > 0 && traceLevels->session > 0)
+    {
+        Trace out(traceLevels->logger, traceLevels->sessionCat);
+        out << "subscriber session with '" << *publisher
+            << "' established at protocol epoch 0; the peer does not support epoch " << instance->getMaxProtocolEpoch();
+    }
+
     // If the publisher session is hosted on a relay, current.con represents the connection to the relay.
     // Otherwise, it represents the connection to the publisher node. In both cases, a fixed proxy is used
     // to ensure the session is no longer used once the connection is closed.
@@ -397,6 +483,7 @@ NodeI::createSubscriberSession(
 
         subscriber->initiateCreateSessionAsync(
             _proxy,
+            instance->getMaxProtocolEpoch(),
             nullptr,
             [self = shared_from_this(), session, subscriber](exception_ptr ex)
             {
@@ -464,6 +551,7 @@ NodeI::createPublisherSession(
             _proxy,
             uncheckedCast<SubscriberSessionPrx>(session->getProxy()),
             false,
+            instance->getMaxProtocolEpoch(),
             nullptr,
             [self = shared_from_this(), publisher, session](exception_ptr ex)
             { self->retrySubscriberSessionCreation(publisher, session, ex); });

--- a/cpp/src/DataStorm/NodeI.h
+++ b/cpp/src/DataStorm/NodeI.h
@@ -28,6 +28,7 @@ namespace DataStormI
 
         void initiateCreateSessionAsync(
             std::optional<DataStormContract::NodePrx>,
+            std::optional<std::int32_t>,
             std::function<void()>,
             std::function<void(std::exception_ptr)>,
             const Ice::Current&) final;
@@ -36,6 +37,7 @@ namespace DataStormI
             std::optional<DataStormContract::NodePrx>,
             std::optional<DataStormContract::SubscriberSessionPrx>,
             bool,
+            std::optional<std::int32_t>,
             std::function<void()>,
             std::function<void(std::exception_ptr)>,
             const Ice::Current&) final;
@@ -43,6 +45,7 @@ namespace DataStormI
         void confirmCreateSessionAsync(
             std::optional<DataStormContract::NodePrx>,
             std::optional<DataStormContract::PublisherSessionPrx>,
+            std::optional<std::int32_t>,
             std::function<void()>,
             std::function<void(std::exception_ptr)>,
             const Ice::Current&) final;
@@ -99,6 +102,13 @@ namespace DataStormI
         }
 
     private:
+        // Negotiates the session protocol epoch with a peer that advertised peerEpoch (unset means an Ice 3.8.0-3.8.2
+        // node, epoch 0). Returns the negotiated epoch, which is the lower of this node's advertised maximum and the
+        // peer's. Returns std::nullopt when the negotiated epoch is below this node's minimum; the caller then rejects
+        // the session through its exception continuation with makeIncompatibleEpochException.
+        [[nodiscard]] std::optional<int>
+        negotiateProtocolEpoch(const std::shared_ptr<Instance>& instance, std::optional<std::int32_t> peerEpoch) const;
+
         [[nodiscard]] std::shared_ptr<SubscriberSessionI>
         createSubscriberSessionServant(const DataStormContract::NodePrx&);
 

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -35,6 +35,7 @@ namespace
 
         void initiateCreateSessionAsync(
             optional<NodePrx> publisher,
+            optional<int32_t> protocolEpoch,
             function<void()> response,
             function<void(exception_ptr)> exception,
             const Current& current) final
@@ -46,8 +47,9 @@ namespace
                 {
                     optional<SessionPrx> sessionPrx;
                     updateNodeAndSessionProxy(*publisher, sessionPrx, current);
-                    // Forward the call to the target Node.
-                    _node->initiateCreateSessionAsync(publisher, response, exception);
+                    // Forward the call to the target Node, carrying the peer's advertised protocol epoch so two
+                    // upgraded nodes negotiate through this relay instead of falling back to epoch 0.
+                    _node->initiateCreateSessionAsync(publisher, protocolEpoch, response, exception);
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
@@ -60,6 +62,7 @@ namespace
             optional<NodePrx> subscriber,
             optional<SubscriberSessionPrx> subscriberSession,
             bool /* fromRelay */,
+            optional<int32_t> protocolEpoch,
             function<void()> response,
             function<void(exception_ptr)> exception,
             const Current& current) final
@@ -84,8 +87,15 @@ namespace
                         subscriberSession->ice_getIdentity(),
                         subscriberIsHostedOnRelay ? subscriberSession->ice_fixed(current.con) : *subscriberSession);
 
-                    // Forward the call to the target Node.
-                    _node->createSessionAsync(subscriber, subscriberSessionForwarder, true, response, exception);
+                    // Forward the call to the target Node, carrying the peer's advertised protocol epoch so two
+                    // upgraded nodes negotiate through this relay instead of falling back to epoch 0.
+                    _node->createSessionAsync(
+                        subscriber,
+                        subscriberSessionForwarder,
+                        true,
+                        protocolEpoch,
+                        response,
+                        exception);
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
@@ -97,6 +107,7 @@ namespace
         void confirmCreateSessionAsync(
             optional<NodePrx> publisher,
             optional<PublisherSessionPrx> publisherSession,
+            optional<int32_t> protocolEpoch,
             function<void()> response,
             function<void(exception_ptr)> exception,
             const Current& current) final
@@ -119,8 +130,14 @@ namespace
                         publisher->ice_getIdentity(),
                         publisherSession->ice_getIdentity(),
                         publisherIsHostedOnRelay ? publisherSession->ice_fixed(current.con) : *publisherSession);
-                    // Forward the request to the target subscriber.
-                    _node->confirmCreateSessionAsync(publisher, publisherSessionForwarder, response, exception);
+                    // Forward the request to the target subscriber, carrying the peer's advertised protocol epoch so
+                    // two upgraded nodes negotiate through this relay instead of falling back to epoch 0.
+                    _node->confirmCreateSessionAsync(
+                        publisher,
+                        publisherSessionForwarder,
+                        protocolEpoch,
+                        response,
+                        exception);
                 }
                 catch (const CommunicatorDestroyedException&)
                 {

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -36,6 +36,48 @@ namespace
         ObjectPtr _servant;
         shared_ptr<CallbackExecutor> _executor;
     };
+
+    // Collapses the per-key batches produced by TopicI::attachElementsAck into one ReaderInitialization per
+    // (writer, reader) pair for the epoch-1 initializeReaders envelope. A multi-key reader produces one batch per key;
+    // merging them and ordering the result by sample id lets the reader's policies (SendTime, sampleCount, history
+    // clearing) observe the writer's global order. Duplicate sample ids (a sample matched by overlapping filters) are
+    // removed. The first-seen order of the (writer, reader) pairs is preserved. Empty batches are kept: an empty
+    // initialization still marks the reader initialized and enables its live sample delivery.
+    ReaderInitializationSeq mergeReaderInitializations(ReaderInitializationSeq batches)
+    {
+        vector<ReaderInitialization> merged;
+        map<pair<int64_t, int64_t>, size_t> index;
+        for (auto& batch : batches)
+        {
+            auto pairKey = make_pair(batch.writerId, batch.readerId);
+            auto p = index.find(pairKey);
+            if (p == index.end())
+            {
+                index.emplace(pairKey, merged.size());
+                merged.push_back(std::move(batch));
+            }
+            else
+            {
+                auto& samples = merged[p->second].samples;
+                samples.insert(samples.end(), batch.samples.begin(), batch.samples.end());
+            }
+        }
+
+        for (auto& init : merged)
+        {
+            sort(
+                init.samples.begin(),
+                init.samples.end(),
+                [](const DataSample& lhs, const DataSample& rhs) { return lhs.id < rhs.id; });
+            init.samples.erase(
+                unique(
+                    init.samples.begin(),
+                    init.samples.end(),
+                    [](const DataSample& lhs, const DataSample& rhs) { return lhs.id == rhs.id; }),
+                init.samples.end());
+        }
+        return merged;
+    }
 }
 
 SessionI::SessionI(shared_ptr<Instance> instance, shared_ptr<NodeI> parent, NodePrx node, SessionPrx proxy)
@@ -369,16 +411,40 @@ SessionI::attachElementsAck(int64_t topicId, ElementSpecAckSeq elements, const C
             }
 
             LongSeq removedIds;
-            auto samples = topic->attachElementsAck(topicId, elements, shared_from_this(), *_session, now, removedIds);
-            if (!samples.empty())
+            auto batches = topic->attachElementsAck(topicId, elements, shared_from_this(), *_session, now, removedIds);
+            if (!batches.empty())
             {
-                if (_traceLevels->session > 2)
+                if (_protocolEpoch >= 1)
                 {
-                    Trace out(_traceLevels->logger, _traceLevels->sessionCat);
-                    out << _id << ": initializing elements '[" << samples << "]@" << topicId << "' on topic '" << topic
-                        << "'";
+                    // Epoch 1: address each reader element exactly and merge the per-key batches sharing a
+                    // (writer, reader) pair into one globally ordered sequence.
+                    auto initializations = mergeReaderInitializations(std::move(batches));
+                    if (_traceLevels->session > 2)
+                    {
+                        Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+                        out << _id << ": initializing readers '[" << initializations << "]@" << topicId
+                            << "' on topic '" << topic << "'";
+                    }
+                    _session->initializeReadersAsync(topic->getId(), std::move(initializations), nullptr);
                 }
-                _session->initSamplesAsync(topic->getId(), samples, nullptr);
+                else
+                {
+                    // Epoch 0: the legacy envelope names only the writer element. Emit one DataSamples per key batch,
+                    // preserving the order and batch ids the 3.8.0-3.8.2 wire uses.
+                    DataSamplesSeq samples;
+                    samples.reserve(batches.size());
+                    for (auto& batch : batches)
+                    {
+                        samples.push_back(DataSamples{.id = batch.writerId, .samples = std::move(batch.samples)});
+                    }
+                    if (_traceLevels->session > 2)
+                    {
+                        Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+                        out << _id << ": initializing elements '[" << samples << "]@" << topicId << "' on topic '"
+                            << topic << "'";
+                    }
+                    _session->initSamplesAsync(topic->getId(), std::move(samples), nullptr);
+                }
             }
 
             if (!removedIds.empty())
@@ -430,6 +496,60 @@ SessionI::detachElements(int64_t id, LongSeq elements, const Current&)
 }
 
 void
+SessionI::deliverReaderInitialization(
+    TopicI* topic,
+    TopicSubscriber& subscriber,
+    const ElementSubscribers& elementSubscribers,
+    const shared_ptr<DataElementI>& element,
+    ElementSubscriber& elementSubscriber,
+    int64_t topicId,
+    int64_t writerId,
+    const DataSampleSeq& samples,
+    const chrono::time_point<chrono::system_clock>& now,
+    bool checkKey)
+{
+    // Mark the reader initialized even for an empty batch: an empty initialization enables the reader's live sample
+    // delivery for this writer.
+    elementSubscriber.initialized = true;
+    if (samples.empty())
+    {
+        return;
+    }
+
+    vector<shared_ptr<Sample>> samplesI;
+    samplesI.reserve(samples.size());
+    const auto& sampleFactory = topic->getSampleFactory();
+    for (const auto& sample : samples)
+    {
+        shared_ptr<Key> key;
+        if (sample.keyValue.empty())
+        {
+            key = subscriber.keys[sample.keyId].first;
+        }
+        else
+        {
+            key = topic->getKeyFactory()->decode(_instance->getCommunicator(), sample.keyValue);
+        }
+        assert(key);
+
+        samplesI.push_back(sampleFactory->create(
+            _id,
+            elementSubscribers.name,
+            sample.id,
+            sample.event,
+            key,
+            subscriber.tags[sample.tag],
+            sample.value,
+            sample.timestamp));
+    }
+
+    // Advance the reader's high-water mark to the writer's highest delivered sample id so later live samples with a
+    // lower id are not re-requested. When checkKey is set, the reader drops samples for keys it does not subscribe to.
+    elementSubscriber.lastId = samplesI.back()->id;
+    element->initSamples(samplesI, topicId, writerId, elementSubscribers.priority, now, checkKey);
+}
+
+void
 SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&)
 {
     lock_guard<mutex> lock(_mutex);
@@ -439,42 +559,69 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
     }
 
     auto now = chrono::system_clock::now();
-    auto communicator = _instance->getCommunicator();
-    for (const auto& samples : samplesSeq)
+
+    // One initSamples request carries a whole initialization round. A writer covering several keys contributes one
+    // batch per key, all under the same writer element id, and two readers of that writer can be attached for
+    // different keys. The original receiver marked every attached reader initialized on the first batch and dropped the
+    // rest, so a multi-key or any-key late reader lost all but one key's samples (issue #5819).
+    //
+    // Group the round's batches by writer element id and merge them, then deliver the merged samples to every attached
+    // reader with checkKey set so the reader keeps only the samples for the keys it subscribes to. This fixes the
+    // dropped and misrouted batches and lets the reader observe the writer's samples in global id order. This is the
+    // epoch-0 best-effort receiver: the DataSamples envelope names only the writer element, so two readers on the same
+    // key with different sample filters still cannot be told apart. Protocol epoch 1 (initializeReaders) addresses each
+    // reader exactly.
+    map<int64_t, DataSampleSeq> batchesByWriter;
+    vector<int64_t> writerOrder;
+    for (auto& batch : samplesSeq)
     {
+        auto [p, inserted] = batchesByWriter.try_emplace(batch.id);
+        if (inserted)
+        {
+            writerOrder.push_back(batch.id);
+        }
+        p->second.insert(
+            p->second.end(),
+            make_move_iterator(batch.samples.begin()),
+            make_move_iterator(batch.samples.end()));
+    }
+
+    for (int64_t writerId : writerOrder)
+    {
+        DataSampleSeq& writerSamples = batchesByWriter[writerId];
+        sort(
+            writerSamples.begin(),
+            writerSamples.end(),
+            [](const DataSample& lhs, const DataSample& rhs) { return lhs.id < rhs.id; });
+        writerSamples.erase(
+            unique(
+                writerSamples.begin(),
+                writerSamples.end(),
+                [](const DataSample& lhs, const DataSample& rhs) { return lhs.id == rhs.id; }),
+            writerSamples.end());
+
         runWithTopics(
             topicId,
             [&](TopicI* topic, TopicSubscriber& subscriber)
             {
-                ElementSubscribers* elementSubscribers = subscriber.get(samples.id);
-                if (elementSubscribers)
+                ElementSubscribers* elementSubscribers = subscriber.get(writerId);
+                if (!elementSubscribers)
                 {
-                    if (_traceLevels->session > 2)
+                    return;
+                }
+
+                for (auto& [element, elementSubscriber] : elementSubscribers->getSubscribers())
+                {
+                    if (elementSubscriber.initialized)
                     {
-                        Trace out(_traceLevels->logger, _traceLevels->sessionCat);
-                        out << _id << ": initializing samples from '" << samples.id << "'"
-                            << " on [";
-                        for (auto q = elementSubscribers->getSubscribers().begin();
-                             q != elementSubscribers->getSubscribers().end();
-                             ++q)
-                        {
-                            if (q != elementSubscribers->getSubscribers().begin())
-                            {
-                                out << ", ";
-                            }
-                            out << q->first;
-                            if (!q->second.facet.empty())
-                            {
-                                out << ":" << q->second.facet;
-                            }
-                        }
-                        out << "]";
+                        continue;
                     }
 
-                    vector<shared_ptr<Sample>> samplesI;
-                    samplesI.reserve(samples.samples.size());
-                    const auto& sampleFactory = topic->getSampleFactory();
-                    for (const auto& sample : samples.samples)
+                    // Select the merged samples this reader matches by key or filter. Routing at the receiver is what
+                    // the legacy envelope leaves to us: each reader keeps only its own keys, so two readers of one
+                    // writer on different keys do not receive each other's samples.
+                    DataSampleSeq selected;
+                    for (const auto& sample : writerSamples)
                     {
                         shared_ptr<Key> key;
                         if (sample.keyValue.empty())
@@ -485,37 +632,97 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
                         {
                             key = topic->getKeyFactory()->decode(_instance->getCommunicator(), sample.keyValue);
                         }
-                        assert(key);
-
-                        samplesI.push_back(sampleFactory->create(
-                            _id,
-                            elementSubscribers->name,
-                            sample.id,
-                            sample.event,
-                            key,
-                            subscriber.tags[sample.tag],
-                            sample.value,
-                            sample.timestamp));
-                    }
-
-                    for (auto& [element, elementSubscriber] : elementSubscribers->getSubscribers())
-                    {
-                        if (!elementSubscriber.initialized)
+                        if (key && element->matchKey(key))
                         {
-                            elementSubscriber.initialized = true;
-                            if (!samplesI.empty())
-                            {
-                                elementSubscriber.lastId = samplesI.back()->id;
-                                element->initSamples(
-                                    samplesI,
-                                    topicId,
-                                    samples.id,
-                                    elementSubscribers->priority,
-                                    now,
-                                    samples.id < 0);
-                            }
+                            selected.push_back(sample);
                         }
                     }
+
+                    // Initialize the reader only when this round carries samples for it, or when the round is empty and
+                    // is therefore the reader's own empty initialization. A non-empty round with nothing for this
+                    // reader belongs to another reader of the same writer; leave this reader for the round that carries
+                    // its samples, rather than marking it initialized and dropping them. The one case the legacy
+                    // envelope cannot resolve - a reader whose empty initialization shares a round with another
+                    // reader's samples - is left to protocol epoch 1.
+                    if (selected.empty() && !writerSamples.empty())
+                    {
+                        continue;
+                    }
+
+                    if (_traceLevels->session > 2)
+                    {
+                        Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+                        out << _id << ": initializing samples from 'e" << writerId << "' on '" << element << "'";
+                    }
+
+                    deliverReaderInitialization(
+                        topic,
+                        subscriber,
+                        *elementSubscribers,
+                        element,
+                        elementSubscriber,
+                        topicId,
+                        writerId,
+                        selected,
+                        now,
+                        /* checkKey */ false);
+                }
+            });
+    }
+}
+
+void
+SessionI::initializeReaders(int64_t topicId, ReaderInitializationSeq initializations, const Current&)
+{
+    lock_guard<mutex> lock(_mutex);
+    if (!_session)
+    {
+        return;
+    }
+
+    auto now = chrono::system_clock::now();
+
+    // Protocol epoch 1: each entry is addressed to an exact reader element and its samples are already merged and
+    // ordered by the publisher, so no receiver-side routing or reordering is needed. Initialize only the named reader.
+    for (const auto& init : initializations)
+    {
+        runWithTopics(
+            topicId,
+            [&](TopicI* topic, TopicSubscriber& subscriber)
+            {
+                ElementSubscribers* elementSubscribers = subscriber.get(init.writerId);
+                if (!elementSubscribers)
+                {
+                    return;
+                }
+
+                for (auto& [element, elementSubscriber] : elementSubscribers->getSubscribers())
+                {
+                    if (element->getId() != init.readerId || elementSubscriber.initialized)
+                    {
+                        continue;
+                    }
+
+                    if (_traceLevels->session > 2)
+                    {
+                        Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+                        out << _id << ": initializing reader 'e" << init.readerId << "' from 'e" << init.writerId
+                            << "' on '" << element << "'";
+                    }
+
+                    // The samples are already addressed and filtered to this reader by the publisher; checkKey mirrors
+                    // the legacy any-key discriminator (a negative writer id is an any-key writer).
+                    deliverReaderInitialization(
+                        topic,
+                        subscriber,
+                        *elementSubscribers,
+                        element,
+                        elementSubscriber,
+                        topicId,
+                        init.writerId,
+                        init.samples,
+                        now,
+                        /* checkKey */ init.writerId < 0);
                 }
             });
     }
@@ -1230,12 +1437,25 @@ SessionI::subscriberInitialized(
     const shared_ptr<Key>& key,
     const std::shared_ptr<DataElementI>& element)
 {
-    // Called with the session locked, from DataElementI::attach.
+    // Called with the session locked, from DataElementI::attach. The subscriber bucket for elementId was created when
+    // this element attached in an earlier round of the same handshake; per-connection message ordering guarantees that
+    // attach ran before this call, so the bucket and its subscriber entry are present. Assert this in debug builds so a
+    // routing or element-id mismatch fails loudly in the tests, but tolerate a missing entry in release rather than
+    // dereferencing a pointer derived from peer-supplied ids.
     assert(_topics.find(topicId) != _topics.end());
     TopicSubscriber& subscriber = _topics.at(topicId).getSubscriber(element->getTopic());
     ElementSubscribers* elementSubscribers = subscriber.get(elementId);
+    assert(elementSubscribers);
+    if (!elementSubscribers)
+    {
+        return {};
+    }
     ElementSubscriber* elementSubscriber = elementSubscribers->getSubscriber(element);
     assert(elementSubscriber);
+    if (!elementSubscriber)
+    {
+        return {};
+    }
 
     if (_traceLevels->session > 1)
     {

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -280,6 +280,7 @@ namespace DataStormI
         void detachElements(std::int64_t, Ice::LongSeq, const Ice::Current&) final;
 
         void initSamples(std::int64_t, DataStormContract::DataSamplesSeq, const Ice::Current&) final;
+        void initializeReaders(std::int64_t, DataStormContract::ReaderInitializationSeq, const Ice::Current&) final;
 
         void disconnected(const Ice::Current&) final;
 
@@ -314,6 +315,11 @@ namespace DataStormI
         [[nodiscard]] bool checkSession();
 
         [[nodiscard]] DataStormContract::SessionPrx getProxy() const { return _proxy; }
+
+        // The negotiated protocol epoch. Set during establishment (before connected()); read on the publisher side
+        // when initializing readers. The set happens-before connected(), which happens-before any element dispatch.
+        [[nodiscard]] int getProtocolEpoch() const { return _protocolEpoch; }
+        void setProtocolEpoch(int epoch) { _protocolEpoch = epoch; }
 
         [[nodiscard]] DataStormContract::NodePrx getNode() const;
         void setNode(DataStormContract::NodePrx);
@@ -363,6 +369,23 @@ namespace DataStormI
             const DataStormContract::DataSampleSeq&,
             const std::shared_ptr<Key>&,
             const std::shared_ptr<DataElementI>&);
+
+        /// Builds and delivers a reader element's initialization samples, records the highest delivered sample id, and
+        /// marks the subscriber initialized. Shared by the epoch-0 (initSamples) and epoch-1 (initializeReaders)
+        /// receive paths; the two paths differ only in how they select and order the samples handed to this method.
+        /// When `checkKey` is set, the reader element drops samples whose key it does not subscribe to: epoch 0 relies
+        /// on this to route a writer's merged samples to the right reader, while epoch 1 samples are already addressed.
+        void deliverReaderInitialization(
+            TopicI* topic,
+            TopicSubscriber& subscriber,
+            const ElementSubscribers& elementSubscribers,
+            const std::shared_ptr<DataElementI>& element,
+            ElementSubscriber& elementSubscriber,
+            std::int64_t topicId,
+            std::int64_t writerId,
+            const DataStormContract::DataSampleSeq& samples,
+            const std::chrono::time_point<std::chrono::system_clock>& now,
+            bool checkKey);
 
         /// Attempts to reconnect the session with the specified node.
         ///
@@ -427,6 +450,11 @@ namespace DataStormI
 
         // The proxy to the peer node that established the session.
         DataStormContract::NodePrx _node;
+
+        // The DataStorm protocol epoch negotiated for this session, set during establishment before connected() and on
+        // each reconnect. Determines whether the publisher side initializes readers with initSamples (epoch 0) or
+        // initializeReaders (epoch 1). Defaults to 0 for a peer that does not advertise an epoch (Ice 3.8.0-3.8.2).
+        int _protocolEpoch{0};
 
         // Indicates whether the session has been destroyed.
         bool _destroyed{false};

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -438,7 +438,7 @@ TopicI::attachElements(
     return specs;
 }
 
-DataSamplesSeq
+ReaderInitializationSeq
 TopicI::attachElementsAck(
     int64_t topicId,
     const ElementSpecAckSeq& elements,
@@ -447,7 +447,10 @@ TopicI::attachElementsAck(
     const chrono::time_point<chrono::system_clock>& now,
     LongSeq& removedIds)
 {
-    DataSamplesSeq samples;
+    // Each attach appends this key's samples for the peer reader, tagged with the peer reader element id. The caller
+    // (SessionI::attachElementsAck) turns these into the epoch-0 initSamples envelope or the epoch-1 initializeReaders
+    // envelope depending on the session's negotiated protocol epoch.
+    ReaderInitializationSeq batches;
     vector<function<void()>> initCallbacks;
     for (const auto& spec : elements)
     {
@@ -485,12 +488,12 @@ TopicI::attachElementsAck(
                             if (spec.id > 0) // Key
                             {
                                 initCb = dataElement
-                                             ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, samples);
+                                             ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);
                             }
                             else if (filter->match(key)) // Filter
                             {
                                 initCb = dataElement
-                                             ->attach(topicId, spec.id, key, filter, session, prx, data, now, samples);
+                                             ->attach(topicId, spec.id, key, filter, session, prx, data, now, batches);
                             }
 
                             if (initCb)
@@ -549,12 +552,12 @@ TopicI::attachElementsAck(
                             {
                                 initCb =
                                     dataElement
-                                        ->attach(topicId, spec.id, nullptr, filter, session, prx, data, now, samples);
+                                        ->attach(topicId, spec.id, nullptr, filter, session, prx, data, now, batches);
                             }
                             else if (filter->match(key))
                             {
                                 initCb = dataElement
-                                             ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, samples);
+                                             ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);
                             }
 
                             if (initCb)
@@ -587,7 +590,7 @@ TopicI::attachElementsAck(
     {
         initCb();
     }
-    return samples;
+    return batches;
 }
 
 void

--- a/cpp/src/DataStorm/TopicI.h
+++ b/cpp/src/DataStorm/TopicI.h
@@ -79,7 +79,7 @@ namespace DataStormI
             const DataStormContract::SessionPrx&,
             const std::chrono::time_point<std::chrono::system_clock>&);
 
-        [[nodiscard]] DataStormContract::DataSamplesSeq attachElementsAck(
+        [[nodiscard]] DataStormContract::ReaderInitializationSeq attachElementsAck(
             std::int64_t,
             const DataStormContract::ElementSpecAckSeq&,
             const std::shared_ptr<SessionI>&,

--- a/cpp/src/DataStorm/TraceUtil.cpp
+++ b/cpp/src/DataStorm/TraceUtil.cpp
@@ -114,4 +114,10 @@ namespace DataStormContract
         os << 'e' << samples.id << ":sz" << samples.samples.size();
         return os;
     }
+
+    ostream& operator<<(ostream& os, const ReaderInitialization& init)
+    {
+        os << 'e' << init.writerId << ":pe" << init.readerId << ":sz" << init.samples.size();
+        return os;
+    }
 }

--- a/cpp/src/Ice/PropertyNames.cpp
+++ b/cpp/src/Ice/PropertyNames.cpp
@@ -557,6 +557,8 @@ const PropertyArray PropertyNames::Glacier2Props
 const Property DataStormPropsData[] =
 {
     Property{"Node.ConnectTo", "", false, false, nullptr},
+    Property{"Node.MaxProtocolEpoch", "1", false, false, nullptr},
+    Property{"Node.MinProtocolEpoch", "0", false, false, nullptr},
     Property{"Node.Multicast", "", false, false, &PropertyNames::ObjectAdapterProps},
     Property{"Node.Multicast.Enabled", "1", false, false, nullptr},
     Property{"Node.Multicast.Proxy", "", false, false, &PropertyNames::ProxyProps},
@@ -583,7 +585,7 @@ const PropertyArray PropertyNames::DataStormProps
     .prefixOnly=false,
     .isOptIn=false,
     .properties=DataStormPropsData,
-    .length=19
+    .length=21
 };
 
 const std::array<PropertyArray, 16> PropertyNames::validProps =

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -458,6 +458,250 @@ void ::Reader::run(int argc, char* argv[])
         test(sample.getKey() == "elem1");
         test(sample.getValue() == "value1");
     }
+
+    // A late-joining reader of a multi-key writer must receive the initialization samples of every key it
+    // subscribes to.
+    {
+        Topic<string, string> topic(node, "lateJoinMultiKey");
+        Topic<string, int> barrier(node, "lateJoinMultiKeyBarrier");
+        Topic<string, int> done(node, "lateJoinMultiKeyDone");
+
+        // Attach and destroy a probe reader first: once its element-level attach completed, the topics are
+        // attached, so creating the reader below announces a new element on the already-attached session and the
+        // writer initiates the element attach (the initialization samples then arrive via the initSamples request).
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        // Wait until the writer published both keys.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto reader = makeMultiKeyReader(topic, {"elemA", "elemB"}, "", config);
+        reader.waitForUnread(2);
+        map<string, string> values;
+        for (const auto& sample : reader.getAllUnread())
+        {
+            test(sample.getEvent() == SampleEvent::Add);
+            values[sample.getKey()] = sample.getValue();
+        }
+        test(values.size() == 2);
+        test(values["elemA"] == "valueA");
+        test(values["elemB"] == "valueB");
+
+        // A late-joining any-key reader must also receive every key's initialization samples.
+        auto anyKeyReader = makeAnyKeyReader(topic, "", config);
+        anyKeyReader.waitForUnread(2);
+        values.clear();
+        for (const auto& sample : anyKeyReader.getAllUnread())
+        {
+            values[sample.getKey()] = sample.getValue();
+        }
+        test(values.size() == 2);
+        test(values["elemA"] == "valueA");
+        test(values["elemB"] == "valueB");
+
+        // Signal the writer that both readers were initialized, so it can tear down.
+        auto doneWriter = makeSingleKeyWriter(done, "done");
+        doneWriter.waitForReaders();
+        doneWriter.update(0);
+    }
+
+    // Two late-joining single-key readers of a multi-key writer must each receive their own key's initialization
+    // samples.
+    {
+        Topic<string, string> topic(node, "lateJoinSingleKeys");
+        Topic<string, int> barrier(node, "lateJoinSingleKeysBarrier");
+        Topic<string, int> done(node, "lateJoinSingleKeysDone");
+
+        // Probe reader: see the previous case.
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto readerA = makeSingleKeyReader(topic, "elemA", "", config);
+        auto readerB = makeSingleKeyReader(topic, "elemB", "", config);
+
+        auto sample = readerA.getNextUnread();
+        test(sample.getKey() == "elemA");
+        test(sample.getValue() == "valueA");
+
+        sample = readerB.getNextUnread();
+        test(sample.getKey() == "elemB");
+        test(sample.getValue() == "valueB");
+
+        test(!readerA.hasUnread()); // readerA must not also receive elemB's sample
+        test(!readerB.hasUnread()); // readerB must not also receive elemA's sample
+
+        // Signal the writer that both readers were initialized, so it can tear down.
+        auto doneWriter = makeSingleKeyWriter(done, "done");
+        doneWriter.waitForReaders();
+        doneWriter.update(0);
+    }
+
+    // Two readers on the same key, created back-to-back so they attach to the writer element in one initialization
+    // round, must each receive the key's initialization sample exactly once. The live update "valueB" is published
+    // only after both attach and drain, so a duplicated initialization sample would surface as a second "valueA"
+    // ahead of it. This depends on the two readers coalescing into one round (very likely with back-to-back creation,
+    // though not guaranteed); when they do not, the case still passes on the fix.
+    {
+        Topic<string, string> topic(node, "coalescedSameKey");
+        Topic<string, int> barrier(node, "coalescedSameKeyBarrier");
+        Topic<string, int> ready(node, "coalescedSameKeyReady");
+
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto readerA1 = makeSingleKeyReader(topic, "elemA", "", config);
+        auto readerA2 = makeSingleKeyReader(topic, "elemA", "", config);
+
+        auto initA1 = readerA1.getNextUnread();
+        test(initA1.getKey() == "elemA" && initA1.getValue() == "valueA");
+        auto initA2 = readerA2.getNextUnread();
+        test(initA2.getKey() == "elemA" && initA2.getValue() == "valueA");
+
+        auto readyWriter = makeSingleKeyWriter(ready, "ready");
+        readyWriter.waitForReaders();
+        readyWriter.update(0);
+
+        // The next sample of each reader must be the live update, not a duplicated initialization sample.
+        auto liveA1 = readerA1.getNextUnread();
+        test(liveA1.getKey() == "elemA" && liveA1.getValue() == "valueB");
+        test(!readerA1.hasUnread());
+
+        auto liveA2 = readerA2.getNextUnread();
+        test(liveA2.getKey() == "elemA" && liveA2.getValue() == "valueB");
+        test(!readerA2.hasUnread());
+    }
+
+    // A late-joining filtered reader must receive the initialization samples of exactly the writer keys its filter
+    // matches (not the writer's other keys), and must stay subscribed afterwards.
+    {
+        Topic<string, string> topic(node, "lateFilter");
+        Topic<string, int> barrier(node, "lateFilterBarrier");
+        Topic<string, int> ready(node, "lateFilterReady");
+
+        {
+            auto probe = makeSingleKeyReader(topic, "elem1", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto reader = makeFilteredKeyReader(topic, Filter<string>("_regex", "elem[0-9]"), "", config);
+        reader.waitForUnread(2);
+        map<string, string> values;
+        for (const auto& sample : reader.getAllUnread())
+        {
+            values[sample.getKey()] = sample.getValue();
+        }
+        test(values.size() == 2); // "other" does not match the filter, so it is not delivered
+        test(values["elem1"] == "value1");
+        test(values["elem2"] == "value2");
+
+        auto readyWriter = makeSingleKeyWriter(ready, "ready");
+        readyWriter.waitForReaders();
+        readyWriter.update(0);
+
+        // The reader is still subscribed after initialization, so it receives the live update on a matching key.
+        auto live = reader.getNextUnread();
+        test(live.getKey() == "elem1");
+        test(live.getValue() == "value1Live");
+    }
+
+    // A late-joining reader of a key the writer covers but never wrote receives an empty initialization batch; it must
+    // still be marked initialized so a later live sample on that key is delivered.
+    {
+        Topic<string, string> topic(node, "lateEmptyBatch");
+        Topic<string, int> barrier(node, "lateEmptyBatchBarrier");
+        Topic<string, int> ready(node, "lateEmptyBatchReady");
+
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto reader = makeSingleKeyReader(topic, "elemB", "", config);
+        reader.waitForWriters(1); // attached via the empty initialization batch; a live sample is now delivered
+
+        auto readyWriter = makeSingleKeyWriter(ready, "ready");
+        readyWriter.waitForReaders();
+        readyWriter.update(0);
+
+        // elemB had no queued sample, so initialization delivered nothing; the live update is the first sample.
+        auto sample = reader.getNextUnread();
+        test(sample.getKey() == "elemB");
+        test(sample.getValue() == "valueB");
+    }
+
+    // A late-joining multi-key reader must receive every key's initialization samples even when the sample ids
+    // interleave across keys (elemA: 1, 3; elemB: 2); the receiver must not drop the lower-id batch as already seen.
+    {
+        Topic<string, string> topic(node, "lateInterleaved");
+        Topic<string, int> barrier(node, "lateInterleavedBarrier");
+        Topic<string, int> done(node, "lateInterleavedDone");
+
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto reader = makeMultiKeyReader(topic, {"elemA", "elemB"}, "", config);
+        reader.waitForUnread(3);
+        map<string, vector<string>> byKey;
+        for (const auto& sample : reader.getAllUnread())
+        {
+            byKey[sample.getKey()].push_back(sample.getValue());
+        }
+        test(byKey.size() == 2);
+        test((byKey["elemA"] == vector<string>{"valueA1", "valueA2"}));
+        test((byKey["elemB"] == vector<string>{"valueB1"}));
+
+        auto doneWriter = makeSingleKeyWriter(done, "done");
+        doneWriter.waitForReaders();
+        doneWriter.update(0);
+    }
+
+    // A late-joining reader of an any-key writer must receive every key's initialization samples. The any-key writer
+    // is registered under the always-match filter, so its addressed acknowledgments travel the filter branch.
+    {
+        Topic<string, string> topic(node, "lateAnyKeyWriter");
+        Topic<string, int> barrier(node, "lateAnyKeyWriterBarrier");
+        Topic<string, int> done(node, "lateAnyKeyWriterDone");
+
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto reader = makeMultiKeyReader(topic, {"elemA", "elemB"}, "", config);
+        reader.waitForUnread(2);
+        map<string, string> values;
+        for (const auto& sample : reader.getAllUnread())
+        {
+            values[sample.getKey()] = sample.getValue();
+        }
+        test(values.size() == 2);
+        test(values["elemA"] == "valueA");
+        test(values["elemB"] == "valueB");
+
+        auto doneWriter = makeSingleKeyWriter(done, "done");
+        doneWriter.waitForReaders();
+        doneWriter.update(0);
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -407,6 +407,166 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // A late-joining reader of a multi-key writer must receive the initialization samples of every key it
+    // subscribes to, not just the first key's batch.
+    cout << "testing late-joining multi-key reader... " << flush;
+    {
+        Topic<string, string> topic(node, "lateJoinMultiKey");
+        Topic<string, int> barrier(node, "lateJoinMultiKeyBarrier");
+        Topic<string, int> done(node, "lateJoinMultiKeyDone");
+
+        auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
+        writer.add("elemA", "valueA");
+        writer.add("elemB", "valueB");
+
+        // The reader side attaches (and destroys) a probe first, then waits on the barrier before creating the
+        // late-joining reader.
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Gate teardown on the reader signalling that both its readers were initialized, so this writer never races
+        // the late readers' lifetime through a listener count that can drop back to zero before it is observed.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
+
+    // Two late-joining single-key readers of a multi-key writer must each receive their own key's initialization
+    // samples: the batches target the same writer element and must be routed per reader.
+    cout << "testing late-joining single-key readers... " << flush;
+    {
+        Topic<string, string> topic(node, "lateJoinSingleKeys");
+        Topic<string, int> barrier(node, "lateJoinSingleKeysBarrier");
+        Topic<string, int> done(node, "lateJoinSingleKeysDone");
+
+        auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
+        writer.add("elemA", "valueA");
+        writer.add("elemB", "valueB");
+
+        // See the previous case regarding the reader-side probe.
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Gate teardown on the reader signalling that both readers were initialized, so this writer never races their
+        // lifetime through a listener count that can drop back to zero before it is observed.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
+
+    // Two readers on the same key, created back-to-back, attach to the writer element in one initialization round.
+    // Each must receive the key's initialization sample exactly once; the live update below, published only after both
+    // readers drained their initialization sample, would surface a duplicated batch as a second "valueA" ahead of it.
+    cout << "testing coalesced same-key readers... " << flush;
+    {
+        Topic<string, string> topic(node, "coalescedSameKey");
+        Topic<string, int> barrier(node, "coalescedSameKeyBarrier");
+        Topic<string, int> ready(node, "coalescedSameKeyReady");
+
+        auto writer = makeSingleKeyWriter(topic, "elemA", "", config);
+        writer.add("valueA");
+
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Gate the live update on the readers signalling that they attached and drained one initialization sample, so
+        // this writer never races the late readers' lifetime through waitForReaders/waitForNoReaders.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(ready, "ready").getNextUnread();
+        writer.update("valueB");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // A late-joining filtered reader must receive the initialization samples of exactly the writer keys its filter
+    // matches, and must stay subscribed: the addressed return acknowledgment must route by key without detaching it.
+    cout << "testing late-joining filtered reader... " << flush;
+    {
+        Topic<string, string> topic(node, "lateFilter");
+        Topic<string, int> barrier(node, "lateFilterBarrier");
+        Topic<string, int> ready(node, "lateFilterReady");
+
+        auto writer = makeMultiKeyWriter(topic, {"elem1", "elem2", "other"}, "", config);
+        writer.add("elem1", "value1");
+        writer.add("elem2", "value2");
+        writer.add("other", "valueOther");
+
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Publish a live update on a matching key only after the reader drained its initialization samples. The reader
+        // must still be subscribed to receive it: a mis-addressed return acknowledgment would have detached it.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(ready, "ready").getNextUnread();
+        writer.update("elem1", "value1Live");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // A late-joining reader of a key the writer covers but never wrote receives an empty initialization batch. The
+    // reader must still be marked initialized so a later live sample on that key is delivered.
+    cout << "testing late-joining reader of an unwritten key... " << flush;
+    {
+        Topic<string, string> topic(node, "lateEmptyBatch");
+        Topic<string, int> barrier(node, "lateEmptyBatchBarrier");
+        Topic<string, int> ready(node, "lateEmptyBatchReady");
+
+        auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
+        writer.add("elemA", "valueA"); // elemB is covered but never written
+
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Delivered only if the empty initialization batch for elemB marked the reader initialized.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(ready, "ready").getNextUnread();
+        writer.update("elemB", "valueB");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // A late-joining multi-key reader must receive every key's initialization samples even when the sample ids
+    // interleave across keys (elemA: 1, 3; elemB: 2); the receiver must not drop the lower-id batch as already seen.
+    cout << "testing late-joining reader with interleaved sample ids... " << flush;
+    {
+        Topic<string, string> topic(node, "lateInterleaved");
+        Topic<string, int> barrier(node, "lateInterleavedBarrier");
+        Topic<string, int> done(node, "lateInterleavedDone");
+
+        auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
+        writer.add("elemA", "valueA1");    // id 1
+        writer.add("elemB", "valueB1");    // id 2
+        writer.update("elemA", "valueA2"); // id 3
+
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Gate teardown on the reader signalling completion, so this writer does not race the late reader's lifetime.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
+
+    // A late-joining reader of an any-key writer must receive every key's initialization samples. An any-key writer
+    // is registered under the always-match filter, so its addressed return acknowledgments travel the filter branch.
+    cout << "testing late-joining reader of an any-key writer... " << flush;
+    {
+        Topic<string, string> topic(node, "lateAnyKeyWriter");
+        Topic<string, int> barrier(node, "lateAnyKeyWriterBarrier");
+        Topic<string, int> done(node, "lateAnyKeyWriterDone");
+
+        auto writer = makeAnyKeyWriter(topic, "", config);
+        writer.add("elemA", "valueA");
+        writer.add("elemB", "valueB");
+
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
+
     cout << "testing topic collocated key reader and writer... " << flush;
     {
         Topic<string, string> topic(node, "collocated");

--- a/cpp/test/DataStorm/events/test.py
+++ b/cpp/test/DataStorm/events/test.py
@@ -11,6 +11,10 @@ traceProps = {
 
 multicastProps = {"DataStorm.Node.Multicast.Enabled": 1}
 
+# Force the legacy protocol epoch 0 on both nodes to exercise the receiver-side initSamples initialization path used
+# with Ice 3.8.0-3.8.2 peers, in addition to the default run, which negotiates epoch 1 and uses initializeReaders.
+epoch0Props = {"DataStorm.Node.MaxProtocolEpoch": 0}
+
 test_cases = [
     ClientServerTestCase(name="Writer/Reader", client=Writer(), server=Reader(), traceProps=traceProps),
 ]
@@ -20,6 +24,15 @@ test_cases.append(
         name="Writer/Reader multicast enabled",
         client=Writer(props=multicastProps),
         server=Reader(props=multicastProps),
+        traceProps=traceProps,
+    ),
+)
+
+test_cases.append(
+    ClientServerTestCase(
+        name="Writer/Reader protocol epoch 0",
+        client=Writer(props=epoch0Props),
+        server=Reader(props=epoch0Props),
         traceProps=traceProps,
     ),
 )


### PR DESCRIPTION
Fixes #5819.

Supersedes #5880, which addressed the same bug by making the writer re-address its initialization batches through a
second `attachElementsAck`. That approach is not safe across 3.8 patch versions (the reasoning is in the
[icerpc-dev discussion](https://github.com/icerpc/icerpc-dev/discussions/5)). This PR takes the agreed alternative: a
receiver-side fix that stays wire-compatible with Ice 3.8.0-3.8.2, plus an opt-in protocol epoch that upgraded nodes
negotiate for an exact fix.

## The bug

A writer covering several keys, or several readers of one writer, produces one initialization batch per key and per
reader. The `initSamples` receiver marked *every* attached reader initialized on the first batch and dropped the rest,
so a late-joining multi-key or any-key reader lost all but one key's samples.

## Receiver-side fix (protocol epoch 0, wire-compatible with 3.8.0-3.8.2)

`SessionI::initSamples` now groups an initialization round's batches by writer element, then delivers the merged
samples to each attached reader filtered by the keys it subscribes to (via the reader's own `matchKey`), in global
sample-id order. This repairs the dropped and misrouted batches for **every** peer, old or new, and the sender wire is
byte-identical to 3.8.2. The one case the legacy `DataSamples` envelope cannot resolve — two readers on the same key
with different sample filters — is left to epoch 1.

## Exact fix (protocol epoch 1)

Two nodes running this release negotiate a protocol epoch during the twoway `Node` handshake — an
`optional(1) int protocolEpoch` on the three establishment operations, absent meaning epoch 0 — and initialize each
reader element by exact address with a new `initializeReaders` operation. Each node advertises the highest epoch it
supports and both use the lower of the two, so the negotiation is automatic and requires no configuration.

- **`DataStorm.Node.MaxProtocolEpoch`** (default `1`) caps the epoch a node advertises. Set it to `0` to make a node
  speak the legacy wire.
- **`DataStorm.Node.MinProtocolEpoch`** (default `0`) is the acceptance floor. Set it to `1` to refuse sessions with
  peers that do not support the exact fix; those sessions are rejected with a `NotSupported` dispatch exception, which
  every Ice version understands.

Relays forward the tagged epoch, so two upgraded nodes negotiate epoch 1 through an upgraded relay; an old relay strips
the tag and both endpoints safely fall back to epoch 0.

## Compatibility

Default-configured nodes stay fully interoperable with 3.8.0-3.8.2 (epoch-0 sessions, with the receiver-side fix
applied) and automatically use the exact fix between upgraded nodes. There is no coordinated-upgrade requirement unless
an operator opts into `MinProtocolEpoch=1`.

The session retry policy still treats the `NotSupported` rejection as a transient failure and retries it within the
retry budget; tightening that classification (so a deterministic protocol rejection is terminal) is a separate change,
tracked as a follow-up.

## Testing

The `test/DataStorm/events` suite covers late-joining multi-key, single-key, any-key, filtered, interleaved-order,
unwritten-key, and coalesced same-key readers. It now runs under both the default configuration (epoch 1, exercising
`initializeReaders`) and a `DataStorm.Node.MaxProtocolEpoch=0` configuration (epoch 0, exercising the receiver-side
`initSamples` fix). The full DataStorm suite passes, including the relay tests.

## Known limitation (pre-existing, tracked separately)

When a single node hosts two `Topic` instances with the *same name* both reading one writer, initialization can be
misrouted because DataStorm element and key ids are only unique within a topic instance. This is not specific to this
change — it predates it and affects the legacy path as well — and it is tracked separately in #6068.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
