### PR TITLE
Capture Windows process output as UTF-8 bytes

### DIFF
--- a/scripts/Expect.py
+++ b/scripts/Expect.py
@@ -455,8 +455,6 @@ class Expect(object):
             # import win32process
             # creationflags = win32process.CREATE_NEW_PROCESS_GROUP)
             #
-            # universal_newlines = True is necessary for Python 3 on Windows
-            #
             # We can't use shell=True because terminate() wouldn't
             # work. This means the PATH isn't searched for the
             # command.
@@ -472,7 +470,6 @@ class Expect(object):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 creationflags=CREATE_NEW_PROCESS_GROUP,
-                universal_newlines=True,
             )
         else:
             self.p = subprocess.Popen(
@@ -575,10 +572,7 @@ class Expect(object):
             self.logfile.write('%s: sendline: "%s"\n' % (self.desc, escape(data)))
             self.logfile.flush()
         data = data + "\n"
-        if win32 or sys.version_info[0] == 2:
-            self.p.stdin.write(data)
-        else:
-            self.p.stdin.write(data.encode("utf-8"))
+        self.p.stdin.write(data.encode("utf-8"))
 
     def wait(self, timeout=None):
         """Wait for the application to terminate for up to timeout seconds, or


### PR DESCRIPTION
Follow-up to #6081, from @pepone's review note there.

`Expect.py` spawned the child with `universal_newlines=True` on Windows, which meant:

- Output was decoded with the locale codepage instead of UTF-8, and arrived as `str` — so it never reached the incremental decoder #6081 added, and that fix only ever helped the POSIX path.
- `sendline()` had to write `str`, since it also makes stdin a text stream.

Dropping it puts both platforms on the same byte path, and `sendline()` now encodes UTF-8 unconditionally — which also removes a dead Python 2 branch.

One behaviour change: `universal_newlines=True` translated a lone `\r` to `\n`, whereas the reader's CR filter drops it. `\r\n` is unaffected.

The path is Windows-only, so nothing I can run here exercises it — worth a Windows CI run before merging.

No changelog fragment — `scripts/` doesn't ship.
