### PR TITLE
Reject out-of-range integers in the Ruby and PHP extensions

### DIFF
--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -1001,9 +1001,9 @@ ZEND_FUNCTION(Ice_register)
         RETURN_NULL();
     }
 
-    // This generous cap guarantees expires * 60 * 1000 fits in an int64_t, making the conversion to milliseconds
-    // below well-defined. INT32_MAX is exactly representable in a double, so the comparison is exact.
-    if (expires > INT32_MAX)
+    // This generous cap (one century, in minutes) keeps the duration well within range for the chrono arithmetic
+    // performed downstream, where the timer uses nanosecond precision: INT64_MAX nanoseconds is about 292 years.
+    if (expires > 60.0 * 24 * 365 * 100)
     {
         invalidArgument("expires is out of range");
         RETURN_NULL();

--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -1001,6 +1001,14 @@ ZEND_FUNCTION(Ice_register)
         RETURN_NULL();
     }
 
+    // This generous cap guarantees expires * 60 * 1000 fits in an int64_t, making the conversion to milliseconds
+    // below well-defined. INT32_MAX is exactly representable in a double, so the comparison is exact.
+    if (expires > INT32_MAX)
+    {
+        invalidArgument("expires is out of range");
+        RETURN_NULL();
+    }
+
     CommunicatorInfoIPtr info = Wrapper<CommunicatorInfoIPtr>::value(comm);
     assert(info);
 
@@ -1034,7 +1042,7 @@ ZEND_FUNCTION(Ice_register)
         // Update the expiration time. If a communicator is registered with multiple IDs, we always use the most
         // recent expiration setting. The expires parameter is number of minutes as a double number, internally we
         // convert it to milliseconds.
-        info->ac->expires = std::chrono::milliseconds(static_cast<int>(expires * 60 * 1000));
+        info->ac->expires = std::chrono::milliseconds(static_cast<int64_t>(expires * 60 * 1000));
         info->ac->lastAccess = std::chrono::steady_clock::now();
         info->ac->reapTask = make_shared<ReapCommunicatorTimerTask>(info->ac);
         _timer->scheduleRepeated(info->ac->reapTask, info->ac->expires / 2);
@@ -1169,6 +1177,14 @@ ZEND_FUNCTION(Ice_identityToString)
     Ice::Identity id;
     if (!extractIdentity(zv, id))
     {
+        RETURN_NULL();
+    }
+
+    if (mode < 0 || mode > static_cast<zend_long>(Ice::ToStringMode::Compat))
+    {
+        ostringstream os;
+        os << "enumerator " << mode << " is out of range for enum Ice::ToStringMode";
+        invalidArgument(os.str());
         RETURN_NULL();
     }
 

--- a/php/src/Connection.cpp
+++ b/php/src/Connection.cpp
@@ -231,20 +231,16 @@ ZEND_METHOD(Ice_Connection, setBufferSize)
         RETURN_NULL();
     }
 
-    // Connection::setBufferSize takes int arguments in C++; reject values outside that range instead of silently
-    // truncating them.
-    if (r < INT_MIN || r > INT_MAX || s < INT_MIN || s > INT_MAX)
+    optional<int32_t> rcvSize = getInt32(r);
+    optional<int32_t> sndSize = getInt32(s);
+    if (!rcvSize || !sndSize)
     {
-        invalidArgument("buffer size must be in the range of a C++ int");
         RETURN_NULL();
     }
 
-    int rcvSize = static_cast<int>(r);
-    int sndSize = static_cast<int>(s);
-
     try
     {
-        _this->setBufferSize(rcvSize, sndSize);
+        _this->setBufferSize(*rcvSize, *sndSize);
     }
     catch (...)
     {

--- a/php/src/Properties.cpp
+++ b/php/src/Properties.cpp
@@ -235,14 +235,14 @@ ZEND_METHOD(Ice_Properties, getPropertyAsIntWithDefault)
     assert(_this);
 
     string_view propName(name, nameLen);
-    if (def < INT32_MIN || def > INT32_MAX)
+    optional<int32_t> defaultValue = getInt32(def);
+    if (!defaultValue)
     {
-        invalidArgument("the default value is out of the range of a 32-bit integer");
         RETURN_NULL();
     }
     try
     {
-        int32_t val = _this->getPropertyAsIntWithDefault(propName, static_cast<int32_t>(def));
+        int32_t val = _this->getPropertyAsIntWithDefault(propName, *defaultValue);
         RETURN_LONG(val);
     }
     catch (...)

--- a/php/src/Proxy.cpp
+++ b/php/src/Proxy.cpp
@@ -459,15 +459,21 @@ ZEND_METHOD(Ice_ObjectPrx, ice_locatorCacheTimeout)
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
     assert(_this);
 
-    zend_long l;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("l"), &l) != SUCCESS)
+    zend_long value;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("l"), &value) != SUCCESS)
+    {
+        RETURN_NULL();
+    }
+
+    optional<int32_t> timeout = getInt32(value);
+    if (!timeout)
     {
         RETURN_NULL();
     }
 
     try
     {
-        if (!_this->clone(return_value, _this->proxy->ice_locatorCacheTimeout(static_cast<int32_t>(l))))
+        if (!_this->clone(return_value, _this->proxy->ice_locatorCacheTimeout(*timeout)))
         {
             RETURN_NULL();
         }
@@ -1119,13 +1125,17 @@ ZEND_METHOD(Ice_ObjectPrx, ice_invocationTimeout)
 
     try
     {
-        zend_long l;
-        if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("l"), &l) != SUCCESS)
+        zend_long value;
+        if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("l"), &value) != SUCCESS)
         {
             RETURN_NULL();
         }
-        // TODO: range check?
-        if (!_this->clone(return_value, _this->proxy->ice_invocationTimeout(static_cast<int32_t>(l))))
+        optional<int32_t> timeout = getInt32(value);
+        if (!timeout)
+        {
+            RETURN_NULL();
+        }
+        if (!_this->clone(return_value, _this->proxy->ice_invocationTimeout(*timeout)))
         {
             RETURN_NULL();
         }

--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -604,6 +604,17 @@ IcePHP::invalidArgument(const string& msg)
     throwError("InvalidArgumentException", msg);
 }
 
+optional<int32_t>
+IcePHP::getInt32(zend_long value)
+{
+    if (value < INT32_MIN || value > INT32_MAX)
+    {
+        invalidArgument("value is out of the range of a 32-bit integer");
+        return nullopt;
+    }
+    return static_cast<int32_t>(value);
+}
+
 static bool
 invokeMethodHelper(zval* obj, const string& name, zval* param)
 {

--- a/php/src/Util.h
+++ b/php/src/Util.h
@@ -93,6 +93,10 @@ namespace IcePHP
     // Raise InvalidArgumentException with the given message.
     void invalidArgument(const std::string&);
 
+    // Convert a PHP long to a 32-bit integer. Returns nullopt after raising InvalidArgumentException if the value is
+    // out of range.
+    std::optional<std::int32_t> getInt32(zend_long value);
+
     // Invoke a method on a PHP object. The method must not take any arguments.
     bool invokeMethod(zval*, const std::string&);
 

--- a/php/test/Ice/proxy/Client.php
+++ b/php/test/Ice/proxy/Client.php
@@ -330,6 +330,12 @@ function allTests($helper)
     $ident2 = Ice\stringToIdentity($idStr);
     test($ident == $ident2);
 
+    try {
+        Ice\identityToString($ident, 3);
+        test(false);
+    } catch (\InvalidArgumentException $ex) {
+    }
+
     $ident2 = Ice\stringToIdentity($communicator->identityToString($ident));
     test($ident == $ident2);
 
@@ -349,6 +355,18 @@ function allTests($helper)
     test($base->ice_getCompress() == Ice\None);
     test($base->ice_compress(true)->ice_getCompress() == true);
     test($base->ice_compress(false)->ice_getCompress() == false);
+
+    try {
+        $base->ice_invocationTimeout(pow(2, 32) + 5000);
+        test(false);
+    } catch (\InvalidArgumentException $ex) {
+    }
+
+    try {
+        $base->ice_locatorCacheTimeout(pow(2, 32) - 1);
+        test(false);
+    } catch (\InvalidArgumentException $ex) {
+    }
 
     echo "ok\n";
 

--- a/php/test/Ice/registeredCommunicator/Client.php
+++ b/php/test/Ice/registeredCommunicator/Client.php
@@ -47,6 +47,14 @@ class Client extends TestHelper
         $communicator = Ice\initialize();
         test(Ice\register($communicator, "Hello6") == false);
 
+        // An out-of-range expiration time is rejected.
+        try {
+            Ice\register($communicator, "Hello7", 1e300);
+            test(false);
+        } catch (\InvalidArgumentException $ex) {
+        }
+        test(Ice\find('Hello7') == null);
+
         // A registered communicator must not be reaped before its expiration time. The reap task runs every
         // expires/2; intermediate ticks must not destroy a communicator that has not yet expired (see #5533).
         $communicator = Ice\initialize();

--- a/php/test/Ice/registeredCommunicator/Client.php
+++ b/php/test/Ice/registeredCommunicator/Client.php
@@ -47,13 +47,18 @@ class Client extends TestHelper
         $communicator = Ice\initialize();
         test(Ice\register($communicator, "Hello6") == false);
 
+        // An expiration time whose value in milliseconds exceeds INT32_MAX is accepted.
+        Ice\register($communicator, "Hello7", 40000);
+        test(Ice\find('Hello7') != null);
+        test(Ice\unregister('Hello7'));
+
         // An out-of-range expiration time is rejected.
         try {
-            Ice\register($communicator, "Hello7", 1e300);
+            Ice\register($communicator, "Hello8", 1e300);
             test(false);
         } catch (\InvalidArgumentException $ex) {
         }
-        test(Ice\find('Hello7') == null);
+        test(Ice\find('Hello8') == null);
 
         // A registered communicator must not be reaped before its expiration time. The reap task runs every
         // expires/2; intermediate ticks must not destroy a communicator that has not yet expired (see #5533).

--- a/ruby/src/IceRuby/Communicator.cpp
+++ b/ruby/src/IceRuby/Communicator.cpp
@@ -223,8 +223,12 @@ IceRuby_identityToString(int argc, VALUE* argv, VALUE /*self*/)
         if (argc == 2)
         {
             volatile VALUE modeValue = callRuby(rb_funcall, argv[1], rb_intern("to_i"), 0);
-            assert(TYPE(modeValue) == T_FIXNUM);
-            toStringMode = static_cast<Ice::ToStringMode>(FIX2LONG(modeValue));
+            int32_t mode = getInteger(modeValue);
+            if (mode < 0 || mode > static_cast<int32_t>(Ice::ToStringMode::Compat))
+            {
+                throw RubyException(rb_eRangeError, "invalid enumerator %d for enum Ice::ToStringMode", mode);
+            }
+            toStringMode = static_cast<Ice::ToStringMode>(mode);
         }
 
         string str = Ice::identityToString(ident, toStringMode);

--- a/ruby/src/IceRuby/Connection.cpp
+++ b/ruby/src/IceRuby/Connection.cpp
@@ -148,17 +148,7 @@ IceRuby_Connection_setBufferSize(VALUE self, VALUE r, VALUE s)
         Ice::ConnectionPtr* p = reinterpret_cast<Ice::ConnectionPtr*>(DATA_PTR(self));
         assert(p);
 
-        long rcvSize = getInteger(r);
-        long sndSize = getInteger(s);
-
-        // Connection::setBufferSize takes int arguments in C++; reject values outside that range instead of silently
-        // truncating them.
-        if (rcvSize < INT_MIN || rcvSize > INT_MAX || sndSize < INT_MIN || sndSize > INT_MAX)
-        {
-            throw RubyException(rb_eRangeError, "buffer size must be in the range of a C++ int");
-        }
-
-        (*p)->setBufferSize(static_cast<int>(rcvSize), static_cast<int>(sndSize));
+        (*p)->setBufferSize(getInteger(r), getInteger(s));
     }
     ICE_RUBY_CATCH
     return Qnil;

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -368,7 +368,7 @@ IceRuby::OperationI::convertParam(VALUE v, long pos)
     ParamInfoPtr param = make_shared<ParamInfo>();
     param->type = getType(RARRAY_AREF(v, 0));
     param->optional = static_cast<bool>(RTEST(RARRAY_AREF(v, 1)));
-    param->tag = static_cast<int>(getInteger(RARRAY_AREF(v, 2)));
+    param->tag = getInteger(RARRAY_AREF(v, 2));
     param->pos = static_cast<int>(pos);
     return param;
 }

--- a/ruby/src/IceRuby/Properties.cpp
+++ b/ruby/src/IceRuby/Properties.cpp
@@ -156,12 +156,7 @@ IceRuby_Properties_getPropertyAsIntWithDefault(VALUE self, VALUE key, VALUE def)
     {
         Ice::PropertiesPtr p = getProperties(self);
         string k = getString(key);
-        long d = getInteger(def);
-        if (d < INT32_MIN || d > INT32_MAX)
-        {
-            throw RubyException(rb_eRangeError, "the default value is out of the range of a 32-bit integer");
-        }
-        int32_t v = p->getPropertyAsIntWithDefault(k, static_cast<int32_t>(d));
+        int32_t v = p->getPropertyAsIntWithDefault(k, getInteger(def));
         return INT2FIX(v);
     }
     ICE_RUBY_CATCH

--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -316,8 +316,7 @@ IceRuby_ObjectPrx_ice_locatorCacheTimeout(VALUE self, VALUE timeout)
         try
         {
             Ice::ObjectPrx p = getProxy(self);
-            long t = getInteger(timeout);
-            return createProxy(p->ice_locatorCacheTimeout(static_cast<int32_t>(t)), rb_class_of(self));
+            return createProxy(p->ice_locatorCacheTimeout(getInteger(timeout)), rb_class_of(self));
         }
         catch (const invalid_argument& ex)
         {
@@ -336,8 +335,7 @@ IceRuby_ObjectPrx_ice_invocationTimeout(VALUE self, VALUE timeout)
         try
         {
             Ice::ObjectPrx p = getProxy(self);
-            long t = getInteger(timeout);
-            return createProxy(p->ice_invocationTimeout(static_cast<int32_t>(t)), rb_class_of(self));
+            return createProxy(p->ice_invocationTimeout(getInteger(timeout)), rb_class_of(self));
         }
         catch (const invalid_argument& ex)
         {

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -337,7 +337,7 @@ IceRuby::StreamUtil::getSlicedDataMember(VALUE obj, ValueMap* valueMap)
 
                 auto info = std::make_shared<Ice::SliceInfo>(
                     getString(typeId),
-                    static_cast<int32_t>(getInteger(compactId)),
+                    getInteger(compactId),
                     std::move(vtmp),
                     hasOptionalMembers == Qtrue,
                     isLastSlice == Qtrue);
@@ -516,33 +516,28 @@ IceRuby::PrimitiveInfo::marshal(VALUE p, Ice::OutputStream* os, ValueMap*, bool)
         }
         case PrimitiveInfo::KindByte:
         {
-            long i = getInteger(p);
+            int32_t i = getInteger(p);
             if (i >= 0 && i <= 255)
             {
                 os->write(static_cast<uint8_t>(i));
                 break;
             }
-            throw RubyException(rb_eTypeError, "value is out of range for a byte");
+            throw RubyException(rb_eRangeError, "value is out of range for a byte");
         }
         case PrimitiveInfo::KindShort:
         {
-            long i = getInteger(p);
+            int32_t i = getInteger(p);
             if (i >= SHRT_MIN && i <= SHRT_MAX)
             {
                 os->write(static_cast<int16_t>(i));
                 break;
             }
-            throw RubyException(rb_eTypeError, "value is out of range for a short");
+            throw RubyException(rb_eRangeError, "value is out of range for a short");
         }
         case PrimitiveInfo::KindInt:
         {
-            long i = getInteger(p);
-            if (i >= INT_MIN && i <= INT_MAX)
-            {
-                os->write(static_cast<int32_t>(i));
-                break;
-            }
-            throw RubyException(rb_eTypeError, "value is out of range for an int");
+            os->write(getInteger(p));
+            break;
         }
         case PrimitiveInfo::KindLong:
         {
@@ -718,7 +713,7 @@ namespace
 
         virtual void element(VALUE key, VALUE value)
         {
-            const int32_t v = static_cast<int32_t>(getInteger(key));
+            const int32_t v = getInteger(key);
             assert(enumerators.find(v) == enumerators.end());
             enumerators[v] = value;
 
@@ -783,7 +778,7 @@ IceRuby::EnumInfo::marshal(VALUE p, Ice::OutputStream* os, ValueMap*, bool)
     // Validate value.
     //
     volatile VALUE val = callRuby(rb_iv_get, p, "@value");
-    const int32_t ival = static_cast<int32_t>(getInteger(val));
+    const int32_t ival = getInteger(val);
     if (enumerators.find(ival) == enumerators.end())
     {
         throw RubyException(rb_eRangeError, "invalid enumerator %d for enum %s", ival, id.c_str());
@@ -852,7 +847,7 @@ convertDataMembers(VALUE members, DataMemberList& reqMembers, DataMemberList& op
         if (allowOptional)
         {
             member->optional = RTEST(RARRAY_AREF(m, 2));
-            member->tag = static_cast<int>(getInteger(RARRAY_AREF(m, 3)));
+            member->tag = getInteger(RARRAY_AREF(m, 3));
         }
         else
         {
@@ -1365,10 +1360,10 @@ IceRuby::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, VALU
                 Ice::ByteSeq seq(static_cast<size_t>(sz));
                 for (long i = 0; i < sz; ++i)
                 {
-                    long val = getInteger(RARRAY_AREF(arr, i));
+                    int32_t val = getInteger(RARRAY_AREF(arr, i));
                     if (val < 0 || val > 255)
                     {
-                        throw RubyException(rb_eTypeError, "invalid value for element %ld of sequence<byte>", i);
+                        throw RubyException(rb_eRangeError, "invalid value for element %ld of sequence<byte>", i);
                     }
                     seq[static_cast<size_t>(i)] = static_cast<byte>(val);
                 }
@@ -1382,10 +1377,10 @@ IceRuby::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, VALU
             Ice::ShortSeq seq(static_cast<size_t>(sz));
             for (long i = 0; i < sz; ++i)
             {
-                long val = getInteger(RARRAY_AREF(arr, i));
+                int32_t val = getInteger(RARRAY_AREF(arr, i));
                 if (val < SHRT_MIN || val > SHRT_MAX)
                 {
-                    throw RubyException(rb_eTypeError, "invalid value for element %ld of sequence<short>", i);
+                    throw RubyException(rb_eRangeError, "invalid value for element %ld of sequence<short>", i);
                 }
                 seq[static_cast<size_t>(i)] = static_cast<int16_t>(val);
             }
@@ -1398,12 +1393,7 @@ IceRuby::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, VALU
             Ice::IntSeq seq(static_cast<size_t>(sz));
             for (long i = 0; i < sz; ++i)
             {
-                long val = getInteger(RARRAY_AREF(arr, i));
-                if (val < INT_MIN || val > INT_MAX)
-                {
-                    throw RubyException(rb_eTypeError, "invalid value for element %ld of sequence<int>", i);
-                }
-                seq[static_cast<size_t>(i)] = static_cast<int32_t>(val);
+                seq[static_cast<size_t>(i)] = getInteger(RARRAY_AREF(arr, i));
             }
             os->write(seq);
             break;
@@ -1933,7 +1923,7 @@ IceRuby::ClassInfo::define(VALUE t, VALUE compact, VALUE intf, VALUE b, VALUE m)
         assert(base);
     }
 
-    const_cast<int32_t&>(compactId) = static_cast<int32_t>(getInteger(compact));
+    const_cast<int32_t&>(compactId) = getInteger(compact);
     const_cast<bool&>(interface) = RTEST(intf);
     convertDataMembers(m, const_cast<DataMemberList&>(members), const_cast<DataMemberList&>(optionalMembers), true);
     const_cast<VALUE&>(rubyClass) = t;

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -24,7 +24,7 @@ namespace
         volatile VALUE major = callRuby(rb_ivar_get, p, rb_intern("@major"));
         volatile VALUE minor = callRuby(rb_ivar_get, p, rb_intern("@minor"));
 
-        long m;
+        int32_t m;
 
         m = getInteger(major);
         if (m < 0 || m > 255)
@@ -151,17 +151,6 @@ namespace
     };
 
     //
-    // Wrapper function to call rb_num2long with rb_protect
-    //
-    VALUE
-    rb_num2long_wrapper(VALUE val)
-    {
-        RubyCallArgs<long>* data = (RubyCallArgs<long>*)val;
-        data->ret = rb_num2long(data->val);
-        return val;
-    }
-
-    //
     // Wrapper function to call rb_num2ll with rb_protect
     //
     VALUE
@@ -173,17 +162,15 @@ namespace
     }
 }
 
-long
+int32_t
 IceRuby::getInteger(VALUE val)
 {
-    RubyCallArgs<long> arg = {val, -1};
-    int error = 0;
-    rb_protect(rb_num2long_wrapper, (VALUE)&arg, &error);
-    if (error)
+    int64_t value = getLong(val);
+    if (value < INT32_MIN || value > INT32_MAX)
     {
-        throw RubyException(rb_eTypeError, "unable to convert value to an int");
+        throw RubyException(rb_eRangeError, "value is out of the range of a 32-bit integer");
     }
-    return arg.ret;
+    return static_cast<int32_t>(value);
 }
 
 int64_t

--- a/ruby/src/IceRuby/Util.h
+++ b/ruby/src/IceRuby/Util.h
@@ -62,9 +62,10 @@ namespace IceRuby
     VALUE createString(std::string_view);
 
     //
-    // Convert a Ruby value into a long. May raise RubyException.
+    // Convert a Ruby value into an std::int32_t. Raises RangeError if the value is outside the range of a
+    // 32-bit integer. May raise RubyException.
     //
-    long getInteger(VALUE);
+    std::int32_t getInteger(VALUE);
 
     //
     // Convert a Ruby value into an std::int64_t. May raise RubyException.

--- a/ruby/test/Ice/operations/Twoways.rb
+++ b/ruby/test/Ice/operations/Twoways.rb
@@ -167,31 +167,31 @@ def twoways(helper, communicator, p)
     begin
         r, b = p.opByte(0x01ff, 0x01ff)
         test(false)
-    rescue TypeError
+    rescue RangeError
     end
 
     begin
         r, s, i, l = p.opShortIntLong(32767 + 1, 0, 0)
         test(false)
-    rescue TypeError
+    rescue RangeError
     end
 
     begin
         r, s, i, l = p.opShortIntLong(-32768 - 1, 0, 0)
         test(false)
-    rescue TypeError
+    rescue RangeError
     end
 
     begin
         r, s, i, l = p.opShortIntLong(0, 2147483647 + 1, 0)
         test(false)
-    rescue TypeError
+    rescue RangeError
     end
 
     begin
         r, s, i, l = p.opShortIntLong(0, -2147483648 - 1, 0)
         test(false)
-    rescue TypeError
+    rescue RangeError
     end
 
     begin

--- a/ruby/test/Ice/proxy/AllTests.rb
+++ b/ruby/test/Ice/proxy/AllTests.rb
@@ -343,6 +343,12 @@ def allTests(helper, communicator)
     ident2 = Ice::stringToIdentity(idStr)
     test(ident == ident2)
 
+    begin
+        Ice::identityToString(ident, 3)
+        test(false)
+    rescue RangeError
+    end
+
     ident2 = Ice::stringToIdentity(communicator.identityToString(ident))
     test(ident == ident2)
 
@@ -376,6 +382,12 @@ def allTests(helper, communicator)
     end
 
     begin
+        base.ice_invocationTimeout(2**32 + 5000)
+        test(false)
+    rescue RangeError
+    end
+
+    begin
         base.ice_locatorCacheTimeout(0)
     rescue
         test(false)
@@ -391,6 +403,12 @@ def allTests(helper, communicator)
         base.ice_locatorCacheTimeout(-2)
         test(false)
     rescue
+    end
+
+    begin
+        base.ice_locatorCacheTimeout(2**32 - 1)
+        test(false)
+    rescue RangeError
     end
 
     puts "ok"


### PR DESCRIPTION
The Ruby and PHP extensions accept a 64-bit integer from the interpreter and narrow it to 32 bits with a bare `static_cast`, so an out-of-range value silently wraps instead of failing — for example `ice_invocationTimeout(2**32 + 5000)` became a real 5-second timeout, and `ice_locatorCacheTimeout(2**32 - 1)` wrapped to -1 (cache forever).

### Ruby

`getInteger` now converts through `int64` and raises `RangeError` when the value is outside the range of a 32-bit integer, making the check independent of `sizeof(long)`. All callers get the check for free; the now-redundant per-site int range checks are removed, along with the narrowing casts. Out-of-range byte/short marshaling errors are aligned on `RangeError` as well — the convention is now: not convertible to an integer → `TypeError`, integer out of range → `RangeError`.

### PHP

A new `getInt32` helper (`std::optional<int32_t>`) raises `InvalidArgumentException` and returns `nullopt` for out-of-range values. It replaces the unchecked casts in `ice_invocationTimeout` and `ice_locatorCacheTimeout`, and the hand-rolled checks in `setBufferSize` and `getPropertyAsIntWithDefault`.

### Both

- `identityToString` validates the mode argument against the `ToStringMode` range instead of casting an unvalidated integer to the enum.
- `Ice\register` (PHP) rejects an `expires` value that would overflow the minutes-to-milliseconds conversion, and performs that conversion in `int64_t`; previously a large value (e.g. 40000 minutes) invoked undefined behavior in the `double` → `int` conversion.

Added regression cases to the Ruby and PHP proxy tests and to the PHP registeredCommunicator test.

Fixes #6066

🤖 Generated with [Claude Code](https://claude.com/claude-code)