### PR TITLE
Use DocC symbol links consistently in Swift doc comments

### DIFF
--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -571,7 +571,8 @@ Slice::TypesVisitor::visitStructStart(const StructPtr& p)
     _out << eb;
 
     _out << sp;
-    _out << nl << "/// An `Ice.InputStream` extension to read `" << docName << "` structured values from the stream.";
+    _out << nl << "/// An " << iceDocLink("InputStream", swiftModule) << " extension to read `" << docName
+         << "` structured values from the stream.";
     _out << nl << "public extension " << getUnqualified("Ice.InputStream", swiftModule);
     _out << sb;
 
@@ -622,7 +623,8 @@ Slice::TypesVisitor::visitStructStart(const StructPtr& p)
     _out << eb;
 
     _out << sp;
-    _out << nl << "/// An `Ice.OutputStream` extension to write `" << docName << "` structured values from the stream.";
+    _out << nl << "/// An " << iceDocLink("OutputStream", swiftModule) << " extension to write `" << docName
+         << "` structured values to the stream.";
     _out << nl << "public extension " << getUnqualified("Ice.OutputStream", swiftModule);
     _out << sb;
 
@@ -701,7 +703,8 @@ Slice::TypesVisitor::visitSequence(const SequencePtr& p)
 
     _out << sp;
     _out << nl << "/// Helper class to read and write `" << unescapedName << "` sequence values from";
-    _out << nl << "/// `Ice.InputStream` and `Ice.OutputStream`.";
+    _out << nl << "/// " << iceDocLink("InputStream", swiftModule) << " and " << iceDocLink("OutputStream", swiftModule)
+         << ".";
     _out << nl << "public struct " << unescapedName << "Helper";
     _out << sb;
 
@@ -845,7 +848,8 @@ Slice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 
     _out << sp;
     _out << nl << "/// Helper class to read and write `" << unescapedName << "` dictionary values from";
-    _out << nl << "/// `Ice.InputStream` and `Ice.OutputStream`.";
+    _out << nl << "/// " << iceDocLink("InputStream", swiftModule) << " and " << iceDocLink("OutputStream", swiftModule)
+         << ".";
     _out << nl << "public struct " << unescapedName << "Helper";
     _out << sb;
 
@@ -1002,7 +1006,8 @@ Slice::TypesVisitor::visitEnum(const EnumPtr& p)
     _out << eb;
 
     _out << sp;
-    _out << nl << "/// An `Ice.InputStream` extension to read `" << docName << "` enumerated values from the stream.";
+    _out << nl << "/// An " << iceDocLink("InputStream", swiftModule) << " extension to read `" << docName
+         << "` enumerated values from the stream.";
     _out << nl << "public extension " << getUnqualified("Ice.InputStream", swiftModule);
     _out << sb;
 
@@ -1037,7 +1042,8 @@ Slice::TypesVisitor::visitEnum(const EnumPtr& p)
     _out << eb;
 
     _out << sp;
-    _out << nl << "/// An `Ice.OutputStream` extension to write `" << docName << "` enumerated values to the stream.";
+    _out << nl << "/// An " << iceDocLink("OutputStream", swiftModule) << " extension to write `" << docName
+         << "` enumerated values to the stream.";
     _out << nl << "public extension " << getUnqualified("Ice.OutputStream", swiftModule);
     _out << sb;
 
@@ -1167,8 +1173,7 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "///    - proxyString: The proxy string to parse.";
     _out << nl << "///    - type: The type of the new proxy.";
     _out << nl << "/// - Returns: A new proxy with the requested type.";
-    _out << nl << "/// - Throws: " << (swiftModule == "Ice" ? "``ParseException``" : "`Ice.ParseException`")
-         << " if the proxy string is invalid.";
+    _out << nl << "/// - Throws: " << iceDocLink("ParseException", swiftModule) << " if the proxy string is invalid.";
     _out << nl << "public func makeProxy(communicator: Ice.Communicator, proxyString: String, type: " << prx
          << ".Protocol) throws -> " << prx;
     _out << sb;
@@ -1193,8 +1198,7 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "///   - context: The optional context dictionary for the remote invocation.";
     _out << nl
          << "/// - Returns: A proxy with the requested type or nil if the target object does not support this type.";
-    _out << nl << "/// - Throws: " << (swiftModule == "Ice" ? "``LocalException``" : "`Ice.LocalException`")
-         << " if a communication error occurs.";
+    _out << nl << "/// - Throws: " << iceDocLink("LocalException", swiftModule) << " if a communication error occurs.";
     _out << nl << "public func checkedCast" << spar << ("prx: " + getUnqualified("Ice.ObjectPrx", swiftModule))
          << ("type: " + prx + ".Protocol") << ("facet: Swift.String? = nil")
          << ("context: " + getUnqualified("Ice.Context", swiftModule) + "? = nil") << epar << " async throws -> " << prx
@@ -1238,7 +1242,8 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     // InputStream extension
     //
     _out << sp;
-    _out << nl << "/// Extension to `Ice.InputStream` class to support reading proxies of type";
+    _out << nl << "/// Extension to " << iceDocLink("InputStream", swiftModule)
+         << " class to support reading proxies of type";
     _out << nl << "/// `" << prx << "`.";
     _out << nl << "public extension " << getUnqualified("Ice.InputStream", swiftModule);
     _out << sb;

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1167,7 +1167,8 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "///    - proxyString: The proxy string to parse.";
     _out << nl << "///    - type: The type of the new proxy.";
     _out << nl << "/// - Returns: A new proxy with the requested type.";
-    _out << nl << "/// - Throws: `Ice.ParseException` if the proxy string is invalid.";
+    _out << nl << "/// - Throws: " << (swiftModule == "Ice" ? "``ParseException``" : "`Ice.ParseException`")
+         << " if the proxy string is invalid.";
     _out << nl << "public func makeProxy(communicator: Ice.Communicator, proxyString: String, type: " << prx
          << ".Protocol) throws -> " << prx;
     _out << sb;
@@ -1192,7 +1193,8 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "///   - context: The optional context dictionary for the remote invocation.";
     _out << nl
          << "/// - Returns: A proxy with the requested type or nil if the target object does not support this type.";
-    _out << nl << "/// - Throws: `Ice.LocalException` if a communication error occurs.";
+    _out << nl << "/// - Throws: " << (swiftModule == "Ice" ? "``LocalException``" : "`Ice.LocalException`")
+         << " if a communication error occurs.";
     _out << nl << "public func checkedCast" << spar << ("prx: " + getUnqualified("Ice.ObjectPrx", swiftModule))
          << ("type: " + prx + ".Protocol") << ("facet: Swift.String? = nil")
          << ("context: " + getUnqualified("Ice.Context", swiftModule) + "? = nil") << epar << " async throws -> " << prx

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -280,17 +280,28 @@ Slice::Swift::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p,
     if (!docExceptions.empty())
     {
         out << nl << "/// - Throws:";
-        for (const auto& docException : docExceptions)
+        for (const auto& [name, lines] : docExceptions)
         {
             if (docExceptions.size() > 1)
             {
                 out << nl << "///   -";
             }
-            out << " " << docException.first;
-            if (!docException.second.empty())
+
+            // Try to locate the exception's definition using the name given in the comment, so we can reference it
+            // with a symbol link.
+            if (ExceptionPtr ex = p->container()->lookupException(name, false))
+            {
+                out << " " << swiftLinkFormatter(name, p, ex);
+            }
+            else
+            {
+                out << " `" << name << "`";
+            }
+
+            if (!lines.empty())
             {
                 out << " ";
-                writeDocLines(out, docException.second, false, "     ");
+                writeDocLines(out, lines, false, "     ");
             }
         }
     }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -378,6 +378,14 @@ Slice::Swift::swiftLinkFormatter(const string& rawLink, const ContainedPtr& sour
     }
 }
 
+string
+Slice::Swift::iceDocLink(const string& name, const string& swiftModule)
+{
+    // DocC does not support cross-module linking, so we can only emit a symbol link when the generated code is part
+    // of the Ice module itself.
+    return swiftModule == "Ice" ? "``" + name + "``" : "`Ice." + name + "`";
+}
+
 void
 Slice::Swift::validateSwiftMetadata(const UnitPtr& unit)
 {

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -17,6 +17,10 @@ namespace Slice::Swift
     std::string
     swiftLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 
+    /// Returns a doc-comment reference to a symbol of the Ice module: a DocC symbol link when the generated code is
+    /// part of the Ice module itself, and the qualified name in monospace formatting otherwise.
+    std::string iceDocLink(const std::string& name, const std::string& swiftModule);
+
     void validateSwiftMetadata(const UnitPtr& unit);
 
     // Swift only allows 1 package per file, so this function checks that if there are multiple top-level-modules

--- a/swift/src/Ice/Communicator.swift
+++ b/swift/src/Ice/Communicator.swift
@@ -11,7 +11,7 @@ import Foundation
 /// You create a communicator with `Ice.initialize`, and it's usually the first object you create when programming
 /// with Ice. You can create multiple communicators in a single program, but this is not common.
 public protocol Communicator: AnyObject, Sendable {
-    /// Destroys this communicator. This method calls ``shutdown()`` implicitly. Calling `destroy` destroys all
+    /// Destroys this communicator. This method calls ``shutdown()`` implicitly. Calling ``destroy()`` destroys all
     /// object adapters and closes all outgoing connections. This method waits for all outstanding dispatches to
     /// complete before returning. This includes "bidirectional dispatches" that execute on outgoing connections.
     func destroy()
@@ -40,8 +40,8 @@ public protocol Communicator: AnyObject, Sendable {
     /// - Parameter str: The stringified proxy to convert into a proxy.
     /// - Returns: The proxy, or `nil` if `str` is an empty string.
     /// - Throws:
-    ///   - `ParseException` when `str` is not a valid proxy string.
-    ///   - `CommunicatorDestroyedException` when the communicator has been destroyed.
+    ///   - ``ParseException`` when `str` is not a valid proxy string.
+    ///   - ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     func stringToProxy(_ str: String) throws -> ObjectPrx?
 
     /// Converts a proxy into a string.
@@ -57,8 +57,8 @@ public protocol Communicator: AnyObject, Sendable {
     /// - Parameter property: The base property name.
     /// - Returns: The proxy, or `nil` if the property is not set.
     /// - Throws:
-    ///   - `ParseException` when the property value is not a valid proxy string.
-    ///   - `CommunicatorDestroyedException` when the communicator has been destroyed.
+    ///   - ``ParseException`` when the property value is not a valid proxy string.
+    ///   - ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     func propertyToProxy(_ property: String) throws -> ObjectPrx?
 
     /// Converts a proxy into a set of proxy properties.
@@ -83,7 +83,7 @@ public protocol Communicator: AnyObject, Sendable {
     ///
     /// - Parameter name: The object adapter name.
     /// - Returns: The new object adapter.
-    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
+    /// - Throws: ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     func createObjectAdapter(_ name: String) throws -> ObjectAdapter
 
     /// Creates a new object adapter with endpoints. This method sets the property `name.Endpoints`, and then
@@ -94,7 +94,7 @@ public protocol Communicator: AnyObject, Sendable {
     ///   - name: The object adapter name.
     ///   - endpoints: The endpoints of the object adapter.
     /// - Returns: The new object adapter.
-    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
+    /// - Throws: ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     func createObjectAdapterWithEndpoints(name: String, endpoints: String) throws -> ObjectAdapter
 
     /// Creates a new object adapter with a router. This method creates a routed object adapter. Calling this
@@ -104,7 +104,7 @@ public protocol Communicator: AnyObject, Sendable {
     ///   - name: The object adapter name.
     ///   - rtr: The router.
     /// - Returns: The new object adapter.
-    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
+    /// - Throws: ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     func createObjectAdapterWithRouter(name: String, rtr: RouterPrx) throws -> ObjectAdapter
 
     /// Gets the object adapter that is associated by default with new outgoing connections created by this
@@ -164,11 +164,12 @@ public protocol Communicator: AnyObject, Sendable {
     ///
     /// - Parameter compress: Specifies whether or not the queued batch requests should be compressed before being
     ///   sent over the wire.
-    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
+    /// - Throws: ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     func flushBatchRequests(_ compress: CompressBatch) async throws
 
     /// Adds the Admin object with all its facets to the provided object adapter. If `Ice.Admin.ServerId`
-    /// is set and the provided object adapter has a Locator, `createAdmin` registers the Admin's Process facet with
+    /// is set and the provided object adapter has a Locator, ``createAdmin(adminAdapter:adminId:)`` registers the
+    /// Admin's Process facet with
     /// the Locator's LocatorRegistry.
     ///
     /// - Parameters:
@@ -177,18 +178,18 @@ public protocol Communicator: AnyObject, Sendable {
     ///   - adminId: The identity of the Admin object.
     /// - Returns: A proxy to the main ("") facet of the Admin object.
     /// - Throws:
-    ///   - `InitializationException` when `createAdmin` is called more than once.
-    ///   - `CommunicatorDestroyedException` when the communicator has been destroyed.
+    ///   - ``InitializationException`` when ``createAdmin(adminAdapter:adminId:)`` is called more than once.
+    ///   - ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     func createAdmin(adminAdapter: ObjectAdapter?, adminId: Identity) throws -> ObjectPrx
 
-    /// Gets a proxy to the main facet of the Admin object. `getAdmin` also creates the Admin object and creates and
-    /// activates the `Ice.Admin` object adapter to host this Admin object if `Ice.Admin.Endpoints` is set. The
-    /// identity of the Admin object created by `getAdmin` is `{value of Ice.Admin.InstanceName}/admin`, or
+    /// Gets a proxy to the main facet of the Admin object. ``getAdmin()`` also creates the Admin object and creates
+    /// and activates the `Ice.Admin` object adapter to host this Admin object if `Ice.Admin.Endpoints` is set. The
+    /// identity of the Admin object created by ``getAdmin()`` is `{value of Ice.Admin.InstanceName}/admin`, or
     /// `{UUID}/admin` when `Ice.Admin.InstanceName` is not set. If `Ice.Admin.DelayCreation` is `0` or not set,
-    /// `getAdmin` is called by the communicator initialization, after initialization of all plugins.
+    /// ``getAdmin()`` is called by the communicator initialization, after initialization of all plugins.
     ///
     /// - Returns: A proxy to the main ("") facet of the Admin object, or `nil` if no Admin object is configured.
-    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
+    /// - Throws: ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     func getAdmin() throws -> ObjectPrx?
 
     /// Adds a new facet to the Admin object.
@@ -197,8 +198,8 @@ public protocol Communicator: AnyObject, Sendable {
     ///   - servant: The servant that implements the new Admin facet.
     ///   - facet: The name of the new Admin facet.
     /// - Throws:
-    ///   - `AlreadyRegisteredException` when a facet with the same name is already registered.
-    ///   - `CommunicatorDestroyedException` when the communicator has been destroyed.
+    ///   - ``AlreadyRegisteredException`` when a facet with the same name is already registered.
+    ///   - ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     func addAdminFacet(servant: Dispatcher, facet: String) throws
 
     /// Removes a facet from the Admin object.
@@ -206,8 +207,8 @@ public protocol Communicator: AnyObject, Sendable {
     /// - Parameter facet: The name of the Admin facet.
     /// - Returns: The servant associated with this Admin facet.
     /// - Throws:
-    ///   - `NotRegisteredException` when no facet with the given name is registered.
-    ///   - `CommunicatorDestroyedException` when the communicator has been destroyed.
+    ///   - ``NotRegisteredException`` when no facet with the given name is registered.
+    ///   - ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     @discardableResult
     func removeAdminFacet(_ facet: String) throws -> Dispatcher
 

--- a/swift/src/Ice/Communicator.swift
+++ b/swift/src/Ice/Communicator.swift
@@ -11,7 +11,7 @@ import Foundation
 /// You create a communicator with `Ice.initialize`, and it's usually the first object you create when programming
 /// with Ice. You can create multiple communicators in a single program, but this is not common.
 public protocol Communicator: AnyObject, Sendable {
-    /// Destroys this communicator. This method calls ``shutdown()`` implicitly. Calling ``destroy()`` destroys all
+    /// Destroys this communicator. This method calls ``shutdown()`` implicitly. Calling `destroy()` destroys all
     /// object adapters and closes all outgoing connections. This method waits for all outstanding dispatches to
     /// complete before returning. This includes "bidirectional dispatches" that execute on outgoing connections.
     func destroy()
@@ -168,8 +168,7 @@ public protocol Communicator: AnyObject, Sendable {
     func flushBatchRequests(_ compress: CompressBatch) async throws
 
     /// Adds the Admin object with all its facets to the provided object adapter. If `Ice.Admin.ServerId`
-    /// is set and the provided object adapter has a Locator, ``createAdmin(adminAdapter:adminId:)`` registers the
-    /// Admin's Process facet with
+    /// is set and the provided object adapter has a Locator, this method registers the Admin's Process facet with
     /// the Locator's LocatorRegistry.
     ///
     /// - Parameters:
@@ -178,15 +177,15 @@ public protocol Communicator: AnyObject, Sendable {
     ///   - adminId: The identity of the Admin object.
     /// - Returns: A proxy to the main ("") facet of the Admin object.
     /// - Throws:
-    ///   - ``InitializationException`` when ``createAdmin(adminAdapter:adminId:)`` is called more than once.
+    ///   - ``InitializationException`` when this method is called more than once.
     ///   - ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     func createAdmin(adminAdapter: ObjectAdapter?, adminId: Identity) throws -> ObjectPrx
 
-    /// Gets a proxy to the main facet of the Admin object. ``getAdmin()`` also creates the Admin object and creates
+    /// Gets a proxy to the main facet of the Admin object. This method also creates the Admin object and creates
     /// and activates the `Ice.Admin` object adapter to host this Admin object if `Ice.Admin.Endpoints` is set. The
-    /// identity of the Admin object created by ``getAdmin()`` is `{value of Ice.Admin.InstanceName}/admin`, or
+    /// identity of the Admin object created by this method is `{value of Ice.Admin.InstanceName}/admin`, or
     /// `{UUID}/admin` when `Ice.Admin.InstanceName` is not set. If `Ice.Admin.DelayCreation` is `0` or not set,
-    /// ``getAdmin()`` is called by the communicator initialization, after initialization of all plugins.
+    /// `getAdmin()` is called by the communicator initialization, after initialization of all plugins.
     ///
     /// - Returns: A proxy to the main ("") facet of the Admin object, or `nil` if no Admin object is configured.
     /// - Throws: ``CommunicatorDestroyedException`` when the communicator has been destroyed.

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -289,8 +289,8 @@ extension Communicator {
     /// already been initialized.
     ///
     /// - Throws:
-    ///   - `InitializationException` if the plug-ins have already been initialized.
-    ///   - `CommunicatorDestroyedException` if the communicator has been destroyed.
+    ///   - ``InitializationException`` if the plug-ins have already been initialized.
+    ///   - ``CommunicatorDestroyedException`` if the communicator has been destroyed.
     public func initializePlugins() throws {
         try autoreleasepool {
             try (self as! CommunicatorI).handle.initializePlugins()

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -283,7 +283,7 @@ extension Communicator {
     /// Initializes the configured plug-ins. The communicator automatically initializes
     /// the plug-ins by default, but an application may need to interact directly with
     /// a plug-in prior to initialization. In this case, the application must set
-    /// `Ice.InitPlugins=0` and then invoke `initializePlugins` manually. The plug-ins are
+    /// `Ice.InitPlugins=0` and then invoke `initializePlugins()` manually. The plug-ins are
     /// initialized in the order in which they are loaded. If a plug-in throws an exception
     /// during initialization, the communicator invokes destroy on the plug-ins that have
     /// already been initialized.

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -18,7 +18,7 @@ public enum CompressBatch: UInt8 {
     }
 }
 
-/// An `Ice.InputStream` extension to read `CompressBatch` enumerated values from the stream.
+/// An ``InputStream`` extension to read ``CompressBatch`` enumerated values from the stream.
 extension InputStream {
     /// Reads an enumerated value.
     ///
@@ -43,7 +43,7 @@ extension InputStream {
     }
 }
 
-/// An `Ice.OutputStream` extension to write `CompressBatch` enumerated values to the stream.
+/// An ``OutputStream`` extension to write ``CompressBatch`` enumerated values to the stream.
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///
@@ -88,7 +88,7 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
     /// - Parameter id: The identity of the target object.
     /// - Returns: A fixed proxy with the provided identity.
     /// - Precondition: `id.name` must not be empty.
-    /// - Throws: `CommunicatorDestroyedException` when the communicator has been destroyed.
+    /// - Throws: ``CommunicatorDestroyedException`` when the communicator has been destroyed.
     func createProxy(_ id: Identity) throws -> ObjectPrx
 
     /// Associates an object adapter with this connection. When a connection receives a request, it dispatches this
@@ -117,7 +117,7 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
     ///
     /// - Parameter compress: Specifies whether or not the queued batch requests should be compressed
     /// before being sent over the wire.
-    /// - Throws: `LocalException` when the flush fails, for example `CommunicatorDestroyedException` when the
+    /// - Throws: ``LocalException`` when the flush fails, for example ``CommunicatorDestroyedException`` when the
     ///   communicator has been destroyed.
     func flushBatchRequests(_ compress: CompressBatch) async throws
 

--- a/swift/src/Ice/CurrentExtensions.swift
+++ b/swift/src/Ice/CurrentExtensions.swift
@@ -7,7 +7,7 @@ extension Current {
     /// The generated code calls this method to ensure that when an operation's mode is not idempotent (locally),
     /// the incoming request's operation mode is not idempotent.
     ///
-    /// - Throws: `MarshalException` when the request's operation mode is ``OperationMode/idempotent`` or
+    /// - Throws: ``MarshalException`` when the request's operation mode is ``OperationMode/idempotent`` or
     /// ``OperationMode/nonmutating``.
     public func checkNonIdempotent() throws {
         if mode != .normal {  // i.e. idempotent or non-mutating
@@ -17,7 +17,7 @@ extension Current {
         }
     }
 
-    /// Creates an OutgoingResponse with reply status `ok`.
+    /// Creates an OutgoingResponse with reply status ``ReplyStatus/ok``.
     ///
     /// - Parameters:
     ///   - result: The result to marshal into the response payload.
@@ -37,7 +37,7 @@ extension Current {
         return OutgoingResponse(ostr)
     }
 
-    /// Creates an empty OutgoingResponse with reply status `ok` and an empty payload.
+    /// Creates an empty OutgoingResponse with reply status ``ReplyStatus/ok`` and an empty payload.
     ///
     /// - Returns: The new response.
     public func makeEmptyOutgoingResponse() -> OutgoingResponse {
@@ -48,10 +48,12 @@ extension Current {
         return OutgoingResponse(ostr)
     }
 
-    /// Creates an OutgoingResponse with the specified payload with reply status `ok` or `user exception`.
+    /// Creates an OutgoingResponse with the specified payload with reply status ``ReplyStatus/ok`` or
+    /// ``ReplyStatus/userException``.
     ///
     /// - Parameters:
-    ///   - ok: When `true`, the reply status is `ok`. When `false`, the reply status is `userException`.
+    ///   - ok: When `true`, the reply status is ``ReplyStatus/ok``. When `false`, the reply status is
+    ///     ``ReplyStatus/userException``.
     ///   - encapsulation: The payload-encapsulation of the response or the user exception.
     /// - Returns: The new response.
     public func makeOutgoingResponse(ok: Bool, encapsulation: Data) -> OutgoingResponse {
@@ -68,7 +70,7 @@ extension Current {
             exceptionId: nil, exceptionDetails: nil, outputStream: ostr)
     }
 
-    /// Creates an OutgoingResponse with a reply status other than `ok`.
+    /// Creates an OutgoingResponse with a reply status other than ``ReplyStatus/ok``.
     ///
     /// - Parameter error: The exception to marshal into the response.
     /// - Returns: The new response.

--- a/swift/src/Ice/CurrentExtensions.swift
+++ b/swift/src/Ice/CurrentExtensions.swift
@@ -17,7 +17,7 @@ extension Current {
         }
     }
 
-    /// Creates an OutgoingResponse with reply status ``ReplyStatus/ok``.
+    /// Creates an OutgoingResponse with a reply status of ``ReplyStatus/ok``.
     ///
     /// - Parameters:
     ///   - result: The result to marshal into the response payload.
@@ -37,7 +37,7 @@ extension Current {
         return OutgoingResponse(ostr)
     }
 
-    /// Creates an empty OutgoingResponse with reply status ``ReplyStatus/ok`` and an empty payload.
+    /// Creates an empty OutgoingResponse with a reply status of ``ReplyStatus/ok`` and an empty payload.
     ///
     /// - Returns: The new response.
     public func makeEmptyOutgoingResponse() -> OutgoingResponse {
@@ -48,7 +48,7 @@ extension Current {
         return OutgoingResponse(ostr)
     }
 
-    /// Creates an OutgoingResponse with the specified payload with reply status ``ReplyStatus/ok`` or
+    /// Creates an OutgoingResponse with the specified payload and a reply status of ``ReplyStatus/ok`` or
     /// ``ReplyStatus/userException``.
     ///
     /// - Parameters:

--- a/swift/src/Ice/EndpointSelectionType.swift
+++ b/swift/src/Ice/EndpointSelectionType.swift
@@ -15,7 +15,7 @@ public enum EndpointSelectionType: UInt8 {
     }
 }
 
-/// An `Ice.InputStream` extension to read `EndpointSelectionType` enumerated values from the stream.
+/// An ``InputStream`` extension to read ``EndpointSelectionType`` enumerated values from the stream.
 extension InputStream {
     /// Reads an enumerated value.
     ///
@@ -40,7 +40,7 @@ extension InputStream {
     }
 }
 
-/// An `Ice.OutputStream` extension to write `EndpointSelectionType` enumerated values to the stream.
+/// An ``OutputStream`` extension to write ``EndpointSelectionType`` enumerated values to the stream.
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///

--- a/swift/src/Ice/ImplicitContext.swift
+++ b/swift/src/Ice/ImplicitContext.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Represents the request context associated with a communicator. When you make a remote invocation without an
 /// explicit request context parameter, Ice uses the per-proxy request context (if any) combined with the
-/// `ImplicitContext` associated with your communicator.
+/// ``ImplicitContext`` associated with your communicator.
 /// The property `Ice.ImplicitContext` controls if your communicator has an associated implicit context,
 /// and when it does, whether this implicit context is per-thread or shared by all threads:
 /// - `None`: No implicit context at all.

--- a/swift/src/Ice/Initialize.swift
+++ b/swift/src/Ice/Initialize.swift
@@ -187,10 +187,10 @@ public let Encoding_1_0 = EncodingVersion(major: 1, minor: 0)
 /// Identifies encoding version 1.1.
 public let Encoding_1_1 = EncodingVersion(major: 1, minor: 1)
 
-/// Converts a stringified identity into an `Identity`.
+/// Converts a stringified identity into an ``Identity``.
 ///
 /// - Parameter string: The stringified identity.
-/// - Returns: An `Identity` containing the name and category components.
+/// - Returns: An ``Identity`` containing the name and category components.
 /// - Throws: ``ParseException`` if `string` cannot be converted to an identity; a ``LocalException`` if the
 ///   identity has an empty name.
 public func stringToIdentity(_ string: String) throws -> Identity {
@@ -205,7 +205,7 @@ public func stringToIdentity(_ string: String) throws -> Identity {
     }
 }
 
-/// Converts an `Identity` into a string using the specified mode.
+/// Converts an ``Identity`` into a string using the specified mode.
 ///
 /// - Parameters:
 ///   - id: The object identity to convert.

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -178,7 +178,7 @@ public final class InputStream {
     }
 
     /// Indicates that unmarshaling is complete, except for any class instances. The application must call this method
-    /// only if the stream actually contains class instances. With the 1.0 encoding, calling ``readPendingValues()``
+    /// only if the stream actually contains class instances. With the 1.0 encoding, calling `readPendingValues()`
     /// triggers the calls to consumers provided to the class-read methods (``read(cb:)`` and ``read(_:cb:)``) to inform
     /// the application that unmarshaling of an instance is complete; with the 1.1 encoding, the consumers are called
     /// while the instance is read and this method does nothing.

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -178,8 +178,8 @@ public final class InputStream {
     }
 
     /// Indicates that unmarshaling is complete, except for any class instances. The application must call this method
-    /// only if the stream actually contains class instances. With the 1.0 encoding, calling `readPendingValues`
-    /// triggers the calls to consumers provided to the class-read methods (`read(cb:)` and `read(_:cb:)`) to inform
+    /// only if the stream actually contains class instances. With the 1.0 encoding, calling ``readPendingValues()``
+    /// triggers the calls to consumers provided to the class-read methods (``read(cb:)`` and ``read(_:cb:)``) to inform
     /// the application that unmarshaling of an instance is complete; with the 1.1 encoding, the consumers are called
     /// while the instance is read and this method does nothing.
     public func readPendingValues() throws {

--- a/swift/src/Ice/LocalExceptions.swift
+++ b/swift/src/Ice/LocalExceptions.swift
@@ -20,7 +20,7 @@ public class DispatchException: LocalException, @unchecked Sendable {
     ///   - message: The exception message.
     ///   - file: The file where the exception was thrown.
     ///   - line: The line where the exception was thrown.
-    /// - Precondition: `replyStatus` must be greater than `ReplyStatus.userException`.
+    /// - Precondition: `replyStatus` must be greater than ``ReplyStatus/userException``.
     public init(
         replyStatus: UInt8, message: String? = nil, file: String = #fileID, line: Int32 = #line
     ) {
@@ -172,8 +172,8 @@ public final class OperationNotExistException: RequestFailedException, @unchecke
     }
 }
 
-/// The exception that is thrown when a dispatch failed with an exception that is not a `LocalException` or a
-/// `UserException`.
+/// The exception that is thrown when a dispatch failed with an exception that is not a ``LocalException`` or a
+/// ``UserException``.
 public class UnknownException: DispatchException, @unchecked Sendable {
     @available(*, deprecated, renamed: "message")
     public var reason: String { message }
@@ -187,14 +187,14 @@ public class UnknownException: DispatchException, @unchecked Sendable {
     }
 }
 
-/// The exception that is thrown when a dispatch failed with a `LocalException` that is not a `DispatchException`.
+/// The exception that is thrown when a dispatch failed with a ``LocalException`` that is not a ``DispatchException``.
 public final class UnknownLocalException: UnknownException, @unchecked Sendable {
     public required init(_ message: String, file: String = #fileID, line: Int32 = #line) {
         super.init(replyStatus: .unknownLocalException, message: message, file: file, line: line)
     }
 }
 
-/// The exception that is thrown when a client receives a `UserException` that was not declared in the operation's
+/// The exception that is thrown when a client receives a ``UserException`` that was not declared in the operation's
 /// exception specification.
 public final class UnknownUserException: UnknownException, @unchecked Sendable {
     public required init(_ message: String, file: String = #fileID, line: Int32 = #line) {

--- a/swift/src/Ice/NativePropertiesAdmin.swift
+++ b/swift/src/Ice/NativePropertiesAdmin.swift
@@ -2,7 +2,7 @@
 
 import IceImpl
 
-/// A callback invoked when the communicator's properties are updated; it receives a `PropertyDict` containing the
+/// A callback invoked when the communicator's properties are updated; it receives a ``PropertyDict`` containing the
 /// properties that were added, changed, or removed. Removed properties are denoted by an entry whose value is an
 /// empty string.
 public typealias PropertiesAdminUpdateCallback = (PropertyDict) -> Void

--- a/swift/src/Ice/Object.swift
+++ b/swift/src/Ice/Object.swift
@@ -83,7 +83,7 @@ public struct ObjectTraits: SliceTraits {
     public static let staticId = "::Ice::Object"
 }
 
-/// `DefaultObject` provides a default implementation of the 4 ``Object`` operations
+/// ``DefaultObject`` provides a default implementation of the 4 ``Object`` operations
 /// (`ice_id`, `ice_ids`, `ice_isA`, `ice_ping`) for a given Slice interface.
 public struct DefaultObject<T: SliceTraits>: Object {
     public init() {}

--- a/swift/src/Ice/ObjectAdapter.swift
+++ b/swift/src/Ice/ObjectAdapter.swift
@@ -81,7 +81,7 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     ///   - servant: The servant to add.
     ///   - id: The identity of the Ice object that is implemented by the servant.
     /// - Returns: A proxy for `id`, created by this object adapter.
-    /// - Throws: `AlreadyRegisteredException` when a servant with the same identity is already registered.
+    /// - Throws: ``AlreadyRegisteredException`` when a servant with the same identity is already registered.
     @discardableResult
     func add(servant: Dispatcher, id: Identity) throws -> ObjectPrx
 
@@ -94,7 +94,7 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     ///   - id: The identity of the Ice object that is implemented by the servant.
     ///   - facet: The facet of the Ice object that is implemented by the servant.
     /// - Returns: A proxy for `id` and `facet`, created by this object adapter.
-    /// - Throws: `AlreadyRegisteredException` when a servant with the same identity and facet is already registered.
+    /// - Throws: ``AlreadyRegisteredException`` when a servant with the same identity and facet is already registered.
     @discardableResult
     func addFacet(servant: Dispatcher, id: Identity, facet: String) throws -> ObjectPrx
 
@@ -103,7 +103,7 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     ///
     /// - Parameter servant: The servant to add.
     /// - Returns: A proxy with the generated UUID identity created by this object adapter.
-    /// - Throws: `ObjectAdapterDestroyedException` when the object adapter has been destroyed.
+    /// - Throws: ``ObjectAdapterDestroyedException`` when the object adapter has been destroyed.
     @discardableResult
     func addWithUUID(_ servant: Dispatcher) throws -> ObjectPrx
 
@@ -114,7 +114,7 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     ///   - servant: The servant to add.
     ///   - facet: The facet of the Ice object that is implemented by the servant.
     /// - Returns: A proxy with the generated UUID identity and specified facet created by this object adapter.
-    /// - Throws: `ObjectAdapterDestroyedException` when the object adapter has been destroyed.
+    /// - Throws: ``ObjectAdapterDestroyedException`` when the object adapter has been destroyed.
     @discardableResult
     func addFacetWithUUID(servant: Dispatcher, facet: String) throws -> ObjectPrx
 
@@ -135,14 +135,14 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     ///   - servant: The default servant to add.
     ///   - category: The category for which the default servant is registered. The empty category means it handles all
     ///     categories.
-    /// - Throws: `AlreadyRegisteredException` when a default servant with the same category is already registered.
+    /// - Throws: ``AlreadyRegisteredException`` when a default servant with the same category is already registered.
     func addDefaultServant(servant: Dispatcher, category: String) throws
 
     /// Removes a servant from the object adapter's Active Servant Map.
     ///
     /// - Parameter id: The identity of the Ice object that is implemented by the servant.
     /// - Returns: The removed servant.
-    /// - Throws: `NotRegisteredException` when no servant with the given identity is registered.
+    /// - Throws: ``NotRegisteredException`` when no servant with the given identity is registered.
     @discardableResult
     func remove(_ id: Identity) throws -> Dispatcher
 
@@ -152,7 +152,7 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     ///   - id: The identity of the Ice object that is implemented by the servant.
     ///   - facet: The facet. An empty facet means the default facet.
     /// - Returns: The removed servant.
-    /// - Throws: `NotRegisteredException` when no servant with the given identity and facet is registered.
+    /// - Throws: ``NotRegisteredException`` when no servant with the given identity and facet is registered.
     @discardableResult
     func removeFacet(id: Identity, facet: String) throws -> Dispatcher
 
@@ -161,7 +161,7 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     ///
     /// - Parameter id: The identity of the Ice object to be removed.
     /// - Returns: A collection containing all the facet names and servants of the removed Ice object.
-    /// - Throws: `NotRegisteredException` when no servant with the given identity is registered.
+    /// - Throws: ``NotRegisteredException`` when no servant with the given identity is registered.
     @discardableResult
     func removeAllFacets(_ id: Identity) throws -> FacetMap
 
@@ -169,7 +169,7 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     ///
     /// - Parameter category: The category of the default servant to remove.
     /// - Returns: The default servant.
-    /// - Throws: `NotRegisteredException` when no default servant is registered for the given category.
+    /// - Throws: ``NotRegisteredException`` when no default servant is registered for the given category.
     @discardableResult
     func removeDefaultServant(_ category: String) throws -> Dispatcher
 
@@ -210,14 +210,14 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     /// - Parameters:
     ///   - locator: The servant locator to add.
     ///   - category: The category. The empty category means `locator` handles all categories.
-    /// - Throws: `AlreadyRegisteredException` when a servant locator with the same category is already registered.
+    /// - Throws: ``AlreadyRegisteredException`` when a servant locator with the same category is already registered.
     func addServantLocator(locator: ServantLocator, category: String) throws
 
     /// Removes a ``ServantLocator`` from this object adapter.
     ///
     /// - Parameter category: The category.
     /// - Returns: The servant locator.
-    /// - Throws: `NotRegisteredException` when no servant locator with the given category is registered.
+    /// - Throws: ``NotRegisteredException`` when no servant locator with the given category is registered.
     @discardableResult
     func removeServantLocator(_ category: String) throws -> ServantLocator
 

--- a/swift/src/Ice/OutgoingResponse.swift
+++ b/swift/src/Ice/OutgoingResponse.swift
@@ -5,12 +5,13 @@ import Foundation
 /// Represents the response to an incoming request. It's returned by ``Dispatcher/dispatch(_:)``.
 public struct OutgoingResponse {
     /// The exception ID of the response.
-    /// It's nil when ``replyStatus`` is `ok` or `userException`. Otherwise, this ID is the value returned by `ice_id` for
-    /// Ice local exceptions. For other errors, this ID is the name of the error's type.
+    /// It's nil when ``replyStatus`` is ``ReplyStatus/ok`` or ``ReplyStatus/userException``. Otherwise, this ID is
+    /// the value returned by ``LocalException/ice_id()`` for Ice local exceptions. For other errors, this ID is the
+    /// name of the error's type.
     public let exceptionId: String?
 
     /// The full details of the exception marshaled into the response.
-    /// It's nil when ``replyStatus`` is `ok` or `userException`.
+    /// It's nil when ``replyStatus`` is ``ReplyStatus/ok`` or ``ReplyStatus/userException``.
     public let exceptionDetails: String?
 
     /// The output stream buffer of the response.
@@ -37,7 +38,7 @@ public struct OutgoingResponse {
         self.outputStream = outputStream
     }
 
-    /// Creates an OutgoingResponse object with the `ok` status.
+    /// Creates an OutgoingResponse object with the ``ReplyStatus/ok`` status.
     ///
     /// - Parameter outputStream: The output stream that holds the response.
     internal init(_ outputStream: OutputStream) {

--- a/swift/src/Ice/OutgoingResponse.swift
+++ b/swift/src/Ice/OutgoingResponse.swift
@@ -5,13 +5,13 @@ import Foundation
 /// Represents the response to an incoming request. It's returned by ``Dispatcher/dispatch(_:)``.
 public struct OutgoingResponse {
     /// The exception ID of the response.
-    /// It's nil when ``replyStatus`` is ``ReplyStatus/ok`` or ``ReplyStatus/userException``. Otherwise, this ID is
+    /// It's `nil` when ``replyStatus`` is ``ReplyStatus/ok`` or ``ReplyStatus/userException``. Otherwise, this ID is
     /// the value returned by ``LocalException/ice_id()`` for Ice local exceptions. For other errors, this ID is the
     /// name of the error's type.
     public let exceptionId: String?
 
     /// The full details of the exception marshaled into the response.
-    /// It's nil when ``replyStatus`` is ``ReplyStatus/ok`` or ``ReplyStatus/userException``.
+    /// It's `nil` when ``replyStatus`` is ``ReplyStatus/ok`` or ``ReplyStatus/userException``.
     public let exceptionDetails: String?
 
     /// The output stream buffer of the response.

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -258,7 +258,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject, Sendable {
 ///    - communicator: The communicator of the new proxy.
 ///    - proxyString: The proxy string to parse.
 ///    - type: The type of the new proxy.
-/// - Throws: `Ice.ParseException` if the proxy string is invalid.
+/// - Throws: ``ParseException`` if the proxy string is invalid.
 /// - Returns: A new proxy with the requested type.
 public func makeProxy(communicator: Ice.Communicator, proxyString: String, type: ObjectPrx.Protocol)
     throws -> ObjectPrx

--- a/swift/src/Ice/ServantLocator.swift
+++ b/swift/src/Ice/ServantLocator.swift
@@ -12,8 +12,8 @@ public protocol ServantLocator: Sendable {
     ///
     /// - Remark: The caller (the object adapter) does not insert the returned servant into its Active Servant Map.
     ///   This must be done by the servant locator implementation, if this is desired.
-    /// - Remark: If you call ``locate(_:)`` from your own code, you must also call ``finished(curr:servant:cookie:)``
-    ///   when you have finished using the servant, provided that ``locate(_:)`` returned a non-nil servant.
+    /// - Remark: If you call `locate(_:)` from your own code, you must also call ``finished(curr:servant:cookie:)``
+    ///   when you have finished using the servant, provided that `locate(_:)` returned a non-nil servant.
     ///
     /// - Parameter curr: Information about the incoming request for which a servant is required.
     /// - Returns: A tuple containing:
@@ -31,9 +31,8 @@ public protocol ServantLocator: Sendable {
     ///   - servant: The servant that was returned by ``locate(_:)``.
     ///   - cookie: The cookie that was returned by ``locate(_:)``.
     /// - Throws: The implementation can throw any exception, including ``UserException``.
-    ///   The Ice runtime will marshal this exception in the response. If both the dispatch and
-    ///   ``finished(curr:servant:cookie:)`` throw an exception, the exception thrown by
-    ///   ``finished(curr:servant:cookie:)`` prevails and is marshaled back to the client.
+    ///   The Ice runtime will marshal this exception in the response. If both the dispatch and this method throw
+    ///   an exception, the exception thrown by this method prevails and is marshaled back to the client.
     func finished(curr: Current, servant: Dispatcher, cookie: AnyObject?) throws
 
     /// Notifies this servant locator that the object adapter in which it's installed is being destroyed.

--- a/swift/src/Ice/ServantLocator.swift
+++ b/swift/src/Ice/ServantLocator.swift
@@ -12,8 +12,8 @@ public protocol ServantLocator: Sendable {
     ///
     /// - Remark: The caller (the object adapter) does not insert the returned servant into its Active Servant Map.
     ///   This must be done by the servant locator implementation, if this is desired.
-    /// - Remark: If you call `locate` from your own code, you must also call ``finished(curr:servant:cookie:)``
-    ///   when you have finished using the servant, provided that `locate` returned a non-nil servant.
+    /// - Remark: If you call ``locate(_:)`` from your own code, you must also call ``finished(curr:servant:cookie:)``
+    ///   when you have finished using the servant, provided that ``locate(_:)`` returned a non-nil servant.
     ///
     /// - Parameter curr: Information about the incoming request for which a servant is required.
     /// - Returns: A tuple containing:
@@ -31,8 +31,9 @@ public protocol ServantLocator: Sendable {
     ///   - servant: The servant that was returned by ``locate(_:)``.
     ///   - cookie: The cookie that was returned by ``locate(_:)``.
     /// - Throws: The implementation can throw any exception, including ``UserException``.
-    ///   The Ice runtime will marshal this exception in the response. If both the dispatch and `finished` throw
-    ///   an exception, the exception thrown by `finished` prevails and is marshaled back to the client.
+    ///   The Ice runtime will marshal this exception in the response. If both the dispatch and
+    ///   ``finished(curr:servant:cookie:)`` throw an exception, the exception thrown by
+    ///   ``finished(curr:servant:cookie:)`` prevails and is marshaled back to the client.
     func finished(curr: Current, servant: Dispatcher, cookie: AnyObject?) throws
 
     /// Notifies this servant locator that the object adapter in which it's installed is being destroyed.

--- a/swift/src/Ice/SliceInfo.swift
+++ b/swift/src/Ice/SliceInfo.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Encapsulates the details of a class slice with an unknown type.
 public struct SliceInfo {
-    /// The Slice type ID for this slice. It's empty when the compact ID is set (`compactId` is not `-1`).
+    /// The Slice type ID for this slice. It's empty when the compact ID is set (``compactId`` is not `-1`).
     public let typeId: String
 
     /// The Slice compact type ID for this slice, or `-1` if the slice has no compact ID.

--- a/swift/src/Ice/ToStringMode.swift
+++ b/swift/src/Ice/ToStringMode.swift
@@ -25,7 +25,7 @@ public enum ToStringMode: UInt8 {
     }
 }
 
-/// An `Ice.InputStream` extension to read `ToStringMode` enumerated values from the stream.
+/// An ``InputStream`` extension to read ``ToStringMode`` enumerated values from the stream.
 extension InputStream {
     /// Read an enumerated value.
     ///
@@ -50,7 +50,7 @@ extension InputStream {
     }
 }
 
-/// An `Ice.OutputStream` extension to write `ToStringMode` enumerated values to the stream.
+/// An ``OutputStream`` extension to write ``ToStringMode`` enumerated values to the stream.
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///


### PR DESCRIPTION
This PR standardizes symbol references in the Swift doc comments on DocC symbol links (``` ``Symbol`` ```), in two parts:

### Hand-written docs (`swift/src/Ice`)

Every reference to a resolvable symbol now uses a symbol link: exception types in `- Throws:` clauses, types, methods (e.g. ``getAdmin()``, ``locate(_:)``), and enumerators (``ReplyStatus/ok``). Module-qualified prose references such as `Ice.InputStream` become bare links (``InputStream``) since the docs build inside the Ice module.

Single backticks remain for non-symbol code fragments: parameter names, literals (`nil`, `true`), configuration property names (`Ice.Admin.Endpoints`) and their values, type expressions (`Dispatcher?`), symbols DocC cannot resolve (`Sendable`, members of internal types), and `Ice.initialize`, whose three overloads share the `initialize(_:)` name and would make a bare symbol link ambiguous.

### Generated docs (`slice2swift`)

- `writeOpDocSummary` used to emit the `@throws` exception name as plain text (`- Throws: ObjectNotFoundException Thrown when ...`). It now resolves the name — the same lookup the other language mappings use — and formats it with the existing link formatter: a symbol link for same-module references, and the qualified name in monospace for cross-module references (which DocC cannot link).
- The hardcoded `makeProxy`/`checkedCast` doc comments emit ``ParseException``/``LocalException`` links when the generated code is part of the Ice module itself, and keep `Ice.ParseException`/`Ice.LocalException` in monospace elsewhere.

Verified by regenerating code for `Ice/Locator.ice` (same-module links), `IceGrid/Registry.ice` (monospace for Ice-typed helpers), and a synthetic interface with multiple `@throws` tags (linked list items).

Fixes #6095

🤖 Generated with [Claude Code](https://claude.com/claude-code)