### PR TITLE
Reject DataStorm.Node.Multicast.Proxy proxies with an unexpected identity

### DIFF
--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -188,18 +188,24 @@ Instance::init(std::optional<Ice::SSL::ServerAuthenticationOptions> serverAuthen
     _nodeSessionManager = make_shared<NodeSessionManager>(self, _node);
     _nodeSessionManager->init();
 
+    const Identity lookupId{.name = "Lookup", .category = "DataStorm"};
     auto lookupI = make_shared<LookupI>(_nodeSessionManager, _topicFactory, _node->getProxy());
-    _adapter->add(lookupI, Identity{.name = "Lookup", .category = "DataStorm"});
+    _adapter->add(lookupI, lookupId);
     if (_multicastAdapter)
     {
-        auto lookup = _multicastAdapter->add<DataStormContract::LookupPrx>(
-            lookupI,
-            Identity{.name = "Lookup", .category = "DataStorm"});
+        auto lookup = _multicastAdapter->add<DataStormContract::LookupPrx>(lookupI, lookupId);
         // The lookup proxy can be customized by setting the property DataStorm.Node.Multicast.Proxy.
         if (!_communicator->getProperties()->getIceProperty("DataStorm.Node.Multicast.Proxy").empty())
         {
             // propertyToProxy only returns a nullopt proxy when the property is empty.
             lookup = *_communicator->propertyToProxy<DataStormContract::LookupPrx>("DataStorm.Node.Multicast.Proxy");
+            if (lookup->ice_getIdentity() != lookupId)
+            {
+                ostringstream os;
+                os << "property 'DataStorm.Node.Multicast.Proxy' has an invalid value: the proxy identity must be '"
+                   << identityToString(lookupId) << "'";
+                throw PropertyException{__FILE__, __LINE__, os.str()};
+            }
         }
         _lookup = lookup->ice_datagram();
     }

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -152,6 +152,28 @@ void ::Writer::run(int argc, char* argv[])
                 Topic<int, string> topic(n15, "discardPolicyAlias");
                 auto reader = makeSingleKeyReader(topic, 0);
             }
+
+            // A DataStorm.Node.Multicast.Proxy value must carry the lookup object identity; any other identity is
+            // rejected by the Node constructor.
+            {
+                Ice::CommunicatorHolder holder{Ice::initialize(makeInitData(
+                    "DataStorm.Node.Multicast.Proxy",
+                    "DataStorm/CustomLookup -d:udp -h 239.255.0.1 -p 10000"))};
+                try
+                {
+                    Node n16{holder.communicator()};
+                    test(false);
+                }
+                catch (const Ice::PropertyException&)
+                {
+                }
+
+                test(holder.communicator()->getDefaultObjectAdapter() == nullptr);
+                holder.communicator()->getProperties()->setProperty(
+                    "DataStorm.Node.Multicast.Proxy",
+                    "DataStorm/Lookup -d:udp -h 239.255.0.1 -p 10000");
+                Node n17{holder.communicator()};
+            }
         }
 
         Node n3;


### PR DESCRIPTION
The identity configured in a `DataStorm.Node.Multicast.Proxy` proxy is consumed by the receiving nodes' multicast object adapter, which dispatches announcements to the lookup servant registered under the fixed identity `DataStorm/Lookup`. An announcement sent to any other identity is dropped by every receiving node — silently, since announcements are oneway datagrams with no reply path. A non-default identity in this property can therefore only produce a discovery outage that is hard to diagnose.

With this change, the `Node` constructor validates the configured proxy and throws `Ice::PropertyException` when its identity is not `DataStorm/Lookup`, making the misconfiguration immediately visible at startup. The property's endpoints and proxy options remain fully configurable; only the identity is constrained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)