### PR TITLE
Document CommunicatorDestroyedException in the Communicator and Connection APIs

### DIFF
--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -278,7 +278,7 @@ namespace Ice
         /// and passes `false` as argument. If you set InitializationData::executor, the executor determines the
         /// thread that executes this function in the asynchronous case.
         /// @return A function that can be called to cancel the flush.
-        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
+        /// @throws CommunicatorDestroyedException Thrown synchronously when the communicator has been destroyed.
         std::function<void()> flushBatchRequestsAsync(
             CompressBatch compress,
             std::function<void(std::exception_ptr)> exception,
@@ -290,7 +290,7 @@ namespace Ice
         /// @param compress Specifies whether or not the queued batch requests should be compressed before being sent
         /// over the wire.
         /// @return A future that becomes available when all batch requests have been sent.
-        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
+        /// @throws CommunicatorDestroyedException Thrown synchronously when the communicator has been destroyed.
         [[nodiscard]] std::future<void> flushBatchRequestsAsync(CompressBatch compress);
 
         /// Adds the Admin object with all its facets to the provided object adapter. If `Ice.Admin.ServerId`

--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -79,6 +79,7 @@ namespace Ice
         /// @param str The stringified proxy to convert into a proxy.
         /// @return The proxy, or nullopt if @p str is an empty string.
         /// @throws ParseException Thrown when @p str is not a valid proxy string.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         /// @see #proxyToString
         template<typename Prx = ObjectPrx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
         std::optional<Prx> stringToProxy(std::string_view str) const
@@ -106,6 +107,7 @@ namespace Ice
         /// @tparam Prx The type of the proxy to return.
         /// @param property The base property name.
         /// @return The proxy, or nullopt if the property is not set.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         template<typename Prx = ObjectPrx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
         std::optional<Prx> propertyToProxy(std::string_view property) const
         {
@@ -138,6 +140,7 @@ namespace Ice
         /// @param name The object adapter name.
         /// @param serverAuthenticationOptions The SSL options for server connections.
         /// @return The new object adapter.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         /// @see #createObjectAdapterWithEndpoints
         /// @see ObjectAdapter
         /// @see Properties
@@ -155,6 +158,7 @@ namespace Ice
         /// @param endpoints The endpoints of the object adapter.
         /// @param serverAuthenticationOptions The SSL options for server connections.
         /// @return The new object adapter.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         /// @see #createObjectAdapter
         /// @see Properties
         /// @see SSL::OpenSSLServerAuthenticationOptions
@@ -170,6 +174,7 @@ namespace Ice
         /// @param name The object adapter name.
         /// @param rtr The router.
         /// @return The new object adapter.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         /// @see #createObjectAdapter
         /// @see Properties
         ObjectAdapterPtr createObjectAdapterWithRouter(std::string name, RouterPrx rtr);
@@ -185,6 +190,7 @@ namespace Ice
         /// Sets the object adapter that will be associated with new outgoing connections created by this
         /// communicator. This function has no effect on existing outgoing connections, or on incoming connections.
         /// @param adapter The object adapter to associate with new outgoing connections.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         /// @see Connection::setAdapter
         void setDefaultObjectAdapter(ObjectAdapterPtr adapter);
 
@@ -222,6 +228,7 @@ namespace Ice
         /// Sets the default router of this communicator. All newly created proxies will use this default router. This
         /// function has no effect on existing proxies.
         /// @param rtr The new default router. Use `nullopt` to remove the default router.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         /// @see #getDefaultRouter
         /// @see #createObjectAdapterWithRouter
         /// @see Router
@@ -229,6 +236,7 @@ namespace Ice
 
         /// Gets the default locator of this communicator.
         /// @return The default locator of this communicator.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         /// @see #setDefaultLocator
         /// @see Locator
         [[nodiscard]] std::optional<Ice::LocatorPrx> getDefaultLocator() const;
@@ -236,6 +244,7 @@ namespace Ice
         /// Sets the default locator of this communicator. All newly created proxies will use this default locator.
         /// This function has no effect on existing proxies or object adapters.
         /// @param loc The new default locator. Use `nullopt` to remove the default locator.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         /// @see #getDefaultLocator
         /// @see Locator
         /// @see ObjectAdapter#setLocator
@@ -252,6 +261,7 @@ namespace Ice
         /// are ignored.
         /// @param compress Specifies whether or not the queued batch requests should be compressed before being sent
         /// over the wire.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         void flushBatchRequests(CompressBatch compress);
 
         /// Flushes any pending batch requests of this communicator. This means all batch requests invoked on fixed
@@ -268,6 +278,7 @@ namespace Ice
         /// and passes `false` as argument. If you set InitializationData::executor, the executor determines the
         /// thread that executes this function in the asynchronous case.
         /// @return A function that can be called to cancel the flush.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         std::function<void()> flushBatchRequestsAsync(
             CompressBatch compress,
             std::function<void(std::exception_ptr)> exception,
@@ -279,6 +290,7 @@ namespace Ice
         /// @param compress Specifies whether or not the queued batch requests should be compressed before being sent
         /// over the wire.
         /// @return A future that becomes available when all batch requests have been sent.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         [[nodiscard]] std::future<void> flushBatchRequestsAsync(CompressBatch compress);
 
         /// Adds the Admin object with all its facets to the provided object adapter. If `Ice.Admin.ServerId`
@@ -290,6 +302,7 @@ namespace Ice
         /// @param adminId The identity of the Admin object.
         /// @return A proxy to the main ("") facet of the Admin object.
         /// @throws InitializationException Thrown when this function is called more than once.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         /// @see #getAdmin
         ObjectPrx createAdmin(const ObjectAdapterPtr& adminAdapter, const Identity& adminId);
 
@@ -307,18 +320,21 @@ namespace Ice
         /// @param servant The servant that implements the new Admin facet.
         /// @param facet The name of the new Admin facet.
         /// @throws AlreadyRegisteredException Thrown when a facet with the same name is already registered.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         void addAdminFacet(ObjectPtr servant, std::string facet);
 
         /// Removes a facet from the Admin object.
         /// @param facet The name of the Admin facet.
         /// @return The servant associated with this Admin facet.
         /// @throws NotRegisteredException Thrown when no facet with the given name is registered.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         ObjectPtr removeAdminFacet(std::string_view facet);
 
         /// Returns a facet of the Admin object.
         /// @tparam T The type of the facet to return.
         /// @param facet The name of the Admin facet.
         /// @return The servant associated with this Admin facet, or null if no facet is registered with the given name.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         template<typename T = Object, std::enable_if_t<std::is_base_of_v<Object, T>, bool> = true>
         std::shared_ptr<T> findAdminFacet(std::string_view facet)
         {
@@ -327,6 +343,7 @@ namespace Ice
 
         /// Returns a map of all facets of the Admin object.
         /// @return A collection containing all the facet names and servants of the Admin object.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         /// @see #findAdminFacet
         FacetMap findAllAdminFacets();
 

--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -75,6 +75,7 @@ namespace Ice
         /// @tparam Prx The type of the proxy to create.
         /// @param id The identity of the target object.
         /// @return A fixed proxy with the provided identity.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         template<typename Prx = ObjectPrx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
         [[nodiscard]] Prx createProxy(Identity id) const
         {
@@ -106,6 +107,7 @@ namespace Ice
         /// This means all batch requests invoked on fixed proxies associated with the connection.
         /// @param compress Specifies whether or not the queued batch requests should be compressed before being sent
         /// over the wire.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         void flushBatchRequests(CompressBatch compress);
 
         /// Flushes any pending batch requests for this connection.
@@ -122,6 +124,7 @@ namespace Ice
         /// InitializationData::executor, the executor determines the thread that executes this function in the
         /// asynchronous case.
         /// @return A function that can be called to cancel the invocation locally.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         virtual std::function<void()> flushBatchRequestsAsync(
             CompressBatch compress,
             std::function<void(std::exception_ptr)> exception,
@@ -132,6 +135,7 @@ namespace Ice
         /// @param compress Specifies whether or not the queued batch requests should be compressed before being sent
         /// over the wire.
         /// @return A future that becomes available when the flush completes.
+        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         [[nodiscard]] std::future<void> flushBatchRequestsAsync(CompressBatch compress);
 
         /// Sets a close callback on the connection. The callback is called by the connection when it's closed.

--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -107,7 +107,8 @@ namespace Ice
         /// This means all batch requests invoked on fixed proxies associated with the connection.
         /// @param compress Specifies whether or not the queued batch requests should be compressed before being sent
         /// over the wire.
-        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
+        /// @throws LocalException Thrown when the flush fails. For example, this function throws
+        /// CommunicatorDestroyedException when the communicator has been destroyed.
         void flushBatchRequests(CompressBatch compress);
 
         /// Flushes any pending batch requests for this connection.
@@ -124,7 +125,7 @@ namespace Ice
         /// InitializationData::executor, the executor determines the thread that executes this function in the
         /// asynchronous case.
         /// @return A function that can be called to cancel the invocation locally.
-        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
+        /// @throws CommunicatorDestroyedException Thrown synchronously when the communicator has been destroyed.
         virtual std::function<void()> flushBatchRequestsAsync(
             CompressBatch compress,
             std::function<void(std::exception_ptr)> exception,
@@ -135,7 +136,7 @@ namespace Ice
         /// @param compress Specifies whether or not the queued batch requests should be compressed before being sent
         /// over the wire.
         /// @return A future that becomes available when the flush completes.
-        /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
+        /// @throws CommunicatorDestroyedException Thrown synchronously when the communicator has been destroyed.
         [[nodiscard]] std::future<void> flushBatchRequestsAsync(CompressBatch compress);
 
         /// Sets a close callback on the connection. The callback is called by the connection when it's closed.

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -416,7 +416,8 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// <param name="progress">The sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes when the flush completes for all connections.</returns>
-    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
+    /// <exception cref="CommunicatorDestroyedException">Thrown synchronously when the communicator has been
+    /// destroyed.</exception>
     public Task flushBatchRequestsAsync(
         CompressBatch compress,
         IProgress<bool>? progress = null,

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -170,6 +170,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// <param name="str">The stringified proxy to convert into a proxy.</param>
     /// <returns>The proxy, or null if <paramref name="str" /> is an empty string.</returns>
     /// <exception cref="ParseException">Thrown when <paramref name="str" /> is not a valid proxy string.</exception>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public ObjectPrx? stringToProxy(string str)
     {
         Reference? reference = instance.referenceFactory().create(str, "");
@@ -191,6 +192,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="property">The base property name.</param>
     /// <returns>The proxy, or <c>null</c> if the property is not set.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public ObjectPrx? propertyToProxy(string property)
     {
         string proxy = instance.initializationData().properties!.getProperty(property);
@@ -225,6 +227,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// <returns>The new object adapter.</returns>
     /// <exception cref="InitializationException">Thrown when a named object adapter is created for which no
     /// configuration can be found.</exception>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public ObjectAdapter createObjectAdapter(
         string name,
         SslServerAuthenticationOptions? serverAuthenticationOptions = null) =>
@@ -239,6 +242,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// <param name="endpoints">The endpoints of the object adapter.</param>
     /// <param name="serverAuthenticationOptions">The SSL options for server connections.</param>
     /// <returns>The new object adapter.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public ObjectAdapter createObjectAdapterWithEndpoints(
         string name,
         string endpoints,
@@ -261,6 +265,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// <param name="name">The object adapter name.</param>
     /// <param name="router">The router.</param>
     /// <returns>The new object adapter.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public ObjectAdapter createObjectAdapterWithRouter(string name, RouterPrx router)
     {
         if (name.Length == 0)
@@ -286,6 +291,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// <see cref="setDefaultObjectAdapter" />.
     /// </summary>
     /// <returns>The object adapter associated by default with new outgoing connections.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     /// <seealso cref="Connection.getAdapter" />
     public ObjectAdapter? getDefaultObjectAdapter() => instance.outgoingConnectionFactory().getDefaultObjectAdapter();
 
@@ -294,6 +300,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// method has no effect on existing outgoing connections, or on incoming connections.
     /// </summary>
     /// <param name="adapter">The object adapter to associate with new outgoing connections.</param>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     /// <seealso cref="Connection.setAdapter" />
     public void setDefaultObjectAdapter(ObjectAdapter? adapter) =>
         instance.outgoingConnectionFactory().setDefaultObjectAdapter(adapter);
@@ -337,6 +344,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// Gets the default router for this communicator.
     /// </summary>
     /// <returns>The default router for this communicator.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public RouterPrx? getDefaultRouter() => instance.referenceFactory().getDefaultRouter();
 
     /// <summary>
@@ -346,12 +354,14 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// <see cref="ObjectPrx.ice_router(RouterPrx?)" /> on the proxy.
     /// </summary>
     /// <param name="router">The default router to use for this communicator.</param>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public void setDefaultRouter(RouterPrx? router) => instance.setDefaultRouter(router);
 
     /// <summary>
     /// Gets the default locator for this communicator.
     /// </summary>
     /// <returns>The default locator for this communicator.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public LocatorPrx? getDefaultLocator() => instance.referenceFactory().getDefaultLocator();
 
     /// <summary>
@@ -363,12 +373,14 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// object adapter.
     /// </summary>
     /// <param name="locator">The default locator to use for this communicator.</param>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public void setDefaultLocator(LocatorPrx? locator) => instance.setDefaultLocator(locator);
 
     /// <summary>
     /// Gets the plug-in manager for this communicator.
     /// </summary>
     /// <returns>This communicator's plug-in manager.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public PluginManager getPluginManager() => instance.pluginManager();
 
     /// <summary>
@@ -378,6 +390,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="compress">Specifies whether or not the queued batch requests should be compressed before being sent
     /// over the wire.</param>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public void flushBatchRequests(CompressBatch compress)
     {
         try
@@ -393,6 +406,17 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Flushes any pending batch requests for this communicator.
+    /// This means all batch requests invoked on fixed proxies for all connections associated with the communicator.
+    /// Any errors that occur while flushing a connection are ignored.
+    /// </summary>
+    /// <param name="compress">Specifies whether or not the queued batch requests should be compressed before being sent
+    /// over the wire.</param>
+    /// <param name="progress">The sent progress provider.</param>
+    /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
+    /// <returns>A task that completes when the flush completes for all connections.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public Task flushBatchRequestsAsync(
         CompressBatch compress,
         IProgress<bool>? progress = null,
@@ -414,6 +438,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// set, create, activate and use the Ice.Admin object adapter.</param>
     /// <param name="adminId">The identity of the Admin object.</param>
     /// <returns>A proxy to the main ("") facet of the Admin object.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public ObjectPrx createAdmin(ObjectAdapter adminAdapter, Identity adminId) =>
         instance.createAdmin(adminAdapter, adminId);
 
@@ -427,6 +452,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// </summary>
     /// <returns>A proxy to the main ("") facet of the Admin object, or a null proxy if no Admin object is configured.
     /// </returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public ObjectPrx? getAdmin() => instance.getAdmin();
 
     /// <summary>
@@ -435,6 +461,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="servant">The servant that implements the new Admin facet.</param>
     /// <param name="facet">The name of the new Admin facet.</param>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public void addAdminFacet(Object servant, string facet) => instance.addAdminFacet(servant, facet);
 
     /// <summary>
@@ -443,6 +470,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="facet">The name of the Admin facet.</param>
     /// <returns>The servant associated with this Admin facet.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public Object removeAdminFacet(string facet) => instance.removeAdminFacet(facet);
 
     /// <summary>
@@ -451,12 +479,14 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// <param name="facet">The name of the Admin facet.</param>
     /// <returns>The servant associated with this Admin facet, or null if no facet is registered with the given name.
     /// </returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public Object? findAdminFacet(string facet) => instance.findAdminFacet(facet);
 
     /// <summary>
     /// Returns a map of all facets of the Admin object.
     /// </summary>
     /// <returns>A collection containing all the facet names and servants of the Admin object.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public Dictionary<string, Object> findAllAdminFacets() => instance.findAllAdminFacets();
 }
 

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -89,7 +89,8 @@ public interface Connection
     /// </summary>
     /// <param name="compress">Specifies whether or not the queued batch requests should be compressed before being sent
     /// over the wire.</param>
-    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
+    /// <exception cref="LocalException">Thrown when the flush fails. For example, this method throws
+    /// <see cref="CommunicatorDestroyedException" /> when the communicator has been destroyed.</exception>
     void flushBatchRequests(CompressBatch compress);
 
     /// <summary>
@@ -101,7 +102,8 @@ public interface Connection
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes when the flush completes.</returns>
-    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
+    /// <exception cref="CommunicatorDestroyedException">Thrown synchronously when the communicator has been
+    /// destroyed.</exception>
     System.Threading.Tasks.Task flushBatchRequestsAsync(
         CompressBatch compress,
         System.IProgress<bool>? progress = null,

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -53,6 +53,7 @@ public interface Connection
     /// </summary>
     /// <param name="id">The identity of the target object.</param>
     /// <returns>A fixed proxy with the provided identity.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     ObjectPrx createProxy(Identity id);
 
     /// <summary>
@@ -88,6 +89,7 @@ public interface Connection
     /// </summary>
     /// <param name="compress">Specifies whether or not the queued batch requests should be compressed before being sent
     /// over the wire.</param>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     void flushBatchRequests(CompressBatch compress);
 
     /// <summary>
@@ -99,6 +101,7 @@ public interface Connection
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>A task that completes when the flush completes.</returns>
+    /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     System.Threading.Tasks.Task flushBatchRequestsAsync(
         CompressBatch compress,
         System.IProgress<bool>? progress = null,

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -483,7 +483,8 @@ public final class Communicator implements AutoCloseable {
      * @param compressBatch specifies whether or not the queued batch requests should be compressed
      *     before being sent over the wire
      * @return a future that will be completed when the invocation completes
-     * @throws CommunicatorDestroyedException if the communicator has been destroyed
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed; this exception is
+     *     thrown synchronously
      */
     public CompletableFuture<Void> flushBatchRequestsAsync(
             CompressBatch compressBatch) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -143,6 +143,7 @@ public final class Communicator implements AutoCloseable {
      * @param str the stringified proxy to convert into a proxy
      * @return the proxy, or null if {@code str} is an empty string
      * @throws ParseException if {@code str} is not a valid proxy string
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @see #proxyToString
      */
     public ObjectPrx stringToProxy(String str) {
@@ -168,6 +169,7 @@ public final class Communicator implements AutoCloseable {
      *
      * @param property the base property name
      * @return the proxy, or null if the property is not set
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      */
     public ObjectPrx propertyToProxy(String property) {
         String proxy = _instance.initializationData().properties.getProperty(property);
@@ -301,6 +303,7 @@ public final class Communicator implements AutoCloseable {
      * @param name the object adapter name
      * @param router the router
      * @return the new object adapter
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @see #createObjectAdapter
      * @see Properties
      */
@@ -336,6 +339,7 @@ public final class Communicator implements AutoCloseable {
      * communicator. This method has no effect on existing outgoing connections, or on incoming connections.
      *
      * @param adapter the object adapter to associate with new outgoing connections
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @see Connection#setAdapter
      */
     public void setDefaultObjectAdapter(ObjectAdapter adapter) {
@@ -412,6 +416,7 @@ public final class Communicator implements AutoCloseable {
      * This method has no effect on existing proxies.
      *
      * @param router the new default router. Use {@code null} to remove the default router.
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @see #getDefaultRouter
      * @see #createObjectAdapterWithRouter
      * @see Router
@@ -437,6 +442,7 @@ public final class Communicator implements AutoCloseable {
      * This method has no effect on existing proxies or object adapters.
      *
      * @param locator the new default locator. Use {@code null} to remove the default locator.
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @see #getDefaultLocator
      * @see Locator
      * @see ObjectAdapter#setLocator
@@ -449,7 +455,7 @@ public final class Communicator implements AutoCloseable {
      * Gets the plug-in manager of this communicator.
      *
      * @return this communicator's plug-in manager
-     * @throws CommunicatorDestroyedException if this communicator has been destroyed
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @see PluginManager
      */
     public PluginManager getPluginManager() {
@@ -463,6 +469,7 @@ public final class Communicator implements AutoCloseable {
      *
      * @param compressBatch specifies whether or not the queued batch requests should be compressed
      *     before being sent over the wire
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      */
     public void flushBatchRequests(CompressBatch compressBatch) {
         _iceI_flushBatchRequestsAsync(compressBatch).waitForResponse();
@@ -476,6 +483,7 @@ public final class Communicator implements AutoCloseable {
      * @param compressBatch specifies whether or not the queued batch requests should be compressed
      *     before being sent over the wire
      * @return a future that will be completed when the invocation completes
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      */
     public CompletableFuture<Void> flushBatchRequestsAsync(
             CompressBatch compressBatch) {
@@ -518,6 +526,7 @@ public final class Communicator implements AutoCloseable {
      * {@code getAdmin} is called by the communicator initialization, after initialization of all plugins.
      *
      * @return a proxy to the main ("") facet of the Admin object, or null if no Admin object is configured
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @see #createAdmin
      */
     public ObjectPrx getAdmin() {
@@ -530,6 +539,7 @@ public final class Communicator implements AutoCloseable {
      * @param servant the servant that implements the new Admin facet
      * @param facet the name of the new Admin facet
      * @throws AlreadyRegisteredException if a facet with the same name is already registered
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      */
     public void addAdminFacet(Object servant, String facet) {
         _instance.addAdminFacet(servant, facet);
@@ -541,6 +551,7 @@ public final class Communicator implements AutoCloseable {
      * @param facet the name of the Admin facet
      * @return the servant associated with this Admin facet
      * @throws NotRegisteredException if no facet with the given name is registered
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      */
     public Object removeAdminFacet(String facet) {
         return _instance.removeAdminFacet(facet);
@@ -551,6 +562,7 @@ public final class Communicator implements AutoCloseable {
      *
      * @param facet the name of the Admin facet
      * @return the servant associated with this Admin facet, or null if no facet is registered with the given name
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      */
     public Object findAdminFacet(String facet) {
         return _instance.findAdminFacet(facet);
@@ -560,6 +572,7 @@ public final class Communicator implements AutoCloseable {
      * Returns a map of all facets of the Admin object.
      *
      * @return a collection containing all the facet names and servants of the Admin object
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @see #findAdminFacet
      */
     public Map<String, Object> findAllAdminFacets() {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
@@ -63,7 +63,8 @@ public interface Connection {
      *
      * @param compress Specifies whether or not the queued batch requests should be compressed before
      *     being sent over the wire.
-     * @throws CommunicatorDestroyedException if the communicator has been destroyed
+     * @throws LocalException if the flush fails; for example, this method throws
+     *     {@link CommunicatorDestroyedException} if the communicator has been destroyed
      */
     void flushBatchRequests(CompressBatch compress);
 
@@ -74,7 +75,8 @@ public interface Connection {
      * @param compress Specifies whether or not the queued batch requests should be compressed before
      *     being sent over the wire.
      * @return a future that becomes available when the flush completes
-     * @throws CommunicatorDestroyedException if the communicator has been destroyed
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed; this exception is
+     *     thrown synchronously
      */
     CompletableFuture<Void> flushBatchRequestsAsync(CompressBatch compress);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
@@ -21,6 +21,7 @@ public interface Connection {
      *
      * @param id the identity of the target object
      * @return a fixed proxy with the provided identity
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      * @see #setAdapter
      */
     ObjectPrx createProxy(Identity id);
@@ -62,6 +63,7 @@ public interface Connection {
      *
      * @param compress Specifies whether or not the queued batch requests should be compressed before
      *     being sent over the wire.
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      */
     void flushBatchRequests(CompressBatch compress);
 
@@ -72,6 +74,7 @@ public interface Connection {
      * @param compress Specifies whether or not the queued batch requests should be compressed before
      *     being sent over the wire.
      * @return a future that becomes available when the flush completes
+     * @throws CommunicatorDestroyedException if the communicator has been destroyed
      */
     CompletableFuture<Void> flushBatchRequestsAsync(CompressBatch compress);
 

--- a/js/packages/ice/src/Ice/Communicator.d.ts
+++ b/js/packages/ice/src/Ice/Communicator.d.ts
@@ -273,7 +273,8 @@ declare module "@zeroc/ice" {
              * communicator. Any errors that occur while flushing a connection are ignored.
              *
              * @returns A promise that resolves when the flush operation is complete.
-             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
+             * @throws {@link CommunicatorDestroyedException} - Thrown synchronously when the communicator has been
+             * destroyed.
              */
             flushBatchRequests(): Promise<void>;
         }

--- a/js/packages/ice/src/Ice/Communicator.d.ts
+++ b/js/packages/ice/src/Ice/Communicator.d.ts
@@ -85,6 +85,7 @@ declare module "@zeroc/ice" {
              *
              * @returns The proxy, or `null` if `proxyString` is an empty string.
              * @throws {@link ParseException} - Thrown when `proxyString` is not a valid proxy string.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link proxyToString}
              */
@@ -106,6 +107,7 @@ declare module "@zeroc/ice" {
              * @param property The base property name.
              * @returns The proxy, or null if the property is not set.
              * @throws {@link ParseException} - Thrown when the property value is not a valid proxy string.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              */
             propertyToProxy(property: string): Ice.ObjectPrx | null;
 
@@ -134,6 +136,7 @@ declare module "@zeroc/ice" {
              *
              * @param name - The object adapter name.
              * @returns A promise that resolves to the created object adapter.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @remarks The returned promise rejects with {@link InitializationException} when a named object adapter
              * has no configuration, with {@link PropertyException} when the adapter properties are invalid (for
@@ -152,6 +155,7 @@ declare module "@zeroc/ice" {
              * {@link setDefaultObjectAdapter}.
              *
              * @returns The object adapter associated by default with new outgoing connections.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link Connection#getAdapter}
              * @see {@link setDefaultObjectAdapter}
@@ -163,6 +167,7 @@ declare module "@zeroc/ice" {
              * communicator. This method has no effect on existing connections.
              *
              * @param adapter - The object adapter to associate by default with new outgoing connections.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link Connection#setAdapter}
              * @see {@link getDefaultObjectAdapter}
@@ -178,6 +183,7 @@ declare module "@zeroc/ice" {
              * @param name - The object adapter name.
              * @param router - The router to associate with the object adapter.
              * @returns A promise that resolves to the created object adapter.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link createObjectAdapter}
              * @see {@link ObjectAdapter}
@@ -211,6 +217,7 @@ declare module "@zeroc/ice" {
              * Retrieves the default router for this communicator.
              *
              * @returns The default router of the communicator.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link setDefaultRouter}
              */
@@ -226,6 +233,7 @@ declare module "@zeroc/ice" {
              *
              * @param router - The default router to use for this communicator, or `null` to disable the default
              *                 router.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link getDefaultRouter}
              * @see {@link createObjectAdapterWithRouter}
@@ -236,6 +244,7 @@ declare module "@zeroc/ice" {
              * Retrieves the communicator's default locator.
              *
              * @returns The default locator of the communicator.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link setDefaultLocator}
              */
@@ -251,6 +260,7 @@ declare module "@zeroc/ice" {
              *
              * @param locator - The default locator to use for this communicator, or `null` to disable the default
              *                  locator.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link getDefaultLocator}
              */
@@ -263,6 +273,7 @@ declare module "@zeroc/ice" {
              * communicator. Any errors that occur while flushing a connection are ignored.
              *
              * @returns A promise that resolves when the flush operation is complete.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              */
             flushBatchRequests(): Promise<void>;
         }

--- a/js/packages/ice/src/Ice/Connection.d.ts
+++ b/js/packages/ice/src/Ice/Connection.d.ts
@@ -73,8 +73,9 @@ declare module "@zeroc/ice" {
             /**
              * Flush any pending batch requests for this connection. This means all batch requests invoked on fixed proxies
              * associated with the connection.
-             * @returns The asynchronous result object for the invocation.
-             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
+             * @returns The asynchronous result object for the invocation. If the flush fails, the promise is
+             * rejected with the corresponding exception, for example {@link CommunicatorDestroyedException} when
+             * the communicator has been destroyed.
              */
             flushBatchRequests(): Promise<void>;
 

--- a/js/packages/ice/src/Ice/Connection.d.ts
+++ b/js/packages/ice/src/Ice/Connection.d.ts
@@ -35,6 +35,7 @@ declare module "@zeroc/ice" {
              *
              * @param id - The identity for which the proxy is to be created.
              * @returns A proxy that matches the given identity and uses this connection.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link setAdapter}
              */
@@ -73,6 +74,7 @@ declare module "@zeroc/ice" {
              * Flush any pending batch requests for this connection. This means all batch requests invoked on fixed proxies
              * associated with the connection.
              * @returns The asynchronous result object for the invocation.
+             * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              */
             flushBatchRequests(): Promise<void>;
 

--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -423,7 +423,8 @@ classdef Communicator < IceInternal.WrapperObject
             %       Ice.Future scalar
             %
             %   Exceptions
-            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed. This exception is
+            %       thrown synchronously.
 
             arguments
                 obj (1, 1) Ice.Communicator

--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -114,8 +114,6 @@ classdef Communicator < IceInternal.WrapperObject
             %STRINGTOPROXY Converts a stringified proxy into a proxy.
             %   Deprecated: Use the constructor of your proxy class instead.
             %
-            %   Throws an Ice.ParseException if str is not a valid proxy string.
-            %
             %   Input Arguments
             %     str - The stringified proxy to convert into a proxy.
             %       character vector
@@ -123,6 +121,10 @@ classdef Communicator < IceInternal.WrapperObject
             %   Output Arguments
             %     r - The proxy, or an empty array if str is an empty string.
             %       Ice.ObjectPrx scalar | empty array of Ice.ObjectPrx
+            %
+            %   Exceptions
+            %     Ice.ParseException - If str is not a valid proxy string.
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Communicator
@@ -175,6 +177,9 @@ classdef Communicator < IceInternal.WrapperObject
             %   Output Arguments
             %     r - The proxy, or an empty array if the property is not set.
             %       Ice.ObjectPrx scalar | empty array of Ice.ObjectPrx
+            %
+            %   Exceptions
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Communicator
@@ -297,6 +302,9 @@ classdef Communicator < IceInternal.WrapperObject
             %   Output Arguments
             %     r - This communicator's default router.
             %       Ice.RouterPrx scalar | empty array of Ice.RouterPrx
+            %
+            %   Exceptions
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Communicator
@@ -318,6 +326,9 @@ classdef Communicator < IceInternal.WrapperObject
             %   Input Arguments
             %     proxy - The default router to use for this communicator.
             %       Ice.RouterPrx scalar | empty array of Ice.RouterPrx
+            %
+            %   Exceptions
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Communicator
@@ -337,6 +348,9 @@ classdef Communicator < IceInternal.WrapperObject
             %   Output Arguments
             %     r - This communicator's default locator.
             %       Ice.LocatorPrx scalar | empty array of Ice.LocatorPrx
+            %
+            %   Exceptions
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Communicator
@@ -358,6 +372,9 @@ classdef Communicator < IceInternal.WrapperObject
             %   Input Arguments
             %     proxy - The default locator to use for this communicator.
             %       Ice.LocatorPrx scalar | empty array of Ice.LocatorPrx
+            %
+            %   Exceptions
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Communicator
@@ -380,6 +397,9 @@ classdef Communicator < IceInternal.WrapperObject
             %     mode - Specifies whether or not the queued batch requests should be compressed before being sent over
             %       the wire.
             %       Ice.CompressBatch scalar
+            %
+            %   Exceptions
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Communicator
@@ -401,6 +421,9 @@ classdef Communicator < IceInternal.WrapperObject
             %   Output Arguments
             %     r - A future that completes when all batch requests have been sent.
             %       Ice.Future scalar
+            %
+            %   Exceptions
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Communicator

--- a/matlab/lib/+Ice/Connection.m
+++ b/matlab/lib/+Ice/Connection.m
@@ -81,6 +81,9 @@ classdef Connection < IceInternal.WrapperObject
             %   Output Arguments
             %     r - A fixed proxy with the provided identity.
             %       Ice.ObjectPrx scalar
+            %
+            %   Exceptions
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Connection
@@ -123,6 +126,9 @@ classdef Connection < IceInternal.WrapperObject
             %     compress - Specifies whether or not the queued batch requests should be compressed before being sent
             %       over the wire.
             %       Ice.CompressBatch scalar
+            %
+            %   Exceptions
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Connection
@@ -143,6 +149,9 @@ classdef Connection < IceInternal.WrapperObject
             %   Output Arguments
             %     r - A future that will be completed when the invocation completes.
             %       Ice.Future scalar
+            %
+            %   Exceptions
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Connection

--- a/matlab/lib/+Ice/Connection.m
+++ b/matlab/lib/+Ice/Connection.m
@@ -128,7 +128,8 @@ classdef Connection < IceInternal.WrapperObject
             %       Ice.CompressBatch scalar
             %
             %   Exceptions
-            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
+            %     Ice.LocalException - If the flush fails. For example, this method throws an
+            %       Ice.CommunicatorDestroyedException if the communicator has been destroyed.
 
             arguments
                 obj (1, 1) Ice.Connection
@@ -151,7 +152,8 @@ classdef Connection < IceInternal.WrapperObject
             %       Ice.Future scalar
             %
             %   Exceptions
-            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed. This exception is
+            %       thrown synchronously.
 
             arguments
                 obj (1, 1) Ice.Connection

--- a/matlab/lib/+Ice/Properties.m
+++ b/matlab/lib/+Ice/Properties.m
@@ -94,8 +94,6 @@ classdef Properties < IceInternal.WrapperObject
         function r = getIceProperty(obj, key)
             %GETICEPROPERTY Gets an Ice property by key. If the property is not set, its default value is returned.
             %
-            %   Throws an Ice.PropertyException if the property is not a known Ice property.
-            %
             %   Input Arguments
             %     key - The property key.
             %       character vector
@@ -103,6 +101,9 @@ classdef Properties < IceInternal.WrapperObject
             %   Output Arguments
             %     r - The property value.
             %       character vector
+            %
+            %   Exceptions
+            %     Ice.PropertyException - If the property is not a known Ice property.
 
             arguments
                 obj (1, 1) Ice.Properties
@@ -136,8 +137,6 @@ classdef Properties < IceInternal.WrapperObject
         function r = getPropertyAsInt(obj, key)
             %GETPROPERTYASINT Gets a property as an integer. If the property is not set, 0 is returned.
             %
-            %   Throws an Ice.PropertyException if the property value is not a valid integer.
-            %
             %   Input Arguments
             %     key - The property key.
             %       character vector
@@ -145,6 +144,9 @@ classdef Properties < IceInternal.WrapperObject
             %   Output Arguments
             %     r - The property value interpreted as an integer.
             %       int32 scalar
+            %
+            %   Exceptions
+            %     Ice.PropertyException - If the property value is not a valid integer.
 
             arguments
                 obj (1, 1) Ice.Properties
@@ -159,9 +161,6 @@ classdef Properties < IceInternal.WrapperObject
             %GETICEPROPERTYASINT Gets an Ice property as an integer. If the property is not set, its default value is
             %   returned.
             %
-            %   Throws an Ice.PropertyException if the property is not a known Ice property or the value is not a
-            %   valid integer.
-            %
             %   Input Arguments
             %     key - The property key.
             %       character vector
@@ -169,6 +168,10 @@ classdef Properties < IceInternal.WrapperObject
             %   Output Arguments
             %     r - The property value interpreted as an integer.
             %       int32 scalar
+            %
+            %   Exceptions
+            %     Ice.PropertyException - If the property is not a known Ice property or the value is not a valid
+            %       integer.
 
             arguments
                 obj (1, 1) Ice.Properties
@@ -182,8 +185,6 @@ classdef Properties < IceInternal.WrapperObject
             %GETPROPERTYASINTWITHDEFAULT Gets a property as an integer. If the property is not set, the given default
             %   value is returned.
             %
-            %   Throws an Ice.PropertyException if the property value is not a valid integer.
-            %
             %   Input Arguments
             %     key - The property key.
             %       character vector
@@ -193,6 +194,9 @@ classdef Properties < IceInternal.WrapperObject
             %   Output Arguments
             %     r - The property value interpreted as an integer, or the default value.
             %       int32 scalar
+            %
+            %   Exceptions
+            %     Ice.PropertyException - If the property value is not a valid integer.
 
             arguments
                 obj (1, 1) Ice.Properties
@@ -235,8 +239,6 @@ classdef Properties < IceInternal.WrapperObject
             %   quotes, you can escape the quote in question with \, e.g. O'Reilly can be written as "O'Reilly" or
             %   'O\'Reilly'.
             %
-            %   Throws an Ice.PropertyException if the property is not a known Ice property.
-            %
             %   Input Arguments
             %     key - The property key.
             %       character vector
@@ -244,6 +246,9 @@ classdef Properties < IceInternal.WrapperObject
             %   Output Arguments
             %     r - The property value interpreted as a list of strings.
             %       string array
+            %
+            %   Exceptions
+            %     Ice.PropertyException - If the property is not a known Ice property.
 
             arguments
                 obj (1, 1) Ice.Properties

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -137,8 +137,9 @@ compress : Ice.CompressBatch
 
 Raises
 ------
-CommunicatorDestroyedException
-    If the communicator has been destroyed.)";
+LocalException
+    If the flush fails. For example, this method raises CommunicatorDestroyedException if the communicator
+    has been destroyed.)";
 
     constexpr const char* connectionFlushBatchRequestsAsync_doc =
         R"(flushBatchRequestsAsync(compress: Ice.CompressBatch) -> Awaitable[None]
@@ -160,7 +161,7 @@ Awaitable[None]
 Raises
 ------
 CommunicatorDestroyedException
-    If the communicator has been destroyed.)";
+    If the communicator has been destroyed. This exception is raised synchronously.)";
 
     constexpr const char* connectionSetCloseCallback_doc =
         R"(setCloseCallback(callback: Callable[[Connection], None] | None) -> None

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -79,7 +79,12 @@ identity : Ice.Identity
 Returns
 -------
 Ice.ObjectPrx
-    A fixed proxy with the provided identity.)";
+    A fixed proxy with the provided identity.
+
+Raises
+------
+CommunicatorDestroyedException
+    If the communicator has been destroyed.)";
 
     constexpr const char* connectionDisableInactivityCheck_doc = R"(disableInactivityCheck() -> None
 
@@ -128,7 +133,12 @@ This corresponds to all batch requests invoked on fixed proxies associated with 
 Parameters
 ----------
 compress : Ice.CompressBatch
-    Specifies whether or not the queued batch requests should be compressed before being sent over the wire.)";
+    Specifies whether or not the queued batch requests should be compressed before being sent over the wire.
+
+Raises
+------
+CommunicatorDestroyedException
+    If the communicator has been destroyed.)";
 
     constexpr const char* connectionFlushBatchRequestsAsync_doc =
         R"(flushBatchRequestsAsync(compress: Ice.CompressBatch) -> Awaitable[None]
@@ -145,7 +155,12 @@ compress : Ice.CompressBatch
 Returns
 -------
 Awaitable[None]
-    A future that becomes available when the flush completes.)";
+    A future that becomes available when the flush completes.
+
+Raises
+------
+CommunicatorDestroyedException
+    If the communicator has been destroyed.)";
 
     constexpr const char* connectionSetCloseCallback_doc =
         R"(setCloseCallback(callback: Callable[[Connection], None] | None) -> None

--- a/python/python/Ice/Communicator.py
+++ b/python/python/Ice/Communicator.py
@@ -562,7 +562,7 @@ class Communicator:
         Raises
         ------
         CommunicatorDestroyedException
-            If the communicator has been destroyed.
+            If the communicator has been destroyed. This exception is raised synchronously.
         """
         return self._impl.flushBatchRequestsAsync(compress)
 

--- a/python/python/Ice/Communicator.py
+++ b/python/python/Ice/Communicator.py
@@ -217,6 +217,8 @@ class Communicator:
         ------
         ParseException
             If ``str`` is not a valid proxy string.
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         return self._impl.stringToProxy(str)
 
@@ -251,6 +253,11 @@ class Communicator:
         -------
         ObjectPrx | None
             The proxy, or ``None`` if the property is not set.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         return self._impl.propertyToProxy(property)
 
@@ -305,6 +312,11 @@ class Communicator:
         -------
         ObjectAdapter
             The new object adapter.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         adapter = self._impl.createObjectAdapter(name)
         return ObjectAdapter(adapter)
@@ -326,6 +338,11 @@ class Communicator:
         -------
         ObjectAdapter
             The new object adapter.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         adapter = self._impl.createObjectAdapterWithEndpoints(name, endpoints)
         return ObjectAdapter(adapter)
@@ -346,6 +363,11 @@ class Communicator:
         -------
         ObjectAdapter
             The new object adapter.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         adapter = self._impl.createObjectAdapterWithRouter(name, router)
         return ObjectAdapter(adapter)
@@ -377,6 +399,11 @@ class Communicator:
         ----------
         adapter : ObjectAdapter | None
             The object adapter to associate with new outgoing connections.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         self._impl.setDefaultObjectAdapter(adapter)
 
@@ -452,6 +479,11 @@ class Communicator:
         ----------
         router : RouterPrx | None
             The new default router. Use ``None`` to remove the default router.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         self._impl.setDefaultRouter(router)
 
@@ -485,6 +517,11 @@ class Communicator:
         ----------
         locator : LocatorPrx | None
             The new default locator. Use ``None`` to remove the default locator.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         self._impl.setDefaultLocator(locator)
 
@@ -498,6 +535,11 @@ class Communicator:
         ----------
         compress : CompressBatch
             Specifies whether or not the queued batch requests should be compressed before being sent over the wire.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         self._impl.flushBatchRequests(compress)
 
@@ -516,6 +558,11 @@ class Communicator:
         -------
         Awaitable[None]
             An :class:`Awaitable` that completes when all batch requests have been sent.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         return self._impl.flushBatchRequestsAsync(compress)
 
@@ -542,6 +589,8 @@ class Communicator:
         ------
         InitializationException
             If this function is called more than once.
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         return self._impl.createAdmin(adminAdapter, adminId)
 
@@ -582,6 +631,8 @@ class Communicator:
         ------
         AlreadyRegisteredException
             If a facet with the same name is already registered.
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         self._impl.addAdminFacet(servant, facet)
 
@@ -604,6 +655,8 @@ class Communicator:
         ------
         NotRegisteredException
             If no facet with the given name is registered.
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         return self._impl.removeAdminFacet(facet)
 
@@ -621,6 +674,11 @@ class Communicator:
         Object | IcePy.NativePropertiesAdmin | None
             The servant associated with this Admin facet, or ``None`` if no facet is registered with the given name,
             or if this facet is implemented by the Ice runtime and has no Python servant.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
 
         Notes
         -----
@@ -640,6 +698,11 @@ class Communicator:
         dict[str, Object | IcePy.NativePropertiesAdmin]
             A collection containing all the facet names and servants of the Admin object. Facets implemented by the
             Ice runtime with no Python servant are omitted; see :meth:`findAdminFacet`.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         return self._impl.findAllAdminFacets()
 

--- a/python/python/IcePy-stubs/__init__.pyi
+++ b/python/python/IcePy-stubs/__init__.pyi
@@ -134,6 +134,11 @@ class Connection:
         -------
         Ice.ObjectPrx
             A fixed proxy with the provided identity.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         ...
 
@@ -191,6 +196,12 @@ class Connection:
         ----------
         compress : Ice.CompressBatch
             Specifies whether or not the queued batch requests should be compressed before being sent over the wire.
+
+        Raises
+        ------
+        LocalException
+            If the flush fails. For example, this method raises CommunicatorDestroyedException if the communicator
+            has been destroyed.
         """
         ...
 
@@ -212,6 +223,11 @@ class Connection:
         -------
         Awaitable[None]
             A future that becomes available when the flush completes.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed. This exception is raised synchronously.
         """
         ...
 

--- a/swift/src/Ice/Communicator.swift
+++ b/swift/src/Ice/Communicator.swift
@@ -39,7 +39,9 @@ public protocol Communicator: AnyObject, Sendable {
     ///
     /// - Parameter str: The stringified proxy to convert into a proxy.
     /// - Returns: The proxy, or `nil` if `str` is an empty string.
-    /// - Throws: `ParseException` when `str` is not a valid proxy string.
+    /// - Throws:
+    ///   - `ParseException` when `str` is not a valid proxy string.
+    ///   - `CommunicatorDestroyedException` when the communicator has been destroyed.
     func stringToProxy(_ str: String) throws -> ObjectPrx?
 
     /// Converts a proxy into a string.
@@ -54,7 +56,9 @@ public protocol Communicator: AnyObject, Sendable {
     ///
     /// - Parameter property: The base property name.
     /// - Returns: The proxy, or `nil` if the property is not set.
-    /// - Throws: ``ParseException`` if the property value is not a valid proxy string.
+    /// - Throws:
+    ///   - `ParseException` when the property value is not a valid proxy string.
+    ///   - `CommunicatorDestroyedException` when the communicator has been destroyed.
     func propertyToProxy(_ property: String) throws -> ObjectPrx?
 
     /// Converts a proxy into a set of proxy properties.
@@ -79,6 +83,7 @@ public protocol Communicator: AnyObject, Sendable {
     ///
     /// - Parameter name: The object adapter name.
     /// - Returns: The new object adapter.
+    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
     func createObjectAdapter(_ name: String) throws -> ObjectAdapter
 
     /// Creates a new object adapter with endpoints. This method sets the property `name.Endpoints`, and then
@@ -89,6 +94,7 @@ public protocol Communicator: AnyObject, Sendable {
     ///   - name: The object adapter name.
     ///   - endpoints: The endpoints of the object adapter.
     /// - Returns: The new object adapter.
+    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
     func createObjectAdapterWithEndpoints(name: String, endpoints: String) throws -> ObjectAdapter
 
     /// Creates a new object adapter with a router. This method creates a routed object adapter. Calling this
@@ -98,6 +104,7 @@ public protocol Communicator: AnyObject, Sendable {
     ///   - name: The object adapter name.
     ///   - rtr: The router.
     /// - Returns: The new object adapter.
+    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
     func createObjectAdapterWithRouter(name: String, rtr: RouterPrx) throws -> ObjectAdapter
 
     /// Gets the object adapter that is associated by default with new outgoing connections created by this
@@ -157,6 +164,7 @@ public protocol Communicator: AnyObject, Sendable {
     ///
     /// - Parameter compress: Specifies whether or not the queued batch requests should be compressed before being
     ///   sent over the wire.
+    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
     func flushBatchRequests(_ compress: CompressBatch) async throws
 
     /// Adds the Admin object with all its facets to the provided object adapter. If `Ice.Admin.ServerId`
@@ -168,7 +176,9 @@ public protocol Communicator: AnyObject, Sendable {
     ///     is set, this method uses the `Ice.Admin` object adapter, after creating and activating it.
     ///   - adminId: The identity of the Admin object.
     /// - Returns: A proxy to the main ("") facet of the Admin object.
-    /// - Throws: `InitializationException` when `createAdmin` is called more than once.
+    /// - Throws:
+    ///   - `InitializationException` when `createAdmin` is called more than once.
+    ///   - `CommunicatorDestroyedException` when the communicator has been destroyed.
     func createAdmin(adminAdapter: ObjectAdapter?, adminId: Identity) throws -> ObjectPrx
 
     /// Gets a proxy to the main facet of the Admin object. `getAdmin` also creates the Admin object and creates and
@@ -178,6 +188,7 @@ public protocol Communicator: AnyObject, Sendable {
     /// `getAdmin` is called by the communicator initialization, after initialization of all plugins.
     ///
     /// - Returns: A proxy to the main ("") facet of the Admin object, or `nil` if no Admin object is configured.
+    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
     func getAdmin() throws -> ObjectPrx?
 
     /// Adds a new facet to the Admin object.
@@ -185,14 +196,18 @@ public protocol Communicator: AnyObject, Sendable {
     /// - Parameters:
     ///   - servant: The servant that implements the new Admin facet.
     ///   - facet: The name of the new Admin facet.
-    /// - Throws: `AlreadyRegisteredException` when a facet with the same name is already registered.
+    /// - Throws:
+    ///   - `AlreadyRegisteredException` when a facet with the same name is already registered.
+    ///   - `CommunicatorDestroyedException` when the communicator has been destroyed.
     func addAdminFacet(servant: Dispatcher, facet: String) throws
 
     /// Removes a facet from the Admin object.
     ///
     /// - Parameter facet: The name of the Admin facet.
     /// - Returns: The servant associated with this Admin facet.
-    /// - Throws: `NotRegisteredException` when no facet with the given name is registered.
+    /// - Throws:
+    ///   - `NotRegisteredException` when no facet with the given name is registered.
+    ///   - `CommunicatorDestroyedException` when the communicator has been destroyed.
     @discardableResult
     func removeAdminFacet(_ facet: String) throws -> Dispatcher
 

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -288,7 +288,9 @@ extension Communicator {
     /// during initialization, the communicator invokes destroy on the plug-ins that have
     /// already been initialized.
     ///
-    /// - Throws: ``InitializationException`` if the plug-ins have already been initialized.
+    /// - Throws:
+    ///   - `InitializationException` if the plug-ins have already been initialized.
+    ///   - `CommunicatorDestroyedException` if the communicator has been destroyed.
     public func initializePlugins() throws {
         try autoreleasepool {
             try (self as! CommunicatorI).handle.initializePlugins()

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -117,7 +117,8 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
     ///
     /// - Parameter compress: Specifies whether or not the queued batch requests should be compressed
     /// before being sent over the wire.
-    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
+    /// - Throws: `LocalException` when the flush fails, for example `CommunicatorDestroyedException` when the
+    ///   communicator has been destroyed.
     func flushBatchRequests(_ compress: CompressBatch) async throws
 
     /// Sets a close callback on the connection. The callback is called by the connection when it's closed. The

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -88,6 +88,7 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
     /// - Parameter id: The identity of the target object.
     /// - Returns: A fixed proxy with the provided identity.
     /// - Precondition: `id.name` must not be empty.
+    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
     func createProxy(_ id: Identity) throws -> ObjectPrx
 
     /// Associates an object adapter with this connection. When a connection receives a request, it dispatches this
@@ -116,6 +117,7 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
     ///
     /// - Parameter compress: Specifies whether or not the queued batch requests should be compressed
     /// before being sent over the wire.
+    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
     func flushBatchRequests(_ compress: CompressBatch) async throws
 
     /// Sets a close callback on the connection. The callback is called by the connection when it's closed. The


### PR DESCRIPTION
This PR documents `CommunicatorDestroyedException` on the operations that throw it, across all language mappings.

- **Communicator**: every operation that goes through a destroyed-state check (proxy creation, object adapter creation, default router/locator accessors, batch flushing, plug-in manager, Admin facets) now documents the exception.
- **Connection**: `createProxy` and the `flushBatchRequests` variants. `createProxy` reaches the communicator's reference factory with no prior connection-state check, so it throws `CommunicatorDestroyedException` in steady state on a connection whose communicator has been destroyed; the flush operations propagate it per the invocation-start contract. The other `Connection` operations either don't touch destroyed-communicator state or already carry the generic "throws the exception that closed the connection" contract, so they are unchanged.

`ObjectAdapter` is deliberately not part of this PR: destroying a communicator destroys its adapters first, and every adapter operation checks its own state before anything else, so adapter operations surface `ObjectAdapterDestroyedException` rather than `CommunicatorDestroyedException`.

Since `Connection` has no Python-side wrapper class, the Python documentation for it lives in the IcePy docstrings (`python/modules/IcePy/Connection.cpp`).

Also converts the touched MATLAB doc comments to structured `Exceptions` sections (`Communicator.m`, `Properties.m`, `Connection.m`).

Doc-comments only — no behavior change, no changelog entry.

Fixes #6094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)