### PR TITLE
Align C# doc comments with the .NET documentation conventions

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -150,8 +150,8 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// <summary>
     /// Checks whether or not <see cref="shutdown" /> was called on this communicator.
     /// </summary>
-    /// <returns><see langword="true"/> if shutdown was called on this communicator;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if shutdown was called on this communicator; otherwise,
+    /// <see langword="false"/>.</returns>
     public bool isShutdown()
     {
         try

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -157,7 +157,7 @@ public class ConnectionInfo
     public readonly ConnectionInfo? underlying;
 
     /// <summary>
-    /// <see langword="true"/> if this is an incoming connection, <see langword="false"/> otherwise.
+    /// <see langword="true"/> if this is an incoming connection; otherwise, <see langword="false"/>.
     /// </summary>
     public readonly bool incoming;
 

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -39,16 +39,16 @@ public class EndpointInfo
     public virtual short type() => underlying?.type() ?? -1;
 
     /// <summary>
-    /// Returns <see langword="true"/> if this endpoint's transport is a datagram transport (namely, UDP),
-    /// <see langword="false"/> otherwise.
+    /// Returns <see langword="true"/> if this endpoint's transport is a datagram transport (namely, UDP); otherwise,
+    /// <see langword="false"/>.
     /// </summary>
-    /// <returns><see langword="true"/> for a UDP endpoint, <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> for a UDP endpoint; otherwise, <see langword="false"/>.</returns>
     public virtual bool datagram() => underlying?.datagram() ?? false;
 
     /// <summary>
-    /// Returns <see langword="true"/> if this endpoint's transport uses SSL, <see langword="false"/> otherwise.
+    /// Returns <see langword="true"/> if this endpoint's transport uses SSL; otherwise, <see langword="false"/>.
     /// </summary>
-    /// <returns><see langword="true"/> for SSL and SSL-based transports, <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> for SSL and SSL-based transports; otherwise, <see langword="false"/>.</returns>
     public virtual bool secure() => underlying?.secure() ?? false;
 
     protected EndpointInfo(EndpointInfo underlying)

--- a/csharp/src/Ice/ImplicitContext.cs
+++ b/csharp/src/Ice/ImplicitContext.cs
@@ -29,7 +29,8 @@ public interface ImplicitContext
     /// Checks if the specified key has an associated value in the request context.
     /// </summary>
     /// <param name="key">The key.</param>
-    /// <returns><see langword="true"/> if the key has an associated value, <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the key has an associated value; otherwise,
+    /// <see langword="false"/>.</returns>
     bool containsKey(string key);
 
     /// <summary>

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -563,7 +563,7 @@ public sealed class InputStream
     /// </summary>
     /// <param name="tag">The tag associated with the value.</param>
     /// <param name="expectedFormat">The optional format for the value.</param>
-    /// <returns><see langword="true"/> if the value is present, <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the value is present; otherwise, <see langword="false"/>.</returns>
     public bool readOptional(int tag, OptionalFormat expectedFormat)
     {
         Debug.Assert(_encapsStack != null);
@@ -1836,7 +1836,8 @@ public sealed class InputStream
     /// <summary>
     /// Determines whether the stream is empty.
     /// </summary>
-    /// <returns><see langword="true"/> if the internal buffer has no data, <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the internal buffer has no data; otherwise,
+    /// <see langword="false"/>.</returns>
     public bool isEmpty() => _buf.empty();
 
     private bool readOptImpl(int readTag, OptionalFormat expectedFormat)

--- a/csharp/src/Ice/Instrumentation.cs
+++ b/csharp/src/Ice/Instrumentation.cs
@@ -232,7 +232,7 @@ public interface CommunicatorObserver
     /// <param name="c">The connection information.</param>
     /// <param name="e">The connection endpoint.</param>
     /// <param name="s">The state of the connection.</param>
-    /// <param name="o">The old connection observer if one is already set or a null reference otherwise.</param>
+    /// <param name="o">The old connection observer if one is already set; otherwise, <see langword="null"/>.</param>
     /// <returns>The connection observer to instrument the connection.</returns>
     ConnectionObserver getConnectionObserver(ConnectionInfo c, Endpoint e, ConnectionState s, ConnectionObserver o);
 
@@ -245,7 +245,7 @@ public interface CommunicatorObserver
     /// <param name="parent">The parent of the thread.</param>
     /// <param name="id">The ID of the thread to observe.</param>
     /// <param name="s">The state of the thread.</param>
-    /// <param name="o">The old thread observer if one is already set or a null reference otherwise.</param>
+    /// <param name="o">The old thread observer if one is already set; otherwise, <see langword="null"/>.</param>
     /// <returns>The thread observer to instrument the thread.</returns>
     ThreadObserver getThreadObserver(string parent, string id, ThreadState s, ThreadObserver o);
 

--- a/csharp/src/Ice/Internal/DictionaryExtensions.cs
+++ b/csharp/src/Ice/Internal/DictionaryExtensions.cs
@@ -18,7 +18,7 @@ public static class DictionaryExtensions
     /// <param name="rhs">The second dictionary to compare.</param>
     /// <param name="valueComparer">The comparer to use to compare the values in the dictionaries or null to use the
     /// value's default equality comparer.</param>
-    /// <returns><see langword="true"/> if the dictionaries are equal; <see langword="false"/>, otherwise.</returns>
+    /// <returns><see langword="true"/> if the dictionaries are equal; otherwise, <see langword="false"/>.</returns>
     public static bool DictionaryEqual<TKey, TValue>(
         this IReadOnlyDictionary<TKey, TValue> lhs,
         IReadOnlyDictionary<TKey, TValue> rhs,

--- a/csharp/src/Ice/Object.cs
+++ b/csharp/src/Ice/Object.cs
@@ -35,7 +35,7 @@ public interface Object
     /// <param name="s">The type ID of the Slice interface to test against.</param>
     /// <param name="current">The Current object of the incoming request.</param>
     /// <returns><see langword="true"/> if this object implements the Slice interface specified by <paramref name="s"/>
-    /// or implements a derived interface, <see langword="false"/> otherwise.</returns>
+    /// or implements a derived interface; otherwise, <see langword="false"/>.</returns>
     public bool ice_isA(string s, Current current)
     {
         foreach (Type type in GetType().GetInterfaces())

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -299,8 +299,8 @@ public sealed class ObjectAdapter
     /// <summary>
     /// Checks whether or not <see cref="deactivate"/> was called on this object adapter.
     /// </summary>
-    /// <returns><see langword="true"/> if <see cref="deactivate"/> was called on this object adapter,
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if <see cref="deactivate"/> was called on this object adapter; otherwise,
+    /// <see langword="false"/>.</returns>
     public bool isDeactivated()
     {
         lock (_mutex)

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -260,7 +260,7 @@ public sealed class OutputStream
     /// <param name="typeId">The Slice type ID corresponding to this slice.</param>
     /// <param name="compactId">The Slice compact type ID corresponding to this slice or -1 if no compact ID
     /// is defined for the type ID.</param>
-    /// <param name="last"><see langword="true"/> if this is the last slice, <see langword="false"/> otherwise.</param>
+    /// <param name="last"><see langword="true"/> if this is the last slice; otherwise, <see langword="false"/>.</param>
     public void startSlice(string typeId, int compactId, bool last)
     {
         Debug.Assert(_encapsStack != null && _encapsStack.encoder != null);
@@ -378,7 +378,7 @@ public sealed class OutputStream
     /// <param name="tag">The numeric tag associated with the value.</param>
     /// <param name="format">The optional format of the value.</param>
     /// <returns><see langword="true"/> if the encoding supports optional values and the header information was written
-    /// to the stream; <see langword="false"/> otherwise.</returns>
+    /// to the stream; otherwise, <see langword="false"/>.</returns>
     public bool writeOptional(int tag, OptionalFormat format)
     {
         Debug.Assert(_encapsStack != null);
@@ -1653,7 +1653,7 @@ public sealed class OutputStream
     /// <summary>
     /// Determines whether the stream is empty.
     /// </summary>
-    /// <returns><see langword="true"/> if no data has been written yet, <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if no data has been written yet; otherwise, <see langword="false"/>.</returns>
     public bool isEmpty() => _buf.empty();
 
     /// <summary>

--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -529,7 +529,7 @@ public sealed class Properties
     /// </summary>
     /// <param name="key">The property key.</param>
     /// <param name="propertyArray">The property array to check.</param>
-    /// <returns>The <see cref="Property" /> if found, null otherwise.</returns>
+    /// <returns>The <see cref="Property" /> if found; otherwise, <see langword="null"/>.</returns>
     private static Property? findProperty(string key, PropertyArray propertyArray)
     {
         foreach (Property prop in propertyArray.properties)

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -24,8 +24,8 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// </summary>
     /// <param name="id">The type ID of the Slice interface to test against.</param>
     /// <param name="context">The request context.</param>
-    /// <returns><see langword="true"/> if the target object implements the Slice interface specified by <paramref name="id"/>
-    /// or implements a derived interface, and <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the target object implements the Slice interface specified by
+    /// <paramref name="id"/> or implements a derived interface; otherwise, <see langword="false"/>.</returns>
     bool ice_isA(string id, Dictionary<string, string>? context = null);
 
     /// <summary>
@@ -36,8 +36,8 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that will complete with <see langword="true"/> if the target object implements the Slice
-    /// interface specified by <paramref name="id"/> or implements a derived interface, and <see langword="false"/>
-    /// otherwise.</returns>
+    /// interface specified by <paramref name="id"/> or implements a derived interface; otherwise,
+    /// <see langword="false"/>.</returns>
     Task<bool> ice_isAAsync(
         string id,
         Dictionary<string, string>? context = null,
@@ -247,14 +247,14 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Returns whether this proxy caches connections.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy caches connections; <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy caches connections; otherwise, <see langword="false"/>.</returns>
     bool ice_isConnectionCached();
 
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for connection caching.
     /// </summary>
-    /// <param name="newCache"><see langword="true"/> if the new proxy should cache connections;
-    /// <see langword="false"/> otherwise.</param>
+    /// <param name="newCache"><see langword="true"/> if the new proxy should cache connections; otherwise,
+    /// <see langword="false"/>.</param>
     /// <returns>The new proxy with the specified caching policy.</returns>
     ObjectPrx ice_connectionCached(bool newCache);
 
@@ -315,15 +315,15 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Returns whether this proxy uses collocation optimization.
     /// </summary>
-    /// <returns><see langword="true"/> if the proxy uses collocation optimization;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the proxy uses collocation optimization; otherwise,
+    /// <see langword="false"/>.</returns>
     bool ice_isCollocationOptimized();
 
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for collocation optimization.
     /// </summary>
-    /// <param name="collocated"><see langword="true"/> if the new proxy enables collocation optimization;
-    /// <see langword="false"/> otherwise.</param>
+    /// <param name="collocated"><see langword="true"/> if the new proxy enables collocation optimization; otherwise,
+    /// <see langword="false"/>.</param>
     /// <returns>The new proxy the specified collocation optimization.</returns>
     ObjectPrx ice_collocationOptimized(bool collocated);
 
@@ -336,8 +336,8 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Returns whether this proxy uses twoway invocations.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy uses twoway invocations;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy uses twoway invocations; otherwise,
+    /// <see langword="false"/>.</returns>
     bool ice_isTwoway();
 
     /// <summary>
@@ -349,8 +349,8 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Returns whether this proxy uses oneway invocations.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy uses oneway invocations;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy uses oneway invocations; otherwise,
+    /// <see langword="false"/>.</returns>
     bool ice_isOneway();
 
     /// <summary>
@@ -362,8 +362,8 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Returns whether this proxy uses batch oneway invocations.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy uses batch oneway invocations;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy uses batch oneway invocations; otherwise,
+    /// <see langword="false"/>.</returns>
     bool ice_isBatchOneway();
 
     /// <summary>
@@ -375,8 +375,8 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Returns whether this proxy uses datagram invocations.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy uses datagram invocations;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy uses datagram invocations; otherwise,
+    /// <see langword="false"/>.</returns>
     bool ice_isDatagram();
 
     /// <summary>
@@ -388,8 +388,8 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Returns whether this proxy uses batch datagram invocations.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy uses batch datagram invocations;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy uses batch datagram invocations; otherwise,
+    /// <see langword="false"/>.</returns>
     bool ice_isBatchDatagram();
 
     /// <summary>
@@ -403,8 +403,8 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Gets the compression override setting of this proxy.
     /// </summary>
-    /// <returns>The compression override setting. If null is returned, no override is set. Otherwise, <see langword="true"/>
-    /// if compression is enabled, <see langword="false"/> otherwise.</returns>
+    /// <returns>The compression override setting, or <see langword="null"/> if no override is set. When set, it's
+    /// <see langword="true"/> if compression is enabled; otherwise, <see langword="false"/>.</returns>
     bool? ice_getCompress();
 
     /// <summary>
@@ -432,7 +432,7 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Returns whether this proxy is a fixed proxy.
     /// </summary>
-    /// <returns><see langword="true"/> if this is a fixed proxy; <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this is a fixed proxy; otherwise, <see langword="false"/>.</returns>
     bool ice_isFixed();
 
     /// <summary>
@@ -525,8 +525,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// respects, that is, if their object identity, endpoints timeout settings, and so on are all equal.
     /// </summary>
     /// <param name="other">The proxy to compare this proxy with.</param>
-    /// <returns><see langword="true"/> if this proxy is equal to <paramref name="other"/>;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy is equal to <paramref name="other"/>; otherwise,
+    /// <see langword="false"/>.</returns>
     public bool Equals(ObjectPrx? other) =>
         other is not null && _reference == ((ObjectPrxHelperBase)other)._reference;
 
@@ -1059,14 +1059,14 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Returns whether this proxy caches connections.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy caches connections; <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy caches connections; otherwise, <see langword="false"/>.</returns>
     public bool ice_isConnectionCached() => _reference.getCacheConnection();
 
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for connection caching.
     /// </summary>
-    /// <param name="newCache"><see langword="true"/> if the new proxy should cache connections;
-    /// <see langword="false"/>, otherwise.</param>
+    /// <param name="newCache"><see langword="true"/> if the new proxy should cache connections; otherwise,
+    /// <see langword="false"/>.</param>
     /// <returns>The new proxy with the specified caching policy.</returns>
     public ObjectPrx ice_connectionCached(bool newCache)
     {
@@ -1185,15 +1185,15 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Returns whether this proxy uses collocation optimization.
     /// </summary>
-    /// <returns><see langword="true"/> if the proxy uses collocation optimization;
-    /// <see langword="false"/>, otherwise.</returns>
+    /// <returns><see langword="true"/> if the proxy uses collocation optimization; otherwise,
+    /// <see langword="false"/>.</returns>
     public bool ice_isCollocationOptimized() => _reference.getCollocationOptimized();
 
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for collocation optimization.
     /// </summary>
-    /// <param name="collocated"><see langword="true"/> if the new proxy enables collocation optimization;
-    /// <see langword="false"/>, otherwise.</param>
+    /// <param name="collocated"><see langword="true"/> if the new proxy enables collocation optimization; otherwise,
+    /// <see langword="false"/>.</param>
     /// <returns>The new proxy the specified collocation optimization.</returns>
     public ObjectPrx ice_collocationOptimized(bool collocated)
     {
@@ -1226,8 +1226,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Returns whether this proxy uses twoway invocations.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy uses twoway invocations;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy uses twoway invocations; otherwise,
+    /// <see langword="false"/>.</returns>
     public bool ice_isTwoway() => _reference.isTwoway;
 
     /// <summary>
@@ -1249,8 +1249,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Returns whether this proxy uses oneway invocations.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy uses oneway invocations;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy uses oneway invocations; otherwise,
+    /// <see langword="false"/>.</returns>
     public bool ice_isOneway() => _reference.getMode() == Reference.Mode.ModeOneway;
 
     /// <summary>
@@ -1272,8 +1272,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Returns whether this proxy uses batch oneway invocations.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy uses batch oneway invocations;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy uses batch oneway invocations; otherwise,
+    /// <see langword="false"/>.</returns>
     public bool ice_isBatchOneway() => _reference.getMode() == Reference.Mode.ModeBatchOneway;
 
     /// <summary>
@@ -1295,8 +1295,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Returns whether this proxy uses datagram invocations.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy uses datagram invocations;
-    /// <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy uses datagram invocations; otherwise,
+    /// <see langword="false"/>.</returns>
     public bool ice_isDatagram() => _reference.getMode() == Reference.Mode.ModeDatagram;
 
     /// <summary>
@@ -1318,8 +1318,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Returns whether this proxy uses batch datagram invocations.
     /// </summary>
-    /// <returns><see langword="true"/> if this proxy uses batch datagram invocations;
-    /// <see langword="false"/>, otherwise.</returns>
+    /// <returns><see langword="true"/> if this proxy uses batch datagram invocations; otherwise,
+    /// <see langword="false"/>.</returns>
     public bool ice_isBatchDatagram() => _reference.getMode() == Reference.Mode.ModeBatchDatagram;
 
     /// <summary>
@@ -1343,8 +1343,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Obtains the compression override setting of this proxy.
     /// </summary>
-    /// <returns>The compression override setting. If no optional value is present, no override is
-    /// set. Otherwise, <see langword="true"/> if compression is enabled, <see langword="false"/> otherwise.</returns>
+    /// <returns>The compression override setting, or <see langword="null"/> if no override is set. When set, it's
+    /// <see langword="true"/> if compression is enabled; otherwise, <see langword="false"/>.</returns>
     public bool? ice_getCompress() => _reference.getCompress();
 
     /// <summary>
@@ -1401,7 +1401,7 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Returns whether this proxy is a fixed proxy.
     /// </summary>
-    /// <returns><see langword="true"/> if this is a fixed proxy; <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if this is a fixed proxy; otherwise, <see langword="false"/>.</returns>
     public bool ice_isFixed() => _reference is Ice.Internal.FixedReference;
 
     public class GetConnectionTaskCompletionCallback : TaskCompletionCallback<Connection?>

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -324,7 +324,7 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// </summary>
     /// <param name="collocated"><see langword="true"/> if the new proxy enables collocation optimization; otherwise,
     /// <see langword="false"/>.</param>
-    /// <returns>The new proxy the specified collocation optimization.</returns>
+    /// <returns>The new proxy with the specified collocation optimization.</returns>
     ObjectPrx ice_collocationOptimized(bool collocated);
 
     /// <summary>

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -1194,7 +1194,7 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// </summary>
     /// <param name="collocated"><see langword="true"/> if the new proxy enables collocation optimization; otherwise,
     /// <see langword="false"/>.</param>
-    /// <returns>The new proxy the specified collocation optimization.</returns>
+    /// <returns>The new proxy with the specified collocation optimization.</returns>
     public ObjectPrx ice_collocationOptimized(bool collocated)
     {
         if (collocated == _reference.getCollocationOptimized())

--- a/csharp/src/Ice/ProxyIdentityKey.cs
+++ b/csharp/src/Ice/ProxyIdentityKey.cs
@@ -22,8 +22,8 @@ public class ProxyIdentityKey : System.Collections.IEqualityComparer, System.Col
     /// </summary>
     /// <param name="x">The first proxy to compare.</param>
     /// <param name="y">The second proxy to compare.</param>
-    /// <returns><see langword="true"/> if the passed proxies have the same object identity; <see langword="false"/>,
-    /// otherwise.</returns>
+    /// <returns><see langword="true"/> if the passed proxies have the same object identity; otherwise,
+    /// <see langword="false"/>.</returns>
     public new bool Equals(object? x, object? y)
     {
         try
@@ -41,7 +41,8 @@ public class ProxyIdentityKey : System.Collections.IEqualityComparer, System.Col
     /// </summary>
     /// <param name="x">The first proxy to compare.</param>
     /// <param name="y">The second proxy to compare.</param>
-    /// <returns>Less than zero if x is less than y; greater than zero if x is greater than y; otherwise zero.</returns>
+    /// <returns>Less than zero if x is less than y; greater than zero if x is greater than y; otherwise,
+    /// zero.</returns>
     public int Compare(object? x, object? y)
     {
         var proxy1 = x as ObjectPrx;
@@ -82,8 +83,8 @@ public class ProxyIdentityFacetKey : System.Collections.IEqualityComparer, Syste
     /// </summary>
     /// <param name="x">The first proxy to compare.</param>
     /// <param name="y">The second proxy to compare.</param>
-    /// <returns><see langword="true"/> if the passed proxies have the same object identity and facet;
-    /// <see langword="false"/>, otherwise.</returns>
+    /// <returns><see langword="true"/> if the passed proxies have the same object identity and facet; otherwise,
+    /// <see langword="false"/>.</returns>
     public new bool Equals(object? x, object? y)
     {
         try
@@ -101,7 +102,8 @@ public class ProxyIdentityFacetKey : System.Collections.IEqualityComparer, Syste
     /// </summary>
     /// <param name="x">The first proxy to compare.</param>
     /// <param name="y">The second proxy to compare.</param>
-    /// <returns>Less than zero if x is less than y; greater than zero if x is greater than y; otherwise zero.</returns>
+    /// <returns>Less than zero if x is less than y; greater than zero if x is greater than y; otherwise,
+    /// zero.</returns>
     public int Compare(object? x, object? y)
     {
         var proxy1 = x as ObjectPrx;

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -164,7 +164,7 @@ public sealed class Util
     /// <param name="lhs">The first proxy to compare.</param>
     /// <param name="rhs">The second proxy to compare.</param>
     /// <returns>-1 if the identity in lhs compares less than the identity in rhs; 0 if the identities compare equal;
-    /// 1, otherwise.</returns>
+    /// otherwise, 1.</returns>
     public static int proxyIdentityCompare(ObjectPrx? lhs, ObjectPrx? rhs)
     {
         if (lhs == null && rhs == null)
@@ -200,7 +200,7 @@ public sealed class Util
     /// <param name="rhs">The second proxy to compare.</param>
     /// <returns>-1 if the identity and facet in lhs compare
     /// less than the identity and facet in rhs; 0 if the identities
-    /// and facets compare equal; 1, otherwise.</returns>
+    /// and facets compare equal; otherwise, 1.</returns>
     public static int proxyIdentityAndFacetCompare(ObjectPrx? lhs, ObjectPrx? rhs)
     {
         if (lhs == null && rhs == null)

--- a/csharp/src/Ice/Value.cs
+++ b/csharp/src/Ice/Value.cs
@@ -44,8 +44,8 @@ public abstract class Value
     /// <summary>
     /// Returns the sliced data associated with this instance.
     /// </summary>
-    /// <returns>The sliced data if this value was sliced during unmarshaling; otherwise null. Unknown slices are
-    /// preserved only when the sender uses the sliced format.</returns>
+    /// <returns>The sliced data if this value was sliced during unmarshaling; otherwise, <see langword="null"/>.
+    /// Unknown slices are preserved only when the sender uses the sliced format.</returns>
     public SlicedData? ice_getSlicedData() => _slicedData;
 
     [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
Sweeps the hand-written XML doc comments in `csharp/src/Ice` and normalizes the conditional-return sentences onto the .NET-conventional form `<value> if <condition>; otherwise, <value>.`, using `<see langword="true"/>`, `<see langword="false"/>`, and `<see langword="null"/>` for keyword values.

This collapses the several variant phrasings the issue listed, e.g.:

- `…, <false/> otherwise.` / `…; <false/> otherwise.` → `…; otherwise, <false/>.`
- `…, <false/>, otherwise.` (stray comma) → `…; otherwise, <false/>.`
- `, and <false/> otherwise` → `; otherwise, <false/>`
- `null otherwise` / `otherwise null` / `a null reference otherwise` → `otherwise, <see langword="null"/>`
- comparison returns `1, otherwise` / `otherwise zero` → `otherwise, 1` / `otherwise, zero`

Inline `//` comments and already-conventional `; otherwise,` forms are left unchanged. No behavior change, so no changelog fragment.

Follow-up from the #5933 review discussion: unlike the other mappings (which share the C++ reference wording, e.g. `, null otherwise`), the C# docs should read idiomatically to .NET developers.

Closes #5956