### PR TITLE
Detach a destroyed DataStorm topic's elements on every subscriber-erase path

### DIFF
--- a/changelog.d/datastorm/5821.md
+++ b/changelog.d/datastorm/5821.md
@@ -1,3 +1,4 @@
-- Fixed a bug in DataStorm where destroying a topic while its session's connection was closing could leave the
-  topic's readers or writers permanently attached to the disconnected peer: `hasWriters()`/`hasReaders()` stayed
-  true, `waitForNoWriters()`/`waitForNoReaders()` hung, and the disconnect callbacks never fired.
+- Fixed a bug in DataStorm where destroying a topic while the connection to a peer was closing or being
+  re-established could leave the topic's readers or writers permanently attached to that peer:
+  `hasWriters()`/`hasReaders()` stayed true, `waitForNoWriters()`/`waitForNoReaders()` hung, and the disconnect
+  callbacks never fired.

--- a/changelog.d/datastorm/5873.md
+++ b/changelog.d/datastorm/5873.md
@@ -1,0 +1,4 @@
+- Fixed a bug in DataStorm where destroying a topic at the same time as a peer topic detach, a session destruction,
+  or a session reconnection could leave the topic's readers or writers permanently attached to the peer:
+  `hasWriters()`/`hasReaders()` stayed true, `waitForNoWriters()`/`waitForNoReaders()` hung, and the disconnect
+  callbacks never fired.

--- a/changelog.d/datastorm/5873.md
+++ b/changelog.d/datastorm/5873.md
@@ -1,4 +1,0 @@
-- Fixed a bug in DataStorm where destroying a topic at the same time as a peer topic detach, a session destruction,
-  or a session reconnection could leave the topic's readers or writers permanently attached to the peer:
-  `hasWriters()`/`hasReaders()` stayed true, `waitForNoWriters()`/`waitForNoReaders()` hung, and the disconnect
-  callbacks never fired.

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -276,7 +276,14 @@ DataElementI::detachKey(
         return;
     }
 
+    // The subscriber can be gone when the element was already detached: the destroyed-topic cleanup paths can
+    // process an element a second time.
     auto subscriber = p->second.get(topicId, elementId);
+    if (!subscriber)
+    {
+        return;
+    }
+
     if (removeConnectedKey(key, subscriber))
     {
         if (key)
@@ -395,7 +402,14 @@ DataElementI::detachFilter(
         return;
     }
 
+    // The subscriber can be gone when the element was already detached: the destroyed-topic cleanup paths can
+    // process an element a second time.
     auto subscriber = p->second.get(topicId, filterId);
+    if (!subscriber)
+    {
+        return;
+    }
+
     if (removeConnectedKey(key, subscriber))
     {
         if (key)
@@ -597,7 +611,14 @@ DataElementI::addConnectedKey(const shared_ptr<Key>& key, const shared_ptr<Subsc
 bool
 DataElementI::removeConnectedKey(const shared_ptr<Key>& key, const shared_ptr<Subscriber>& subscriber)
 {
-    auto& subscribers = _connectedKeys[key];
+    // Don't use operator[]: a second detach of the same element looks up a key that was already removed, and
+    // must not insert an empty entry.
+    auto q = _connectedKeys.find(key);
+    if (q == _connectedKeys.end())
+    {
+        return false;
+    }
+    auto& subscribers = q->second;
     auto p = find(subscribers.begin(), subscribers.end(), subscriber);
     if (p != subscribers.end())
     {
@@ -609,7 +630,7 @@ DataElementI::removeConnectedKey(const shared_ptr<Key>& key, const shared_ptr<Su
                 _executor->queue([callback = _onConnectedKeys, key]
                                  { callback(DataStorm::CallbackReason::Disconnect, key); });
             }
-            _connectedKeys.erase(key);
+            _connectedKeys.erase(q);
         }
         return true;
     }

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -129,7 +129,8 @@ namespace DataStormI
 
             [[nodiscard]] std::shared_ptr<Subscriber> get(std::int64_t topicId, std::int64_t elementId)
             {
-                return subscribers.find(std::make_pair(topicId, elementId))->second;
+                auto p = subscribers.find(std::make_pair(topicId, elementId));
+                return p == subscribers.end() ? nullptr : p->second;
             }
 
             [[nodiscard]] bool remove(std::int64_t topicId, std::int64_t elementId)

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -103,11 +103,28 @@ SessionI::announceTopics(TopicInfoSeq topics, bool, const Current&)
         }
 
         // Reap dead topics corresponding to subscriptions from a previous session instance ID. Subscribers from the
-        // previous session instance ID that were not reattached to the new session instance ID are removed.
+        // previous session instance ID that were not reattached to the new session instance ID are removed. Before a
+        // subscriber is removed, detach its elements: a topic destroyed while the session was disconnected still
+        // holds element listeners (the detach paths skip destroyed topics), and TopicI::disconnect can no longer
+        // detach them once the subscriber entry is gone. The detach is a no-op for a subscriber whose elements were
+        // already detached when the session disconnected.
         auto p = _topics.begin();
         while (p != _topics.end())
         {
-            if (p->second.reap(_sessionInstanceId))
+            auto detach = [this, topicId = p->first](TopicI* topic, TopicSubscriber& subscriber)
+            {
+                if (subscriber.getAll().empty())
+                {
+                    // No element subscriptions: nothing to detach. The element subscribers are also what keeps the
+                    // topic alive (each element holds its parent topic), so the topic must not be dereferenced here.
+                    return;
+                }
+                unique_lock<mutex> topicLock(topic->getMutex());
+                _topicLock = &topicLock;
+                unsubscribe(topicId, topic);
+                _topicLock = nullptr;
+            };
+            if (p->second.reap(_sessionInstanceId, detach))
             {
                 _topics.erase(p++);
             }
@@ -190,9 +207,23 @@ SessionI::detachTopic(int64_t id, const Current&)
         return;
     }
 
-    runWithTopics(
-        id,
-        [&](TopicI* topic, TopicSubscriber&)
+    auto t = _topics.find(id);
+    if (t == _topics.end())
+    {
+        return;
+    }
+
+    for (auto& [topic, subscriber] : t->second.getSubscribers())
+    {
+        unique_lock<mutex> topicLock(topic->getMutex());
+        _topicLock = &topicLock;
+        if (topic->isDestroyed())
+        {
+            // The topic is being destroyed: TopicI::disconnect detaches its elements only while the subscriber
+            // entry exists, and the entry is erased below. Detach the elements directly instead.
+            unsubscribe(id, topic);
+        }
+        else
         {
             if (_traceLevels->session > 2)
             {
@@ -200,10 +231,12 @@ SessionI::detachTopic(int64_t id, const Current&)
                 out << _id << ": detaching topic '" << id << "' from '" << topic << "'";
             }
             topic->detach(id, shared_from_this());
-        });
+        }
+        _topicLock = nullptr;
+    }
 
     // Erase the topic
-    _topics.erase(id);
+    _topics.erase(t);
 }
 
 void
@@ -848,9 +881,24 @@ SessionI::destroyImpl(const exception_ptr& ex)
         _connection = nullptr;
 
         auto self = shared_from_this();
-        for (const auto& t : _topics)
+        for (auto& [topicId, subscribers] : _topics)
         {
-            runWithTopics(t.first, [id = t.first, self](TopicI* topic, TopicSubscriber&) { topic->detach(id, self); });
+            for (auto& [topic, subscriber] : subscribers.getSubscribers())
+            {
+                unique_lock<mutex> topicLock(topic->getMutex());
+                _topicLock = &topicLock;
+                if (topic->isDestroyed())
+                {
+                    // The topic is being destroyed: TopicI::disconnect detaches its elements only while the
+                    // subscriber entry exists, and the map is cleared below. Detach the elements directly instead.
+                    unsubscribe(topicId, topic);
+                }
+                else
+                {
+                    topic->detach(topicId, self);
+                }
+                _topicLock = nullptr;
+            }
         }
         _topics.clear();
     }

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -121,7 +121,19 @@ SessionI::announceTopics(TopicInfoSeq topics, bool, const Current&)
                 }
                 unique_lock<mutex> topicLock(topic->getMutex());
                 _topicLock = &topicLock;
-                unsubscribe(topicId, topic);
+                if (topic->isDestroyed())
+                {
+                    // The topic is being destroyed: TopicI::disconnect detaches its elements only while the
+                    // subscriber entry exists, and the entry is erased below. Detach the elements directly instead.
+                    unsubscribe(topicId, topic);
+                }
+                else
+                {
+                    // A live topic whose subscriber went stale (the peer topic was destroyed while the session was
+                    // disconnected, so it was not re-announced). Take the normal detach path, which also drops this
+                    // session from the topic's listeners.
+                    topic->detach(topicId, shared_from_this());
+                }
                 _topicLock = nullptr;
             };
             if (p->second.reap(_sessionInstanceId, detach))
@@ -213,7 +225,7 @@ SessionI::detachTopic(int64_t id, const Current&)
         return;
     }
 
-    for (auto& [topic, subscriber] : t->second.getSubscribers())
+    for (auto& [topic, _] : t->second.getSubscribers())
     {
         unique_lock<mutex> topicLock(topic->getMutex());
         _topicLock = &topicLock;
@@ -883,7 +895,7 @@ SessionI::destroyImpl(const exception_ptr& ex)
         auto self = shared_from_this();
         for (auto& [topicId, subscribers] : _topics)
         {
-            for (auto& [topic, subscriber] : subscribers.getSubscribers())
+            for (auto& [topic, _] : subscribers.getSubscribers())
             {
                 unique_lock<mutex> topicLock(topic->getMutex());
                 _topicLock = &topicLock;

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -708,6 +708,9 @@ SessionI::disconnectedImpl(const ConnectionPtr& connection, exception_ptr ex)
     auto self = shared_from_this();
     for (const auto& [topicId, _] : _topics)
     {
+        // The analyzer falsely flags the lambda's captures as undefined: it loses track of the closure once it
+        // is stored in runWithTopics' std::function parameter.
+        // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
         runWithTopics(topicId, [topicId, self](TopicI* topic, TopicSubscriber&) { topic->detach(topicId, self); });
     }
 

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -221,12 +221,18 @@ namespace DataStormI
 
             std::map<TopicI*, TopicSubscriber>& getSubscribers() { return _subscribers; }
 
-            // Determine if the subscriber should be reaped.
-            [[nodiscard]] bool reap(int sessionInstanceId)
+            // Determine if the subscriber should be reaped. The detach callback is called for each removed
+            // subscriber, before it is removed.
+            [[nodiscard]] bool reap(int sessionInstanceId, const std::function<void(TopicI*, TopicSubscriber&)>& detach)
             {
                 if (sessionInstanceId != _sessionInstanceId)
                 {
                     // If using a prior session instance id, we can remove all subscribers.
+                    for (auto& [topic, subscriber] : _subscribers)
+                    {
+                        detach(topic, subscriber);
+                    }
+                    _subscribers.clear();
                     return true;
                 }
 
@@ -236,6 +242,7 @@ namespace DataStormI
                     if (p->second.sessionInstanceId != sessionInstanceId)
                     {
                         // Remove the subscriber if it is using a prior session instance id.
+                        detach(p->first, p->second);
                         _subscribers.erase(p++);
                     }
                     else


### PR DESCRIPTION
Fixes #5873.

PR #5872 covered the main path: `SessionI::disconnect` — called by `TopicI::destroy` via `TopicI::disconnect` —
detaches a destroyed topic's elements as long as the session still holds the topic's subscriber entry. Three
sibling paths still erased that entry without running the element detach, so the destroy's own cleanup found
nothing to clean and the same leak occurred (stale element listener entries, `_listenerCount > 0` debug assert,
release `waitForNoWriters()`/`waitForNoReaders()` hang, pinned session servant):

1. a peer `detachTopic` (`runWithTopics` skips the destroyed topic, then `_topics.erase(id)` dropped the entry);
2. `SessionI::destroyImpl` (same shape, then `_topics.clear()`);
3. the reconnect reap in `announceTopics` (a destroyed topic cannot re-attach, so its subscriber kept the stale
   session instance id and was reaped wholesale).

## Fix

- `detachTopic` and `destroyImpl` now iterate the entry's subscribers directly: a live topic takes the normal
  `TopicI::detach` path; a destroyed topic gets its elements detached via `unsubscribe` under the topic mutex
  before the entry is erased. The later `TopicI::disconnect` then finds the entry gone and returns — the two
  cleaners serialize on the session mutex, so each subscriber is cleaned exactly once.
- `TopicSubscribers::reap` takes a detach callback invoked for each subscriber it removes, before removal. The
  callback skips subscribers with no element subscriptions: nothing to detach, and the element subscriptions are
  also what keeps the topic alive (each element holds its parent topic through a `const shared_ptr<TopicI>`), so
  a subscriber without them must not dereference the raw `TopicI*`. For stale subscribers whose elements were
  already detached when the connection was lost, the detach is a no-op.
- The element detach paths are fail-soft so processing an element twice is a no-op: `Listener::get` returns null
  instead of dereferencing an unchecked `find()`, `detachKey`/`detachFilter` guard on it, and
  `removeConnectedKey` no longer inserts an empty `_connectedKeys` entry when looking up an already-removed key.
  This also makes the callbacks and `_listenerCount` bookkeeping single-fire by construction.

The new `detachTopic`/`destroyImpl` loops dereference exactly the same `TopicI*` set the replaced
`runWithTopics` calls dereference today, so the change adds no new pointer-liveness exposure.

## Testing

No new test, for the same reason as #5872: each window requires the erase to land between `TopicI::destroy`
marking the topic destroyed and `TopicI::disconnect` acquiring the session mutex, which is not drivable
deterministically from the public API. The full DataStorm suite passes. A changelog fragment is included.
