### PR TITLE
Fix bugs in the Python test scripts

### DIFF
--- a/scripts/Component.py
+++ b/scripts/Component.py
@@ -251,14 +251,14 @@ for m in filter(lambda x: os.path.isdir(os.path.join(Util.toplevel, x)), os.list
     elif m == "swift" or re.match("swift-.*", m):
         # Swift mapping requires Swift 5.0 or greater
         Util.Mapping.add(
-            "swift",
+            m,
             Util.SwiftMapping(),
             component,
             enable=Util.platform.hasSwift((5, 0)),
         )
-    elif m == "csharp" or re.match("charp-.*", m):
+    elif m == "csharp" or re.match("csharp-.*", m):
         Util.Mapping.add(
-            "csharp",
+            m,
             Util.CSharpMapping(),
             component,
             enable=isinstance(Util.platform, Util.Windows) or Util.platform.hasDotNet(),

--- a/scripts/Controller.py
+++ b/scripts/Controller.py
@@ -79,8 +79,9 @@ class ControllerDriver(Driver):
                     sys.stdout.write("adding trust settings for the HTTP server certificate... ")
                     sys.stdout.flush()
                     if os.system("security add-trusted-cert -r trustAsRoot " + serverCert) != 0:
-                        print("error: couldn't add trust settings for the HTTP server certificate")
-                    print("ok")
+                        print("\nerror: couldn't add trust settings for the HTTP server certificate")
+                    else:
+                        print("ok")
                     print("run " + sys.argv[0] + " --clean to remove the trust setting")
 
         self.initCommunicator()
@@ -108,12 +109,15 @@ class ControllerDriver(Driver):
                     )
 
             def stopServerSide(self, success, c):
-                if self.serverSideRunning:
-                    try:
-                        self.current.serverTestCase._stopServerSide(self.current, success)
-                        return self.current.result.getOutput()
-                    except Exception as ex:
-                        raise Test_Common.TestCaseFailedException(self.current.result.getOutput() + "\n" + str(ex))
+                if not self.serverSideRunning:
+                    return self.current.result.getOutput()
+                try:
+                    self.current.serverTestCase._stopServerSide(self.current, success)
+                except Exception as ex:
+                    # Leave serverSideRunning set so destroy() retries the teardown.
+                    raise Test_Common.TestCaseFailedException(self.current.result.getOutput() + "\n" + str(ex))
+                self.serverSideRunning = False
+                return self.current.result.getOutput()
 
             def runClientSide(self, host, config, c):
                 self.updateCurrent(config)
@@ -125,6 +129,7 @@ class ControllerDriver(Driver):
 
             def destroy(self, c):
                 if self.serverSideRunning:
+                    self.serverSideRunning = False
                     try:
                         self.current.serverTestCase._stopServerSide(self.current, False)
                     except Exception:
@@ -176,8 +181,8 @@ class ControllerDriver(Driver):
             def getOptionOverrides(self, c):
                 return Test_Common.OptionOverrides(ipv6=([False] if not self.driver.hostIPv6 else [False, True]))
 
-            def getHost(self, name, ipv6, c):
-                pass
+            def getHost(self, protocol, ipv6, c):
+                return self.driver.getHost(protocol, ipv6)
 
         import Ice
 
@@ -192,14 +197,16 @@ class ControllerDriver(Driver):
     def getCurrent(self, mapping, testsuite, testcase, cross, protocol=None, host=None, args=[]):
         from Test import Common as Test_Common
 
-        mapping = Mapping.getByName(mapping)
+        mappingName = mapping
+        mapping = Mapping.getByName(mappingName)
         if not mapping:
-            raise Test_Common.TestCaseNotExistException("unknown mapping {0}".format(mapping))
+            raise Test_Common.TestCaseNotExistException("unknown mapping {0}".format(mappingName))
 
         if cross:
-            cross = Mapping.getByName(cross)
+            crossName = cross
+            cross = Mapping.getByName(crossName)
             if not cross:
-                raise Test_Common.TestCaseNotExistException("unknown mapping {0} for cross testing".format(cross))
+                raise Test_Common.TestCaseNotExistException("unknown mapping {0} for cross testing".format(crossName))
 
         ts = mapping.findTestSuite(testsuite)
         if not ts:

--- a/scripts/Controller.py
+++ b/scripts/Controller.py
@@ -197,16 +197,18 @@ class ControllerDriver(Driver):
     def getCurrent(self, mapping, testsuite, testcase, cross, protocol=None, host=None, args=[]):
         from Test import Common as Test_Common
 
-        mappingName = mapping
-        mapping = Mapping.getByName(mappingName)
-        if not mapping:
-            raise Test_Common.TestCaseNotExistException("unknown mapping {0}".format(mappingName))
+        # Mapping.getByName raises RuntimeError for an unknown mapping, but runTestCase is declared to
+        # throw TestCaseNotExistException.
+        try:
+            mapping = Mapping.getByName(mapping)
+        except RuntimeError as ex:
+            raise Test_Common.TestCaseNotExistException(str(ex))
 
         if cross:
-            crossName = cross
-            cross = Mapping.getByName(crossName)
-            if not cross:
-                raise Test_Common.TestCaseNotExistException("unknown mapping {0} for cross testing".format(crossName))
+            try:
+                cross = Mapping.getByName(cross)
+            except RuntimeError as ex:
+                raise Test_Common.TestCaseNotExistException("{0} for cross testing".format(ex))
 
         ts = mapping.findTestSuite(testsuite)
         if not ts:

--- a/scripts/Expect.py
+++ b/scripts/Expect.py
@@ -1,5 +1,6 @@
 # Copyright (c) ZeroC, Inc.
 
+import codecs
 import io
 import os
 import platform
@@ -130,34 +131,47 @@ class reader(threading.Thread):
         self.watchDog = watchDog
 
     def run(self):
+        # Depending on the platform, the value read below is either a string or a single byte, in
+        # which case it's decoded incrementally since a character can span several reads.
+        decoder = codecs.getincrementaldecoder("utf-8")("replace")
         try:
             while True:
                 c = self.p.stdout.read(1)
                 if not c:
                     self.cv.acquire()
-                    self.trace(None)
-                    self._finish = True  # We have finished processing output
-                    self.cv.notify()
-                    self.cv.release()
+                    try:
+                        self.trace(None)
+                        self._finish = True  # We have finished processing output
+                        self.cv.notify()
+                    finally:
+                        self.cv.release()
                     break
-                if c == "\r":
-                    continue
+                if not isinstance(c, str):
+                    c = decoder.decode(c)
+                    if not c:
+                        continue  # Incomplete character, read more bytes.
 
                 self.cv.acquire()
                 try:
-                    # Depending on Python version and platform, the value c could be a
-                    # string or a bytes object.
-                    if not isinstance(c, str):
-                        c = c.decode()
-                    self.trace(c)
+                    # Decoding can yield more than one character, so trace and buffer them one by one.
+                    for char in c:
+                        if char == "\r":
+                            continue
+                        self.trace(char)
+                        self.buf.write(char)
                     if self.watchDog is not None:
                         self.watchDog.reset()
-                    self.buf.write(c)
                     self.cv.notify()
                 finally:
                     self.cv.release()
-        except IOError as e:
+        except Exception as e:
             print(e)
+        finally:
+            # Always wake up the waiters, otherwise they would block until their timeout expires.
+            self.cv.acquire()
+            self._finish = True
+            self.cv.notify()
+            self.cv.release()
 
     def trace(self, c):
         if self._trace:
@@ -213,21 +227,24 @@ class reader(threading.Thread):
                 tdesc = "<infinite>"
             else:
                 tdesc = "%.2fs" % timeout
-            p = [escape(s) for (s, r) in pattern]
             pdesc = io.StringIO()
-            if len(p) == 1:
-                pdesc.write(escape(p[0]))
+            if len(pattern) == 1:
+                pdesc.write(escape(pattern[0][0]))
             else:
                 pdesc.write("[")
-                for pat in p:
-                    if pat != p[0]:
+                for index, (s, regexp) in enumerate(pattern):
+                    if index > 0:
                         pdesc.write(",")
-                    pdesc.write(escape(pat))
+                    pdesc.write(escape(s))
                 pdesc.write("]")
             self.logfile.write('%s: expect: "%s" timeout: %s\n' % (self.desc, pdesc.getvalue(), tdesc))
             self.logfile.flush()
 
         maxend = None
+
+        def patternDesc():
+            return ",".join([escape(s) for (s, regexp) in pattern])
+
         self.cv.acquire()
         try:
             try:  # This second try/except block is necessary because of python 2.3
@@ -306,7 +323,8 @@ class reader(threading.Thread):
                     # If no match and we have finished processing output raise a TIMEOUT
                     if self._finish:
                         raise TIMEOUT(
-                            'timeout exceeded in match\npattern: "%s"\nbuffer: "%s"\n' % (escape(s), escape(buf, False))
+                            'timeout exceeded in match\npattern: "%s"\nbuffer: "%s"\n'
+                            % (patternDesc(), escape(buf, False))
                         )
 
                     if timeout is None:
@@ -317,13 +335,13 @@ class reader(threading.Thread):
                             # Log the failure
                             if self.logfile:
                                 self.logfile.write(
-                                    '%s: match failed.\npattern: "%s"\nbuffer: "%s"\n"'
-                                    % (self.desc, escape(s), escape(buf))
+                                    '%s: match failed.\npattern: "%s"\nbuffer: "%s"\n'
+                                    % (self.desc, patternDesc(), escape(buf))
                                 )
                                 self.logfile.flush()
                             raise TIMEOUT(
                                 'timeout exceeded in match\npattern: "%s"\nbuffer: "%s"\n'
-                                % (escape(s), escape(buf, False))
+                                % (patternDesc(), escape(buf, False))
                             )
             except TIMEOUT as e:
                 if (TIMEOUT, None) in pattern:
@@ -617,12 +635,13 @@ class Expect(object):
 
         def kill():
             ex = None
-            while True:
+            for _ in range(5):
                 try:
                     if not self.p:
                         return
                     killProcess(self.p)
                     self.wait()
+                    ex = None
                     break
                 except KeyboardInterrupt as e:
                     ex = e

--- a/scripts/Expect.py
+++ b/scripts/Expect.py
@@ -140,6 +140,11 @@ class reader(threading.Thread):
                 if not c:
                     self.cv.acquire()
                     try:
+                        # Flush the character the decoder may still be holding, otherwise a process
+                        # exiting in the middle of a multi-byte sequence loses its last character.
+                        for char in decoder.decode(b"", True):
+                            self.trace(char)
+                            self.buf.write(char)
                         self.trace(None)
                         self._finish = True  # We have finished processing output
                         self.cv.notify()

--- a/scripts/IceGridUtil.py
+++ b/scripts/IceGridUtil.py
@@ -33,7 +33,7 @@ class IceGridProcess:
             props["Ice.Default.Locator"] = testcase.getMasterLocator(current)
         else:
             for r in testcase.icegridregistry:
-                # Match either the IceGridRegistrySlave object or the slave replica number
+                # Match either the IceGridRegistry object or its replica name (e.g. "Master", "Slave1")
                 if self.replica in [r, r.name]:
                     props["Ice.Default.Locator"] = r.getLocator(current)
                     break

--- a/scripts/IceStormUtil.py
+++ b/scripts/IceStormUtil.py
@@ -62,6 +62,7 @@ class IceStorm(ProcessFromBinDir, Server):
             os.mkdir(self.dbdir)
 
     def teardown(self, current, success):
+        Server.teardown(self, current, success)
         if self.cleanDb:
             # Remove the database directory tree
             try:

--- a/scripts/LocalDriver.py
+++ b/scripts/LocalDriver.py
@@ -258,7 +258,8 @@ class RemoteTestCaseRunner(TestCaseRunner):
         for key, values in options.items():
             for opts in [self.serverOptions, self.clientOptions]:
                 if hasattr(opts, key) and getattr(opts, key) is not None:
-                    options[key] = [v for v in values if v in getattr(opts, key)]
+                    values = [v for v in values if v in getattr(opts, key)]
+            options[key] = values
         return options
 
     def startServerSide(self, testcase, current):
@@ -346,7 +347,7 @@ class XmlExporter:
             out.write('<?xml version="1.1" encoding="UTF-8"?>\n')
             out.write(
                 '<testsuites tests="{0}" failures="{1}" time="{2:.9f}">\n'.format(
-                    len(self.results), self.duration, len(self.failures)
+                    len(self.results), len(self.failures), self.duration
                 )
             )
             for r in self.results:
@@ -428,9 +429,10 @@ class LocalDriver(Driver):
         )
 
         if self.cross:
-            self.cross = Mapping.getByName(self.cross)
-            if not self.cross:
+            cross = Mapping.getByName(self.cross)
+            if not cross:
                 raise RuntimeError("unknown mapping `{0}' for --cross option".format(self.cross))
+            self.cross = cross
 
         self.results = []
         self.threadlocal = threading.local()
@@ -621,7 +623,7 @@ class LocalDriver(Driver):
                 # behind.
                 #
                 failure = []
-                sem = threading.Semaphore(0)
+                stopped = threading.Event()
 
                 def stopServerSide():
                     try:
@@ -630,23 +632,23 @@ class LocalDriver(Driver):
                         failure.append(ex)
                     except KeyboardInterrupt:  # Potentially raised by Except.py if Ctrl-C
                         pass
-                    sem.release()
+                    finally:
+                        stopped.set()
 
                 t = threading.Thread(target=stopServerSide)
                 t.start()
-                while True:
+                #
+                # NOTE: we can't just use join() here because of https://bugs.python.org/issue21822
+                # We wait on an event instead, which stays set once the servers are stopped, so a
+                # Ctrl-C interrupting the wait can't leave us blocking on an already consumed permit.
+                #
+                while not stopped.is_set():
                     try:
-                        #
-                        # NOTE: we can't just use join() here because of https://bugs.python.org/issue21822
-                        # We use a semaphore to wait for the servers to be stopped and return.
-                        #
-                        sem.acquire()
-                        if failure:
-                            raise failure[0]
-                        t.join()
-                        break
+                        stopped.wait()
                     except KeyboardInterrupt:
                         pass  # Ignore keyboard interrupts
+                if failure:
+                    raise failure[0]
 
     def runTestCase(self, current):
         if self.cross or self.allCross:

--- a/scripts/LocalDriver.py
+++ b/scripts/LocalDriver.py
@@ -337,17 +337,20 @@ class RemoteTestCaseRunner(TestCaseRunner):
 
 
 class XmlExporter:
-    def __init__(self, results, duration, failures):
+    def __init__(self, results, duration):
         self.results = results
         self.duration = duration
-        self.failures = failures
 
     def save(self, filename, hostname):
+        # The root element aggregates the per-testsuite counts, each result can write several testcases.
+        counts = [r.getXmlCounts() for r in self.results]
         with open(filename, "w", encoding="utf-8") as out:
             out.write('<?xml version="1.1" encoding="UTF-8"?>\n')
             out.write(
                 '<testsuites tests="{0}" failures="{1}" time="{2:.9f}">\n'.format(
-                    len(self.results), len(self.failures), self.duration
+                    sum(tests for (tests, _) in counts),
+                    sum(failures for (_, failures) in counts),
+                    self.duration,
                 )
             )
             for r in self.results:
@@ -429,10 +432,11 @@ class LocalDriver(Driver):
         )
 
         if self.cross:
-            cross = Mapping.getByName(self.cross)
-            if not cross:
+            # Mapping.getByName raises RuntimeError for an unknown mapping.
+            try:
+                self.cross = Mapping.getByName(self.cross)
+            except RuntimeError:
                 raise RuntimeError("unknown mapping `{0}' for --cross option".format(self.cross))
-            self.cross = cross
 
         self.results = []
         self.threadlocal = threading.local()
@@ -495,7 +499,7 @@ class LocalDriver(Driver):
                 duration = time.time() - now
 
                 if self.exportToXml:
-                    XmlExporter(results, duration, failures).save(self.exportToXml, os.getenv("NODE_NAME", ""))
+                    XmlExporter(results, duration).save(self.exportToXml, os.getenv("NODE_NAME", ""))
 
                 m, s = divmod(duration, 60)
                 print("")

--- a/scripts/NetworkProxy.py
+++ b/scripts/NetworkProxy.py
@@ -63,7 +63,7 @@ class BaseConnection(threading.Thread):
                         if len(data) == 0:
                             self.closed = True
                             break
-                        w.send(data)
+                        w.sendall(data)
             except InvalidRequest:
                 print("invalid request")
             except Exception:

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -2019,6 +2019,13 @@ class Result:
         self._stdout.write(msg)
         self._stdout.write("\n")
 
+    def getXmlCounts(self):
+        # The (tests, failures) counts as written to the XML report by writeAsXml.
+        return (
+            len([k for k in self._testcases if not isinstance(k, str) and k not in self._skipped]),
+            len(self._failed),
+        )
+
     def writeAsXml(self, out, hostname=""):
         # Don't keep track of the setup/teardown steps (they use string keys) and don't write skipped
         # tests, this doesn't really provide useful information and clutters the output.

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -2548,6 +2548,7 @@ class AndroidProcessController(RemoteProcessController):
         RemoteProcessController.__init__(self, current, None)
         self.device = current.config.device if current.config.device != "" else None
         self.avd = current.config.avd
+        self.createdAvd = False  # Only the AVD we create is deleted on shutdown
         self.emulator = None  # Keep a reference to the android emulator process
         self.controllerPid = None
 
@@ -2632,6 +2633,7 @@ class AndroidProcessController(RemoteProcessController):
             except Exception:
                 pass
             run('avdmanager -v create avd -k "{0}" -d "Nexus 6" -n IceTests'.format(sdk))
+            self.createdAvd = True
             self.startEmulator("IceTests")
         elif current.config.device != "usb":
             run("adb connect {}".format(current.config.device))
@@ -2717,9 +2719,9 @@ class AndroidProcessController(RemoteProcessController):
             except Exception:
                 pass
 
-            if self.avd == "IceTests":
+            if self.createdAvd:
                 try:
-                    run("avdmanager -v delete avd -n IceTests")  # Delete the created device
+                    run("avdmanager -v delete avd -n IceTests")  # Delete the device we created
                 except Exception:
                     pass
 

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -48,7 +48,8 @@ def run(cmd, cwd=None, expectErr=False, stdout=False, stdin=None, stdinRepeat=Tr
             except Exception:
                 pass
 
-        out = (p.stderr if stdout else p.stdout).read().decode("UTF-8").strip()
+        # With stdout=True, the child writes directly to our stdout, there's no pipe to read from.
+        out = "" if stdout else p.stdout.read().decode("UTF-8").strip()
 
         status = p.wait()
 
@@ -66,7 +67,8 @@ def run(cmd, cwd=None, expectErr=False, stdout=False, stdin=None, stdinRepeat=Tr
         #
         # ResourceWarning: unclosed file <_io.TextIOWrapper name=3 encoding='cp1252'>
         #
-        (p.stderr if stdout else p.stdout).close()
+        if p.stdout:
+            p.stdout.close()
         try:
             p.stdin.close()
         except Exception:
@@ -259,7 +261,7 @@ class Platform(object):
                 if m and m.group(1):
                     self._hasSwift = tuple([int(n) for n in m.group(1).split(".")]) >= version
                 else:
-                    self.hasSwift = False
+                    self._hasSwift = False
             except Exception:
                 self._hasSwift = False
         return self._hasSwift
@@ -951,10 +953,10 @@ class Mapping(object):
                         # WORKAROUND for Python issue 15230 (fixed in 3.2) where run_path doesn't work correctly.
                         #
                         # runpy.run_path(os.path.join(root, "test.py"))
-                        origsyspath = sys.path
+                        syspath = sys.path
                         sys.path = [root] + sys.path
                         runpy.run_module("test", init_globals=globals(), run_name=root)
-                        origsyspath = sys.path
+                        sys.path = syspath
                         continue
 
                     #
@@ -2018,9 +2020,13 @@ class Result:
         self._stdout.write("\n")
 
     def writeAsXml(self, out, hostname=""):
+        # Don't keep track of the setup/teardown steps (they use string keys) and don't write skipped
+        # tests, this doesn't really provide useful information and clutters the output.
+        testcases = [(k, v) for k, v in self._testcases.items() if not isinstance(k, str) and k not in self._skipped]
+
         out.write(
             '  <testsuite tests="{0}" failures="{1}" skipped="{2}" time="{3:.9f}" name="{5}/{4}">\n'.format(
-                len(self._testcases) - 2,
+                len(testcases),
                 len(self._failed),
                 0,
                 self._duration,
@@ -2029,16 +2035,7 @@ class Result:
             )
         )
 
-        for k, v in self._testcases.items():
-            if isinstance(k, str):
-                # Don't keep track of setup/teardown steps
-                continue
-
-            # Don't write skipped tests, this doesn't really provide useful information and clutters
-            # the output.
-            if k in self._skipped:
-                continue
-
+        for k, v in testcases:
             (tc, cf) = k
             (s, e, d, c) = v
             if c:
@@ -2905,7 +2902,7 @@ class iOSSimulatorProcessController(RemoteProcessController):
         sys.stdout.write("shutting down simulator... ")
         sys.stdout.flush()
         try:
-            run('xcrun simctl shutdown "{0}"'.format(self.simulatorID))
+            run('xcrun simctl shutdown "{0}"'.format(self.device))
         except Exception:
             pass
         print("ok")

--- a/scripts/icehashpassword.py
+++ b/scripts/icehashpassword.py
@@ -115,10 +115,13 @@ def main():
             usage()
             return 2
     if salt is not None:
-        if not passScheme.min_salt_size <= salt <= passScheme.max_salt_size:
+        # The schemes report a minimum salt size of 0, but hashing a password without a salt is never
+        # what the user wants: passlib emits an empty salt field that verifies just fine.
+        minSaltSize = max(1, passScheme.min_salt_size)
+        if not minSaltSize <= salt <= passScheme.max_salt_size:
             print(
                 "Invalid salt size for the digest algorithm. Value must be an integer between %s and %s"
-                % (passScheme.min_salt_size, passScheme.max_salt_size)
+                % (minSaltSize, passScheme.max_salt_size)
             )
             usage()
             return 2

--- a/scripts/icehashpassword.py
+++ b/scripts/icehashpassword.py
@@ -106,7 +106,7 @@ def main():
         #
         passScheme = passlib.hosts.host_context
 
-    if rounds:
+    if rounds is not None:
         if not passScheme.min_rounds <= rounds <= passScheme.max_rounds:
             print(
                 "Invalid number rounds for the digest algorithm. Value must be an integer between %s and %s"
@@ -114,7 +114,7 @@ def main():
             )
             usage()
             return 2
-    if salt:
+    if salt is not None:
         if not passScheme.min_salt_size <= salt <= passScheme.max_salt_size:
             print(
                 "Invalid salt size for the digest algorithm. Value must be an integer between %s and %s"
@@ -124,16 +124,16 @@ def main():
             return 2
 
     args = []
-    if sys.stdout.isatty():
+    if sys.stdin.isatty():
         args.append(getpass.getpass("Password: "))
     else:
-        args.append(sys.stdin.readline().strip())
+        args.append(sys.stdin.readline().removesuffix("\n").removesuffix("\r"))
 
     opts = {}
-    if salt:
+    if salt is not None:
         opts["salt_size"] = salt
 
-    if rounds:
+    if rounds is not None:
         opts["rounds"] = rounds
 
     # passlib 1.7 renamed encrypt to hash

--- a/scripts/process_windows_crash_dumps.py
+++ b/scripts/process_windows_crash_dumps.py
@@ -89,12 +89,12 @@ def copy_with_pdb(binary: Path, dest_dir: Path) -> None:
     """Copy *binary* and its sibling .pdb (if any) into *dest_dir*."""
     dest_dir.mkdir(parents=True, exist_ok=True)
 
-    for src in (binary, binary.with_suffix(".pdb")):
+    for kind, src in (("Binary", binary), ("PDB", binary.with_suffix(".pdb"))):
         if src.exists():
             shutil.copy2(src, dest_dir / src.name)
             LOGGER.info("Copied %s → %s", src, dest_dir / src.name)
         else:
-            LOGGER.debug("PDB not found: %s", src)
+            LOGGER.debug("%s not found: %s", kind, src)
 
 
 def process_dump(dump: Path, workspace: Path, reports_root: Path, cdb_exe: str) -> None:
@@ -161,6 +161,8 @@ def main(argv: List[str] | None = None) -> None:
             process_dump(dump, args.workspace, args.reports, args.cdb)
         except subprocess.CalledProcessError as exc:
             LOGGER.error("cdb failed for %s (exit code %s)", dump, exc.returncode)
+        except Exception as exc:
+            LOGGER.error("Failed to process %s: %s", dump, exc)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/Ice/objects.py
+++ b/scripts/tests/Ice/objects.py
@@ -6,13 +6,13 @@
 # a client stack overflow if the client stack is too small compared to the
 # Java server stack.
 #
-from Util import ClientServerTestCase, CollocatedTestCase, Mapping, Server, TestSuite
+from Util import ClientServerTestCase, CollocatedTestCase, JavaMapping, Mapping, Server, TestSuite
 
 
 class ObjectClientServerTestCase(ClientServerTestCase):
     def getProps(self, process, current):
         props = ClientServerTestCase.getProps(self, process, current)
-        if process.getMapping(current) in ["java"] and isinstance(process, Server):
+        if isinstance(process.getMapping(current), JavaMapping) and isinstance(process, Server):
             props["Ice.ThreadPool.Server.StackSize"] = 512 * 1024
         elif current.config.buildPlatform == "iphoneos":
             #

--- a/scripts/ws_ping_probe.py
+++ b/scripts/ws_ping_probe.py
@@ -24,19 +24,31 @@ _OP_PING = 0x9
 _OP_PONG = 0xA
 
 
-def _recvn(sock, n):
-    """Read exactly n bytes, raising if the connection closes first."""
-    buf = b""
-    while len(buf) < n:
-        chunk = sock.recv(n - len(buf))
-        if not chunk:
-            raise RuntimeError("connection closed while reading {0} bytes".format(n))
-        buf += chunk
-    return buf
+class _Reader:
+    """A buffered socket reader, primed with the bytes already read past the upgrade response."""
+
+    def __init__(self, sock, buf=b""):
+        self._sock = sock
+        self._buf = buf
+
+    def recvn(self, n):
+        """Read exactly n bytes, raising if the connection closes first."""
+        while len(self._buf) < n:
+            chunk = self._sock.recv(n - len(self._buf))
+            if not chunk:
+                raise RuntimeError("connection closed while reading {0} bytes".format(n))
+            self._buf += chunk
+        buf, self._buf = self._buf[:n], self._buf[n:]
+        return buf
 
 
 def _upgrade(sock, host, port):
-    """Perform the WebSocket upgrade handshake; raise unless the server returns 101."""
+    """
+    Perform the WebSocket upgrade handshake; raise unless the server returns 101.
+
+    Returns the bytes read past the end of the response headers: the server can send its first
+    frame in the same packet as the 101 response, and those bytes must not be dropped.
+    """
     key = base64.b64encode(os.urandom(16)).decode("ascii")
     request = (
         "\r\n".join(
@@ -63,6 +75,7 @@ def _upgrade(sock, host, port):
     status = buf.split(b"\r\n", 1)[0].decode("ascii", errors="replace") if buf else "<no response>"
     if not status.startswith("HTTP/1.1 101"):
         raise RuntimeError("WebSocket upgrade rejected: {0}".format(status))
+    return buf.partition(b"\r\n\r\n")[2]
 
 
 def _client_frame(opcode, payload):
@@ -74,18 +87,18 @@ def _client_frame(opcode, payload):
     return bytes([0x80 | opcode, 0x80 | len(payload)]) + mask + masked
 
 
-def _read_frame(sock):
+def _read_frame(reader):
     """Read one server->client frame and return (opcode, payload). Server frames are unmasked."""
-    b0, b1 = _recvn(sock, 2)
+    b0, b1 = reader.recvn(2)
     opcode = b0 & 0x0F
     masked = b1 & 0x80
     length = b1 & 0x7F
     if length == 126:
-        length = int.from_bytes(_recvn(sock, 2), "big")
+        length = int.from_bytes(reader.recvn(2), "big")
     elif length == 127:
-        length = int.from_bytes(_recvn(sock, 8), "big")
-    mask = _recvn(sock, 4) if masked else b""
-    payload = _recvn(sock, length) if length else b""
+        length = int.from_bytes(reader.recvn(8), "big")
+    mask = reader.recvn(4) if masked else b""
+    payload = reader.recvn(length) if length else b""
     if masked:
         payload = bytes(p ^ mask[i % 4] for i, p in enumerate(payload))
     return opcode, payload
@@ -99,10 +112,10 @@ def ping_pong(host, port, payload=b"", timeout=10.0):
     message) are skipped. Raises if the server sends CLOSE or never ponngs.
     """
     with socket.create_connection((host, port), timeout=timeout) as sock:
-        _upgrade(sock, host, port)
+        reader = _Reader(sock, _upgrade(sock, host, port))
         sock.sendall(_client_frame(_OP_PING, payload))
         for _ in range(16):
-            opcode, data = _read_frame(sock)
+            opcode, data = _read_frame(reader)
             if opcode == _OP_PONG:
                 return data
             if opcode == _OP_CLOSE:


### PR DESCRIPTION
A review pass over the Python under `scripts/`. The `Expect.py` one is the reason for the PR; the rest turned up while reviewing the same tree.

**`Expect.py`**
- The reader thread died on any non-ASCII output byte, so every later `expect()` blocked its full timeout and reported a bogus TIMEOUT. On POSIX the child is spawned without text mode, so `stdout.read(1)` returns a single *byte* and decoding it in isolation raised `UnicodeDecodeError`, which `except IOError` didn't catch. Now decoded incrementally and flushed at EOF, and waiters are always woken when the reader exits.
- `if c == "\r"` compared bytes to str, so it never stripped anything.
- `terminate()` re-raised a stale exception after a retry succeeded, and retried forever.

**`Util.py`**
- `sys.path` was never restored after loading a `test.py` — the assignment was backwards, leaving every test directory on the path.
- `hasSwift` assigned `self.hasSwift = False`, replacing its own method with a bool; the next call raised `TypeError`.
- `run(stdout=True)` read `p.stderr`, which is always `None`.
- The iOS simulator was shut down by an ID that is `None` unless that run created the device.
- The Android AVD teardown deleted any device named `IceTests`, so `--avd=IceTests` — the documented way to reuse one — destroyed it.
- The JUnit `tests=` count included skipped cases the loop then omitted.

**`LocalDriver.py`**
- The `<testsuites>` attributes were misordered, putting the duration in `failures=` and the failure count in `time=`. The root also counted suites where the children count testcases.
- A Ctrl-C arriving after the semaphore permit was consumed hung the driver forever; it now waits on an event.
- `filterOptions` never rebound `values`, so the client controller's filter discarded the server's instead of intersecting.

**`Controller.py`**
- `"ok"` was printed even when adding the certificate trust settings failed.
- `serverSideRunning` was never cleared, so `destroy()` re-ran the whole server teardown.
- `getHost` was an unimplemented `pass` stub, silently returning an empty host.
- `Mapping.getByName` raises rather than returning falsy, so the unknown-mapping checks were dead and `TestCaseNotExistException` could never be raised.

**Others**
- `Component.py`: `re.match("charp-.*", m)` was a typo for `csharp-.*`. Versioned directories now register under their own name — `Mapping.init` derives the path from the name, so `csharp-3.8` resolved to `$toplevel/csharp`.
- `tests/Ice/objects.py`: compared a `Mapping` object against a string. `Mapping` has no `__eq__`, so the 512KB server stack size this file exists to set was never applied.
- `icehashpassword.py`: prompted based on `sys.stdout.isatty()` while reading the password from stdin, so `icehashpassword.py > hash.txt` echoed it to the terminal. An explicit `-s 0` also produced an empty salt that `verify()` accepts.
- `ws_ping_probe.py`: `_upgrade` discarded bytes read past the response headers, desyncing the frame reader.
- `NetworkProxy.py`: `send()` could silently truncate relayed data.
- `IceStormUtil.teardown`: never called the base implementation, so trace files were never cleaned up.
- `process_windows_crash_dumps.py`: one failed copy aborted every remaining dump.

No changelog fragment — `scripts/` is the internal test framework and none of it ships.
