### PR TITLE
Fix typos and grammar in the Swift mapping

### DIFF
--- a/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
+++ b/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
@@ -49,7 +49,7 @@ enum PluginError: Error {
             return "Missing slice compiler: '\(path)'."
         case .missingConfigFile(let path, let target):
             return
-                "Missing config file '\(path)` for target `\(target)`. '. This file must be included in your sources."
+                "Missing config file '\(path)' for target '\(target)'. This file must be included in your sources."
         case .missingIceSliceFiles(let path):
             return "The Ice slice files are missing. Expected location: `\(path)`"
         }

--- a/swift/Plugins/CompileSlice/README.md
+++ b/swift/Plugins/CompileSlice/README.md
@@ -4,7 +4,7 @@ The `CompileSlice` plugin is a SwiftPM plugin that compiles Slice files to Swift
 compiling Slice files as part of the SwiftPM build process, without having to manually run the `slice2swift`
 compiler.
 
-To use the plugin with with a target that relies on generated Swift files, add the plugin to the target's plugins
+To use the plugin with a target that relies on generated Swift files, add the plugin to the target's plugins
 list:
 
 ```swift

--- a/swift/src/Ice/Endpoint.swift
+++ b/swift/src/Ice/Endpoint.swift
@@ -77,7 +77,7 @@ open class IPEndpointInfo: EndpointInfo {
     }
 }
 
-/// Provides access to a TCP endpoint information.
+/// Provides access to TCP endpoint information.
 public final class TCPEndpointInfo: IPEndpointInfo {
     private let _type: Int16
     private let _secure: Bool
@@ -97,11 +97,11 @@ public final class TCPEndpointInfo: IPEndpointInfo {
     }
 }
 
-/// Provides access to an SSL endpoint information.
+/// Provides access to SSL endpoint information.
 public final class SSLEndpointInfo: EndpointInfo {
 }
 
-/// Provides access to a UDP endpoint information.
+/// Provides access to UDP endpoint information.
 public final class UDPEndpointInfo: IPEndpointInfo {
     /// The multicast interface.
     public let mcastInterface: String
@@ -127,7 +127,7 @@ public final class UDPEndpointInfo: IPEndpointInfo {
     }
 }
 
-/// Provides access to a WebSocket endpoint information.
+/// Provides access to WebSocket endpoint information.
 public final class WSEndpointInfo: EndpointInfo {
     /// The URI configured with the endpoint.
     public let resource: String
@@ -138,7 +138,7 @@ public final class WSEndpointInfo: EndpointInfo {
     }
 }
 
-/// Provides access to an IAP endpoint information.
+/// Provides access to IAP endpoint information.
 public final class IAPEndpointInfo: EndpointInfo {
     /// The accessory manufacturer. Can be empty.
     public let manufacturer: String
@@ -182,7 +182,7 @@ public final class OpaqueEndpointInfo: EndpointInfo {
     /// The encoding version of the opaque endpoint (to decode or encode the rawBytes).
     public let rawEncoding: EncodingVersion
 
-    /// The raw encoding of the opaque endpoint.
+    /// The raw bytes of the opaque endpoint.
     public let rawBytes: ByteSeq
 
     private let _type: Int16

--- a/swift/src/Ice/Initialize.swift
+++ b/swift/src/Ice/Initialize.swift
@@ -6,7 +6,7 @@ import IceImpl
 // Factories are registered once when `factoriesRegistered' is lazy initialized,
 // all Swift global variables are lazy initialized.
 //
-// All code paths that require the use of the factories before `initialize' is call
+// All code paths that require the use of the factories before `initialize' is called
 // should check `factoriesRegistered' to ensure lazy initialization occurs before
 // the factories are used.
 //
@@ -75,7 +75,7 @@ public func initialize(_ initData: InitializationData = InitializationData()) th
 
         precondition(propsHandle === handle.getProperties(), "initialize changed the properties object")
 
-        // Update newInitData.logger reference in case we are using a C++ logger (defined though a property) or
+        // Update newInitData.logger reference in case we are using a C++ logger (defined through a property) or
         // a C++ logger plug-in installed a new logger.
         if let objcLogger = handle.getLogger() as? ICELogger {
             newInitData.logger = objcLogger.getSwiftObject(ObjcLoggerWrapper.self) {

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -579,7 +579,7 @@ extension InputStream {
         // The goal of this check is to ensure that when we start un-marshaling
         // a new sequence, we check the minimal size of this new sequence against
         // the estimated remaining buffer size. This estimation is based on
-        // the minimum size of the enclosing sequences, it's minSeqSize.
+        // the minimum size of the enclosing sequences, i.e., minSeqSize.
         //
         // 'sz' is peer-controlled (up to Int32.max), so we compute the minimum size of this
         // sequence as an Int64: 'sz * minSize' would overflow a 32-bit value and bypass the
@@ -594,7 +594,7 @@ extension InputStream {
         //
         // If there isn't enough data to read on the stream for the sequence (and
         // possibly enclosed sequences), something is wrong with the marshaled
-        // data: it's claiming having more data that what is possible to read.
+        // data: it's claiming having more data than what is possible to read.
         //
         if Int64(startSeq) + newMinSeqSize > Int64(data.count) {
             throw MarshalException(endOfBufferMessage)
@@ -638,7 +638,8 @@ extension InputStream {
             }
             var tag = Int32(v >> 3)
             if tag > 30 {
-                // We check for '> 30' instead of '> 29' because 30 is special sentinel tag, handled by the next block.
+                // We check for '> 30' instead of '> 29' because 30 is a special sentinel tag, handled by the next
+                // block.
                 throw MarshalException("invalid tag '\(tag)': tags larger than 29 must be encoded as a size")
             }
             if tag == 30 {
@@ -690,7 +691,7 @@ extension InputStream {
         }
     }
 
-    /// Reads an enumerator from the stream, as a Int32.
+    /// Reads an enumerator from the stream, as an Int32.
     ///
     /// - Parameter enumMaxValue: The maximum value for the enumerators (used only for the 1.0 encoding).
     /// - Returns: The enumerator's Int32 value.
@@ -1051,7 +1052,7 @@ private class EncapsDecoder10: EncapsDecoder {
         precondition(sliceType == .NoSlice)
 
         //
-        // User exception with the 1.0 encoding start with a boolean flag
+        // User exceptions with the 1.0 encoding start with a boolean flag
         // that indicates whether or not the exception has classes.
         //
         // This allows reading the pending instances even if some part of
@@ -1512,7 +1513,7 @@ private class EncapsDecoder11: EncapsDecoder {
 
         //
         // Read the indirect instance table. We read the instances or their
-        // IDs if the instance is a reference to an already unmarhshaled
+        // IDs if the instance is a reference to an already unmarshaled
         // instance.
         //
         if current.sliceFlags.contains(.FLAG_HAS_INDIRECTION_TABLE) {

--- a/swift/src/Ice/OutputStream.swift
+++ b/swift/src/Ice/OutputStream.swift
@@ -696,7 +696,7 @@ private final class EncapsEncoder10: EncapsEncoder {
     }
 
     func writeException(v: UserException) {
-        // User exception with the 1.0 encoding start with a boolean
+        // User exception with the 1.0 encoding starts with a boolean
         // flag that indicates whether or not the exception uses classes.
         //
         // This allows reading the pending instances even if some part of
@@ -884,7 +884,7 @@ private final class EncapsEncoder11: EncapsEncoder {
         os.write(UInt8(0))  // Placeholder for the slice flags
 
         // For instance slices, encode the flag and the type ID either as a
-        // string or index. For exception slices, always encode the type ID a string.
+        // string or index. For exception slices, always encode the type ID as a string.
         if current.sliceType == SliceType.ValueSlice {
             // Encode the type ID (only in the first slice for the compact encoding).
             if encaps.format == .slicedFormat || current.firstSlice {
@@ -992,7 +992,7 @@ private final class EncapsEncoder11: EncapsEncoder {
     }
 
     func writeInstance(_ v: Value) {
-        // If the instance was already marshaled, just write it's ID.
+        // If the instance was already marshaled, just write its ID.
         if let p = marshaledMap[ValueHolder(v)] {
             os.write(size: p)
             return

--- a/swift/test/Ice/location/AllTests.swift
+++ b/swift/test/Ice/location/AllTests.swift
@@ -445,7 +445,7 @@ func allTests(_ helper: TestHelper) async throws {
                 try await Task.sleep(for: .milliseconds(10))
             }
         } catch is Ice.LocalException {
-            // Expected to fail once they endpoints have been updated in the background.
+            // Expected to fail once the endpoints have been updated in the background.
         }
 
         do {
@@ -454,7 +454,7 @@ func allTests(_ helper: TestHelper) async throws {
                 try await Task.sleep(for: .milliseconds(10))
             }
         } catch is Ice.LocalException {
-            // Expected to fail once they endpoints have been updated in the background.
+            // Expected to fail once the endpoints have been updated in the background.
         }
         ic.destroy()
     }
@@ -540,12 +540,12 @@ func allTests(_ helper: TestHelper) async throws {
         // Calls on the well-known proxy are not collocated because of issue #507
     }
 
-    // Ensure that calls on the indirect proxy (with adapter ID) is collocated
+    // Ensure that calls on the indirect proxy (with adapter ID) are collocated
     var helloPrx = try await checkedCast(
         prx: adapter.createIndirectProxy(ident), type: HelloPrx.self)!
     try await test(helloPrx.ice_getConnection() == nil)
 
-    // Ensure that calls on the direct proxy is collocated
+    // Ensure that calls on the direct proxy are collocated
     helloPrx = try await checkedCast(prx: adapter.createDirectProxy(ident), type: HelloPrx.self)!
     try await test(helloPrx.ice_getConnection() == nil)
 

--- a/swift/test/Ice/operations/Collocated.swift
+++ b/swift/test/Ice/operations/Collocated.swift
@@ -12,7 +12,7 @@ class Collocated: TestHelperI, @unchecked Sendable {
         properties.setProperty(key: "Ice.BatchAutoFlushSize", value: "100")
 
         //
-        // Its possible to have batch oneway requests dispatched
+        // It's possible to have batch oneway requests dispatched
         // after the adapter is deactivated due to thread
         // scheduling so we suppress this warning.
         //

--- a/swift/test/Ice/operations/Server.swift
+++ b/swift/test/Ice/operations/Server.swift
@@ -7,7 +7,7 @@ class Server: TestHelperI, @unchecked Sendable {
     override public func run(args: [String]) async throws {
         let properties = try createTestProperties(args)
         //
-        // Its possible to have batch oneway requests dispatched
+        // It's possible to have batch oneway requests dispatched
         // after the adapter is deactivated due to thread
         // scheduling so we suppress this warning.
         //

--- a/swift/test/Ice/udp/AllTests.swift
+++ b/swift/test/Ice/udp/AllTests.swift
@@ -86,7 +86,7 @@ public func allTests(_ helper: TestHelper) async throws {
 
     if try communicator.getProperties().getIcePropertyAsInt("Ice.Override.Compress") == 0 {
         //
-        // Only run this test if compression is disabled, the test expect fixed message size
+        // Only run this test if compression is disabled, the test expects fixed message size
         // to be sent over the wire.
         //
         var seq: ByteSeq
@@ -102,7 +102,7 @@ public func allTests(_ helper: TestHelper) async throws {
         } catch is Ice.DatagramLimitException {
             //
             // The server's Ice.UDP.RcvSize property is set to 16384, which means that DatagramLimitException
-            // will be throw when try to send a packet bigger than that.
+            // will be thrown when trying to send a packet bigger than that.
             //
             try test(seq.count > 16384)
         }

--- a/swift/test/Ice/udp/Server.swift
+++ b/swift/test/Ice/udp/Server.swift
@@ -34,7 +34,7 @@ class Server: TestHelperI, @unchecked Sendable {
 
         var endpoint = "udp -h "
         //
-        // Use loopback to prevent other machines to answer.
+        // Use loopback to prevent other machines from answering.
         //
         if properties.getIceProperty("Ice.IPv6") == "1" {
             endpoint += "\"ff15::1:1\""

--- a/swift/test/ios/TestDriverApp/ControllerI.swift
+++ b/swift/test/ios/TestDriverApp/ControllerI.swift
@@ -325,13 +325,13 @@ class ControllerHelperI: ControllerHelper, TextWriter, @unchecked Sendable {
 
 class LogHelper {
     static func createLogDirectory(_ path: String) -> URL {
-        // Get the appropriate directory (Documents for iOS)
-        guard let documentsDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-            fatalError("Unable to access documents directory")
+        // Get the appropriate directory (Caches for iOS)
+        guard let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            fatalError("Unable to access caches directory")
         }
 
         // Create log directory path
-        let logDirectory = documentsDirectory.appendingPathComponent(path)
+        let logDirectory = cachesDirectory.appendingPathComponent(path)
 
         // Create directory if it doesn't exist
         try? FileManager.default.createDirectory(at: logDirectory, withIntermediateDirectories: true, attributes: nil)


### PR DESCRIPTION
Comment and doc-comment typo fixes across the Swift mapping — misspellings (`unmarhshaled`), duplicated words (`with with`), subject-verb agreement, and `its`/`it's`. No behavior changes.

Three edits are worth a closer look, since they are not pure comment fixes:

- `CompileSlicePlugin.swift` — the "Missing config file" error message had mismatched quoting (a `'` opened and a backtick closed it, plus a stray ` '` before the period). Now uses matching single quotes.
- `ControllerI.swift` — renamed the local `documentsDirectory` to `cachesDirectory`, and the matching `fatalError` text. The code asks for `.cachesDirectory`, so the old name and message described the wrong location. Local variable only.
- `Endpoint.swift` — `OpaqueEndpointInfo.rawBytes` was documented as "the raw encoding of the opaque endpoint"; it is a `ByteSeq`, so it now reads "the raw bytes".

The remaining changes are comments and doc comments only. Where a comment is mirrored in the other language mappings, only the Swift copy is touched here — the siblings are handled in the companion PRs.