### PR TITLE
Document ParseException in the propertyToProxy doc comments

### DIFF
--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -107,6 +107,7 @@ namespace Ice
         /// @tparam Prx The type of the proxy to return.
         /// @param property The base property name.
         /// @return The proxy, or nullopt if the property is not set.
+        /// @throws ParseException Thrown when the property value is not a valid proxy string.
         /// @throws CommunicatorDestroyedException Thrown when the communicator has been destroyed.
         template<typename Prx = ObjectPrx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
         std::optional<Prx> propertyToProxy(std::string_view property) const

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -192,6 +192,7 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="property">The base property name.</param>
     /// <returns>The proxy, or <c>null</c> if the property is not set.</returns>
+    /// <exception cref="ParseException">Thrown when the property value is not a valid proxy string.</exception>
     /// <exception cref="CommunicatorDestroyedException">Thrown when the communicator has been destroyed.</exception>
     public ObjectPrx? propertyToProxy(string property)
     {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -169,6 +169,7 @@ public final class Communicator implements AutoCloseable {
      *
      * @param property the base property name
      * @return the proxy, or null if the property is not set
+     * @throws ParseException if the property value is not a valid proxy string
      * @throws CommunicatorDestroyedException if the communicator has been destroyed
      */
     public ObjectPrx propertyToProxy(String property) {

--- a/python/python/Ice/Communicator.py
+++ b/python/python/Ice/Communicator.py
@@ -256,6 +256,8 @@ class Communicator:
 
         Raises
         ------
+        ParseException
+            If the property value is not a valid proxy string.
         CommunicatorDestroyedException
             If the communicator has been destroyed.
         """


### PR DESCRIPTION
`Communicator::propertyToProxy` parses the property value as a stringified proxy and throws `ParseException` when it's invalid — the same path as `stringToProxy` — but only the CommunicatorDestroyedException was documented. This PR adds the missing `@throws`/`<exception>`/`Raises` entry in C++, C#, Java, and Python, using each mapping's `stringToProxy` phrasing.

The JS and Swift doc comments (and MATLAB, as part of #6099) already document it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)