### PR TITLE
Reject malformed hosts and non-IP endpoints in the Glacier2 address filters

### DIFF
--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <cctype>
+#include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -538,36 +540,64 @@ namespace Glacier2
         return true;
     }
 
-    // Returns true when an endpoint of the proxy has a host that the address rules cannot match reliably;
-    // when an address filter is configured, such a proxy is rejected outright:
-    // - A host longer than 255 characters. No legal host name or IP address is that long, and the bound keeps
-    //   the cost of matching the address rules low.
+    // Returns the host of the innermost IP endpoint underlying an endpoint, or nullopt when no such endpoint
+    // exists: the transport is not IP based (such as Bluetooth), or it is unknown to this communicator. An
+    // unknown transport, including an IP-based one whose plug-in is not loaded, is opaque and carries no typed
+    // endpoint info, so it is indistinguishable from a non-IP transport here.
+    static optional<string> ipEndpointHost(const EndpointPtr& endpoint)
+    {
+        for (EndpointInfoPtr info = endpoint->getInfo(); info; info = info->underlying)
+        {
+            if (auto ipInfo = dynamic_pointer_cast<IPEndpointInfo>(info))
+            {
+                return ipInfo->host;
+            }
+        }
+        return nullopt;
+    }
+
+    // Returns true when an endpoint of the proxy has a host that the address rules cannot match reliably:
+    // - A non-IP endpoint (such as Bluetooth), or an endpoint whose transport is unknown to this communicator.
+    // - An empty host.
+    // - A host containing a control character or a space.
+    // - A host longer than 255 characters. No legal host name or IP address is that long.
     // - A non-canonical spelling of an IPv4 address, such as 0x7f000001, 2130706433, 0177.0.0.1, or 127.1.
-    //   The resolver accepts many aliases for the same address (with platform-dependent readings), so the
-    //   spelling would bypass rules written for the dotted quad.
     // - An IPv4 address with a trailing dot: the resolver reads it as a DNS name, not as an address.
     // A DNS name with a trailing dot is fine: the resolver treats 'name.' as 'name', and the matching strips
     // the dot the same way.
+    // Returns false for an indirect proxy: it has no endpoints, so there is no host to check here (the address
+    // rules match nothing, and the identity and adapter-id filters constrain it instead).
     static bool hasDisallowedHost(const ObjectPrx& proxy)
     {
         for (const auto& endpoint : proxy->ice_getEndpoints())
         {
-            string host;
-            if (extractPart("-h ", endpoint->toString(), host))
+            optional<string> optHost = ipEndpointHost(endpoint);
+            if (!optHost)
             {
-                if (host.size() > 255)
-                {
-                    return true;
-                }
-                bool trailingDot = host.size() > 1 && host.back() == '.';
-                if (trailingDot)
-                {
-                    host.pop_back();
-                }
-                if (isIPv4Numeral(host) && (trailingDot || !isCanonicalIPv4Spelling(host)))
-                {
-                    return true;
-                }
+                return true;
+            }
+            string host = std::move(*optHost);
+
+            if (host.empty())
+            {
+                return true;
+            }
+            if (any_of(host.begin(), host.end(), [](unsigned char c) { return c == ' ' || iscntrl(c) != 0; }))
+            {
+                return true;
+            }
+            if (host.size() > 255)
+            {
+                return true;
+            }
+            bool trailingDot = host.size() > 1 && host.back() == '.';
+            if (trailingDot)
+            {
+                host.pop_back();
+            }
+            if (isIPv4Numeral(host) && (trailingDot || !isCanonicalIPv4Spelling(host)))
+            {
+                return true;
             }
         }
         return false;

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -491,6 +491,35 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                     ],
                     [],
                 ),
+                (
+                    # An endpoint with no host is rejected outright: Ice resolves it to the loopback address,
+                    # yet it matches no address rule, so without the rejection a reject rule for loopback would
+                    # not catch a proxy that connects to loopback. The same accepted IP endpoint flips to
+                    # rejected once the host-less endpoint is added alongside it, so the host-less endpoint
+                    # cannot ride in behind a legitimate one.
+                    "testing address filter rejects an endpoint with no host",
+                    ("", "127.0.0.1", "", "", "", ""),
+                    [
+                        (True, "hello:tcp -h localhost -p 12010"),
+                        (False, "hello:tcp -p 12010"),
+                        (False, "hello:tcp -h localhost -p 12010:tcp -p 12010"),
+                    ],
+                    [],
+                ),
+                (
+                    # A proxy with a non-IP endpoint (here an opaque endpoint of an unknown transport) is
+                    # rejected outright: the address rules describe IP hosts and ports, so an endpoint they
+                    # cannot interpret is rejected rather than admitted unchecked. The same accepted IP endpoint
+                    # flips to rejected once the non-IP endpoint is added alongside it, so the non-IP endpoint
+                    # cannot ride in behind a legitimate one.
+                    "testing address filter rejects a non-IP endpoint",
+                    ("", "127.0.0.1", "", "", "", ""),
+                    [
+                        (True, "hello:tcp -h localhost -p 12010"),
+                        (False, "hello:tcp -h localhost -p 12010:opaque -t 99 -v ABCD"),
+                    ],
+                    [],
+                ),
             ]
         )
 


### PR DESCRIPTION
Follow-up to #6049. When address filters are configured, the Glacier2 router now rejects a proxy outright when any of its endpoints:

- is not IP-based (such as a Bluetooth endpoint), or uses a transport unknown to the router — the address rules describe IP hosts and ports, so an endpoint they cannot interpret is rejected rather than admitted unchecked;
- has an empty host — Ice resolves it to the loopback address, yet it matches no address rule, so a reject rule for loopback would not catch it;
- has a host containing a control character or a space — the resolver stops at an embedded null while the rules see the whole string, and a space can split an injected option (such as ` -p `) out of the rendered endpoint, letting the endpoint the router connects to differ from the one the rules matched.

The `hasDisallowedHost` check introduced by #6049 now reads the host from the typed `IPEndpointInfo` (walking `underlying` for ssl/ws/wss) instead of parsing the endpoint's string representation. That rendering was never meant to carry this check: an empty host emits no `-h` option at all, and an embedded null or space renders ambiguously.

The new static filtering test cases verify that a proxy pairing a legitimate accepted endpoint with a host-less or non-IP endpoint flips to rejected, so such an endpoint cannot ride in behind a legitimate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)