### PR TITLE
Return an empty SliceInfo.typeId for compact-ID slices in Ice for Swift

### DIFF
--- a/changelog.d/swift/5969.md
+++ b/changelog.d/swift/5969.md
@@ -1,0 +1,3 @@
+- `Ice.SliceInfo.typeId` is now empty for the slice of a class with a compact type ID, matching the C++, Java, and
+  Python mappings. Previously, `typeId` held the stringified compact ID. The compact ID itself remains available
+  through `Ice.SliceInfo.compactId`.

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -1500,7 +1500,6 @@ private class EncapsDecoder11: EncapsDecoder {
             let bytes = stream.data.subdata(in: start..<dataEnd)  // copy
 
             let info = SliceInfo(
-                // When the slice was decoded via a compact type ID, expose an empty type ID.
                 typeId: current.compactId == -1 ? current.typeId : "",
                 compactId: current.compactId,
                 bytes: bytes,

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -1500,7 +1500,8 @@ private class EncapsDecoder11: EncapsDecoder {
             let bytes = stream.data.subdata(in: start..<dataEnd)  // copy
 
             let info = SliceInfo(
-                typeId: current.typeId,
+                // When the slice was decoded via a compact type ID, expose an empty type ID.
+                typeId: current.compactId == -1 ? current.typeId : "",
                 compactId: current.compactId,
                 bytes: bytes,
                 instances: [],

--- a/swift/src/Ice/SliceInfo.swift
+++ b/swift/src/Ice/SliceInfo.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Encapsulates the details of a class slice with an unknown type.
 public struct SliceInfo {
-    /// The Slice type ID for this slice.
+    /// The Slice type ID for this slice. It's empty when the compact ID is set (`compactId` is not `-1`).
     public let typeId: String
 
     /// The Slice compact type ID for this slice, or `-1` if the slice has no compact ID.


### PR DESCRIPTION
Fixes #5969.

Final mapping in the series started by #5976 (MATLAB), #5977 (C#), and #5978 (JavaScript). Swift was flagged by
@bernardnormier in https://github.com/zeroc-ice/ice/issues/5969#issuecomment-4984966944 and not covered by those PRs.

### Problem

For a value slice decoded via a compact type ID (Ice encoding 1.1), `Ice.SliceInfo.typeId` held the **stringified
compact ID** (e.g. `"57"`), whereas C++, Java, and Python leave it **empty** and carry the compact ID only in
`SliceInfo.compactId` (C++ and Java both document *and* assert the empty behavior). This is observable to
applications inspecting `SlicedData`, e.g. in a `SliceLoader`.

`EncapsDecoder11.startSlice` sets `current.typeId = "\(current.compactId!)"` for a compact-ID slice
(`swift/src/Ice/InputStream.swift:1384`), and `skipSlice` passed it verbatim into `SliceInfo` — unlike Java, which
discards the stringified value at the `SliceInfo` construction.

### Fix

Mirror the Java reference: keep the internal stringified type ID (it is load-bearing) and blank `typeId` **only** at
the single `SliceInfo` construction site when a compact ID is present — `swift/src/Ice/InputStream.swift:1502`. Also
update the `SliceInfo.typeId` doc (`swift/src/Ice/SliceInfo.swift`) to state it is empty when the compact ID is set,
matching C++/Java.

Per @bernardnormier's note on the issue, `current.typeId` itself is untouched, so `mostDerivedId`
(`InputStream.swift:1566`) still feeds the stringified compact ID to `UnknownSlicedValue.ice_id()`.

Re-marshaling is unaffected, as in the other mappings: `OutputStream.swift:976` passes `info.typeId`/`info.compactId`
to `startSlice`, which takes the `compactId != -1` branch (`OutputStream.swift:891-894`) and never writes `typeId`.

`SlicedData.swift` is the only other Swift consumer of `SliceInfo`, and it just stores the array.

### Testing

No new regression test, consistent with the three companion PRs. The slicing suite does not inspect
`SliceInfo.typeId`: its compact types are client-known (fully reconstructed, so no `SlicedData`), and every "unknown
preserved" server operation returns string-ID types. A true end-to-end test would require new, coordinated
cross-language `.ice` types plus a preserving operation. Happy to add that as a follow-up if wanted.

Verified locally on macOS/arm64: `swift build` for the root package and `swift/test` both clean, `swift format lint`
clean on the changed files, and `python3 swift/allTests.py --config=debug --filter="Ice/slicing"` passes (2/2 —
`Ice/slicing/exceptions` and `Ice/slicing/objects`, both encodings). That confirms no regression; it does not cover
the new behavior, for the reason above.

### Changelog

Keeping `changelog.d/swift/5969.md` for consistency with the merged C#, MATLAB, and JS fragments — the
fragment-removal request on #5978 was withdrawn on the same grounds.
