### PR TITLE
Fix IceStorm election LLU bugs that could adopt a stale replica's state

### DIFF
--- a/changelog.d/service-icestorm/election-stale-replica-state.md
+++ b/changelog.d/service-icestorm/election-stale-replica-state.md
@@ -1,0 +1,3 @@
+- Fixed an election bug in replicated IceStorm deployments. After a restart of all the replicas, or after a
+  sequence of replica outages, the elected coordinator could adopt the state of a stale replica, silently
+  discarding previously created topics and subscriptions.

--- a/cpp/src/IceStorm/NodeI.cpp
+++ b/cpp/src/IceStorm/NodeI.cpp
@@ -590,7 +590,12 @@ NodeI::mergeContinue()
         max = _max;
     }
 
-    // Prepare the LogUpdate for this generation.
+    // Prepare the LogUpdate for this generation. The new stamp must be larger than every LLU in the group, including
+    // our own.
+    if (myLlu > maxllu)
+    {
+        maxllu = myLlu;
+    }
     maxllu.generation++;
     maxllu.iteration = 0;
 

--- a/cpp/src/IceStorm/TopicManagerI.cpp
+++ b/cpp/src/IceStorm/TopicManagerI.cpp
@@ -257,9 +257,14 @@ TopicManagerImpl::TopicManagerImpl(shared_ptr<PersistentInstance> instance)
     {
         IceDB::ReadWriteTxn txn(_instance->dbEnv());
 
-        // Ensure that the llu counter is present in the log.
-        LogUpdate empty = {0, 0};
-        _instance->lluMap().put(txn, lluDbKey, empty);
+        // Ensure that the llu counter is present in the log, without overwriting the last value persisted by a
+        // previous run.
+        LogUpdate llu;
+        if (!_instance->lluMap().get(txn, lluDbKey, llu))
+        {
+            LogUpdate empty = {0, 0};
+            _instance->lluMap().put(txn, lluDbKey, empty);
+        }
 
         // Recreate each of the topics.
         SubscriberRecordKey k;

--- a/cpp/test/IceStorm/rep1/test.py
+++ b/cpp/test/IceStorm/rep1/test.py
@@ -293,6 +293,49 @@ class IceStormRep1TestCase(IceStormTestCase):
         runtest("--twoway", "--cycle")
         current.writeln("ok")
 
+        current.write("testing replica rejoin with an outdated database... ")
+        sys.stdout.flush()
+
+        # Advance the database of replicas 1 and 2 by two updates while replica 0 is down. Bounce
+        # replica 1 first to force an election, so replicas 1 and 2 move a full generation ahead
+        # of replica 0.
+        stopReplica(0)
+        stopReplica(1)
+        startReplica(1)
+        self.runadmin(current, "create before1")
+        self.runadmin(current, "create before2")
+
+        # Swap replica 1 out for replica 0 and commit one update: replica 2, which holds the most
+        # recent database, coordinates a group in which every other replica is outdated.
+        stopReplica(1)
+        startReplica(0)
+        self.runadmin(current, "create after")
+
+        # When replica 1 rejoins, the election must not prefer its database over the group's, which
+        # saw the later 'after' creation.
+        startReplica(1)
+        for replica in [1, 0, 2]:
+            adminForReplica(replica, "create after", "error: topic 'after' exists")
+        current.writeln("ok")
+
+        current.write("testing full restart with a stale replica... ")
+        sys.stdout.flush()
+
+        # Make replica 2's database stale: create a topic while replica 2 is down.
+        stopReplica(2)
+        self.runadmin(current, "create fresh")
+
+        # Restart the group. The election must adopt the state of a replica that saw the topic
+        # creation, even though the stale replica has the highest node priority.
+        stopReplica(1)
+        stopReplica(0)
+        for replica in range(0, 3):
+            startReplica(replica)
+
+        for replica in range(0, 3):
+            adminForReplica(replica, "create fresh", "error: topic 'fresh' exists")
+        current.writeln("ok")
+
         current.write("stopping replicas... ")
         sys.stdout.flush()
         self.stopIceStorm(current)


### PR DESCRIPTION
This PR fixes two bugs in how replicated IceStorm tracks the last-log-update (LLU) record the election uses to decide which replica holds the freshest database. Either bug could make an election adopt a stale replica's state, silently discarding committed topics and subscriptions.

1. **The persisted LLU was reset to `{0,0}` on every startup.** `TopicManagerImpl`'s constructor seeded the LLU record with an unconditional `put`, overwriting whatever the previous run persisted. After a full-group restart, every replica reported `{0,0}`, so the coordinator never synced from a fresher replica and imposed its own, possibly stale, content. The constructor now seeds `{0,0}` only when the record is absent (a fresh database), restoring the behavior of the original HA implementation — the guard was lost in a storage-layer migration.

2. **The new generation stamp ignored the coordinator's own LLU.** `NodeI::mergeContinue` computed the stamp of the new generation as the maximum over the slaves' reported LLUs only. When the coordinator itself held the newest state — reachable with 3 replicas through ordinary sequential outages, whenever the highest-priority replica is the one that stays up — the new stamp could fail to exceed all existing records, breaking the LLU ordering; a later election could then sync from a replica whose content was older and roll back updates committed in the meantime. The coordinator's own LLU is now folded into the maximum before the generation bump.

The `rep1` suite gains a regression scenario per bug, each verified to fail on the unfixed code:

- *"testing full restart with a stale replica"* (bug 1): a topic created while the highest-priority replica is down must survive a stop and restart of the whole group.
- *"testing replica rejoin with an outdated database"* (bug 2): after the group moves a generation ahead of a stopped replica and reforms around the freshest replica as coordinator, a topic created by the reformed group must survive the stale replica's rejoin. (This scenario isolates bug 2 only with bug 1 fixed — the startup LLU reset otherwise erases the rejoining replica's newer LLU and masks the rollback.)

The `IceStorm/rep1`, `IceStorm/repgrid`, and `IceStorm/repstress` suites pass with these changes.

Fixes #5845
Fixes #5846

🤖 Generated with [Claude Code](https://claude.com/claude-code)