### PR TITLE
Report the JS idle-timeout in seconds in the idle-check abort message

### DIFF
--- a/changelog.d/js/5948.md
+++ b/changelog.d/js/5948.md
@@ -1,0 +1,3 @@
+- Fixed the `ConnectionAbortedException` raised by the idle check to report the idle timeout in seconds. It
+  previously reported the value in milliseconds while still labeling it with an `s` suffix, so a default 60-second
+  idle timeout was described as `60000s`.

--- a/changelog.d/js/5948.md
+++ b/changelog.d/js/5948.md
@@ -1,3 +1,0 @@
-- Fixed the `ConnectionAbortedException` raised by the idle check to report the idle timeout in seconds. It
-  previously reported the value in milliseconds while still labeling it with an `s` suffix, so a default 60-second
-  idle timeout was described as `60000s`.

--- a/js/packages/ice/src/Ice/IdleTimeoutTransceiverDecorator.js
+++ b/js/packages/ice/src/Ice/IdleTimeoutTransceiverDecorator.js
@@ -5,8 +5,7 @@ export class IdleTimeoutTransceiverDecorator {
         console.assert(idleTimeout > 0);
 
         this._decoratee = decoratee;
-        this._idleTimeout = idleTimeout; // in seconds, as reported by the idle check
-        this._idleTimeoutMs = idleTimeout * 1000; // in milliseconds, for the timers
+        this._idleTimeoutMs = idleTimeout * 1000;
         this._timer = timer;
         this._connection = connection;
 
@@ -94,7 +93,7 @@ export class IdleTimeoutTransceiverDecorator {
         if (this._idleCheckEnabled) {
             this.cancelReadTimer();
             this._readTimerToken = this._timer.schedule(() => {
-                this._connection.idleCheck(this._idleTimeout);
+                this._connection.idleCheck(this._idleTimeoutMs / 1000);
             }, this._idleTimeoutMs);
         }
     }

--- a/js/packages/ice/src/Ice/IdleTimeoutTransceiverDecorator.js
+++ b/js/packages/ice/src/Ice/IdleTimeoutTransceiverDecorator.js
@@ -5,7 +5,8 @@ export class IdleTimeoutTransceiverDecorator {
         console.assert(idleTimeout > 0);
 
         this._decoratee = decoratee;
-        this._idleTimeout = idleTimeout * 1000; // Convert seconds to milliseconds
+        this._idleTimeout = idleTimeout; // in seconds, as reported by the idle check
+        this._idleTimeoutMs = idleTimeout * 1000; // in milliseconds, for the timers
         this._timer = timer;
         this._connection = connection;
 
@@ -94,7 +95,7 @@ export class IdleTimeoutTransceiverDecorator {
             this.cancelReadTimer();
             this._readTimerToken = this._timer.schedule(() => {
                 this._connection.idleCheck(this._idleTimeout);
-            }, this._idleTimeout);
+            }, this._idleTimeoutMs);
         }
     }
 
@@ -102,6 +103,6 @@ export class IdleTimeoutTransceiverDecorator {
         this.cancelWriteTimer();
         this._writeTimerToken = this._timer.schedule(() => {
             this._connection.sendHeartbeat();
-        }, this._idleTimeout / 2);
+        }, this._idleTimeoutMs / 2);
     }
 }

--- a/js/packages/test/Ice/idleTimeout/Client.ts
+++ b/js/packages/test/Ice/idleTimeout/Client.ts
@@ -137,6 +137,8 @@ async function testServerWithEnableDisableIdleCheck(
         } catch (ex) {
             test(ex instanceof Ice.ConnectionAbortedException);
             test(enabled);
+            // The idle check must report the timeout in seconds (1s), not milliseconds (1000s). See issue #5948.
+            test((ex as Error).message.includes("did not receive any bytes for 1s."), ex as Error);
         }
         output.writeLine("ok");
     } finally {

--- a/js/packages/test/Ice/idleTimeout/Client.ts
+++ b/js/packages/test/Ice/idleTimeout/Client.ts
@@ -137,7 +137,7 @@ async function testServerWithEnableDisableIdleCheck(
         } catch (ex) {
             test(ex instanceof Ice.ConnectionAbortedException);
             test(enabled);
-            // The idle check must report the timeout in seconds (1s), not milliseconds (1000s). See issue #5948.
+            // The idle check must report the timeout in seconds (1s), not milliseconds (1000s).
             test((ex as Error).message.includes("did not receive any bytes for 1s."), ex as Error);
         }
         output.writeLine("ok");


### PR DESCRIPTION
Fixes #5948.

When the JS idle check aborts a connection, the `ConnectionAbortedException` message reported the idle timeout in **milliseconds** while labeling it with an `s` suffix. For the default 60s idle timeout:

```
Connection aborted by the idle check because it did not receive any bytes for 60000s.
```

`IdleTimeoutTransceiverDecorator` stored the idle timeout already converted to milliseconds and passed that same value to `Connection.idleCheck`, whose message template appends `s`.

## Fix

This mirrors the C++/C# mappings, where `idleCheck` receives the timeout in seconds and only the timer scheduling uses milliseconds (C++ stores `_idleTimeout` as `chrono::seconds` and converts to milliseconds only for the heartbeat timer):

- Keep a single `_idleTimeoutMs` field (milliseconds, used by both timer `schedule()` calls) and convert to seconds at the one call that needs it — `idleCheck(this._idleTimeoutMs / 1000)`. `ConnectionI.js` is unchanged — its `${idleTimeout}s` template is now correct.
- Strengthen the existing `Ice/idleTimeout` client test to assert the abort message reports the timeout in seconds (`...for 1s.`). The test previously checked only the exception type, so the bug was untested.

No changelog fragment: the incorrect suffix is a minor cosmetic issue not worth a changelog entry.
