### PR TITLE
Split nightly release orchestration from release builds

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,31 +1,33 @@
 # Release Workflows
 
-The release workflows support building and publishing Ice packages for the `3.8` and `nightly` channels.
+The release workflows build and publish stable, release candidate, and nightly Ice packages. The release channel is
+read from `config/version.env` on the branch or tag being built.
 
-The `3.8` channel publishes packages to the stable release repositories, while the `nightly` channel publishes to the
-unstable nightly repositories.
+Nightly packages are intended for testing the latest development and must not be used in production. The
+`dispatch-nightly-release` workflow is the central scheduler: it runs from the default branch and dispatches nightly
+releases for `main` and the supported maintenance branches.
 
-The nightly repositories are updated daily from the `zeroc-ice/ice` `main` branch. These releases are intended for
-testing the latest development and must not be used in production.
+## Building and Publishing
 
-To build a stable release for `3.8`, run the `build-release` workflow and pass `3.8` as the channel.
-To build a dev release for `nightly`, run the `build-release` workflow and pass `nightly` as the channel.
+The `build-release` workflow builds all packages and uploads their artifacts. It never publishes them. For stable and
+release candidate releases, run `build-release`, make any required updates between building and publishing (such as
+updating the Swift package manifest with release binary hashes), and then run `publish-release` with the build's
+`run_id`, `channel`, and `quality`.
 
-The `build-nightly-release` workflow schedules a daily `build-release` run for the `nightly` channel.
+The `nightly-release` workflow orchestrates the nightly path. It always runs `build-release`; when `publish` is true,
+it then prunes expired nightly artifacts and runs `publish-release`. Pruning must finish before publishing because it
+can remove packages from the APT and RPM repository trees, while the publish workflows regenerate their metadata.
+Run `nightly-release` with `publish` false to build nightly artifacts without changing the repositories.
+
+The scheduler dispatches `nightly-release` for branches that contain this split workflow. Maintenance branches that
+have not received the workflow yet continue to use their branch-local `build-release` orchestration.
 
 ## Implementation Notes
 
-Each `build-xxx-package` workflow builds the corresponding `xxx` package, and each `publish-xxx-package` workflow
-publishes it.
+Each `build-xxx-package` workflow builds the corresponding package, and each `publish-xxx-package` workflow publishes
+it. `publish-release` calls all package-specific publish workflows and can also be run manually to publish artifacts
+from a specified build run.
 
-The `build-release` workflow orchestrates the build of all packages and triggers `publish-release` after all
-`build-xxx-package` workflows have completed successfully.
-
-The `publish-release` workflow orchestrates the publishing of all packages to their respective repositories by calling
-the `publish-xxx-package` workflows. You can also run it manually by providing a `run_id` and `channel`; in this case,
-it will publish the artifacts from the specified run to the specified channel.
-
-The RPM and DEB packaging workflows use Docker images from `packaging/rpm/docker` and `packaging/deb/docker`.
-
-The release pipeline is configured to use `ghcr.io`. These images can be built using the `build-container-images`
-workflow, which builds and publishes them to `ghcr.io` for internal use.
+The RPM and DEB packaging workflows use Docker images from `packaging/rpm/docker` and `packaging/deb/docker`. The
+release pipeline uses `ghcr.io`; the `build-container-images` workflow builds and publishes these images for internal
+use.

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -2,6 +2,10 @@ name: Build Release
 
 on:
   workflow_call:
+    outputs:
+      channel:
+        description: "The release channel from config/version.env"
+        value: ${{ jobs.configure.outputs.channel }}
     inputs:
       build_number:
         required: false
@@ -10,10 +14,6 @@ on:
       quality:
         required: true
         type: string
-      publish:
-        required: false
-        type: boolean
-        default: false
       authenticode_sign:
         description: "Sign Windows binaries with Authenticode (always true for stable quality)"
         required: false
@@ -30,11 +30,6 @@ on:
         description: "Release quality (e.g., stable, nightly, RC)"
         required: true
         default: "nightly"
-      publish:
-        description: "Publish the packages"
-        required: false
-        default: false
-        type: boolean
       authenticode_sign:
         description: "Sign Windows binaries with Authenticode (always true for stable quality)"
         required: false
@@ -290,28 +285,3 @@ jobs:
       - build-cpp-nuget-packages
     steps:
       - run: echo "All packages built successfully"
-
-  prune-nightly-artifacts:
-    name: Prune Nightly Artifacts
-    if: ${{ inputs.publish == true && inputs.quality == 'nightly' }}
-    needs:
-      - configure
-      - build-all
-    uses: ./.github/workflows/prune-nightly-artifacts.yml
-    with:
-      channel: ${{ needs.configure.outputs.channel }}
-    secrets: inherit
-
-  publish-release:
-    name: Publish Release
-    if: ${{ inputs.publish == true }}
-    needs:
-      - configure
-      - build-all
-      - prune-nightly-artifacts
-    uses: ./.github/workflows/publish-release.yml
-    with:
-      channel: ${{ needs.configure.outputs.channel }}
-      quality: ${{ inputs.quality }}
-      run_id: ${{ github.run_id }}
-    secrets: inherit

--- a/.github/workflows/dispatch-nightly-release.yml
+++ b/.github/workflows/dispatch-nightly-release.yml
@@ -25,15 +25,16 @@ jobs:
         uses: ./.github/actions/dispatch-workflow
         with:
           ref: main
-          workflow: build-release.yml
+          workflow: nightly-release.yml
           token: ${{ secrets.GITHUB_TOKEN }}
-          inputs: '{"quality": "nightly", "publish": true}'
+          inputs: '{"publish": true}'
 
       - name: Dispatch nightly build for 3.8 (3:00 UTC)
         if: github.event.schedule == '0 3 * * *'
         uses: ./.github/actions/dispatch-workflow
         with:
           ref: 3.8
+          # Use the existing orchestrator until nightly-release.yml is backported.
           workflow: build-release.yml
           token: ${{ secrets.GITHUB_TOKEN }}
           inputs: '{"quality": "nightly", "publish": true}'
@@ -43,6 +44,7 @@ jobs:
         uses: ./.github/actions/dispatch-workflow
         with:
           ref: 3.7
+          # Use the existing orchestrator until nightly-release.yml is backported.
           workflow: build-release.yml
           token: ${{ secrets.GITHUB_TOKEN }}
           inputs: '{"quality": "nightly", "publish": true}'

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,53 @@
+name: Nightly Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: "Build number for nightly releases"
+        required: false
+        default: "1"
+      publish:
+        description: "Prune old nightly artifacts and publish the new packages"
+        required: false
+        default: false
+        type: boolean
+      authenticode_sign:
+        description: "Sign Windows binaries with Authenticode"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    name: Build Release
+    uses: ./.github/workflows/build-release.yml
+    with:
+      quality: nightly
+      build_number: ${{ inputs.build_number }}
+      authenticode_sign: ${{ inputs.authenticode_sign }}
+    secrets: inherit
+
+  prune:
+    name: Prune Nightly Artifacts
+    if: ${{ inputs.publish == true }}
+    needs: build
+    uses: ./.github/workflows/prune-nightly-artifacts.yml
+    with:
+      channel: ${{ needs.build.outputs.channel }}
+    secrets: inherit
+
+  publish:
+    name: Publish Release
+    # Pruning removes dated packages from the APT and RPM repositories without
+    # updating their metadata. Publishing must run afterwards to rebuild it.
+    if: ${{ inputs.publish == true }}
+    needs:
+      - build
+      - prune
+    uses: ./.github/workflows/publish-release.yml
+    with:
+      channel: ${{ needs.build.outputs.channel }}
+      quality: nightly
+      run_id: ${{ github.run_id }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

- make `build-release` build-only and expose its configured release channel
- add a dedicated nightly orchestrator that preserves build -> prune -> publish ordering
- preserve optional Authenticode signing for manually dispatched nightly releases
- update the central scheduler and release workflow documentation

The scheduler switches `main` to the new workflow. The `3.8` and `3.7` schedules continue to use their existing branch-local orchestration until this workflow split is backported to those branches.

## Validation

- `git diff --check`
- `actionlint -shellcheck= .github/workflows/build-release.yml .github/workflows/nightly-release.yml .github/workflows/dispatch-nightly-release.yml`

Fixes #6037
