### PR TITLE
Forward-port the ICE_LICENSE copyright update from the 3.8 branch

### DIFF
--- a/ICE_LICENSE
+++ b/ICE_LICENSE
@@ -12,17 +12,6 @@ details.
 You should have received a copy of the GNU General Public License version
 2 along with this program; if not, see http://www.gnu.org/licenses.
 
-Linking Ice statically or dynamically with other software (such as a
-library, module or application) is making a combined work based on Ice.
-Thus, the terms and conditions of the GNU General Public License version
-2 cover this combined work.
-
-If such software can only be used together with Ice, then not only the
-combined work but the software itself is a work derived from Ice and as
-such shall be licensed under the terms of the GNU General Public License
-version 2. This includes the situation where Ice is only being used
-through an abstraction layer.
-
 As a special exception to the above, ZeroC grants to the copyright
 holders and contributors of the Mumble project (http://www.mumble.info)
 the permission to license the Ice-based software they contribute to


### PR DESCRIPTION
Forward-ports the `ICE_LICENSE` change made on the 3.8 branch in #5327 to `main`, so the license text stays in sync across branches.

Removes the GPL "combined work" paragraphs from `ICE_LICENSE`. After this change, `main`'s `ICE_LICENSE` is byte-identical to the 3.8 branch's.

Original 3.8 commit: 7669db0f5daf8717689f556074385ec1cc2ad5ed (#5327).