### PR TITLE
Discard DataStorm partial updates that have no base value

### DIFF
--- a/changelog.d/datastorm/partial-update-no-base.md
+++ b/changelog.d/datastorm/partial-update-no-base.md
@@ -1,7 +1,7 @@
-- Fixed a bug in DataStorm where a partial update for a key with no current value—no full value was written for the
-  key, or the key was removed—was resolved against an invalid base value: applications using class-typed values
-  typically crashed, and with other value types the update was silently applied to a default-constructed value,
-  resurrecting removed keys. A remove now clears the key's value, and a partial update for a key with no value is
-  discarded, by both writers and readers.
+- Fixed a bug in DataStorm where a partial update for a key with no current value was resolved against an invalid
+  base value: applications using class-typed values typically crashed, and with other value types the update was
+  silently applied to a default-constructed value, resurrecting removed keys. A key has no current value when no full
+  value was written for it yet, or when it was removed. A remove now clears the key's value; publishing a partial
+  update for a key with no value now throws `std::logic_error` on the writer and is discarded on the reader.
 - Fixed a bug in DataStorm where a remove sample's value was indeterminate for scalar value types: `getValue()` on
   the remove sample returned arbitrary data instead of a default-constructed value.

--- a/changelog.d/datastorm/partial-update-no-base.md
+++ b/changelog.d/datastorm/partial-update-no-base.md
@@ -3,5 +3,5 @@
   silently applied to a default-constructed value, resurrecting removed keys. A key has no current value when no full
   value was written for it yet, or when it was removed. A remove now clears the key's value; publishing a partial
   update for a key with no value now throws `std::logic_error` on the writer and is discarded on the reader.
-- Fixed a bug in DataStorm where a remove sample's value was indeterminate for scalar value types: `getValue()` on
-  the remove sample returned arbitrary data instead of a default-constructed value.
+- Fixed a bug in DataStorm where calling `getValue()` on a sample carrying the `Remove` event returned indeterminate
+  data instead of the documented default-constructed value, when the topic's value type is a scalar type.

--- a/changelog.d/datastorm/partial-update-no-base.md
+++ b/changelog.d/datastorm/partial-update-no-base.md
@@ -1,0 +1,7 @@
+- Fixed a bug in DataStorm where a partial update for a key with no current value—no full value was written for the
+  key, or the key was removed—was resolved against an invalid base value: applications using class-typed values
+  typically crashed, and with other value types the update was silently applied to a default-constructed value,
+  resurrecting removed keys. A remove now clears the key's value, and a partial update for a key with no value is
+  discarded, by both writers and readers.
+- Fixed a bug in DataStorm where a remove sample's value was indeterminate for scalar value types: `getValue()` on
+  the remove sample returned arbitrary data instead of a default-constructed value.

--- a/changelog.d/datastorm/partial-update-no-base.md
+++ b/changelog.d/datastorm/partial-update-no-base.md
@@ -1,7 +1,6 @@
-- Fixed a bug in DataStorm where a partial update for a key with no current value was resolved against an invalid
-  base value: applications using class-typed values typically crashed, and with other value types the update was
-  silently applied to a default-constructed value, resurrecting removed keys. A key has no current value when no full
-  value was written for it yet, or when it was removed. A remove now clears the key's value; publishing a partial
-  update for a key with no value now throws `std::logic_error` on the writer and is discarded on the reader.
-- Fixed a bug in DataStorm where calling `getValue()` on a sample carrying the `Remove` event returned indeterminate
-  data instead of the documented default-constructed value, when the topic's value type is a scalar type.
+- Fixed the handling of partial updates for keys with no value. A key has no value when it was removed, or when no
+  full value was written for it yet. Previously, such a partial update crashed applications using class-typed
+  values; with other value types, it silently resurrected removed keys. Now a writer throws `std::logic_error`
+  when publishing such an update, and a reader discards incoming ones.
+- Fixed a bug where calling `getValue()` on a `Remove` sample could return indeterminate data instead of the
+  documented default value.

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -767,8 +767,10 @@ namespace DataStorm
         /// function generates a SampleEvent::PartialUpdate sample with the given partial update value.
         /// The UpdateValue template parameter must match the UpdateValue type used to register the updater with
         /// the Topic::setUpdater method.
-        /// A partial update resolves against the key's current value. When the key has no value—no full value was
-        /// written yet, or the key was removed—the partial update is discarded and nothing is published.
+        /// A partial update resolves against the key's current value, so the key must have a current value when the
+        /// returned function is called: a full value was written for the key and the key was not since removed.
+        /// Calling the returned function for a key with no current value is an application error that throws
+        /// std::logic_error and publishes nothing.
         /// @param tag The partial update tag.
         template<typename UpdateValue>
         [[nodiscard]] std::function<void(const UpdateValue&)> partialUpdate(const UpdateTag& tag);
@@ -822,8 +824,10 @@ namespace DataStorm
         /// function generates a SampleEvent::PartialUpdate sample with the given partial update value.
         /// The UpdateValue template parameter must match the UpdateValue type used to register the updater with
         /// the Topic::setUpdater method.
-        /// A partial update resolves against the key's current value. When the key has no value—no full value was
-        /// written yet, or the key was removed—the partial update is discarded and nothing is published.
+        /// A partial update resolves against the key's current value, so the key must have a current value when the
+        /// returned function is called: a full value was written for the key and the key was not since removed.
+        /// Calling the returned function for a key with no current value is an application error that throws
+        /// std::logic_error and publishes nothing.
         /// @param tag The partial update tag.
         template<typename UpdateValue>
         [[nodiscard]] std::function<void(const Key&, const UpdateValue&)> partialUpdate(const UpdateTag& tag);

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -1639,8 +1639,11 @@ namespace DataStorm
                                            const std::shared_ptr<DataStormI::Sample>& next,
                                            const Ice::CommunicatorPtr& communicator)
             {
-                // Callers discard partial updates that have no usable base before invoking the updater; assert that
-                // here, and keep the default-value fallback as defense in depth for release builds.
+                // Every updater call site ensures the previous sample exists and has a value before invoking the
+                // updater (the writer throws otherwise, the reader drops the sample), so this assert holds and the
+                // clone below always runs. The guarded branch is not a safe release-build fallback for a broken
+                // invariant: a default-constructed base is null for class-typed values, which the user's updater
+                // would dereference just as if the guard were absent.
                 assert(previous && previous->hasValue());
                 Value value{};
                 if (previous && previous->hasValue())

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -10,6 +10,7 @@
 #include "Node.h"
 #include "Types.h"
 
+#include <cassert>
 #include <regex>
 
 #if defined(__clang__)
@@ -1634,8 +1635,9 @@ namespace DataStorm
                                            const std::shared_ptr<DataStormI::Sample>& next,
                                            const Ice::CommunicatorPtr& communicator)
             {
-                // A value-less previous sample is not a usable base: fall back to a default value. This is defense
-                // in depth: callers discard partial updates that have no usable base before invoking the updater.
+                // Callers discard partial updates that have no usable base before invoking the updater; assert that
+                // here, and keep the default-value fallback as defense in depth for release builds.
+                assert(previous && previous->hasValue());
                 Value value{};
                 if (previous && previous->hasValue())
                 {

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -766,6 +766,8 @@ namespace DataStorm
         /// function generates a SampleEvent::PartialUpdate sample with the given partial update value.
         /// The UpdateValue template parameter must match the UpdateValue type used to register the updater with
         /// the Topic::setUpdater method.
+        /// A partial update resolves against the key's current value. When the key has no value—no full value was
+        /// written yet, or the key was removed—the partial update is discarded and nothing is published.
         /// @param tag The partial update tag.
         template<typename UpdateValue>
         [[nodiscard]] std::function<void(const UpdateValue&)> partialUpdate(const UpdateTag& tag);
@@ -819,6 +821,8 @@ namespace DataStorm
         /// function generates a SampleEvent::PartialUpdate sample with the given partial update value.
         /// The UpdateValue template parameter must match the UpdateValue type used to register the updater with
         /// the Topic::setUpdater method.
+        /// A partial update resolves against the key's current value. When the key has no value—no full value was
+        /// written yet, or the key was removed—the partial update is discarded and nothing is published.
         /// @param tag The partial update tag.
         template<typename UpdateValue>
         [[nodiscard]] std::function<void(const Key&, const UpdateValue&)> partialUpdate(const UpdateTag& tag);
@@ -1630,8 +1634,10 @@ namespace DataStorm
                                            const std::shared_ptr<DataStormI::Sample>& next,
                                            const Ice::CommunicatorPtr& communicator)
             {
-                Value value;
-                if (previous)
+                // A value-less previous sample is not a usable base: fall back to a default value. This is defense
+                // in depth: callers discard partial updates that have no usable base before invoking the updater.
+                Value value{};
+                if (previous && previous->hasValue())
                 {
                     value = Cloner<Value>::clone(
                         std::static_pointer_cast<DataStormI::SampleT<Key, Value, UpdateTag>>(previous)->getValue());

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -403,7 +403,9 @@ namespace DataStormI
 
     private:
         bool _hasValue;
-        Value _value;
+        // Value-initialized so a value-less sample (such as a remove) holds a determinate default value: scalar
+        // types would otherwise be indeterminate, and encodeValue encodes this member for remove samples.
+        Value _value{};
     };
 
     template<typename Key, typename Value, typename UpdateTag> class SampleFactoryT final : public SampleFactory

--- a/cpp/include/DataStorm/Types.h
+++ b/cpp/include/DataStorm/Types.h
@@ -186,10 +186,13 @@ namespace DataStorm
         static T clone(const T& value) noexcept { return value; }
     };
 
-    /// Cloner template specialization to clone shared Ice values using ice_clone.
+    /// Cloner template specialization to clone shared Ice values using ice_clone. A null value clones to null.
     template<typename T> struct Cloner<std::shared_ptr<T>, typename std::enable_if_t<std::is_base_of_v<Ice::Value, T>>>
     {
-        static std::shared_ptr<T> clone(const std::shared_ptr<T>& value) noexcept { return value->ice_clone(); }
+        static std::shared_ptr<T> clone(const std::shared_ptr<T>& value) noexcept
+        {
+            return value ? value->ice_clone() : nullptr;
+        }
     };
 
     // Encoder template implementation.

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -770,8 +770,9 @@ DataReaderI::initSamples(
         {
             // The discard only affects the application-visible delivery: when the key has no base yet, still record
             // the discarded sample as the base partial updates resolve against, otherwise a later partial update on
-            // the key would have no base.
+            // the key would have no base. A remove carries no value and cannot serve as a base.
             if (sample->event != DataStorm::SampleEvent::PartialUpdate &&
+                sample->event != DataStorm::SampleEvent::Remove &&
                 previousByKey.find(sample->key) == previousByKey.end())
             {
                 try
@@ -797,11 +798,11 @@ DataReaderI::initSamples(
             if (sample->event == DataStorm::SampleEvent::PartialUpdate)
             {
                 auto p = previousByKey.find(sample->key);
-                if (p == previousByKey.end())
+                if (p == previousByKey.end() || !p->second->hasValue())
                 {
-                    // No base to resolve the partial update against (for example a peer writer that doesn't
-                    // bootstrap the base): drop the sample rather than apply the update to a default-constructed
-                    // value.
+                    // No usable base to resolve the partial update against (the key was never set, was removed, or
+                    // the base sample carries no value): drop the sample rather than apply the update to a
+                    // default-constructed value.
                     if (_traceLevels->data > 0)
                     {
                         Trace out(_traceLevels->logger, _traceLevels->dataCat);
@@ -826,8 +827,10 @@ DataReaderI::initSamples(
                     continue;
                 }
             }
-            else
+            else if (sample->event != DataStorm::SampleEvent::Remove)
             {
+                // A remove's value is irrelevant and is left default-constructed: skipping the decoding ensures a
+                // decoding failure cannot drop the remove and leave the key's stale base in place below.
                 try
                 {
                     sample->decode(_parent->instance()->getCommunicator());
@@ -841,7 +844,17 @@ DataReaderI::initSamples(
             }
         }
         valid.push_back(sample);
-        previousByKey[sample->key] = sample;
+
+        // A remove clears the per-key base: the key has no value anymore, so a later partial update for the key
+        // has no base to resolve against and is discarded.
+        if (sample->event == DataStorm::SampleEvent::Remove)
+        {
+            previousByKey.erase(sample->key);
+        }
+        else
+        {
+            previousByKey[sample->key] = sample;
+        }
     }
 
     if (_traceLevels->data > 2 && valid.size() < samples.size())
@@ -971,8 +984,9 @@ DataReaderI::queue(
 
         // The discard only affects the application-visible delivery: when the key has no base yet, still record the
         // discarded sample as the base partial updates resolve against, otherwise a later partial update on the key
-        // would have no base.
-        if (sample->event != DataStorm::SampleEvent::PartialUpdate && _lastByKey.find(sample->key) == _lastByKey.end())
+        // would have no base. A remove carries no value and cannot serve as a base.
+        if (sample->event != DataStorm::SampleEvent::PartialUpdate && sample->event != DataStorm::SampleEvent::Remove &&
+            _lastByKey.find(sample->key) == _lastByKey.end())
         {
             try
             {
@@ -995,10 +1009,11 @@ DataReaderI::queue(
         if (sample->event == DataStorm::SampleEvent::PartialUpdate)
         {
             auto p = _lastByKey.find(sample->key);
-            if (p == _lastByKey.end())
+            if (p == _lastByKey.end() || !p->second->hasValue())
             {
-                // No base to resolve the partial update against (for example a peer writer that doesn't bootstrap
-                // the base): drop the sample rather than apply the update to a default-constructed value.
+                // No usable base to resolve the partial update against (the key was never set, was removed, or the
+                // base sample carries no value): drop the sample rather than apply the update to a
+                // default-constructed value.
                 if (_traceLevels->data > 0)
                 {
                     Trace out(_traceLevels->logger, _traceLevels->dataCat);
@@ -1020,8 +1035,10 @@ DataReaderI::queue(
                 return;
             }
         }
-        else
+        else if (sample->event != DataStorm::SampleEvent::Remove)
         {
+            // A remove's value is irrelevant and is left default-constructed: skipping the decoding ensures a
+            // decoding failure cannot drop the remove and leave the key's stale base in place below.
             try
             {
                 sample->decode(_parent->instance()->getCommunicator());
@@ -1037,7 +1054,16 @@ DataReaderI::queue(
     _lastSendTime = sample->timestamp;
 
     // The per-key base for partial updates is maintained even when the element keeps no history (sampleCount == 0).
-    _lastByKey[sample->key] = sample;
+    // A remove clears the base: the key has no value anymore, so a later partial update for the key has no base to
+    // resolve against and is discarded.
+    if (sample->event == DataStorm::SampleEvent::Remove)
+    {
+        _lastByKey.erase(sample->key);
+    }
+    else
+    {
+        _lastByKey[sample->key] = sample;
+    }
 
     if (_onSamples)
     {
@@ -1154,8 +1180,15 @@ DataWriterI::publish(const shared_ptr<Key>& key, const shared_ptr<Sample>& sampl
     {
         assert(!sample->hasValue());
         auto p = _lastByKey.find(key);
-        _parent->getUpdater(
-            sample->tag)(p == _lastByKey.end() ? nullptr : p->second, sample, _parent->instance()->getCommunicator());
+        if (p == _lastByKey.end())
+        {
+            // No base to resolve the partial update against (the key was never set, or was removed): discard the
+            // update rather than apply it to a default-constructed value, like the reader side does.
+            Warning out(_traceLevels->logger);
+            out << this << ": discarded partial update: no base value for the key";
+            return;
+        }
+        _parent->getUpdater(sample->tag)(p->second, sample, _parent->instance()->getCommunicator());
     }
 
     sample->id = ++_parent->_nextSampleId;
@@ -1169,7 +1202,16 @@ DataWriterI::publish(const shared_ptr<Key>& key, const shared_ptr<Sample>& sampl
     send(key, sample);
 
     // The per-key base for partial updates is maintained even when the element keeps no history (sampleCount == 0).
-    _lastByKey[key] = sample;
+    // A remove clears the base: the key has no value anymore, so a later partial update for the key has no base to
+    // resolve against and is discarded.
+    if (sample->event == DataStorm::SampleEvent::Remove)
+    {
+        _lastByKey.erase(key);
+    }
+    else
+    {
+        _lastByKey[key] = sample;
+    }
 
     if (_config->sampleLifetime && *_config->sampleLifetime > 0)
     {

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <set>
+#include <stdexcept>
 
 using namespace std;
 using namespace DataStormI;
@@ -1182,12 +1183,12 @@ DataWriterI::publish(const shared_ptr<Key>& key, const shared_ptr<Sample>& sampl
         auto p = _lastByKey.find(key);
         if (p == _lastByKey.end())
         {
-            // No base to resolve the partial update against (the key was never set, or was removed): discard the
-            // update rather than apply it to a default-constructed value. The reader side discards such updates
-            // the same way.
-            Warning out(_traceLevels->logger);
-            out << this << ": discarded partial update: no base value for the key";
-            return;
+            // No base to resolve the partial update against: the key was never given a full value, or its last
+            // value was removed. On the writer this is always an application sequencing error, because _lastByKey
+            // holds only this writer's own published samples, so no other writer's remove can clear it (unlike the
+            // reader, where a concurrent remove can legitimately leave the key with no base). Throw so the mistake
+            // surfaces at the partialUpdate call site instead of being silently dropped.
+            throw std::logic_error("cannot apply a partial update to a key that has no value");
         }
         _parent->getUpdater(sample->tag)(p->second, sample, _parent->instance()->getCommunicator());
     }

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -772,6 +772,11 @@ DataReaderI::initSamples(
             // The discard only affects the application-visible delivery: when the key has no base yet, still record
             // the discarded sample as the base partial updates resolve against, otherwise a later partial update on
             // the key would have no base. A remove carries no value and cannot serve as a base.
+            //
+            // Accepted trade-off (as in queue): a remove erases the key's base rather than leaving a tombstone, so a
+            // stale full update that loses the discard race can re-seed it here and let a following partial update
+            // resolve for a key last seen removed. This is strictly better than the pre-fix crash and a tombstone to
+            // distinguish the two states isn't worth it.
             if (sample->event != DataStorm::SampleEvent::PartialUpdate &&
                 sample->event != DataStorm::SampleEvent::Remove &&
                 previousByKey.find(sample->key) == previousByKey.end())
@@ -877,17 +882,15 @@ DataReaderI::initSamples(
             });
     }
 
+    // The per-key bases for partial updates are maintained even when the element keeps no history (sampleCount == 0),
+    // and even when every sample was discarded or dropped, so a later partial update on their keys can resolve.
+    _lastByKey = std::move(previousByKey);
+
     if (valid.empty())
     {
-        // Even when every sample was discarded or dropped, keep the bases recorded above so a later partial update
-        // on their keys can resolve.
-        _lastByKey = std::move(previousByKey);
         return;
     }
     _lastSendTime = valid.back()->timestamp;
-
-    // The per-key bases for partial updates are maintained even when the element keeps no history (sampleCount == 0).
-    _lastByKey = std::move(previousByKey);
 
     if (_config->sampleLifetime && *_config->sampleLifetime > 0)
     {
@@ -986,6 +989,11 @@ DataReaderI::queue(
         // The discard only affects the application-visible delivery: when the key has no base yet, still record the
         // discarded sample as the base partial updates resolve against, otherwise a later partial update on the key
         // would have no base. A remove carries no value and cannot serve as a base.
+        //
+        // Accepted trade-off: a remove erases the key's base rather than leaving a tombstone, so this cannot tell
+        // "removed" from "never seen". A stale full update that loses the discard race can re-seed the base here and
+        // let a following partial update resolve for a key the application last saw removed. This is strictly better
+        // than the pre-fix crash; distinguishing the two states would need a remove tombstone and isn't worth it.
         if (sample->event != DataStorm::SampleEvent::PartialUpdate && sample->event != DataStorm::SampleEvent::Remove &&
             _lastByKey.find(sample->key) == _lastByKey.end())
         {
@@ -1181,13 +1189,15 @@ DataWriterI::publish(const shared_ptr<Key>& key, const shared_ptr<Sample>& sampl
     {
         assert(!sample->hasValue());
         auto p = _lastByKey.find(key);
-        if (p == _lastByKey.end())
+        if (p == _lastByKey.end() || !p->second->hasValue())
         {
             // No base to resolve the partial update against: the key was never given a full value, or its last
             // value was removed. On the writer this is always an application sequencing error, because _lastByKey
             // holds only this writer's own published samples, so no other writer's remove can clear it (unlike the
             // reader, where a concurrent remove can legitimately leave the key with no base). Throw so the mistake
-            // surfaces at the partialUpdate call site instead of being silently dropped.
+            // surfaces at the partialUpdate call site instead of being silently dropped. The value-less check
+            // mirrors the reader's guards: a remove erases the base rather than storing a value-less one, so it
+            // can't fire here today, but both sides consume _lastByKey with identical semantics.
             throw std::logic_error("cannot apply a partial update to a key that has no value");
         }
         _parent->getUpdater(sample->tag)(p->second, sample, _parent->instance()->getCommunicator());

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -1183,7 +1183,8 @@ DataWriterI::publish(const shared_ptr<Key>& key, const shared_ptr<Sample>& sampl
         if (p == _lastByKey.end())
         {
             // No base to resolve the partial update against (the key was never set, or was removed): discard the
-            // update rather than apply it to a default-constructed value, like the reader side does.
+            // update rather than apply it to a default-constructed value. The reader side discards such updates
+            // the same way.
             Warning out(_traceLevels->logger);
             out << this << ": discarded partial update: no base value for the key";
             return;

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -15,8 +15,10 @@ namespace
     static Topic::Updater noOpUpdater = // NOLINT(cert-err58-cpp)
         [](const shared_ptr<Sample>& previous, const shared_ptr<Sample>& next, const CommunicatorPtr&)
     {
-        // Callers discard partial updates that have no usable base before invoking the updater; assert that here,
-        // and keep the default-value fallback as defense in depth for release builds.
+        // Every updater call site ensures the previous sample exists and has a value before invoking the updater
+        // (the writer throws otherwise, the reader drops the sample), so this assert holds. A broken invariant is not
+        // made safe here: setValue(nullptr) stores a default-constructed value with _hasValue == true, resurrecting
+        // the removed key from a default value — the very bug the call sites prevent.
         assert(previous && previous->hasValue());
         next->setValue(previous && previous->hasValue() ? previous : nullptr);
     };

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -14,7 +14,11 @@ namespace
 {
     static Topic::Updater noOpUpdater = // NOLINT(cert-err58-cpp)
         [](const shared_ptr<Sample>& previous, const shared_ptr<Sample>& next, const CommunicatorPtr&)
-    { next->setValue(previous); };
+    {
+        // A value-less previous sample is not a usable base: fall back to a default value. This is defense in
+        // depth: callers discard partial updates that have no usable base before invoking the updater.
+        next->setValue(previous && previous->hasValue() ? previous : nullptr);
+    };
 
     // The always match filter always matches the value, it's used by the any key reader/writer.
     class AlwaysMatchFilter final : public Filter

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -15,8 +15,9 @@ namespace
     static Topic::Updater noOpUpdater = // NOLINT(cert-err58-cpp)
         [](const shared_ptr<Sample>& previous, const shared_ptr<Sample>& next, const CommunicatorPtr&)
     {
-        // A value-less previous sample is not a usable base: fall back to a default value. This is defense in
-        // depth: callers discard partial updates that have no usable base before invoking the updater.
+        // Callers discard partial updates that have no usable base before invoking the updater; assert that here,
+        // and keep the default-value fallback as defense in depth for release builds.
+        assert(previous && previous->hasValue());
         next->setValue(previous && previous->hasValue() ? previous : nullptr);
     };
 

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -402,9 +402,16 @@ void ::Writer::run(int argc, char* argv[])
         test(skw.getLast().getKey() == "key");
         test(skw.getLast().getValue() == "");
         test(skw.getLast().getEvent() == SampleEvent::Remove);
-        // A partial update requires the key to have a current value; after the remove it has none, so the partial
-        // update is discarded and the remove stays the last sample.
-        skw.partialUpdate<string>("partialupdate")("update");
+        // A partial update requires the key to have a current value; after the remove it has none, so publishing a
+        // partial update throws and the remove stays the last sample.
+        try
+        {
+            skw.partialUpdate<string>("partialupdate")("update");
+            test(false);
+        }
+        catch (const std::logic_error&)
+        {
+        }
         test(skw.getLast().getEvent() == SampleEvent::Remove);
         // A new full value makes the key updatable again.
         skw.add("test3");

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -402,9 +402,15 @@ void ::Writer::run(int argc, char* argv[])
         test(skw.getLast().getKey() == "key");
         test(skw.getLast().getValue() == "");
         test(skw.getLast().getEvent() == SampleEvent::Remove);
+        // A partial update requires the key to have a current value; after the remove it has none, so the partial
+        // update is discarded and the remove stays the last sample.
+        skw.partialUpdate<string>("partialupdate")("update");
+        test(skw.getLast().getEvent() == SampleEvent::Remove);
+        // A new full value makes the key updatable again.
+        skw.add("test3");
         skw.partialUpdate<string>("partialupdate")("update");
         test(skw.getLast().getKey() == "key");
-        test(skw.getLast().getValue() == "");
+        test(skw.getLast().getValue() == "test3"); // no updater is registered: the previous value carries over
         test(skw.getLast().getUpdateTag() == "partialupdate");
         test(skw.getLast().getEvent() == SampleEvent::PartialUpdate);
 

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -334,8 +334,8 @@ void ::Reader::run(int argc, char* argv[])
         done.update(0);
     }
 
-    // A partial update requires the key to have a current value: after a remove, the writer discards the partial
-    // update and publishes nothing; the next full value makes the key updatable again.
+    // A partial update requires the key to have a current value: after a remove, publishing a partial update throws
+    // on the writer and nothing is published; the next full value makes the key updatable again.
     Topic<string, StockPtr> removeTopic(node, "removeTopic");
     removeTopic.setReaderDefaultConfig(config);
     removeTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
@@ -383,6 +383,42 @@ void ::Reader::run(int argc, char* argv[])
         }
         test(sawRemove);
         test(resync->lastBid == 201.0f); // writer 2's full value, not a merge against a stale base
+    }
+
+    // A late-joining reader initializes across a remove. It receives the add, the remove, the re-add, and the partial
+    // update as initialization samples; the remove clears the key's base within the init batch and the partial
+    // resolves against the re-added value, not the pre-remove value or a default-constructed one.
+    Topic<string, StockPtr> initRemoveTopic(node, "initRemoveTopic");
+    initRemoveTopic.setReaderDefaultConfig(config);
+    initRemoveTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> initRemoveBarrier(node, "initRemoveBarrier");
+    {
+        // Wait until the writer has published all four samples, then attach as a late joiner.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(initRemoveBarrier, "barrier").getNextUnread();
+
+        auto reader = makeSingleKeyReader(initRemoveTopic, "AAPL");
+
+        auto sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Add);
+        test(sample.getValue()->price == 12.0f);
+
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Remove);
+
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Add);
+        test(sample.getValue()->price == 20.0f);
+
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::PartialUpdate);
+        test(sample.getValue()->price == 25.0f);   // resolved against the re-added value
+        test(sample.getValue()->lastBid == 21.0f); // carried from the re-added value, not the pre-remove value
+        test(sample.getValue()->lastAsk == 22.0f);
+
+        // Tell the writer the samples were verified.
+        auto done = makeSingleKeyWriter(initRemoveBarrier, "done");
+        done.waitForReaders();
+        done.update(0);
     }
 }
 

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -333,6 +333,57 @@ void ::Reader::run(int argc, char* argv[])
         done.waitForReaders();
         done.update(0);
     }
+
+    // A partial update requires the key to have a current value: after a remove, the writer discards the partial
+    // update and publishes nothing; the next full value makes the key updatable again.
+    Topic<string, StockPtr> removeTopic(node, "removeTopic");
+    removeTopic.setReaderDefaultConfig(config);
+    removeTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    {
+        auto reader = makeSingleKeyReader(removeTopic, "AAPL");
+
+        auto sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Add);
+        test(sample.getValue()->price == 12.0f);
+
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Remove);
+
+        // The discarded partial update was never published: the next sample is the full update.
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Update);
+        test(sample.getValue()->price == 20.0f);
+    }
+
+    // Two writers publish the same key: writer 2's partial update reaches the reader after writer 1's remove
+    // cleared the key's value. The reader discards the partial update and resynchronizes on writer 2's next full
+    // value.
+    Topic<string, StockPtr> twoWritersTopic(node, "twoWritersTopic");
+    twoWritersTopic.setReaderDefaultConfig(config);
+    twoWritersTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    {
+        auto reader = makeSingleKeyReader(twoWritersTopic, "AAPL");
+
+        // Consume until writer 2's resynchronizing full value; the partial update published after the remove must
+        // never surface.
+        bool sawRemove = false;
+        shared_ptr<Stock> resync;
+        while (!resync)
+        {
+            auto sample = reader.getNextUnread();
+            test(sample.getEvent() != SampleEvent::PartialUpdate);
+            if (sample.getEvent() == SampleEvent::Remove)
+            {
+                sawRemove = true;
+            }
+            else if (sample.getValue()->price == 200.0f)
+            {
+                resync = sample.getValue();
+            }
+        }
+        test(sawRemove);
+        test(resync->lastBid == 201.0f); // writer 2's full value, not a merge against a stale base
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -287,7 +287,8 @@ void ::Writer::run(int argc, char* argv[])
 
     // Two writers publish the same key: writer 2's partial update reaches the reader after writer 1's remove
     // cleared the key's value. The reader discards the partial update and resynchronizes on writer 2's next full
-    // value.
+    // value. Both writers deliver through the node's single session connection and the reader node dispatches
+    // samples serialized, so the reader is guaranteed to process the remove before the partial update.
     Topic<string, StockPtr> twoWritersTopic(node, "twoWritersTopic");
     twoWritersTopic.setWriterDefaultConfig(config);
     twoWritersTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -319,6 +319,32 @@ void ::Writer::run(int argc, char* argv[])
         writer2.waitForNoReaders();
     }
     cout << "ok" << endl;
+
+    // A reader that joins late initializes across a remove: the writer's history holds an add, a remove, a re-add,
+    // and a partial update, all delivered as initialization samples. The remove clears the key's base within the
+    // init batch, the re-add re-establishes it, and the trailing partial update resolves against the re-added value.
+    Topic<string, StockPtr> initRemoveTopic(node, "initRemoveTopic");
+    initRemoveTopic.setWriterDefaultConfig(config); // keep full history so the reader initializes from all four samples
+    initRemoveTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    Topic<string, int> initRemoveBarrier(node, "initRemoveBarrier");
+    cout << "testing partial update to a late joiner across a remove... " << flush;
+    {
+        auto writer = makeSingleKeyWriter(initRemoveTopic, "AAPL");
+        writer.add(make_shared<Stock>(12.0f, 13.0f, 14.0f));
+        writer.remove();
+        writer.add(make_shared<Stock>(20.0f, 21.0f, 22.0f));
+        writer.partialUpdate<float>("price")(25.0f); // resolves against the re-added value
+
+        // Let the reader attach as a late joiner, after all four samples are in history.
+        auto barrier = makeSingleKeyWriter(initRemoveBarrier, "barrier");
+        barrier.waitForReaders();
+        barrier.update(0);
+
+        // The reader only consumes initialization samples, so wait until it verified them rather than on the reader
+        // count, which would race with its attach/detach.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(initRemoveBarrier, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
 }
 
 DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -345,6 +345,21 @@ void ::Writer::run(int argc, char* argv[])
         [[maybe_unused]] auto _ = makeSingleKeyReader(initRemoveBarrier, "done").getNextUnread();
     }
     cout << "ok" << endl;
+
+    // A null class value is a valid base value. With no updater registered, the no-op updater resolves the partial
+    // update by carrying the previous value over: it clones the null base to null instead of dereferencing it.
+    Topic<string, StockPtr> nullValueTopic(node, "nullValueTopic");
+    nullValueTopic.setWriterDefaultConfig(config);
+    // Intentionally no updater registered, so the no-op updater resolves the partial update.
+    cout << "testing partial update against a null class value... " << flush;
+    {
+        auto writer = makeSingleKeyWriter(nullValueTopic, "AAPL");
+        writer.add(nullptr); // a legitimate null class value establishes the base
+        writer.partialUpdate<float>("price")(15.0f);
+        test(writer.getLast().getEvent() == SampleEvent::PartialUpdate);
+        test(writer.getLast().getValue() == nullptr); // the null base was cloned to null, not dereferenced
+    }
+    cout << "ok" << endl;
 }
 
 DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -267,8 +267,9 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
-    // A partial update requires the key to have a current value: after a remove, the writer discards the partial
-    // update and publishes nothing; the next full value makes the key updatable again.
+    // A partial update requires the key to have a current value: after a remove, publishing a partial update is an
+    // application error that throws logic_error and publishes nothing; the next full value makes the key updatable
+    // again.
     Topic<string, StockPtr> removeTopic(node, "removeTopic");
     removeTopic.setWriterDefaultConfig(config);
     removeTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
@@ -278,8 +279,15 @@ void ::Writer::run(int argc, char* argv[])
         writer.waitForReaders();
         writer.add(make_shared<Stock>(12.0f, 13.0f, 14.0f));
         writer.remove();
-        writer.partialUpdate<float>("price")(15.0f);              // discarded: the key has no value after the remove
-        test(writer.getLast().getEvent() == SampleEvent::Remove); // the discarded update was not published
+        try
+        {
+            writer.partialUpdate<float>("price")(15.0f);
+            test(false);
+        }
+        catch (const std::logic_error&)
+        {
+        }
+        test(writer.getLast().getEvent() == SampleEvent::Remove); // the rejected update was not published
         writer.update(make_shared<Stock>(20.0f, 21.0f, 22.0f));
         writer.waitForNoReaders();
     }

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -266,6 +266,50 @@ void ::Writer::run(int argc, char* argv[])
         [[maybe_unused]] auto _ = makeSingleKeyReader(throwBarrier, "done").getNextUnread();
     }
     cout << "ok" << endl;
+
+    // A partial update requires the key to have a current value: after a remove, the writer discards the partial
+    // update and publishes nothing; the next full value makes the key updatable again.
+    Topic<string, StockPtr> removeTopic(node, "removeTopic");
+    removeTopic.setWriterDefaultConfig(config);
+    removeTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    cout << "testing partial update after remove... " << flush;
+    {
+        auto writer = makeSingleKeyWriter(removeTopic, "AAPL");
+        writer.waitForReaders();
+        writer.add(make_shared<Stock>(12.0f, 13.0f, 14.0f));
+        writer.remove();
+        writer.partialUpdate<float>("price")(15.0f);              // discarded: the key has no value after the remove
+        test(writer.getLast().getEvent() == SampleEvent::Remove); // the discarded update was not published
+        writer.update(make_shared<Stock>(20.0f, 21.0f, 22.0f));
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // Two writers publish the same key: writer 2's partial update reaches the reader after writer 1's remove
+    // cleared the key's value. The reader discards the partial update and resynchronizes on writer 2's next full
+    // value.
+    Topic<string, StockPtr> twoWritersTopic(node, "twoWritersTopic");
+    twoWritersTopic.setWriterDefaultConfig(config);
+    twoWritersTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    cout << "testing partial update after another writer's remove... " << flush;
+    {
+        auto writer1 = makeSingleKeyWriter(twoWritersTopic, "AAPL", "writer1");
+        auto writer2 = makeSingleKeyWriter(twoWritersTopic, "AAPL", "writer2");
+        writer1.waitForReaders();
+        writer2.waitForReaders();
+        writer1.add(make_shared<Stock>(12.0f, 13.0f, 14.0f));
+        writer2.add(make_shared<Stock>(100.0f, 101.0f, 102.0f));
+        writer1.remove();
+        // Writer 2 resolves the partial update against its own value and publishes it, but the reader no longer
+        // has a value for the key.
+        writer2.partialUpdate<float>("price")(55.0f);
+        test(writer2.getLast().getEvent() == SampleEvent::PartialUpdate);
+        test(writer2.getLast().getValue()->price == 55.0f);
+        writer2.update(make_shared<Stock>(200.0f, 201.0f, 202.0f));
+        writer1.waitForNoReaders();
+        writer2.waitForNoReaders();
+    }
+    cout << "ok" << endl;
 }
 
 DEFINE_TEST(::Writer)


### PR DESCRIPTION
A partial update resolves against the key's current value, but `publish`, `queue`, and `initSamples` recorded every sample—including a value-less `Remove`—as the per-key base. Resolving a later partial update against such a base cloned a value the sample doesn't have: applications using class-typed values typically crashed (`ice_clone` on a nil handle), and other value types silently resurrected the removed key from a default-constructed value.

With this change:

- A `Remove` clears the key's per-key base, on the writer and on the reader (live samples, init samples, and the discard-policy base seeding).
- A partial update for a key with no base value—no full value was written yet, or the key was removed—is discarded: the writer logs a warning and publishes nothing, matching the reader-side drop introduced by #5882. The `partialUpdate` API docs now state this contract.
- `Cloner<std::shared_ptr<T>>` (Ice values) clones a null value to null instead of dereferencing it, and the `setUpdater` wrapper and `noOpUpdater` treat a value-less previous sample as absent: a legitimate null class value (`writer.add(nullptr)`) no longer crashes the resolution path.
- `SampleT::_value` and the updater wrapper's local value are value-initialized: a remove sample's value was previously indeterminate for scalar value types (and those indeterminate bytes were encoded on the wire).

The `partial` test gains two scenarios: a writer discarding a partial update published after its own `remove`, and a reader discarding a partial update from one writer that arrives after another writer's `remove` of the same key (previously both crashed for class-typed topics, reproduced red→green). The `api` test's sample block is updated to the new contract.

Fixes zeroc-ice/ice-audit#103.
