### PR TITLE
Address DataStorm reader initialization to the exact reader element

### DIFF
--- a/changelog.d/datastorm/5819.md
+++ b/changelog.d/datastorm/5819.md
@@ -1,0 +1,7 @@
+- Fixed a bug where a late-joining reader of a writer that spans several keys — a multi-key, any-key, or filtered
+  reader — silently lost all but one key's initialization samples, and where such a reader could be initialized with
+  another reader's samples.
+- DataStorm nodes running this release no longer interoperate with nodes running Ice 3.8.0 through 3.8.2. Fixing the
+  reader-initialization bug above required a change to the DataStorm session protocol, and nodes now use the object
+  identity `DataStorm/Lookup2` for discovery so that a node only establishes sessions with peers running Ice 3.8.3 or
+  later. Upgrade all the DataStorm nodes in a deployment together.

--- a/changelog.d/datastorm/5819.md
+++ b/changelog.d/datastorm/5819.md
@@ -1,7 +1,6 @@
-- Fixed a bug where a late-joining reader of a writer that spans several keys — a multi-key, any-key, or filtered
-  reader — silently lost all but one key's initialization samples, and where such a reader could be initialized with
-  another reader's samples.
+- Fixed the initialization of late-joining readers. A reader of a writer that spans several keys — a multi-key,
+  any-key, or filtered reader — silently lost all but one key's initialization samples. Such a reader could also be
+  initialized with another reader's samples.
 - DataStorm nodes running this release no longer interoperate with nodes running Ice 3.8.0 through 3.8.2. Fixing the
-  reader-initialization bug above required a change to the DataStorm session protocol, and nodes now use the object
-  identity `DataStorm/Lookup2` for discovery so that a node only establishes sessions with peers running Ice 3.8.3 or
-  later. Upgrade all the DataStorm nodes in a deployment together.
+  reader-initialization bug above required a change to the DataStorm session protocol, and a node only establishes
+  sessions with peers running Ice 3.8.3 or later. Upgrade all the DataStorm nodes in a deployment together.

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -61,12 +61,17 @@ module DataStormContract
     /// A queue of {@link DataSample}
     ["cpp:type:std::deque<DataSample>"] sequence<DataSample> DataSampleSeq;
 
-    /// Represents a collection of data samples produced by a specific writer.
+    /// Represents a collection of data samples produced by a specific writer to initialize a specific reader.
     ["cpp:custom-print"]
     struct DataSamples
     {
         /// The unique identifier for the writer.
         long id;
+
+        /// The unique identifier for the reader element these samples initialize.
+        /// The sender produces one `DataSamples` per writer-reader pair, with its samples merged across the reader's
+        /// keys, so the receiver initializes exactly the reader element identified by `peerId`.
+        long peerId;
 
         /// The sequence of samples produced by the writer.
         DataSampleSeq samples;
@@ -460,7 +465,9 @@ module DataStormContract
 
     /// The lookup interface is used by DataStorm nodes to announce their topic readers and writers to other connected
     /// nodes. When multicast is enabled, the lookup interface also broadcasts these announcements.
-    /// Each DataStorm node hosts a lookup servant with the identity `DataStorm/Lookup`.
+    /// Each DataStorm node hosts a lookup servant with the identity `DataStorm/Lookup2`. Ice 3.8.3 changed this
+    /// identity from `DataStorm/Lookup` (used by Ice 3.8.0 through 3.8.2) to prevent nodes running the incompatible
+    /// pre-3.8.3 reader-initialization protocol from establishing sessions with each other.
     interface Lookup
     {
         /// Announce a topic reader.

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -68,13 +68,11 @@ module DataStormContract
         /// The unique identifier for the writer.
         long id;
 
-        /// The unique identifier for the reader element these samples initialize.
-        /// The sender produces one `DataSamples` per writer-reader pair, with its samples merged across the reader's
-        /// keys, so the receiver initializes exactly the reader element identified by `peerId`.
-        long peerId;
-
         /// The sequence of samples produced by the writer.
         DataSampleSeq samples;
+
+        /// The unique identifier for the reader element these samples initialize.
+        long peerId;
     }
     sequence<DataSamples> DataSamplesSeq;
 
@@ -465,9 +463,7 @@ module DataStormContract
 
     /// The lookup interface is used by DataStorm nodes to announce their topic readers and writers to other connected
     /// nodes. When multicast is enabled, the lookup interface also broadcasts these announcements.
-    /// Each DataStorm node hosts a lookup servant with the identity `DataStorm/Lookup2`. Ice 3.8.3 changed this
-    /// identity from `DataStorm/Lookup` (used by Ice 3.8.0 through 3.8.2) to prevent nodes running the incompatible
-    /// pre-3.8.3 reader-initialization protocol from establishing sessions with each other.
+    /// Each DataStorm node hosts a lookup servant with the same identity (currently, `DataStorm/Lookup2`).
     interface Lookup
     {
         /// Announce a topic reader.

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -133,13 +133,13 @@ DataElementI::attach(
         auto q = data.lastIds.find(_id);
         int64_t lastId = q != data.lastIds.end() ? q->second : 0;
         LongLongDict lastIds = key ? session->getLastIds(topicId, id, shared_from_this()) : LongLongDict{};
-        DataSamples samples = getSamples(key, sampleFilter, data.config, lastId, now);
+        DataSamples initializationBatch = getSamples(key, sampleFilter, data.config, lastId, now);
 
         acks.push_back(ElementDataAck{
             .id = _id,
             .config = _config,
             .lastIds = std::move(lastIds),
-            .samples = std::move(samples.samples),
+            .samples = std::move(initializationBatch.samples),
             .peerId = data.id});
     }
 }
@@ -154,7 +154,7 @@ DataElementI::attach(
     SessionPrx prx,
     const ElementDataAck& data,
     const chrono::time_point<chrono::system_clock>& now,
-    DataSamplesSeq& samples)
+    DataSamplesSeq& initializationBatches)
 {
     // Called with the topic and session from TopicI::attachElementsAck locked.
     shared_ptr<Filter> sampleFilter;
@@ -189,12 +189,12 @@ DataElementI::attach(
     {
         auto q = data.lastIds.find(_id);
         int64_t lastId = q != data.lastIds.end() ? q->second : 0;
-        DataSamples ds = getSamples(key, sampleFilter, data.config, lastId, now);
+        DataSamples initializationBatch = getSamples(key, sampleFilter, data.config, lastId, now);
         // Address the batch to the peer reader element so the receiver initializes exactly that reader. A multi-key
         // writer produces one batch per key here; the session merges the batches sharing a writer-reader pair before
         // sending them.
-        ds.peerId = data.id;
-        samples.push_back(std::move(ds));
+        initializationBatch.peerId = data.id;
+        initializationBatches.push_back(std::move(initializationBatch));
     }
 
     auto samplesI =
@@ -1408,8 +1408,8 @@ KeyDataWriterI::getSamples(
     const chrono::time_point<chrono::system_clock>& now)
 {
     // Collect all queued samples that match the key and sample filter, are newer than the lastId, and are not stale.
-    DataSamples samples;
-    samples.id = _keys.empty() ? -_id : _id;
+    DataSamples initializationBatch;
+    initializationBatch.id = _keys.empty() ? -_id : _id;
 
     // Orders the source samples to deliver by id, caps them to the reader's history depth, and delivers them. A
     // partial base is sent as a full Update, and the earliest delivered sample of each key is likewise resolved to a
@@ -1467,16 +1467,16 @@ KeyDataWriterI::getSamples(
         set<shared_ptr<Key>> seen;
         for (const auto& sample : sources)
         {
-            DataSample ds = toSample(sample, getCommunicator(), _keys.empty());
+            DataSample initializationSample = toSample(sample, getCommunicator(), _keys.empty());
             // The earliest delivered sample of each key must carry a full value; a partial is sent as a full Update
             // built from the sample's own resolved value.
             if (seen.insert(sample->key).second && sample->event == DataStorm::SampleEvent::PartialUpdate)
             {
-                ds.tag = 0;
-                ds.event = DataStorm::SampleEvent::Update;
-                ds.value = sample->encodeValue(getCommunicator());
+                initializationSample.tag = 0;
+                initializationSample.event = DataStorm::SampleEvent::Update;
+                initializationSample.value = sample->encodeValue(getCommunicator());
             }
-            samples.samples.push_back(std::move(ds));
+            initializationBatch.samples.push_back(std::move(initializationSample));
         }
     };
 
@@ -1503,7 +1503,7 @@ KeyDataWriterI::getSamples(
     if (config->sampleCount && *config->sampleCount == 0)
     {
         finalize(collectBases({}));
-        return samples;
+        return initializationBatch;
     }
 
     // Reap stale samples before collecting any samples.
@@ -1567,7 +1567,7 @@ KeyDataWriterI::getSamples(
     auto bases = collectBases(covered);
     sources.insert(sources.end(), bases.begin(), bases.end());
     finalize(std::move(sources));
-    return samples;
+    return initializationBatch;
 }
 
 void

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -189,7 +189,12 @@ DataElementI::attach(
     {
         auto q = data.lastIds.find(_id);
         int64_t lastId = q != data.lastIds.end() ? q->second : 0;
-        samples.push_back(getSamples(key, sampleFilter, data.config, lastId, now));
+        DataSamples ds = getSamples(key, sampleFilter, data.config, lastId, now);
+        // Address the batch to the peer reader element so the receiver initializes exactly that reader. A multi-key
+        // writer produces one batch per key here; the session merges the batches sharing a writer-reader pair before
+        // sending them.
+        ds.peerId = data.id;
+        samples.push_back(std::move(ds));
     }
 
     auto samplesI =

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -193,8 +193,8 @@ namespace DataStormI
         /// @param data The acknowledgment data associated with the remote element, describing its configuration or
         /// state.
         /// @param now The timestamp indicating when the attachment was requested.
-        /// @param samples Output parameter filled with the data samples in the publisher's queue. This parameter is
-        /// always empty when the method is called on the subscriber side.
+        /// @param initializationBatches Output parameter filled with the initialization batches built from the
+        /// publisher's queued samples. This parameter is always empty when the method is called on the subscriber side.
         /// @return A function that initializes the reader with the prepared samples:
         /// - For a publisher, this method always returns a `nullptr` function.
         /// - For a subscriber, this method returns a function that initializes the reader with samples provided by the
@@ -208,7 +208,7 @@ namespace DataStormI
             DataStormContract::SessionPrx prx,
             const DataStormContract::ElementDataAck& data,
             const std::chrono::time_point<std::chrono::system_clock>& now,
-            DataStormContract::DataSamplesSeq& samples);
+            DataStormContract::DataSamplesSeq& initializationBatches);
 
         [[nodiscard]] bool attachKey(
             std::int64_t,

--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -188,21 +188,22 @@ Instance::init(std::optional<Ice::SSL::ServerAuthenticationOptions> serverAuthen
     _nodeSessionManager = make_shared<NodeSessionManager>(self, _node);
     _nodeSessionManager->init();
 
+    const Identity lookupId = lookupIdentity();
     auto lookupI = make_shared<LookupI>(_nodeSessionManager, _topicFactory, _node->getProxy());
-    _adapter->add(lookupI, lookupIdentity);
+    _adapter->add(lookupI, lookupId);
     if (_multicastAdapter)
     {
-        auto lookup = _multicastAdapter->add<DataStormContract::LookupPrx>(lookupI, lookupIdentity);
+        auto lookup = _multicastAdapter->add<DataStormContract::LookupPrx>(lookupI, lookupId);
         // The lookup proxy can be customized by setting the property DataStorm.Node.Multicast.Proxy.
         if (!_communicator->getProperties()->getIceProperty("DataStorm.Node.Multicast.Proxy").empty())
         {
             // propertyToProxy only returns a nullopt proxy when the property is empty.
             lookup = *_communicator->propertyToProxy<DataStormContract::LookupPrx>("DataStorm.Node.Multicast.Proxy");
-            if (lookup->ice_getIdentity() != lookupIdentity)
+            if (lookup->ice_getIdentity() != lookupId)
             {
                 ostringstream os;
                 os << "property 'DataStorm.Node.Multicast.Proxy' has an invalid value: the proxy identity must be '"
-                   << identityToString(lookupIdentity) << "'";
+                   << identityToString(lookupId) << "'";
                 throw PropertyException{__FILE__, __LINE__, os.str()};
             }
         }

--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -188,22 +188,21 @@ Instance::init(std::optional<Ice::SSL::ServerAuthenticationOptions> serverAuthen
     _nodeSessionManager = make_shared<NodeSessionManager>(self, _node);
     _nodeSessionManager->init();
 
-    const Identity lookupId{.name = "Lookup", .category = "DataStorm"};
     auto lookupI = make_shared<LookupI>(_nodeSessionManager, _topicFactory, _node->getProxy());
-    _adapter->add(lookupI, lookupId);
+    _adapter->add(lookupI, lookupIdentity);
     if (_multicastAdapter)
     {
-        auto lookup = _multicastAdapter->add<DataStormContract::LookupPrx>(lookupI, lookupId);
+        auto lookup = _multicastAdapter->add<DataStormContract::LookupPrx>(lookupI, lookupIdentity);
         // The lookup proxy can be customized by setting the property DataStorm.Node.Multicast.Proxy.
         if (!_communicator->getProperties()->getIceProperty("DataStorm.Node.Multicast.Proxy").empty())
         {
             // propertyToProxy only returns a nullopt proxy when the property is empty.
             lookup = *_communicator->propertyToProxy<DataStormContract::LookupPrx>("DataStorm.Node.Multicast.Proxy");
-            if (lookup->ice_getIdentity() != lookupId)
+            if (lookup->ice_getIdentity() != lookupIdentity)
             {
                 ostringstream os;
                 os << "property 'DataStorm.Node.Multicast.Proxy' has an invalid value: the proxy identity must be '"
-                   << identityToString(lookupId) << "'";
+                   << identityToString(lookupIdentity) << "'";
                 throw PropertyException{__FILE__, __LINE__, os.str()};
             }
         }

--- a/cpp/src/DataStorm/Instance.h
+++ b/cpp/src/DataStorm/Instance.h
@@ -22,11 +22,7 @@ namespace DataStormI
     class NodeI;
     class CallbackExecutor;
 
-    // The object identity of the Lookup servant. Ice 3.8.3 changed this from "DataStorm/Lookup" (used by Ice
-    // 3.8.0-3.8.2) to segregate nodes speaking the incompatible pre-3.8.3 reader-initialization protocol: a node only
-    // discovers peers whose Lookup servant uses the matching identity, so a 3.8.3 node never establishes a session
-    // with a 3.8.0-3.8.2 node. This identity must be used everywhere the Lookup servant is registered or addressed. See
-    // issue #5819.
+    // The object identity shared by all Lookup servants and proxies.
     inline Ice::Identity lookupIdentity() { return {.name = "Lookup2", .category = "DataStorm"}; }
 
     class Instance final : public std::enable_shared_from_this<Instance>

--- a/cpp/src/DataStorm/Instance.h
+++ b/cpp/src/DataStorm/Instance.h
@@ -25,8 +25,9 @@ namespace DataStormI
     // The object identity of the Lookup servant. Ice 3.8.3 changed this from "DataStorm/Lookup" (used by Ice
     // 3.8.0-3.8.2) to segregate nodes speaking the incompatible pre-3.8.3 reader-initialization protocol: a node only
     // discovers peers whose Lookup servant uses the matching identity, so a 3.8.3 node never establishes a session
-    // with a 3.8.0-3.8.2 node. This constant must be used everywhere the Lookup identity is needed. See issue #5819.
-    inline const Ice::Identity lookupIdentity{.name = "Lookup2", .category = "DataStorm"};
+    // with a 3.8.0-3.8.2 node. This identity must be used everywhere the Lookup servant is registered or addressed. See
+    // issue #5819.
+    inline Ice::Identity lookupIdentity() { return {.name = "Lookup2", .category = "DataStorm"}; }
 
     class Instance final : public std::enable_shared_from_this<Instance>
     {

--- a/cpp/src/DataStorm/Instance.h
+++ b/cpp/src/DataStorm/Instance.h
@@ -22,6 +22,12 @@ namespace DataStormI
     class NodeI;
     class CallbackExecutor;
 
+    // The object identity of the Lookup servant. Ice 3.8.3 changed this from "DataStorm/Lookup" (used by Ice
+    // 3.8.0-3.8.2) to segregate nodes speaking the incompatible pre-3.8.3 reader-initialization protocol: a node only
+    // discovers peers whose Lookup servant uses the matching identity, so a 3.8.3 node never establishes a session
+    // with a 3.8.0-3.8.2 node. This constant must be used everywhere the Lookup identity is needed. See issue #5819.
+    inline const Ice::Identity lookupIdentity{.name = "Lookup2", .category = "DataStorm"};
+
     class Instance final : public std::enable_shared_from_this<Instance>
     {
     public:

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -186,7 +186,7 @@ NodeSessionI::enableAnnouncementForwarding()
 {
     if (!_lookup)
     {
-        _lookup = _connection->createProxy<LookupPrx>(lookupIdentity);
+        _lookup = _connection->createProxy<LookupPrx>(lookupIdentity());
     }
 }
 

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -186,7 +186,7 @@ NodeSessionI::enableAnnouncementForwarding()
 {
     if (!_lookup)
     {
-        _lookup = _connection->createProxy<LookupPrx>(Identity{.name = "Lookup", .category = "DataStorm"});
+        _lookup = _connection->createProxy<LookupPrx>(lookupIdentity);
     }
 }
 

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -79,7 +79,7 @@ NodeSessionManager::init()
     const string connectTo = communicator->getProperties()->getIceProperty("DataStorm.Node.ConnectTo");
     if (!connectTo.empty())
     {
-        connect(LookupPrx{communicator, communicator->identityToString(lookupIdentity) + ':' + connectTo}, _nodePrx);
+        connect(LookupPrx{communicator, communicator->identityToString(lookupIdentity()) + ':' + connectTo}, _nodePrx);
     }
 }
 

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -79,7 +79,7 @@ NodeSessionManager::init()
     const string connectTo = communicator->getProperties()->getIceProperty("DataStorm.Node.ConnectTo");
     if (!connectTo.empty())
     {
-        connect(LookupPrx{communicator, "DataStorm/Lookup:" + connectTo}, _nodePrx);
+        connect(LookupPrx{communicator, communicator->identityToString(lookupIdentity) + ':' + connectTo}, _nodePrx);
     }
 }
 

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -461,18 +461,19 @@ SessionI::attachElementsAck(int64_t topicId, ElementSpecAckSeq elements, const C
             }
 
             LongSeq removedIds;
-            auto samples = topic->attachElementsAck(topicId, elements, shared_from_this(), *_session, now, removedIds);
-            if (!samples.empty())
+            auto initializationBatches =
+                topic->attachElementsAck(topicId, elements, shared_from_this(), *_session, now, removedIds);
+            if (!initializationBatches.empty())
             {
                 // Collapse the per-key batches into one addressed DataSamples per writer-reader pair before sending.
-                samples = mergeInitSamples(std::move(samples));
+                initializationBatches = mergeInitSamples(std::move(initializationBatches));
                 if (_traceLevels->session > 2)
                 {
                     Trace out(_traceLevels->logger, _traceLevels->sessionCat);
-                    out << _id << ": initializing elements '[" << samples << "]@" << topicId << "' on topic '" << topic
-                        << "'";
+                    out << _id << ": initializing elements '[" << initializationBatches << "]@" << topicId
+                        << "' on topic '" << topic << "'";
                 }
-                _session->initSamplesAsync(topic->getId(), samples, nullptr);
+                _session->initSamplesAsync(topic->getId(), initializationBatches, nullptr);
             }
 
             if (!removedIds.empty())
@@ -524,7 +525,7 @@ SessionI::detachElements(int64_t id, LongSeq elements, const Current&)
 }
 
 void
-SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&)
+SessionI::initSamples(int64_t topicId, DataSamplesSeq initializationBatches, const Current&)
 {
     lock_guard<mutex> lock(_mutex);
     if (!_session)
@@ -539,13 +540,13 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
     // batch to exactly that reader. This delivers every key's samples to a multi-key or any-key reader in a single
     // merged batch, and tells two readers of one writer apart by their element id. An empty batch still marks its
     // reader initialized, enabling the reader's live sample delivery.
-    for (const auto& samples : samplesSeq)
+    for (const auto& initializationBatch : initializationBatches)
     {
         runWithTopics(
             topicId,
             [&](TopicI* topic, TopicSubscriber& subscriber)
             {
-                ElementSubscribers* elementSubscribers = subscriber.get(samples.id);
+                ElementSubscribers* elementSubscribers = subscriber.get(initializationBatch.id);
                 if (!elementSubscribers)
                 {
                     return;
@@ -557,7 +558,7 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
                 auto q = find_if(
                     subscribers.begin(),
                     subscribers.end(),
-                    [&](const auto& s) { return s.first->getId() == samples.peerId; });
+                    [&](const auto& s) { return s.first->getId() == initializationBatch.peerId; });
                 if (q == subscribers.end() || q->second.initialized)
                 {
                     return;
@@ -567,10 +568,11 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
                 if (_traceLevels->session > 2)
                 {
                     Trace out(_traceLevels->logger, _traceLevels->sessionCat);
-                    out << _id << ": initializing samples from 'e" << samples.id << "' on '" << element << "'";
+                    out << _id << ": initializing samples from 'e" << initializationBatch.id << "' on '" << element
+                        << "'";
                 }
 
-                if (samples.samples.empty())
+                if (initializationBatch.samples.empty())
                 {
                     // An empty batch carries no history; mark the reader initialized so its live samples can flow.
                     elementSubscriber.initialized = true;
@@ -578,9 +580,9 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
                 }
 
                 vector<shared_ptr<Sample>> samplesI;
-                samplesI.reserve(samples.samples.size());
+                samplesI.reserve(initializationBatch.samples.size());
                 const auto& sampleFactory = topic->getSampleFactory();
-                for (const auto& sample : samples.samples)
+                for (const auto& sample : initializationBatch.samples)
                 {
                     shared_ptr<Key> key;
                     if (sample.keyValue.empty())
@@ -608,7 +610,13 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
                 // construction above throws, the reader stays uninitialized so a later redelivery can initialize it.
                 elementSubscriber.initialized = true;
                 elementSubscriber.lastId = samplesI.back()->id;
-                element->initSamples(samplesI, topicId, samples.id, elementSubscribers->priority, now, samples.id < 0);
+                element->initSamples(
+                    samplesI,
+                    topicId,
+                    initializationBatch.id,
+                    elementSubscribers->priority,
+                    now,
+                    initializationBatch.id < 0);
             });
     }
 }

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -67,7 +67,10 @@ namespace
 
         for (auto& batch : merged)
         {
-            sort(
+            // stable_sort so that when two batches carry the same sample id, unique keeps the first in batch order.
+            // getSamples resolves the earliest delivered sample of each key to a full value per batch, so keeping the
+            // first-seen copy preserves that resolved base rather than an arbitrary duplicate.
+            stable_sort(
                 batch.samples.begin(),
                 batch.samples.end(),
                 [](const DataSample& lhs, const DataSample& rhs) { return lhs.id < rhs.id; });

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -570,9 +570,10 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
                     out << _id << ": initializing samples from 'e" << samples.id << "' on '" << element << "'";
                 }
 
-                elementSubscriber.initialized = true;
                 if (samples.samples.empty())
                 {
+                    // An empty batch carries no history; mark the reader initialized so its live samples can flow.
+                    elementSubscriber.initialized = true;
                     return;
                 }
 
@@ -603,6 +604,9 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
                         sample.timestamp));
                 }
 
+                // Mark the reader initialized only after its samples are decoded and built: if decoding or sample
+                // construction above throws, the reader stays uninitialized so a later redelivery can initialize it.
+                elementSubscriber.initialized = true;
                 elementSubscriber.lastId = samplesI.back()->id;
                 element->initSamples(samplesI, topicId, samples.id, elementSubscribers->priority, now, samples.id < 0);
             });

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -9,6 +9,8 @@
 #include "TopicI.h"
 #include "TraceUtil.h"
 
+#include <algorithm>
+
 using namespace std;
 using namespace DataStormI;
 using namespace DataStormContract;
@@ -36,6 +38,48 @@ namespace
         ObjectPtr _servant;
         shared_ptr<CallbackExecutor> _executor;
     };
+
+    // Collapses the per-key batches produced by TopicI::attachElementsAck into one DataSamples per writer-reader pair.
+    // A multi-key writer produces one batch per key, all under the same writer id and addressed to the same reader
+    // (peerId); merging them and ordering the result by sample id lets the reader's policies (SendTime, sampleCount,
+    // history clearing) observe the writer's global order. Duplicate sample ids (a sample matched by overlapping
+    // filters) are removed. The first-seen order of the pairs is preserved. An empty batch is kept: it still marks its
+    // reader initialized and enables the reader's live sample delivery.
+    DataSamplesSeq mergeInitSamples(DataSamplesSeq batches)
+    {
+        DataSamplesSeq merged;
+        map<pair<int64_t, int64_t>, size_t> index;
+        for (auto& batch : batches)
+        {
+            auto pairKey = make_pair(batch.id, batch.peerId);
+            auto p = index.find(pairKey);
+            if (p == index.end())
+            {
+                index.emplace(pairKey, merged.size());
+                merged.push_back(std::move(batch));
+            }
+            else
+            {
+                auto& samples = merged[p->second].samples;
+                samples.insert(samples.end(), batch.samples.begin(), batch.samples.end());
+            }
+        }
+
+        for (auto& batch : merged)
+        {
+            sort(
+                batch.samples.begin(),
+                batch.samples.end(),
+                [](const DataSample& lhs, const DataSample& rhs) { return lhs.id < rhs.id; });
+            batch.samples.erase(
+                unique(
+                    batch.samples.begin(),
+                    batch.samples.end(),
+                    [](const DataSample& lhs, const DataSample& rhs) { return lhs.id == rhs.id; }),
+                batch.samples.end());
+        }
+        return merged;
+    }
 }
 
 SessionI::SessionI(shared_ptr<Instance> instance, shared_ptr<NodeI> parent, NodePrx node, SessionPrx proxy)
@@ -417,6 +461,8 @@ SessionI::attachElementsAck(int64_t topicId, ElementSpecAckSeq elements, const C
             auto samples = topic->attachElementsAck(topicId, elements, shared_from_this(), *_session, now, removedIds);
             if (!samples.empty())
             {
+                // Collapse the per-key batches into one addressed DataSamples per writer-reader pair before sending.
+                samples = mergeInitSamples(std::move(samples));
                 if (_traceLevels->session > 2)
                 {
                     Trace out(_traceLevels->logger, _traceLevels->sessionCat);
@@ -484,7 +530,12 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
     }
 
     auto now = chrono::system_clock::now();
-    auto communicator = _instance->getCommunicator();
+
+    // One initSamples request carries a whole initialization round. Each DataSamples is addressed to a specific reader
+    // element (peerId), and its samples were merged across the reader's keys and ordered by the sender, so route each
+    // batch to exactly that reader. This delivers every key's samples to a multi-key or any-key reader in a single
+    // merged batch, and tells two readers of one writer apart by their element id. An empty batch still marks its
+    // reader initialized, enabling the reader's live sample delivery.
     for (const auto& samples : samplesSeq)
     {
         runWithTopics(
@@ -492,76 +543,65 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq samplesSeq, const Current&
             [&](TopicI* topic, TopicSubscriber& subscriber)
             {
                 ElementSubscribers* elementSubscribers = subscriber.get(samples.id);
-                if (elementSubscribers)
+                if (!elementSubscribers)
                 {
-                    if (_traceLevels->session > 2)
-                    {
-                        Trace out(_traceLevels->logger, _traceLevels->sessionCat);
-                        out << _id << ": initializing samples from '" << samples.id << "'"
-                            << " on [";
-                        for (auto q = elementSubscribers->getSubscribers().begin();
-                             q != elementSubscribers->getSubscribers().end();
-                             ++q)
-                        {
-                            if (q != elementSubscribers->getSubscribers().begin())
-                            {
-                                out << ", ";
-                            }
-                            out << q->first;
-                            if (!q->second.facet.empty())
-                            {
-                                out << ":" << q->second.facet;
-                            }
-                        }
-                        out << "]";
-                    }
-
-                    vector<shared_ptr<Sample>> samplesI;
-                    samplesI.reserve(samples.samples.size());
-                    const auto& sampleFactory = topic->getSampleFactory();
-                    for (const auto& sample : samples.samples)
-                    {
-                        shared_ptr<Key> key;
-                        if (sample.keyValue.empty())
-                        {
-                            key = subscriber.keys[sample.keyId].first;
-                        }
-                        else
-                        {
-                            key = topic->getKeyFactory()->decode(_instance->getCommunicator(), sample.keyValue);
-                        }
-                        assert(key);
-
-                        samplesI.push_back(sampleFactory->create(
-                            _id,
-                            elementSubscribers->name,
-                            sample.id,
-                            sample.event,
-                            key,
-                            subscriber.tags[sample.tag],
-                            sample.value,
-                            sample.timestamp));
-                    }
-
-                    for (auto& [element, elementSubscriber] : elementSubscribers->getSubscribers())
-                    {
-                        if (!elementSubscriber.initialized)
-                        {
-                            elementSubscriber.initialized = true;
-                            if (!samplesI.empty())
-                            {
-                                elementSubscriber.lastId = samplesI.back()->id;
-                                element->initSamples(
-                                    samplesI,
-                                    topicId,
-                                    samples.id,
-                                    elementSubscribers->priority,
-                                    now,
-                                    samples.id < 0);
-                            }
-                        }
-                    }
+                    return;
                 }
+
+                // Initialize the reader element this batch is addressed to; the writer's other readers are initialized
+                // by their own batches.
+                auto& subscribers = elementSubscribers->getSubscribers();
+                auto q = find_if(
+                    subscribers.begin(),
+                    subscribers.end(),
+                    [&](const auto& s) { return s.first->getId() == samples.peerId; });
+                if (q == subscribers.end() || q->second.initialized)
+                {
+                    return;
+                }
+                auto& [element, elementSubscriber] = *q;
+
+                if (_traceLevels->session > 2)
+                {
+                    Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+                    out << _id << ": initializing samples from 'e" << samples.id << "' on '" << element << "'";
+                }
+
+                elementSubscriber.initialized = true;
+                if (samples.samples.empty())
+                {
+                    return;
+                }
+
+                vector<shared_ptr<Sample>> samplesI;
+                samplesI.reserve(samples.samples.size());
+                const auto& sampleFactory = topic->getSampleFactory();
+                for (const auto& sample : samples.samples)
+                {
+                    shared_ptr<Key> key;
+                    if (sample.keyValue.empty())
+                    {
+                        key = subscriber.keys[sample.keyId].first;
+                    }
+                    else
+                    {
+                        key = topic->getKeyFactory()->decode(_instance->getCommunicator(), sample.keyValue);
+                    }
+                    assert(key);
+
+                    samplesI.push_back(sampleFactory->create(
+                        _id,
+                        elementSubscribers->name,
+                        sample.id,
+                        sample.event,
+                        key,
+                        subscriber.tags[sample.tag],
+                        sample.value,
+                        sample.timestamp));
+                }
+
+                elementSubscriber.lastId = samplesI.back()->id;
+                element->initSamples(samplesI, topicId, samples.id, elementSubscribers->priority, now, samples.id < 0);
             });
     }
 }

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -484,13 +484,13 @@ TopicI::attachElementsAck(
                             function<void()> initCb;
                             if (spec.id > 0) // Key
                             {
-                                initCb =
-                                    dataElement->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);
+                                initCb = dataElement
+                                             ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);
                             }
                             else if (filter->match(key)) // Filter
                             {
-                                initCb =
-                                    dataElement->attach(topicId, spec.id, key, filter, session, prx, data, now, batches);
+                                initCb = dataElement
+                                             ->attach(topicId, spec.id, key, filter, session, prx, data, now, batches);
                             }
 
                             if (initCb)
@@ -547,13 +547,14 @@ TopicI::attachElementsAck(
                             function<void()> initCb;
                             if (spec.id < 0) // Filter
                             {
-                                initCb = dataElement
-                                             ->attach(topicId, spec.id, nullptr, filter, session, prx, data, now, batches);
+                                initCb =
+                                    dataElement
+                                        ->attach(topicId, spec.id, nullptr, filter, session, prx, data, now, batches);
                             }
                             else if (filter->match(key))
                             {
-                                initCb =
-                                    dataElement->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);
+                                initCb = dataElement
+                                             ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);
                             }
 
                             if (initCb)

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -447,7 +447,7 @@ TopicI::attachElementsAck(
     const chrono::time_point<chrono::system_clock>& now,
     LongSeq& removedIds)
 {
-    DataSamplesSeq samples;
+    DataSamplesSeq batches;
     vector<function<void()>> initCallbacks;
     for (const auto& spec : elements)
     {
@@ -484,13 +484,13 @@ TopicI::attachElementsAck(
                             function<void()> initCb;
                             if (spec.id > 0) // Key
                             {
-                                initCb = dataElement
-                                             ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, samples);
+                                initCb =
+                                    dataElement->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);
                             }
                             else if (filter->match(key)) // Filter
                             {
-                                initCb = dataElement
-                                             ->attach(topicId, spec.id, key, filter, session, prx, data, now, samples);
+                                initCb =
+                                    dataElement->attach(topicId, spec.id, key, filter, session, prx, data, now, batches);
                             }
 
                             if (initCb)
@@ -547,14 +547,13 @@ TopicI::attachElementsAck(
                             function<void()> initCb;
                             if (spec.id < 0) // Filter
                             {
-                                initCb =
-                                    dataElement
-                                        ->attach(topicId, spec.id, nullptr, filter, session, prx, data, now, samples);
+                                initCb = dataElement
+                                             ->attach(topicId, spec.id, nullptr, filter, session, prx, data, now, batches);
                             }
                             else if (filter->match(key))
                             {
-                                initCb = dataElement
-                                             ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, samples);
+                                initCb =
+                                    dataElement->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);
                             }
 
                             if (initCb)
@@ -587,7 +586,7 @@ TopicI::attachElementsAck(
     {
         initCb();
     }
-    return samples;
+    return batches;
 }
 
 void

--- a/cpp/src/DataStorm/TraceUtil.cpp
+++ b/cpp/src/DataStorm/TraceUtil.cpp
@@ -111,7 +111,7 @@ namespace DataStormContract
 
     ostream& operator<<(ostream& os, const DataSamples& samples)
     {
-        os << 'e' << samples.id << ":sz" << samples.samples.size();
+        os << 'e' << samples.id << "->e" << samples.peerId << ":sz" << samples.samples.size();
         return os;
     }
 }

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -171,7 +171,7 @@ void ::Writer::run(int argc, char* argv[])
                 test(holder.communicator()->getDefaultObjectAdapter() == nullptr);
                 holder.communicator()->getProperties()->setProperty(
                     "DataStorm.Node.Multicast.Proxy",
-                    "DataStorm/Lookup -d:udp -h 239.255.0.1 -p 10000");
+                    "DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p 10000");
                 Node n17{holder.communicator()};
             }
         }

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -458,6 +458,250 @@ void ::Reader::run(int argc, char* argv[])
         test(sample.getKey() == "elem1");
         test(sample.getValue() == "value1");
     }
+
+    // A late-joining reader of a multi-key writer must receive the initialization samples of every key it
+    // subscribes to.
+    {
+        Topic<string, string> topic(node, "lateJoinMultiKey");
+        Topic<string, int> barrier(node, "lateJoinMultiKeyBarrier");
+        Topic<string, int> done(node, "lateJoinMultiKeyDone");
+
+        // Attach and destroy a probe reader first: once its element-level attach completed, the topics are
+        // attached, so creating the reader below announces a new element on the already-attached session and the
+        // writer initiates the element attach (the initialization samples then arrive via the initSamples request).
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        // Wait until the writer published both keys.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto reader = makeMultiKeyReader(topic, {"elemA", "elemB"}, "", config);
+        reader.waitForUnread(2);
+        map<string, string> values;
+        for (const auto& sample : reader.getAllUnread())
+        {
+            test(sample.getEvent() == SampleEvent::Add);
+            values[sample.getKey()] = sample.getValue();
+        }
+        test(values.size() == 2);
+        test(values["elemA"] == "valueA");
+        test(values["elemB"] == "valueB");
+
+        // A late-joining any-key reader must also receive every key's initialization samples.
+        auto anyKeyReader = makeAnyKeyReader(topic, "", config);
+        anyKeyReader.waitForUnread(2);
+        values.clear();
+        for (const auto& sample : anyKeyReader.getAllUnread())
+        {
+            values[sample.getKey()] = sample.getValue();
+        }
+        test(values.size() == 2);
+        test(values["elemA"] == "valueA");
+        test(values["elemB"] == "valueB");
+
+        // Signal the writer that both readers were initialized, so it can tear down.
+        auto doneWriter = makeSingleKeyWriter(done, "done");
+        doneWriter.waitForReaders();
+        doneWriter.update(0);
+    }
+
+    // Two late-joining single-key readers of a multi-key writer must each receive their own key's initialization
+    // samples, and neither the other reader's.
+    {
+        Topic<string, string> topic(node, "lateJoinSingleKeys");
+        Topic<string, int> barrier(node, "lateJoinSingleKeysBarrier");
+        Topic<string, int> done(node, "lateJoinSingleKeysDone");
+
+        // Probe reader: see the previous case.
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto readerA = makeSingleKeyReader(topic, "elemA", "", config);
+        auto readerB = makeSingleKeyReader(topic, "elemB", "", config);
+
+        auto sample = readerA.getNextUnread();
+        test(sample.getKey() == "elemA");
+        test(sample.getValue() == "valueA");
+
+        sample = readerB.getNextUnread();
+        test(sample.getKey() == "elemB");
+        test(sample.getValue() == "valueB");
+
+        test(!readerA.hasUnread()); // readerA must not also receive elemB's sample
+        test(!readerB.hasUnread()); // readerB must not also receive elemA's sample
+
+        // Signal the writer that both readers were initialized, so it can tear down.
+        auto doneWriter = makeSingleKeyWriter(done, "done");
+        doneWriter.waitForReaders();
+        doneWriter.update(0);
+    }
+
+    // Two readers on the same key, created back-to-back so they attach to the writer element in one initialization
+    // round, must each receive the key's initialization sample exactly once. The live update "valueB" is published
+    // only after both attach and drain, so a duplicated initialization sample would surface as a second "valueA"
+    // ahead of it. This depends on the two readers coalescing into one round (very likely with back-to-back creation,
+    // though not guaranteed); when they do not, the case still passes.
+    {
+        Topic<string, string> topic(node, "coalescedSameKey");
+        Topic<string, int> barrier(node, "coalescedSameKeyBarrier");
+        Topic<string, int> ready(node, "coalescedSameKeyReady");
+
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto readerA1 = makeSingleKeyReader(topic, "elemA", "", config);
+        auto readerA2 = makeSingleKeyReader(topic, "elemA", "", config);
+
+        auto initA1 = readerA1.getNextUnread();
+        test(initA1.getKey() == "elemA" && initA1.getValue() == "valueA");
+        auto initA2 = readerA2.getNextUnread();
+        test(initA2.getKey() == "elemA" && initA2.getValue() == "valueA");
+
+        auto readyWriter = makeSingleKeyWriter(ready, "ready");
+        readyWriter.waitForReaders();
+        readyWriter.update(0);
+
+        // The next sample of each reader must be the live update, not a duplicated initialization sample.
+        auto liveA1 = readerA1.getNextUnread();
+        test(liveA1.getKey() == "elemA" && liveA1.getValue() == "valueB");
+        test(!readerA1.hasUnread());
+
+        auto liveA2 = readerA2.getNextUnread();
+        test(liveA2.getKey() == "elemA" && liveA2.getValue() == "valueB");
+        test(!readerA2.hasUnread());
+    }
+
+    // A late-joining filtered reader must receive the initialization samples of exactly the writer keys its filter
+    // matches (not the writer's other keys), and must stay subscribed afterwards.
+    {
+        Topic<string, string> topic(node, "lateFilter");
+        Topic<string, int> barrier(node, "lateFilterBarrier");
+        Topic<string, int> ready(node, "lateFilterReady");
+
+        {
+            auto probe = makeSingleKeyReader(topic, "elem1", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto reader = makeFilteredKeyReader(topic, Filter<string>("_regex", "elem[0-9]"), "", config);
+        reader.waitForUnread(2);
+        map<string, string> values;
+        for (const auto& sample : reader.getAllUnread())
+        {
+            values[sample.getKey()] = sample.getValue();
+        }
+        test(values.size() == 2); // "other" does not match the filter, so it is not delivered
+        test(values["elem1"] == "value1");
+        test(values["elem2"] == "value2");
+
+        auto readyWriter = makeSingleKeyWriter(ready, "ready");
+        readyWriter.waitForReaders();
+        readyWriter.update(0);
+
+        // The reader is still subscribed after initialization, so it receives the live update on a matching key.
+        auto live = reader.getNextUnread();
+        test(live.getKey() == "elem1");
+        test(live.getValue() == "value1Live");
+    }
+
+    // A late-joining reader of a key the writer covers but never wrote receives an empty initialization batch; it must
+    // still be marked initialized so a later live sample on that key is delivered.
+    {
+        Topic<string, string> topic(node, "lateEmptyBatch");
+        Topic<string, int> barrier(node, "lateEmptyBatchBarrier");
+        Topic<string, int> ready(node, "lateEmptyBatchReady");
+
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto reader = makeSingleKeyReader(topic, "elemB", "", config);
+        reader.waitForWriters(1); // attached via the empty initialization batch; a live sample is now delivered
+
+        auto readyWriter = makeSingleKeyWriter(ready, "ready");
+        readyWriter.waitForReaders();
+        readyWriter.update(0);
+
+        // elemB had no queued sample, so initialization delivered nothing; the live update is the first sample.
+        auto sample = reader.getNextUnread();
+        test(sample.getKey() == "elemB");
+        test(sample.getValue() == "valueB");
+    }
+
+    // A late-joining multi-key reader must receive every key's initialization samples even when the sample ids
+    // interleave across keys (elemA: 1, 3; elemB: 2).
+    {
+        Topic<string, string> topic(node, "lateInterleaved");
+        Topic<string, int> barrier(node, "lateInterleavedBarrier");
+        Topic<string, int> done(node, "lateInterleavedDone");
+
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto reader = makeMultiKeyReader(topic, {"elemA", "elemB"}, "", config);
+        reader.waitForUnread(3);
+        map<string, vector<string>> byKey;
+        for (const auto& sample : reader.getAllUnread())
+        {
+            byKey[sample.getKey()].push_back(sample.getValue());
+        }
+        test(byKey.size() == 2);
+        test((byKey["elemA"] == vector<string>{"valueA1", "valueA2"}));
+        test((byKey["elemB"] == vector<string>{"valueB1"}));
+
+        auto doneWriter = makeSingleKeyWriter(done, "done");
+        doneWriter.waitForReaders();
+        doneWriter.update(0);
+    }
+
+    // A late-joining reader of an any-key writer must receive every key's initialization samples. This exercises the
+    // any-key (always-match filter) writer branch.
+    {
+        Topic<string, string> topic(node, "lateAnyKeyWriter");
+        Topic<string, int> barrier(node, "lateAnyKeyWriterBarrier");
+        Topic<string, int> done(node, "lateAnyKeyWriterDone");
+
+        {
+            auto probe = makeSingleKeyReader(topic, "elemA", "", config);
+            probe.waitForWriters(1);
+        }
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto reader = makeMultiKeyReader(topic, {"elemA", "elemB"}, "", config);
+        reader.waitForUnread(2);
+        map<string, string> values;
+        for (const auto& sample : reader.getAllUnread())
+        {
+            values[sample.getKey()] = sample.getValue();
+        }
+        test(values.size() == 2);
+        test(values["elemA"] == "valueA");
+        test(values["elemB"] == "valueB");
+
+        auto doneWriter = makeSingleKeyWriter(done, "done");
+        doneWriter.waitForReaders();
+        doneWriter.update(0);
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -542,11 +542,10 @@ void ::Reader::run(int argc, char* argv[])
         doneWriter.update(0);
     }
 
-    // Two readers on the same key, created back-to-back so they attach to the writer element in one initialization
-    // round, must each receive the key's initialization sample exactly once. The live update "valueB" is published
-    // only after both attach and drain, so a duplicated initialization sample would surface as a second "valueA"
-    // ahead of it. This depends on the two readers coalescing into one round (very likely with back-to-back creation,
-    // though not guaranteed); when they do not, the case still passes.
+    // Two readers subscribing to the same key are distinct reader elements, so each must be initialized with the key's
+    // sample exactly once and stay independently subscribed. The live update "valueB", published only after both
+    // readers drain their initialization sample, must then be the next sample each sees; a reader initialized with the
+    // wrong reader's batch, or twice, would surface a second "valueA" ahead of it.
     {
         Topic<string, string> topic(node, "coalescedSameKey");
         Topic<string, int> barrier(node, "coalescedSameKeyBarrier");
@@ -659,14 +658,13 @@ void ::Reader::run(int argc, char* argv[])
 
         auto reader = makeMultiKeyReader(topic, {"elemA", "elemB"}, "", config);
         reader.waitForUnread(3);
-        map<string, vector<string>> byKey;
-        for (const auto& sample : reader.getAllUnread())
-        {
-            byKey[sample.getKey()].push_back(sample.getValue());
-        }
-        test(byKey.size() == 2);
-        test((byKey["elemA"] == vector<string>{"valueA1", "valueA2"}));
-        test((byKey["elemB"] == vector<string>{"valueB1"}));
+        // The samples must be delivered in global sample-id order (elemA:1, elemB:2, elemA:3), not grouped by key, so
+        // a broken or removed sort in the merge is caught.
+        auto samples = reader.getAllUnread();
+        test(samples.size() == 3);
+        test(samples[0].getKey() == "elemA" && samples[0].getValue() == "valueA1");
+        test(samples[1].getKey() == "elemB" && samples[1].getValue() == "valueB1");
+        test(samples[2].getKey() == "elemA" && samples[2].getValue() == "valueA2");
 
         auto doneWriter = makeSingleKeyWriter(done, "done");
         doneWriter.waitForReaders();

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -454,9 +454,9 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
-    // Two readers on the same key, created back-to-back, attach to the writer element in one initialization round.
-    // Each must receive the key's initialization sample exactly once; the live update below, published only after both
-    // readers drained their initialization sample, would surface a duplicated batch as a second "valueA" ahead of it.
+    // Two readers subscribing to the same key are distinct reader elements and must each be initialized with the key's
+    // sample exactly once. The live update below, published only after both readers drained their initialization
+    // sample, would surface a misrouted or duplicated initialization batch as a second "valueA" ahead of it.
     cout << "testing coalesced same-key readers... " << flush;
     {
         Topic<string, string> topic(node, "coalescedSameKey");

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -407,6 +407,166 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // A late-joining reader of a multi-key writer must receive the initialization samples of every key it
+    // subscribes to, not just the first key's batch.
+    cout << "testing late-joining multi-key reader... " << flush;
+    {
+        Topic<string, string> topic(node, "lateJoinMultiKey");
+        Topic<string, int> barrier(node, "lateJoinMultiKeyBarrier");
+        Topic<string, int> done(node, "lateJoinMultiKeyDone");
+
+        auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
+        writer.add("elemA", "valueA");
+        writer.add("elemB", "valueB");
+
+        // The reader side attaches (and destroys) a probe first, then waits on the barrier before creating the
+        // late-joining reader.
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Gate teardown on the reader signalling that both its readers were initialized, so this writer never races
+        // the late readers' lifetime through a listener count that can drop back to zero before it is observed.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
+
+    // Two late-joining single-key readers of a multi-key writer must each receive their own key's initialization
+    // samples: the batches target the same writer element and must be routed per reader.
+    cout << "testing late-joining single-key readers... " << flush;
+    {
+        Topic<string, string> topic(node, "lateJoinSingleKeys");
+        Topic<string, int> barrier(node, "lateJoinSingleKeysBarrier");
+        Topic<string, int> done(node, "lateJoinSingleKeysDone");
+
+        auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
+        writer.add("elemA", "valueA");
+        writer.add("elemB", "valueB");
+
+        // See the previous case regarding the reader-side probe.
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Gate teardown on the reader signalling that both readers were initialized, so this writer never races their
+        // lifetime through a listener count that can drop back to zero before it is observed.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
+
+    // Two readers on the same key, created back-to-back, attach to the writer element in one initialization round.
+    // Each must receive the key's initialization sample exactly once; the live update below, published only after both
+    // readers drained their initialization sample, would surface a duplicated batch as a second "valueA" ahead of it.
+    cout << "testing coalesced same-key readers... " << flush;
+    {
+        Topic<string, string> topic(node, "coalescedSameKey");
+        Topic<string, int> barrier(node, "coalescedSameKeyBarrier");
+        Topic<string, int> ready(node, "coalescedSameKeyReady");
+
+        auto writer = makeSingleKeyWriter(topic, "elemA", "", config);
+        writer.add("valueA");
+
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Gate the live update on the readers signalling that they attached and drained one initialization sample, so
+        // this writer never races the late readers' lifetime through waitForReaders/waitForNoReaders.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(ready, "ready").getNextUnread();
+        writer.update("valueB");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // A late-joining filtered reader must receive the initialization samples of exactly the writer keys its filter
+    // matches, and must stay subscribed so it still receives a later live update on a matching key.
+    cout << "testing late-joining filtered reader... " << flush;
+    {
+        Topic<string, string> topic(node, "lateFilter");
+        Topic<string, int> barrier(node, "lateFilterBarrier");
+        Topic<string, int> ready(node, "lateFilterReady");
+
+        auto writer = makeMultiKeyWriter(topic, {"elem1", "elem2", "other"}, "", config);
+        writer.add("elem1", "value1");
+        writer.add("elem2", "value2");
+        writer.add("other", "valueOther");
+
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Publish a live update on a matching key only after the reader drained its initialization samples. The reader
+        // must still be subscribed to receive it.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(ready, "ready").getNextUnread();
+        writer.update("elem1", "value1Live");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // A late-joining reader of a key the writer covers but never wrote receives an empty initialization batch. The
+    // reader must still be marked initialized so a later live sample on that key is delivered.
+    cout << "testing late-joining reader of an unwritten key... " << flush;
+    {
+        Topic<string, string> topic(node, "lateEmptyBatch");
+        Topic<string, int> barrier(node, "lateEmptyBatchBarrier");
+        Topic<string, int> ready(node, "lateEmptyBatchReady");
+
+        auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
+        writer.add("elemA", "valueA"); // elemB is covered but never written
+
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Delivered only if the empty initialization batch for elemB marked the reader initialized.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(ready, "ready").getNextUnread();
+        writer.update("elemB", "valueB");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // A late-joining multi-key reader must receive every key's initialization samples even when the sample ids
+    // interleave across keys (elemA: 1, 3; elemB: 2).
+    cout << "testing late-joining reader with interleaved sample ids... " << flush;
+    {
+        Topic<string, string> topic(node, "lateInterleaved");
+        Topic<string, int> barrier(node, "lateInterleavedBarrier");
+        Topic<string, int> done(node, "lateInterleavedDone");
+
+        auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
+        writer.add("elemA", "valueA1");    // id 1
+        writer.add("elemB", "valueB1");    // id 2
+        writer.update("elemA", "valueA2"); // id 3
+
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Gate teardown on the reader signalling completion, so this writer does not race the late reader's lifetime.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
+
+    // A late-joining reader of an any-key writer must receive every key's initialization samples. This exercises the
+    // any-key (always-match filter) writer branch.
+    cout << "testing late-joining reader of an any-key writer... " << flush;
+    {
+        Topic<string, string> topic(node, "lateAnyKeyWriter");
+        Topic<string, int> barrier(node, "lateAnyKeyWriterBarrier");
+        Topic<string, int> done(node, "lateAnyKeyWriterDone");
+
+        auto writer = makeAnyKeyWriter(topic, "", config);
+        writer.add("elemA", "valueA");
+        writer.add("elemB", "valueB");
+
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
+
     cout << "testing topic collocated key reader and writer... " << flush;
     {
         Topic<string, string> topic(node, "collocated");

--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -62,10 +62,10 @@ class Writer(Client, DataStormProcess):
             # Need to use --interface 127.0.0.1 for the macOS GitHub runners.
             if isinstance(platform, Darwin):
                 props["DataStorm.Node.Multicast.Proxy"] = (
-                    f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
+                    f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
                 )
             else:
-                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port}"
+                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(
@@ -94,10 +94,10 @@ class Reader(Server, DataStormProcess):
             # Need to use --interface 127.0.0.1 for the macOS GitHub runners.
             if isinstance(platform, Darwin):
                 props["DataStorm.Node.Multicast.Proxy"] = (
-                    f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
+                    f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
                 )
             else:
-                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port}"
+                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(


### PR DESCRIPTION
Fixes #5819. Closes #5881 (duplicate).

Supersedes #6067, which fixed the same bug while preserving wire compatibility with Ice 3.8.0–3.8.2 through a negotiated protocol epoch. Per the [icerpc-dev discussion](https://github.com/icerpc/icerpc-dev/discussions/5) we decided to break compatibility with 3.8.0–3.8.2 instead — DataStorm is a young product with no known production deployments — which lets us drop all of the epoch machinery in favor of the simple, exact fix.

## The bug

A writer covering several keys, or several readers of one writer, produces one initialization batch per key under the same writer element id, and nothing on the wire identifies the target reader. `SessionI::initSamples` marked *every* attached reader initialized on the first batch and dropped the rest, so a late-joining multi-key, any-key, or filtered reader lost all but one key's initialization samples, and a sibling reader could be initialized with another reader's samples.

## The fix

`DataSamples` now carries a `peerId` identifying the reader element it initializes (as proposed in #5881, mirroring `ElementDataAck.peerId`). The publisher merges the per-key batches sharing a writer–reader pair into one globally ordered, de-duplicated batch, and the receiver initializes exactly the reader named by `peerId`. No new operation, no epoch negotiation, no receiver-side heuristics.

## Breaking change

This changes the DataStorm session wire, so 3.8.3 nodes no longer interoperate with 3.8.0–3.8.2 nodes. To keep incompatible nodes from establishing sessions, the `Lookup` servant identity changes from `DataStorm/Lookup` to `DataStorm/Lookup2`: all cross-node contact bootstraps through the `Lookup` servant, so a node only discovers peers whose `Lookup` servant uses the matching identity. Upgrade all the DataStorm nodes in a deployment together.

## Testing

`test/DataStorm/events` gains late-joining scenarios: multi-key reader, two single-key readers of a multi-key writer, coalesced same-key readers, filtered reader, unwritten-key (empty-batch) reader, interleaved sample ids, and any-key writer. Verified red→green — the new scenarios hang on `origin/main` (a reader waits forever for the dropped samples) and pass with the fix. The full `DataStorm/*` suite passes, including the relay tests.

## Known limitation (pre-existing, tracked separately)

When a single node hosts two `Topic` instances with the *same name* both reading one writer, initialization can still be misrouted because DataStorm reader element ids are only unique within a topic instance, so `peerId` cannot tell the two readers apart. This predates this change and affects the legacy path as well; it is tracked in #6068.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
