### PR TITLE
Mark a replicated IceStorm topic destroyed only after its transaction commits

### DIFF
--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -1156,7 +1156,6 @@ TopicImpl::observerDestroyTopic(const LogUpdate& llu)
     {
         return;
     }
-    _destroyed = true;
 
     auto traceLevels = _instance->traceLevels();
     if (traceLevels->topic > 0)
@@ -1165,7 +1164,11 @@ TopicImpl::observerDestroyTopic(const LogUpdate& llu)
         out << _name << ": destroyed";
         out << " llu: " << llu.generation << "/" << llu.iteration;
     }
+
+    // Mark the topic destroyed only once its database transaction has committed, so a failed commit leaves the topic
+    // intact and still destroyable.
     destroyInternal(llu, false);
+    _destroyed = true;
 
     _observer.detach();
 }


### PR DESCRIPTION
PR #5940 fixed `TopicImpl::destroy` to set `_destroyed` only after the database transaction commits, but its replica-side twin `observerDestroyTopic` still marked the topic destroyed first. When a replica failed to apply a master's topic destroy (e.g. on a database write error), it latched an inconsistent in-memory state: the topic was undestroyable yet kept delivering, and could be resurrected cluster-wide if that replica was later promoted.

Now the topic stays intact and consistent with the replica's database; the replica is evicted from the group by the failed observer call as usual, and reconciliation retries the destroy on the next election.

Fixes #6036

🤖 Generated with [Claude Code](https://claude.com/claude-code)