### PR TITLE
Document exceptions with an Exceptions section in hand-written MATLAB doc comments

### DIFF
--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -179,6 +179,7 @@ classdef Communicator < IceInternal.WrapperObject
             %       Ice.ObjectPrx scalar | empty array of Ice.ObjectPrx
             %
             %   Exceptions
+            %     Ice.ParseException - If the property value is not a valid proxy string.
             %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             arguments

--- a/matlab/lib/+Ice/Connection.m
+++ b/matlab/lib/+Ice/Connection.m
@@ -193,12 +193,15 @@ classdef Connection < IceInternal.WrapperObject
         end
 
         function r = getInfo(obj)
-            %GETINFO Returns the connection information. If the connection is closed, this method throws the exception
-            %   that caused the closure.
+            %GETINFO Returns the connection information.
             %
             %   Output Arguments
             %     r - The connection information.
             %       Ice.ConnectionInfo scalar
+            %
+            %   Exceptions
+            %     Ice.LocalException - If the connection is closed. This method throws the exception that caused the
+            %       closure.
 
             arguments
                 obj (1, 1) Ice.Connection
@@ -226,10 +229,12 @@ classdef Connection < IceInternal.WrapperObject
 
         function throwException(obj)
             %THROWEXCEPTION Throws the exception that provides the reason for the closure of this connection.
-            %   This method does nothing if the connection is not yet closing or closed. For example, this method
-            %   throws Ice.CloseConnectionException when the connection was closed gracefully by the peer,
-            %   Ice.ConnectionClosedException when the connection was closed gracefully by the application, and
-            %   Ice.ConnectionAbortedException when the connection was aborted with abort.
+            %   This method does nothing if the connection is not yet closing or closed.
+            %
+            %   Exceptions
+            %     Ice.CloseConnectionException - If the connection was closed gracefully by the peer.
+            %     Ice.ConnectionClosedException - If the connection was closed gracefully by the application.
+            %     Ice.ConnectionAbortedException - If the connection was aborted, for example with abort.
 
             arguments
                 obj (1, 1) Ice.Connection

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -91,6 +91,10 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %   Output Arguments
             %     obj - The new ObjectPrx.
             %       Ice.ObjectPrx scalar
+            %
+            %   Exceptions
+            %     Ice.ParseException - If proxyString is not a valid proxy string.
+            %     Ice.CommunicatorDestroyedException - If the communicator has been destroyed.
 
             if nargin == 0 % default constructor, typically called with multiple inheritance
                 superArgs = {};

--- a/matlab/lib/+Ice/stringToIdentity.m
+++ b/matlab/lib/+Ice/stringToIdentity.m
@@ -8,6 +8,9 @@ function r = stringToIdentity(s)
     %   Output Arguments
     %     r - The converted object identity.
     %       Ice.Identity scalar
+    %
+    %   Exceptions
+    %     Ice.ParseException - If s is not a valid identity string.
 
     % Copyright (c) ZeroC, Inc.
 


### PR DESCRIPTION
This PR documents the exceptions thrown by the hand-written MATLAB classes with an `Exceptions` section, matching the convention used by the generated code and by the already-converted `Ice.Communicator`/`Ice.Properties`:

- `Ice.Connection` — `getInfo` (the closure exception, as `Ice.LocalException`) and `throwException` (the three close/abort exceptions), both converted from prose.
- `Ice.ObjectPrx` — the constructor (`Ice.ParseException`, `Ice.CommunicatorDestroyedException`).
- `Ice.stringToIdentity` — `Ice.ParseException`.
- `Ice.Communicator` — adds the missing `Ice.ParseException` to `propertyToProxy`, found by checking each `Exceptions` section against the corresponding C++ function.

Each entry was verified against the implementation or the documented exceptions of the same operation in the other language mappings. `InputStream`/`OutputStream` methods have no per-method help blocks, so documenting their exceptions is out of scope for this sweep.

Fixes #6096

🤖 Generated with [Claude Code](https://claude.com/claude-code)