### PR TITLE
Fix typos and grammar in the JavaScript mapping

### DIFF
--- a/js/packages/ice/src/Ice/ConnectionI.js
+++ b/js/packages/ice/src/Ice/ConnectionI.js
@@ -994,7 +994,7 @@ export class ConnectionI {
             }
 
             // We send a heartbeat to the peer to generate a "write" on the connection. This write in turns creates
-            // a read on the peer, and resets the peer's idle check timer. When _sendStream is not empty, there is
+            // a read on the peer, and resets the peer's idle check timer. When _sendStreams is not empty, there is
             // already an outstanding write, so we don't need to send a heartbeat. It's possible the first message
             // of _sendStreams was already sent but not yet removed from _sendStreams: it means the last write
             // occurred very recently, which is good enough with respect to the idle check.

--- a/js/packages/ice/src/Ice/Endpoint.d.ts
+++ b/js/packages/ice/src/Ice/Endpoint.d.ts
@@ -83,13 +83,13 @@ declare module "@zeroc/ice" {
         }
 
         /**
-         * Provides access to a TCP endpoint information.
+         * Provides access to TCP endpoint information.
          * @see Endpoint
          */
         class TCPEndpointInfo extends IPEndpointInfo {}
 
         /**
-         * Provides access to a WebSocket endpoint information.
+         * Provides access to WebSocket endpoint information.
          */
         class WSEndpointInfo extends EndpointInfo {
             /**

--- a/js/packages/ice/src/Ice/Endpoint.js
+++ b/js/packages/ice/src/Ice/Endpoint.js
@@ -64,7 +64,7 @@ export class IPEndpointInfo extends EndpointInfo {
 }
 
 /**
- *  Provides access to a TCP endpoint information.
+ *  Provides access to TCP endpoint information.
  *  @see {@link Endpoint}
  */
 export class TCPEndpointInfo extends IPEndpointInfo {
@@ -84,7 +84,7 @@ export class TCPEndpointInfo extends IPEndpointInfo {
 }
 
 /**
- *  Provides access to a WebSocket endpoint information.
+ *  Provides access to WebSocket endpoint information.
  */
 export class WSEndpointInfo extends EndpointInfo {
     constructor(underlying, resource) {

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -297,7 +297,6 @@ class EncapsDecoder10 extends EncapsDecoder {
         // string.
         //
         if (this._sliceType === SliceType.ValueSlice) {
-            // For exceptions, the type ID is always encoded as a string
             const isIndex = this._stream.readBool();
             this._typeId = this.readTypeId(isIndex);
         } else {
@@ -1233,7 +1232,7 @@ export class InputStream {
         //
         // If there isn't enough data to read on the stream for the sequence (and
         // possibly enclosed sequences), something is wrong with the marshaled
-        // data: it's claiming having more data that what is possible to read.
+        // data: it's claiming having more data than what is possible to read.
         //
         if (this._startSeq + this._minSeqSize > this._buf.limit) {
             throw new MarshalException(endOfBufferMessage);
@@ -1425,7 +1424,8 @@ export class InputStream {
             const format = OptionalFormat.valueOf(v & 0x07); // First 3 bits.
             let tag = v >> 3;
             if (tag > 30) {
-                // We check for '> 30' instead of '> 29' because 30 is special sentinel tag, handled by the next block.
+                // We check for '> 30' instead of '> 29' because 30 is a special sentinel tag, handled by the next
+                // block.
                 throw new MarshalException(`invalid tag '${tag}': tags larger than 29 must be encoded as a size`);
             }
             if (tag === 30) {

--- a/js/packages/ice/src/Ice/LocatorInfo.js
+++ b/js/packages/ice/src/Ice/LocatorInfo.js
@@ -287,7 +287,7 @@ export class LocatorInfo {
         if (proxy === null || proxy._getReference().isIndirect()) {
             //
             // Remove the cached references of well-known objects for which we tried
-            // to resolved the endpoints if these endpoints are empty.
+            // to resolve the endpoints if these endpoints are empty.
             //
             for (let i = 0; i < wellKnownRefs.length; ++i) {
                 this._table.removeObjectReference(wellKnownRefs[i].getIdentity());

--- a/js/packages/ice/src/Ice/OutputStream.js
+++ b/js/packages/ice/src/Ice/OutputStream.js
@@ -434,7 +434,7 @@ class EncapsEncoder11 extends EncapsEncoder {
         console.assert(v !== null && v !== undefined);
 
         //
-        // If the instance was already marshaled, just write it's ID.
+        // If the instance was already marshaled, just write its ID.
         //
         const p = this._marshaledMap.get(v);
         if (p !== undefined) {

--- a/js/packages/ice/src/Ice/Properties.js
+++ b/js/packages/ice/src/Ice/Properties.js
@@ -397,13 +397,13 @@ export class Properties {
                 return prop;
             }
 
-            // If the property has a property array, check if the key is a prefix of the property.
+            // If the property has a property array, check if the property is a prefix of the key.
             if (prop.propertyArray) {
-                // Check if the key is a prefix of the property.
+                // Check if the property pattern is a prefix of the key.
                 // The key must be:
-                // - shorter than the property pattern
-                // - the property pattern must start with the key
-                // - the pattern character after the key must be a dot
+                // - longer than the property pattern
+                // - the key must start with the property pattern
+                // - the key character after the property pattern must be a dot
                 if (key.length > prop.pattern.length && key.startsWith(`${prop.pattern}.`)) {
                     // Plus one to skip the dot.
                     let substring = key.substring(prop.pattern.length + 1);

--- a/js/packages/ice/src/Ice/SSL/EndpointInfo.d.ts
+++ b/js/packages/ice/src/Ice/SSL/EndpointInfo.d.ts
@@ -2,7 +2,7 @@ declare module "@zeroc/ice" {
     namespace Ice {
         namespace SSL {
             /**
-             * Provides access to an SSL endpoint information.
+             * Provides access to SSL endpoint information.
              */
             class EndpointInfo extends Ice.EndpointInfo {}
         }

--- a/js/packages/ice/src/Ice/SSL/EndpointInfo.js
+++ b/js/packages/ice/src/Ice/SSL/EndpointInfo.js
@@ -3,6 +3,6 @@
 import { EndpointInfo as IceEndpointInfo } from "../Endpoint.js";
 
 /**
- *  Provides access to an SSL endpoint information.
+ *  Provides access to SSL endpoint information.
  */
 export class EndpointInfo extends IceEndpointInfo {}

--- a/js/packages/ice/src/Ice/StringUtil.js
+++ b/js/packages/ice/src/Ice/StringUtil.js
@@ -371,7 +371,7 @@ function checkChar(s, pos) {
         } else {
             msg = "first character";
         }
-        msg += " has invalid ordinal value" + c;
+        msg += " has invalid ordinal value " + c;
         throw new RangeError(msg);
     }
     return s.charAt(pos);

--- a/js/packages/test/Ice/idleTimeout/Client.ts
+++ b/js/packages/test/Ice/idleTimeout/Client.ts
@@ -103,16 +103,16 @@ async function testConnectionAbortedByIdleCheck(properties: Ice.Properties, help
     }
 }
 
-// Verifies the behavior with the server idle check enabled or disabled when the client and the server have mismatched idle
+// Verifies the behavior with the idle check enabled or disabled when the client and the server have mismatched idle
 // timeouts (here: 3s on the server side and 1s on the client side).
-async function testServerWithEnableDisableIdleCheck(
+async function testEnableDisableIdleCheck(
     enabled: boolean,
     properties: Ice.Properties,
     helper: TestHelper,
 ): Promise<void> {
     const output = helper.getWriter();
     const enabledString = enabled ? "enabled" : "disabled";
-    output.write(`testing with server idle check ${enabledString}... `);
+    output.write(`testing connection with idle check ${enabledString}... `);
 
     // The server has 3s idle timeout, and enabled idle check.
     const proxyString3s = `test: ${helper.getTestEndpoint(2)}`;
@@ -179,8 +179,8 @@ export class Client extends TestHelper {
         await testConnectionAbortedByIdleCheck(communicator.getProperties(), this);
         await testConnectionNotAbortedByIdleCheck(communicator.getProperties(), this);
 
-        await testServerWithEnableDisableIdleCheck(true, communicator.getProperties(), this);
-        await testServerWithEnableDisableIdleCheck(false, communicator.getProperties(), this);
+        await testEnableDisableIdleCheck(true, communicator.getProperties(), this);
+        await testEnableDisableIdleCheck(false, communicator.getProperties(), this);
 
         await testNoIdleTimeout(communicator.getProperties(), this);
 

--- a/js/packages/test/Ice/inactivityTimeout/Client.ts
+++ b/js/packages/test/Ice/inactivityTimeout/Client.ts
@@ -66,7 +66,7 @@ async function testWithOutstandingRequest(p: Test.TestIntfPrx, oneway: boolean, 
         // With a oneway invocation, the inactivity timeout on the client side shut down the first connection.
         test(connection2 != connection);
     } else {
-        // With a two-way invocation, the inactivity timeout should not shutdown any connection.
+        // With a two-way invocation, the inactivity timeout should not shut down any connection.
         test(connection2 == connection);
     }
     await connection2.close();

--- a/js/packages/test/Ice/location/Client.ts
+++ b/js/packages/test/Ice/location/Client.ts
@@ -386,7 +386,7 @@ export class Client extends TestHelper {
                     await Ice.Promise.delay(10);
                 }
             } catch (ex) {
-                // Expected to fail once they endpoints have been updated in the background.
+                // Expected to fail once the endpoints have been updated in the background.
                 test(ex instanceof Ice.LocalException, ex as Error);
             }
             try {
@@ -395,7 +395,7 @@ export class Client extends TestHelper {
                     await Ice.Promise.delay(10);
                 }
             } catch (ex) {
-                // Expected to fail once they endpoints have been updated in the background.
+                // Expected to fail once the endpoints have been updated in the background.
                 test(ex instanceof Ice.LocalException, ex as Error);
             }
             await ic.destroy();


### PR DESCRIPTION
Comment and doc-comment typo fixes across the JavaScript mapping — `that`/`than`, `its`/`it's`, missing articles, a stale `_sendStream` field reference, and `shutdown` used as a verb. No behavior changes.

Four edits go beyond plain comment fixes and are worth a look:

- `StringUtil.js` — `"has invalid ordinal value" + c` was missing the trailing space, so the message read `...ordinal value3`. This is a user-visible exception message.
- `Properties.js` — the comment block describing the property-prefix match had the comparison backwards (it said the property must start with the key, and described the key as shorter). Rewritten to match what the code does; the code is unchanged.
- `idleTimeout/Client.ts` — renamed `testServerWithEnableDisableIdleCheck` to `testEnableDisableIdleCheck` and adjusted the test banner: the helper drives the client-side idle check, not the server's. Test-local; both call sites updated.
- `InputStream.js` — dropped a comment line that duplicated a sentence already present three lines above it.

Where a comment is mirrored in the other language mappings, only the JavaScript copy is touched here — the siblings are handled in the companion PRs.