### PR TITLE
Add coverage-gap @throws and align Instrumentation wording in the Java Ice API docs

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -205,7 +205,8 @@ public final class Communicator implements AutoCloseable {
      *
      * @param name the object adapter name
      * @return the new object adapter
-     * @throws InitializationException if the object adapter configuration is invalid
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
+     * @throws InitializationException if the object adapter's configuration is invalid
      * @throws AlreadyRegisteredException if an object adapter with the same name already exists
      * @see #createObjectAdapterWithEndpoints
      * @see Properties
@@ -230,7 +231,8 @@ public final class Communicator implements AutoCloseable {
      *     calling {@link #createObjectAdapter(String)}.
      * @return the new object adapter
      * @throws IllegalArgumentException if the provided name is empty and sslEngineFactory is non-null
-     * @throws InitializationException if the object adapter configuration is invalid
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
+     * @throws InitializationException if the object adapter's configuration is invalid
      * @throws AlreadyRegisteredException if an object adapter with the same name already exists
      * @see #createObjectAdapterWithEndpoints
      * @see Properties
@@ -251,7 +253,8 @@ public final class Communicator implements AutoCloseable {
      * @param name the object adapter name
      * @param endpoints the endpoints of the object adapter
      * @return the new object adapter
-     * @throws InitializationException if the object adapter configuration is invalid
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
+     * @throws InitializationException if the object adapter's configuration is invalid
      * @throws AlreadyRegisteredException if an object adapter with the same name already exists
      * @see #createObjectAdapter
      * @see Properties
@@ -275,7 +278,8 @@ public final class Communicator implements AutoCloseable {
      *     through {@code Ice.SSL} configuration properties. Passing {@code null} is equivalent to
      *     calling {@link #createObjectAdapterWithEndpoints(String, String)}.
      * @return the new object adapter
-     * @throws InitializationException if the object adapter configuration is invalid
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
+     * @throws InitializationException if the object adapter's configuration is invalid
      * @throws AlreadyRegisteredException if an object adapter with the same name already exists
      * @see #createObjectAdapter
      * @see Properties
@@ -497,7 +501,8 @@ public final class Communicator implements AutoCloseable {
      * @return a proxy to the main ("") facet of the Admin object
      * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @throws IllegalArgumentException if the admin identity is not valid
-     * @throws InitializationException if this method is called more than once
+     * @throws InitializationException if the Admin object is already created, the Admin facility is
+     *     disabled, or {@code Ice.Admin.Endpoints} is not set
      * @see #getAdmin
      */
     public ObjectPrx createAdmin(ObjectAdapter adminAdapter, Identity adminId) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -205,6 +205,8 @@ public final class Communicator implements AutoCloseable {
      *
      * @param name the object adapter name
      * @return the new object adapter
+     * @throws InitializationException if the object adapter configuration is invalid
+     * @throws AlreadyRegisteredException if an object adapter with the same name already exists
      * @see #createObjectAdapterWithEndpoints
      * @see Properties
      */
@@ -228,6 +230,8 @@ public final class Communicator implements AutoCloseable {
      *     calling {@link #createObjectAdapter(String)}.
      * @return the new object adapter
      * @throws IllegalArgumentException if the provided name is empty and sslEngineFactory is non-null
+     * @throws InitializationException if the object adapter configuration is invalid
+     * @throws AlreadyRegisteredException if an object adapter with the same name already exists
      * @see #createObjectAdapterWithEndpoints
      * @see Properties
      */
@@ -247,6 +251,8 @@ public final class Communicator implements AutoCloseable {
      * @param name the object adapter name
      * @param endpoints the endpoints of the object adapter
      * @return the new object adapter
+     * @throws InitializationException if the object adapter configuration is invalid
+     * @throws AlreadyRegisteredException if an object adapter with the same name already exists
      * @see #createObjectAdapter
      * @see Properties
      */
@@ -269,6 +275,8 @@ public final class Communicator implements AutoCloseable {
      *     through {@code Ice.SSL} configuration properties. Passing {@code null} is equivalent to
      *     calling {@link #createObjectAdapterWithEndpoints(String, String)}.
      * @return the new object adapter
+     * @throws InitializationException if the object adapter configuration is invalid
+     * @throws AlreadyRegisteredException if an object adapter with the same name already exists
      * @see #createObjectAdapter
      * @see Properties
      */
@@ -412,6 +420,7 @@ public final class Communicator implements AutoCloseable {
      * Gets the default locator of this communicator.
      *
      * @return the default locator of this communicator
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @see #setDefaultLocator
      * @see Locator
      */
@@ -486,6 +495,8 @@ public final class Communicator implements AutoCloseable {
      *     after creating and activating this adapter.
      * @param adminId the identity of the Admin object
      * @return a proxy to the main ("") facet of the Admin object
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
+     * @throws IllegalArgumentException if the admin identity is not valid
      * @throws InitializationException if this method is called more than once
      * @see #getAdmin
      */

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
@@ -107,6 +107,8 @@ public interface Connection {
      * Returns the connection information.
      *
      * @return the connection information
+     * @throws LocalException if the connection is closed; the exception provides the reason for the
+     *     closure (see {@link #throwException}).
      */
     ConnectionInfo getInfo();
 
@@ -115,6 +117,8 @@ public interface Connection {
      *
      * @param rcvSize the size of the receive buffer
      * @param sndSize the size of the send buffer
+     * @throws LocalException if the connection is closed; the exception provides the reason for the
+     *     closure (see {@link #throwException}).
      */
     void setBufferSize(int rcvSize, int sndSize);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/DispatchException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/DispatchException.java
@@ -16,9 +16,15 @@ public class DispatchException extends LocalException {
      *     than {@link ReplyStatus#UserException}
      * @param message the detail message
      * @param cause the cause
+     * @throws IllegalArgumentException if {@code replyStatus} does not fit in a byte or is not
+     *     greater than {@link ReplyStatus#UserException}
      */
     public DispatchException(int replyStatus, String message, Throwable cause) {
         super(createMessage(message, replyStatus), cause);
+        if (replyStatus <= ReplyStatus.UserException.value() || replyStatus > 255) {
+            throw new IllegalArgumentException(
+                "The reply status of a DispatchException must fit in a byte and be greater than ReplyStatus.UserException.");
+        }
         this.replyStatus = replyStatus;
     }
 
@@ -28,6 +34,8 @@ public class DispatchException extends LocalException {
      * @param replyStatus the reply status as an int (see {@link ReplyStatus}); it must be greater
      *     than {@link ReplyStatus#UserException}
      * @param message the detail message
+     * @throws IllegalArgumentException if {@code replyStatus} does not fit in a byte or is not
+     *     greater than {@link ReplyStatus#UserException}
      */
     public DispatchException(int replyStatus, String message) {
         this(replyStatus, message, null);
@@ -38,6 +46,8 @@ public class DispatchException extends LocalException {
      *
      * @param replyStatus the reply status as an int (see {@link ReplyStatus}); it must be greater
      *     than {@link ReplyStatus#UserException}
+     * @throws IllegalArgumentException if {@code replyStatus} does not fit in a byte or is not
+     *     greater than {@link ReplyStatus#UserException}
      */
     public DispatchException(int replyStatus) {
         this(replyStatus, null, null);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/DispatchException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/DispatchException.java
@@ -12,7 +12,8 @@ public class DispatchException extends LocalException {
     /**
      * Constructs a DispatchException with the specified reply status, message, and cause.
      *
-     * @param replyStatus the reply status as an int (see {@link ReplyStatus})
+     * @param replyStatus the reply status as an int (see {@link ReplyStatus}); it must be greater
+     *     than {@link ReplyStatus#UserException}
      * @param message the detail message
      * @param cause the cause
      */
@@ -24,7 +25,8 @@ public class DispatchException extends LocalException {
     /**
      * Constructs a DispatchException with the specified reply status and message.
      *
-     * @param replyStatus the reply status as an int (see {@link ReplyStatus})
+     * @param replyStatus the reply status as an int (see {@link ReplyStatus}); it must be greater
+     *     than {@link ReplyStatus#UserException}
      * @param message the detail message
      */
     public DispatchException(int replyStatus, String message) {
@@ -34,7 +36,8 @@ public class DispatchException extends LocalException {
     /**
      * Constructs a DispatchException with the specified reply status.
      *
-     * @param replyStatus the reply status as an int (see {@link ReplyStatus})
+     * @param replyStatus the reply status as an int (see {@link ReplyStatus}); it must be greater
+     *     than {@link ReplyStatus#UserException}
      */
     public DispatchException(int replyStatus) {
         this(replyStatus, null, null);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/CommunicatorObserver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/CommunicatorObserver.java
@@ -10,15 +10,15 @@ import com.zeroc.Ice.ObjectPrx;
 import java.util.Map;
 
 /**
- * The communicator observer interface used by the Ice run-time to obtain and update observers for
+ * The communicator observer interface used by the Ice runtime to obtain and update observers for
  * its observable objects. This interface should be implemented by add-ins that wish to observe Ice
  * objects in order to collect statistics. An instance of this interface can be provided to the Ice
- * run-time through the Ice communicator initialization data.
+ * runtime through the Ice communicator initialization data.
  */
 public interface CommunicatorObserver {
     /**
-     * This method should return an observer for the given endpoint information and connector. The
-     * Ice run-time calls this method for each connection establishment attempt.
+     * Gets an observer for the given endpoint information and connector. The Ice runtime calls this
+     * method for each connection establishment attempt.
      *
      * @param endpoint The endpoint.
      * @param connector The description of the connector.
@@ -28,9 +28,9 @@ public interface CommunicatorObserver {
     Observer getConnectionEstablishmentObserver(Endpoint endpoint, String connector);
 
     /**
-     * This method should return an observer for the given endpoint information. The Ice run-time
-     * calls this method to resolve an endpoint and obtain the list of connectors. For IP endpoints,
-     * this typically involves doing a DNS lookup to obtain the IP addresses associated with the DNS name.
+     * Gets an observer for the given endpoint information. The Ice runtime calls this method to
+     * resolve an endpoint and obtain the list of connectors. For IP endpoints, this typically
+     * involves doing a DNS lookup to obtain the IP addresses associated with the DNS name.
      *
      * @param endpoint The endpoint.
      * @return The observer to instrument the endpoint lookup.
@@ -38,8 +38,8 @@ public interface CommunicatorObserver {
     Observer getEndpointLookupObserver(Endpoint endpoint);
 
     /**
-     * This method should return a connection observer for the given connection. The Ice run-time
-     * calls this method for each new connection and for all the Ice communicator connections when
+     * Gets an observer for the given connection. The Ice runtime calls this method for each new
+     * connection and for all the Ice communicator connections when
      * {@link ObserverUpdater#updateConnectionObservers} is called.
      *
      * @param c The connection information.
@@ -51,8 +51,8 @@ public interface CommunicatorObserver {
     ConnectionObserver getConnectionObserver(ConnectionInfo c, Endpoint e, ConnectionState s, ConnectionObserver o);
 
     /**
-     * This method should return a thread observer for the given thread. The Ice run-time calls this
-     * method for each new thread and for all the Ice communicator threads when {@link
+     * Gets a thread observer for the given thread. The Ice runtime calls this method for each new
+     * thread and for all the Ice communicator threads when {@link
      * ObserverUpdater#updateThreadObservers} is called.
      *
      * @param parent The parent of the thread.
@@ -64,8 +64,8 @@ public interface CommunicatorObserver {
     ThreadObserver getThreadObserver(String parent, String id, ThreadState s, ThreadObserver o);
 
     /**
-     * This method should return an invocation observer for the given invocation. The Ice run-time
-     * calls this method for each new invocation on a proxy.
+     * Gets an invocation observer for the given invocation. The Ice runtime calls this method for
+     * each new invocation on a proxy.
      *
      * @param prx The proxy used for the invocation.
      * @param operation The name of the operation.
@@ -75,8 +75,8 @@ public interface CommunicatorObserver {
     InvocationObserver getInvocationObserver(ObjectPrx prx, String operation, Map<String, String> ctx);
 
     /**
-     * This method should return a dispatch observer for the given dispatch. The Ice run-time calls
-     * this method each time it receives an incoming invocation to be dispatched for an Ice object.
+     * Gets a dispatch observer for the given dispatch. The Ice runtime calls this method each time
+     * it receives an incoming invocation to be dispatched for an Ice object.
      *
      * @param c The current object as provided to the Ice servant dispatching the invocation.
      * @param size The size of the dispatch.
@@ -85,9 +85,9 @@ public interface CommunicatorObserver {
     DispatchObserver getDispatchObserver(Current c, int size);
 
     /**
-     * The Ice run-time calls this method when the communicator is initialized. The add-in
-     * implementing this interface can use this object to get the Ice run-time to re-obtain
-     * observers for observed objects.
+     * Sets the observer updater. The Ice runtime calls this method when the communicator is
+     * initialized. The add-in implementing this interface can use this object to get the Ice runtime
+     * to re-obtain observers for observed objects.
      *
      * @param updater The observer updater object.
      */

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/Observer.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/Observer.java
@@ -7,14 +7,12 @@ package com.zeroc.Ice.Instrumentation;
  */
 public interface Observer {
     /**
-     * This method is called when the instrumented object is created or when the observer is
-     * attached to an existing object.
+     * Notifies the observer that an instrumented object was created.
      */
     void attach();
 
     /**
-     * This method is called when the instrumented object is destroyed and as a result the observer
-     * detached from the object.
+     * Notifies the observer that an instrumented object was destroyed.
      */
     void detach();
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/ObserverUpdater.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/ObserverUpdater.java
@@ -3,7 +3,7 @@
 package com.zeroc.Ice.Instrumentation;
 
 /**
- * The observer updater interface. This interface is implemented by the Ice run-time and an instance of this interface
+ * The observer updater interface. This interface is implemented by the Ice runtime and an instance of this interface
  * is provided by the Ice communicator on initialization to the {@link CommunicatorObserver} object set with the
  * communicator initialization data. The Ice communicator calls {@link CommunicatorObserver#setObserverUpdater} to
  * provide the observer updater. This interface can be used by add-ins implementing the {@link CommunicatorObserver}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -300,6 +300,7 @@ public interface ObjectPrx {
      *
      * @param connection the fixed proxy connection
      * @return a fixed proxy bound to the given connection
+     * @throws IllegalArgumentException if the connection is null or not a valid Ice connection
      */
     ObjectPrx ice_fixed(Connection connection);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -209,6 +209,7 @@ public interface ObjectPrx {
      *
      * @param newIdentity the identity for the new proxy
      * @return a proxy with the new identity
+     * @throws IllegalArgumentException if the name of the new identity is empty
      */
     ObjectPrx ice_identity(Identity newIdentity);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManager.java
@@ -12,6 +12,7 @@ public interface PluginManager {
      * initialization, the communicator calls {@link Plugin#destroy} on the plug-ins that have already been initialized.
      *
      * @throws InitializationException if the plug-ins have already been initialized
+     * @throws PluginInitializationException if a plug-in fails to initialize
      */
     void initializePlugins();
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManager.java
@@ -28,6 +28,7 @@ public interface PluginManager {
      *
      * @param name the plug-in's name
      * @return the plug-in
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @throws NotRegisteredException if no plug-in is found with the given name
      */
     Plugin getPlugin(String name);
@@ -37,6 +38,7 @@ public interface PluginManager {
      *
      * @param name the plug-in's name
      * @param pi the plug-in
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @throws AlreadyRegisteredException if a plug-in already exists with the given name
      */
     void addPlugin(String name, Plugin pi);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -336,6 +336,9 @@ public final class Properties {
      *
      * @param key the property key
      * @param value the property value
+     * @throws InitializationException if the key is empty
+     * @throws PropertyException if the key is an unknown Ice property, or is in an opt-in property
+     *     prefix that has not been explicitly enabled
      * @see #getProperty
      */
     public void setProperty(String key, String value) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -337,8 +337,8 @@ public final class Properties {
      * @param key the property key
      * @param value the property value
      * @throws InitializationException if the key is empty
-     * @throws PropertyException if the key is an unknown Ice property, or is in an opt-in property
-     *     prefix that has not been explicitly enabled
+     * @throws PropertyException if the key is an unknown Ice property, or belongs to an opt-in
+     *     property prefix that has not been explicitly enabled
      * @see #getProperty
      */
     public void setProperty(String key, String value) {


### PR DESCRIPTION
Follow-up doc-quality items for the **com.zeroc.ice** mapping deferred from #5933 (to keep that PR aligned with the C++ #5867 / C# #5868 scope). Javadoc-only; each `@throws` was verified against the implementation. Closes #5935.

### 1. Instrumentation wording (Java-specific)

- **`Instrumentation/CommunicatorObserver.java`** — all "Ice run-time" → "Ice runtime" (10 occurrences), and the pre-3.8 "This method should return X…" summaries rephrased into the modern C++ voice from `cpp/include/Ice/Instrumentation.h`: the imperative "Gets an observer for…" for the getters, plus a proper "Sets the observer updater." summary on `setObserverUpdater`.
- **`Instrumentation/Observer.java`** — `attach`/`detach` now use "Notifies the observer that an instrumented object was created/destroyed." (matches C++).
- **`Instrumentation/ObserverUpdater.java`** — the 1 remaining "run-time" → "runtime".

> Note: for `CommunicatorObserver` I used the C++-accurate "Gets…" getter voice rather than "Notifies…" (the issue's shorthand) — these methods return observers, they don't notify. "Notifies…" is applied only to `Observer.attach`/`detach`, where it's correct.

### 2. Coverage-gap `@throws`

| Method | Added | Verified in |
|---|---|---|
| `Communicator.getDefaultLocator` | `CommunicatorDestroyedException` | `referenceFactory()` path; matches sibling `getDefaultRouter` |
| `Communicator.createObjectAdapter` / `…WithEndpoints` (4 overloads) | `InitializationException`, `AlreadyRegisteredException` | `ObjectAdapter.java`, `ObjectAdapterFactory.java:108` |
| `Communicator.createAdmin` | `CommunicatorDestroyedException`, `IllegalArgumentException` | `Instance.createAdmin` |
| `PluginManager.getPlugin` / `addPlugin` | `CommunicatorDestroyedException` | `PluginManagerI.java:67,81` |
| `ObjectPrx.ice_identity` | `IllegalArgumentException` (empty name) | `_ObjectPrxI.ice_identity` |
| `Properties.setProperty` | `InitializationException` (empty key), `PropertyException` (unknown / opt-in prefix) | `Properties.java:348,356,362` |
| `Connection.getInfo` / `setBufferSize` | `LocalException` (rethrown close reason) | `ConnectionI.java:949,957` |
| `DispatchException` (3 ctors) | `@param replyStatus` now states it must be greater than `ReplyStatus.UserException` | matches C++/C# `LocalExceptions` |

### Cross-mapping note

Some of these gaps (`setProperty`, `getInfo`/`setBufferSize`, `createObjectAdapter`'s `InitializationException`) are **also** missing in C++/C# per the audit and could use a coordinated pass. The Instrumentation rephrasing is Java-only.

Refs: Java doc audit report, sections C/D/E; PR #5933.