### PR TITLE
Bound the Ice::Service daemonize file-descriptor snapshot loop

### DIFF
--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -11,6 +11,7 @@
 #    include <winsock2.h>
 #else
 #    include "Network.h"
+#    include <algorithm>
 #    include <csignal>
 #    include <sys/resource.h>
 #    include <sys/stat.h>

--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -12,6 +12,7 @@
 #else
 #    include "Network.h"
 #    include <csignal>
+#    include <sys/resource.h>
 #    include <sys/stat.h>
 #    include <sys/types.h>
 #    ifdef ICE_USE_SYSTEMD
@@ -1598,13 +1599,18 @@ Ice::Service::runDaemon(int argc, char* argv[], InitializationData initData)
             // have an opportunity to use stdin/stdout/stderr if necessary. This also
             // conveniently allows the Ice.PrintProcessId property to work as expected.
             //
-            int fdMax = static_cast<int>(sysconf(_SC_OPEN_MAX));
-            if (fdMax <= 0)
+            // Bound the probe loop by the soft RLIMIT_NOFILE — the kernel never allocates a
+            // descriptor at or above it — capped so the loop stays cheap even with a very large
+            // limit (such as LimitNOFILE=infinity under systemd).
+            //
+            rlim_t fdMax = 1 << 20;
+            rlimit fdLimit{};
+            if (getrlimit(RLIMIT_NOFILE, &fdLimit) == 0)
             {
-                throw SyscallException{__FILE__, __LINE__, "sysconf failed", errno};
+                fdMax = std::min(fdMax, fdLimit.rlim_cur);
             }
 
-            for (int i = 0; i < fdMax; ++i)
+            for (int i = 0; i < static_cast<int>(fdMax); ++i)
             {
                 if (fcntl(i, F_GETFL) != -1)
                 {


### PR DESCRIPTION
Fixes #6065

In the daemonize path, `Ice::Service::run` snapshots the open file descriptors in the forked child with an `fcntl(fd, F_GETFL)` probe loop bounded by `sysconf(_SC_OPEN_MAX)`, i.e. the soft `RLIMIT_NOFILE`. With a very large limit — e.g. a unit with systemd `LimitNOFILE=infinity`, where the effective soft limit is ~2^30 — the child issues on the order of a billion `fcntl` calls before completing startup, while the parent (and any supervisor waiting on it) blocks on the startup pipe.

This is the same root cause as the IceGrid `Activator` fork-child close loop fixed in #6064, but `close_range(2)` is not applicable here: the code deliberately builds a *snapshot* and defers the `close()` calls until after the communicator is initialized, so plug-ins can still use stdin/stdout/stderr and `Ice.StdOut`/`Ice.StdErr` are honored. The fix is to bound the probe loop instead: the soft `RLIMIT_NOFILE` (the kernel never allocates a descriptor at or above it) capped at `1 << 20`, matching the bounded-loop tier of #6064. A descriptor numbered at or above the cap would require over a million descriptors open at daemonize time, which happens right at startup.

The switch from `sysconf` to `getrlimit` also simplifies the error handling: if `getrlimit` ever failed, the loop just keeps the capped bound instead of aborting daemon startup, so the former `SyscallException` branch is gone.

No changelog entry: `Ice::Service` is effectively an implementation detail of the Ice services, the stall is startup-only, and there are no field reports of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)