### PR TITLE
Draw DataStorm topic element, key, tag, and filter ids from a node-wide counter

### DIFF
--- a/changelog.d/datastorm/6068.md
+++ b/changelog.d/datastorm/6068.md
@@ -1,0 +1,5 @@
+- Fixed a bug in DataStorm where a node hosting two or more `Topic` instances with the same name that read from the
+  same remote writer misrouted reader initialization and sample delivery: a reader received the wrong key's value or
+  blocked. Topic element, key, tag, and filter ids are now drawn from a node-wide counter instead of a per-topic one,
+  so they stay unique across same-name topics. Element ids are node-local handles the peer only echoes back, so this
+  is wire-compatible with earlier 3.8.x nodes.

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -1520,12 +1520,17 @@ namespace DataStorm
     Topic<Key, Value, UpdateTag>::Topic(const Node& node, std::string name) noexcept
         : _name(std::move(name)),
           _topicFactory(node._factory),
-          _keyFactory(DataStormI::KeyFactoryT<Key>::createFactory()),
-          _tagFactory(DataStormI::TagFactoryT<UpdateTag>::createFactory()),
+          // The key, tag, and filter ids are drawn from a node-wide counter (rather than per-topic) so they are
+          // unique across all the node's topics; the peer echoes them back as opaque handles that this node
+          // resolves against every same-name topic, so per-topic ids would collide and misroute.
+          _keyFactory(DataStormI::KeyFactoryT<Key>::createFactory(node.getIdCounter())),
+          _tagFactory(DataStormI::TagFactoryT<UpdateTag>::createFactory(node.getIdCounter())),
           _keyFilterFactories(std::make_shared<DataStormI::FilterManagerT<DataStormI::KeyT<Key>>>()),
           _sampleFilterFactories(
               std::make_shared<DataStormI::FilterManagerT<DataStormI::SampleT<Key, Value, UpdateTag>>>())
     {
+        _keyFilterFactories->setIdCounter(node.getIdCounter());
+        _sampleFilterFactories->setIdCounter(node.getIdCounter());
         RegexFilter<Key, Key>::add(_keyFilterFactories);
         RegexFilter<Sample<Key, Value, UpdateTag>, Value>::add(_sampleFilterFactories);
         _sampleFilterFactories->set("_event", makeSampleEventFilter(*this));

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -8,6 +8,8 @@
 #include "InternalI.h"
 #include "Types.h"
 
+#include <atomic>
+
 #if defined(__clang__)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
@@ -156,6 +158,11 @@ namespace DataStormI
 
         void init() { _deleter = Deleter{std::enable_shared_from_this<AbstractFactoryT<K, V>>::shared_from_this()}; }
 
+        // Draw element ids from the given node-wide counter instead of this factory's own, so ids are unique across
+        // all the node's topics rather than per-topic (see Instance::getIdCounter). Must be called before any
+        // element is created.
+        void setIdCounter(std::shared_ptr<std::atomic<std::int64_t>> counter) noexcept { _nextId = std::move(counter); }
+
         template<typename F, typename... Args>
         [[nodiscard]] std::shared_ptr<typename V::BaseClassType> create(F&& value, Args&&... args)
         {
@@ -208,7 +215,7 @@ namespace DataStormI
             }
 
             auto k =
-                std::shared_ptr<V>(new V(std::forward<F>(value), std::forward<Args>(args)..., ++_nextId), _deleter);
+                std::shared_ptr<V>(new V(std::forward<F>(value), std::forward<Args>(args)..., ++(*_nextId)), _deleter);
             _elements[k->get()] = k;
             _elementsById[k->getId()] = k;
             return k;
@@ -237,7 +244,9 @@ namespace DataStormI
         mutable std::mutex _mutex;
         std::map<K, std::weak_ptr<V>> _elements;
         std::map<std::int64_t, std::weak_ptr<V>> _elementsById;
-        std::int64_t _nextId{1};
+        // Defaults to this factory's own counter (starting at 1, so the first id is 2 and id 1 stays reserved for
+        // the match-all filter); setIdCounter replaces it with the shared node-wide counter.
+        std::shared_ptr<std::atomic<std::int64_t>> _nextId{std::make_shared<std::atomic<std::int64_t>>(1)};
     };
 
     template<typename K> class KeyT final : public Key, public AbstractElementT<K>
@@ -265,10 +274,15 @@ namespace DataStormI
             return AbstractFactoryT<K, KeyT<K>>::create(DecoderT<K>::decode(communicator, data));
         }
 
-        [[nodiscard]] static std::shared_ptr<KeyFactoryT<K>> createFactory()
+        [[nodiscard]] static std::shared_ptr<KeyFactoryT<K>>
+        createFactory(std::shared_ptr<std::atomic<std::int64_t>> idCounter = nullptr)
         {
             auto f = std::make_shared<KeyFactoryT<K>>();
             f->init();
+            if (idCounter)
+            {
+                f->setIdCounter(std::move(idCounter));
+            }
             return f;
         }
     };
@@ -298,10 +312,15 @@ namespace DataStormI
             return AbstractFactoryT<T, TagT<T>>::create(DecoderT<T>::decode(communicator, data));
         }
 
-        [[nodiscard]] static std::shared_ptr<TagFactoryT<T>> createFactory()
+        [[nodiscard]] static std::shared_ptr<TagFactoryT<T>>
+        createFactory(std::shared_ptr<std::atomic<std::int64_t>> idCounter = nullptr)
         {
             auto f = std::make_shared<TagFactoryT<T>>();
             f->init();
+            if (idCounter)
+            {
+                f->setIdCounter(std::move(idCounter));
+            }
             return f;
         }
     };
@@ -565,6 +584,10 @@ namespace DataStormI
             if (lambda)
             {
                 auto factory = std::make_unique<FactoryT<Criteria>>(name, std::move(lambda));
+                if (_idCounter)
+                {
+                    factory->filterFactory.setIdCounter(_idCounter);
+                }
                 _factories.emplace(std::move(name), std::move(factory));
             }
             else
@@ -573,9 +596,17 @@ namespace DataStormI
             }
         }
 
+        // Draw filter ids from the given node-wide counter, so filter ids are unique across all the node's topics
+        // rather than per-topic (see Instance::getIdCounter). Must be called before any filter factory is set.
+        void setIdCounter(std::shared_ptr<std::atomic<std::int64_t>> counter) noexcept
+        {
+            _idCounter = std::move(counter);
+        }
+
     private:
         // A map containing the filter factories, indexed by the filter name.
         std::map<std::string, std::unique_ptr<Factory>> _factories;
+        std::shared_ptr<std::atomic<std::int64_t>> _idCounter;
     };
 }
 

--- a/cpp/include/DataStorm/Node.h
+++ b/cpp/include/DataStorm/Node.h
@@ -6,6 +6,7 @@
 #include "Config.h"
 #include "InternalI.h"
 
+#include <atomic>
 #include <functional>
 
 namespace DataStorm
@@ -112,6 +113,10 @@ namespace DataStorm
             options.nodeOwnsCommunicator = true;
             return options;
         }
+
+        // The node-wide counter that a topic's key, tag, and filter factories draw their ids from, so those ids are
+        // unique across all the node's topics rather than per-topic (see Instance::getIdCounter). Used by Topic.
+        [[nodiscard]] std::shared_ptr<std::atomic<std::int64_t>> getIdCounter() const;
 
         std::shared_ptr<DataStormI::Instance> _instance;
         std::shared_ptr<DataStormI::TopicFactory> _factory;

--- a/cpp/src/DataStorm/Instance.h
+++ b/cpp/src/DataStorm/Instance.h
@@ -9,6 +9,7 @@
 #include "DataStorm/Types.h"
 #include "Ice/Ice.h"
 
+#include <atomic>
 #include <cmath>
 #include <mutex>
 
@@ -102,6 +103,24 @@ namespace DataStormI
 
         [[nodiscard]] int getRetryCount() const { return _retryCount; }
 
+        // Returns the next topic element id. Element ids are drawn from this single node-wide counter (rather than
+        // per-topic) so that they are unique across all the node's topics. Several same-name topics can read the
+        // same remote writer, and reader initialization and sample delivery are addressed by the local element id;
+        // two same-name topics numbering their elements independently would collide and misroute. Keyed, any-key,
+        // and filtered elements share the counter because any-key and filtered elements are both presented to the
+        // peer as negated ids and must stay distinct from each other.
+        [[nodiscard]] std::int64_t nextElementId() noexcept { return ++_nextElementId; }
+
+        // The node-wide counter that keys, tags, and filters draw their ids from. Like element ids, these ids are
+        // echoed back by the peer as opaque handles and resolved locally against every same-name topic, so they
+        // must be unique across all the node's topics rather than per-topic. The counter starts at 1, reserving id
+        // 1 for the match-all filter. The factories hold a shared_ptr to it, so it outlives this instance if
+        // needed.
+        [[nodiscard]] const std::shared_ptr<std::atomic<std::int64_t>>& getIdCounter() const noexcept
+        {
+            return _idCounter;
+        }
+
         void shutdown();
         [[nodiscard]] bool isShutdown() const;
         void checkShutdown() const;
@@ -159,6 +178,9 @@ namespace DataStormI
         int _retryCount;
         DataStorm::ReaderConfig _defaultReaderConfig;
         DataStorm::WriterConfig _defaultWriterConfig;
+
+        std::atomic<std::int64_t> _nextElementId{0};
+        const std::shared_ptr<std::atomic<std::int64_t>> _idCounter{std::make_shared<std::atomic<std::int64_t>>(1)};
 
         mutable std::mutex _mutex;
         mutable std::condition_variable _cond;

--- a/cpp/src/DataStorm/Node.cpp
+++ b/cpp/src/DataStorm/Node.cpp
@@ -72,6 +72,12 @@ Node::~Node()
     }
 }
 
+shared_ptr<atomic<int64_t>>
+Node::getIdCounter() const
+{
+    return _instance->getIdCounter();
+}
+
 void
 Node::shutdown() noexcept
 {

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -899,7 +899,7 @@ TopicReaderI::createFiltered(
     auto element = make_shared<FilteredDataReaderI>(
         this,
         std::move(name),
-        ++_nextId,
+        _instance->nextElementId(),
         filter,
         std::move(sampleFilterName),
         std::move(sampleFilterCriteria),
@@ -920,7 +920,7 @@ TopicReaderI::create(
     auto element = make_shared<KeyDataReaderI>(
         this,
         std::move(name),
-        ++_nextId,
+        _instance->nextElementId(),
         keys,
         std::move(sampleFilterName),
         std::move(sampleFilterCriteria),
@@ -1016,7 +1016,8 @@ shared_ptr<DataWriter>
 TopicWriterI::create(const vector<shared_ptr<Key>>& keys, string name, DataStorm::WriterConfig config)
 {
     lock_guard<mutex> lock(_mutex);
-    auto element = make_shared<KeyDataWriterI>(this, std::move(name), ++_nextId, keys, mergeConfigs(config));
+    auto element =
+        make_shared<KeyDataWriterI>(this, std::move(name), _instance->nextElementId(), keys, mergeConfigs(config));
     add(element, keys);
     return element;
 }

--- a/cpp/src/DataStorm/TopicI.h
+++ b/cpp/src/DataStorm/TopicI.h
@@ -179,10 +179,8 @@ namespace DataStormI
         // The number of connected listeners.
         size_t _listenerCount{0};
 
-        // Element ids are drawn from a single counter for all elements of a topic (keyed, any-key, and filtered).
-        // Any-key and filtered elements are both presented to the peer as negated ids (filter subscriptions), so
-        // distinct raw values are required across all of them to keep their subscriptions apart.
-        std::int64_t _nextId{0};
+        // Element ids are drawn from a node-wide counter on the Instance (see Instance::nextElementId), not from a
+        // per-topic counter, so they are unique across all the node's topics.
         std::int64_t _nextSampleId{0};
     };
 

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -458,6 +458,31 @@ void ::Reader::run(int argc, char* argv[])
         test(sample.getKey() == "elem1");
         test(sample.getValue() == "value1");
     }
+
+    // Two same-name topics on this node, each with a single-key reader on a different key of the one multi-key
+    // writer. Each reader receives only its own key's value. The reader element id and key id are drawn from a
+    // node-wide counter, so the two readers stay distinct across the same-name topics; per-topic ids gave both
+    // readers the same element and key id, and the writer's samples were delivered to the wrong reader.
+    {
+        Topic<string, string> topicA(node, "sameNameInit");
+        Topic<string, string> topicB(node, "sameNameInit");
+
+        // A prior reader on each topic, so the reader under test is the second key element of its topic: with
+        // per-topic numbering the two topics then assign it the same element and key id.
+        auto firstA = makeSingleKeyReader(topicA, "firstA", "", config);
+        auto firstB = makeSingleKeyReader(topicB, "firstB", "", config);
+
+        auto readerA = makeSingleKeyReader(topicA, "elemA", "", config);
+        auto readerB = makeSingleKeyReader(topicB, "elemB", "", config);
+
+        auto sampleA = readerA.getNextUnread();
+        test(sampleA.getKey() == "elemA");
+        test(sampleA.getValue() == "valueA");
+
+        auto sampleB = readerB.getNextUnread();
+        test(sampleB.getKey() == "elemB");
+        test(sampleB.getValue() == "valueB");
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -407,6 +407,21 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // A single multi-key writer read by two same-name reader topics on the peer node, each with a single-key
+    // reader on one of the writer's keys. Each reader's sample must reach the reader that subscribed the key.
+    // Before the node-wide id counter, the two same-name reader topics assigned colliding ids and the samples
+    // were misrouted.
+    cout << "testing sample routing across same-name reader topics... " << flush;
+    {
+        Topic<string, string> topic(node, "sameNameInit");
+        auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
+        writer.waitForReaders(2); // the two single-key readers whose keys the writer covers
+        writer.add("elemA", "valueA");
+        writer.add("elemB", "valueB");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
     cout << "testing topic collocated key reader and writer... " << flush;
     {
         Topic<string, string> topic(node, "collocated");


### PR DESCRIPTION
Fixes #6068.

A node can host several `Topic` instances with the same name reading the same remote writer (topics are value
objects, so independent components each create their own instance for a shared name). Reader initialization and
sample delivery are addressed by the local element id and resolved by the local key id, and the peer echoes both
back as opaque handles that the receiver resolves against **every** same-name topic (`runWithTopics` fans a
sample/ack over all local topics subscribed to the one remote topic). Element and key ids were numbered
per-`TopicI`, so two same-name topics assigned colliding ids: a reader received the wrong key's value (legacy
path) or blocked (epoch-1 path in #6067).

### Note on the diagnosis

The issue proposed node-scoping **element ids only**, stating "key ids can stay per-topic … only element ids need
to be node-unique." That is not sufficient: the reproduction test confirms **key ids collide the same way**. In
`TopicI::attachElements`, the peer-echoed local key id (`spec.peerId`) is resolved with `_keyFactory->get(peerId)`
against every same-name topic, so a key id valid in one topic resolves to a *different* key in another. Fixing only
element ids leaves the reader subscribed to both writer keys and still misrouted. This PR node-scopes element,
key, tag, and filter ids.

### Fix

- Element ids are drawn from a node-wide counter on `Instance` (`Instance::nextElementId`, used by `TopicI`).
- Key, tag, and filter ids are drawn from a second node-wide counter shared by the per-topic factories
  (`KeyFactoryT`/`TagFactoryT`/`FilterManagerT`), reached from the `Topic` constructor via a private
  `Node::getIdCounter()`. The counter starts at 1, preserving the reserved match-all filter id 1.

All of these are node-local handles the peer only echoes back (cross-node matching is by value), so renumbering
them changes the values, not the protocol: mixed 3.8.x meshes interoperate unchanged and no protocol epoch is
required. Independent of #6067's epoch work, which can land separately.

### Testing

`cpp/test/DataStorm/events` gains a scenario with two same-name reader topics reading one multi-key writer, each
reader on a different key; each must receive only its own key's value. Verified red→green (without the fix the
reader receives the other key's value).

The test uses the live-delivery path rather than a late-joining initialization path on purpose: the late-join
variant additionally trips a pre-existing same-name-topic teardown crash (a use-after-free from the session
subscriber maps keying on raw `TopicI*`, tracked in #6088 and fixed by #5873/#6087, neither on `main` yet). This
fix only changes id values, not teardown, and the full DataStorm suite passes with it.
