### PR TITLE
Fix typos and grammar in the C++ core and services

### DIFF
--- a/cpp/include/DataStorm/Node.h
+++ b/cpp/include/DataStorm/Node.h
@@ -98,10 +98,10 @@ namespace DataStorm
         [[nodiscard]] Ice::CommunicatorPtr getCommunicator() const noexcept;
 
         /// Returns the Ice connection associated with a session given a session identifier. Session identifiers are
-        /// provided with the sample origin data member as the first tuple element.
+        /// returned by DataStorm::Sample::getSession.
         /// @param ident The session identifier.
         /// @return The connection associated with the given session
-        /// @see DataStorm::Sample::ElementId DataStorm::Sample::getSession
+        /// @see DataStorm::Sample::getSession
         [[nodiscard]] Ice::ConnectionPtr getSessionConnection(std::string_view ident) const noexcept;
 
     private:

--- a/cpp/include/DataStorm/Types.h
+++ b/cpp/include/DataStorm/Types.h
@@ -22,7 +22,7 @@ namespace DataStorm
         /// Samples are never discarded.
         None,
 
-        /// Samples are discared based on the sample timestamp. If the received sample timestamp is older than the
+        /// Samples are discarded based on the sample timestamp. If the received sample timestamp is older than the
         /// last received sample, the sample is discarded. This ensures that readers will eventually always end up
         /// with the same view of the data if multiple writers are sending samples.
         SendTime,
@@ -36,7 +36,7 @@ namespace DataStorm
     /// event of the received sample.
     enum struct ClearHistoryPolicy
     {
-        /// Clear the sample history when a Add sample is received.
+        /// Clear the sample history when an Add sample is received.
         OnAdd,
 
         /// Clear the sample history when a Remove sample is received.
@@ -81,7 +81,7 @@ namespace DataStorm
         std::optional<int> sampleLifetime;
 
         /// The clear history policy specifies when samples are removed from the sample history. By default,
-        /// samples are removed when a new sample is is received which effectively disables the sample history.
+        /// samples are removed when a new sample is received which effectively disables the sample history.
         std::optional<ClearHistoryPolicy> clearHistory;
     };
 
@@ -146,7 +146,7 @@ namespace DataStorm
         Disconnect
     };
 
-    /// The Encoder template provides a method to encode decode user types.
+    /// The Encoder template provides a method to encode user types.
     /// The encoder template can be specialized to provide encoding for types that don't support being encoded with
     /// Ice. By default, the Slice encoding is used if no Encoder template specialization is provided for the type.
     /// @headerfile DataStorm/DataStorm.h
@@ -181,7 +181,7 @@ namespace DataStorm
         /// Clones the given value. This helper is used when processing partial update to clone the previous value
         /// and compute the new value with the partial update. The default implementation performs a plain C++ copy
         /// with the copy constructor.
-        /// @param value The value to encode
+        /// @param value The value to clone
         /// @return The cloned value
         static T clone(const T& value) noexcept { return value; }
     };

--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -409,7 +409,7 @@ namespace Ice
         CommunicatorHolder& operator=(CommunicatorHolder&& holder) noexcept;
 
         /// Determines whether this holder holds a communicator.
-        /// @return `true` if the holder currently a holds communicator, `false` otherwise.
+        /// @return `true` if the holder currently holds a communicator, `false` otherwise.
         explicit operator bool() const noexcept { return _communicator != nullptr; }
 
         ~CommunicatorHolder();

--- a/cpp/include/Ice/Endpoint.h
+++ b/cpp/include/Ice/Endpoint.h
@@ -123,7 +123,7 @@ namespace Ice
         }
     };
 
-    /// Provides access to a TCP endpoint information.
+    /// Provides access to TCP endpoint information.
     /// @see Endpoint
     /// @headerfile Ice/Ice.h
     class ICE_API TCPEndpointInfo final : public IPEndpointInfo
@@ -155,7 +155,7 @@ namespace Ice
         const bool _secure;
     };
 
-    /// Provides access to a UDP endpoint information.
+    /// Provides access to UDP endpoint information.
     /// @see Endpoint
     /// @headerfile Ice/Ice.h
     class ICE_API UDPEndpointInfo final : public IPEndpointInfo
@@ -189,7 +189,7 @@ namespace Ice
         }
     };
 
-    /// Provides access to a WebSocket endpoint information.
+    /// Provides access to WebSocket endpoint information.
     /// @headerfile Ice/Ice.h
     class ICE_API WSEndpointInfo final : public EndpointInfo
     {
@@ -209,7 +209,7 @@ namespace Ice
         }
     };
 
-    /// Provides access to an IAP endpoint information.
+    /// Provides access to IAP endpoint information.
     /// @headerfile Ice/Ice.h
     class IAPEndpointInfo final : public EndpointInfo
     {

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -510,7 +510,7 @@ namespace Ice
         void read(std::vector<std::int32_t>& v);
 
         /// Reads a long from the stream.
-        /// @param[out]v The extracted long.
+        /// @param[out] v The extracted long.
         void read(std::int64_t& v);
 
         /// Reads a sequence of longs from the stream.

--- a/cpp/include/Ice/Instrumentation.h
+++ b/cpp/include/Ice/Instrumentation.h
@@ -222,14 +222,14 @@ namespace Ice::Instrumentation
     public:
         virtual ~ObserverUpdater() = default;
 
-        /// Updates connection observers associated with each of the Ice connection from the communicator and its object
-        /// adapters.
+        /// Updates connection observers associated with each of the Ice connections from the communicator and its
+        /// object adapters.
         /// When called, this method goes through all the connections and for each connection
         /// CommunicatorObserver::getConnectionObserver is called. The implementation of getConnectionObserver
         /// has the possibility to return an updated observer if necessary.
         virtual void updateConnectionObservers() = 0;
 
-        /// Updates thread observers associated with each of the Ice thread from the communicator and its object
+        /// Updates thread observers associated with each of the Ice threads from the communicator and its object
         /// adapters. When called, this method goes through all the threads and for each thread
         /// CommunicatorObserver::getThreadObserver is called. The implementation of getThreadObserver has the
         /// possibility to return an updated observer if necessary.

--- a/cpp/include/Ice/Object.h
+++ b/cpp/include/Ice/Object.h
@@ -36,12 +36,12 @@ namespace Ice
         /// not throw any exception and any @p sendResponse wrapper must not throw any exception. @p sendResponse can be
         /// called by the thread that called dispatch (the "dispatch thread") or by another thread. The implementation
         /// must call @p sendResponse exactly once or throw an exception.
-        /// @remark Calling @p sendResponse can be thought as returning the outgoing response. Just like when you return
-        /// a value from a remote operation, you can only return it once and you don't know if the client receives this
-        /// value. In practice, the Ice-provided @p sendResponse attempts to send the response to the client
-        /// synchronously, but may send it asynchronously. It can also silently fail to send the response back to the
-        /// client. This function is the main building block for the Ice dispatch pipeline. The implementation provided
-        /// by the base class (Object) dispatches incoming requests to the four `Object` operations (`ice_isA`,
+        /// @remark Calling @p sendResponse can be thought of as returning the outgoing response. Just like when you
+        /// return a value from a remote operation, you can only return it once and you don't know if the client
+        /// receives this value. In practice, the Ice-provided @p sendResponse attempts to send the response to the
+        /// client synchronously, but may send it asynchronously. It can also silently fail to send the response back to
+        /// the client. This function is the main building block for the Ice dispatch pipeline. The implementation
+        /// provided by the base class (Object) dispatches incoming requests to the four `Object` operations (`ice_isA`,
         /// `ice_ping`, `ice_ids` and `ice_id`), and throws OperationNotExistException for all other operations. This
         /// base implementation is trivial and should be overridden and fully replaced by all derived classes.
         virtual void dispatch(IncomingRequest& request, std::function<void(OutgoingResponse)> sendResponse);

--- a/cpp/include/Ice/ObjectAdapter.h
+++ b/cpp/include/Ice/ObjectAdapter.h
@@ -290,7 +290,7 @@ namespace Ice
         virtual void setLocator(std::optional<LocatorPrx> loc) = 0;
 
         /// Gets the Ice locator used by this object adapter.
-        /// @return The locator used by this object adapter, or nullptr if no locator is used by this object adapter.
+        /// @return The locator used by this object adapter, or nullopt if no locator is used by this object adapter.
         [[nodiscard]] virtual std::optional<LocatorPrx> getLocator() const noexcept = 0;
 
         /// Gets the set of endpoints configured on this object adapter.

--- a/cpp/include/Ice/OutgoingAsync.h
+++ b/cpp/include/Ice/OutgoingAsync.h
@@ -143,7 +143,7 @@ namespace IceInternal
     //
     // Base class for proxy based invocations. This class handles the
     // retry for proxy invocations. It also ensures the child observer is
-    // correct notified of failures and make sure the retry task is
+    // correctly notified of failures and makes sure the retry task is
     // correctly canceled when the invocation completes.
     //
     class ICE_API ProxyOutgoingAsyncBase : public OutgoingAsyncBase, public TimerTask

--- a/cpp/include/Ice/SSL/EndpointInfo.h
+++ b/cpp/include/Ice/SSL/EndpointInfo.h
@@ -15,7 +15,7 @@
 
 namespace Ice::SSL
 {
-    /// Provides access to an SSL endpoint information.
+    /// Provides access to SSL endpoint information.
     class ICE_API EndpointInfo final : public Ice::EndpointInfo
     {
     public:

--- a/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
@@ -84,7 +84,7 @@ namespace Ice::SSL
         /// @snippet Ice/SSL/SchannelServerAuthenticationOptions.cpp clientCertificateValidationCallback
         ///
         /// @param context An opaque object representing the security context associated with the current connection.
-        /// This context contains security data relevant for validation, such as the server's certificate chain and
+        /// This context contains security data relevant for validation, such as the client's certificate chain and
         /// cipher suite.
         /// @param info The connection info object that provides additional connection-related data. The
         /// `ConnectionInfo` type is an alias for the platform-specific connection info class.

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -291,7 +291,7 @@ namespace Ice
         }
     };
 
-    /// Helper the array custom sequence mapping.
+    /// Helper for the array custom sequence mapping.
     template<typename T> struct StreamHelper<std::pair<const T*, const T*>, StreamHelperCategorySequence>
     {
         static void write(OutputStream* stream, std::pair<const T*, const T*> v) { stream->write(v.first, v.second); }

--- a/cpp/include/IceBT/Plugin.h
+++ b/cpp/include/IceBT/Plugin.h
@@ -15,7 +15,7 @@ namespace IceBT
 {
     /// Returns the factory for the Bluetooth transport plug-in, IceBT.
     /// @return The factory for the IceBT plug-in.
-    /// @see InitializationData::pluginFactories
+    /// @see Ice::InitializationData::pluginFactories
     ICEBT_API Ice::PluginFactory btPluginFactory();
 
     /// A name-value map.

--- a/cpp/include/IceGrid/PluginFacade.h
+++ b/cpp/include/IceGrid/PluginFacade.h
@@ -143,7 +143,7 @@ namespace IceGrid
         /// Removes a replica group filter.
         /// @param id The identifier of the filter.
         /// @param filter The filter implementation.
-        /// @return `true` of the filter was removed, `false` otherwise.
+        /// @return `true` if the filter was removed, `false` otherwise.
         virtual bool
         removeReplicaGroupFilter(const std::string& id, const std::shared_ptr<ReplicaGroupFilter>& filter) noexcept = 0;
 
@@ -153,9 +153,9 @@ namespace IceGrid
         virtual void addTypeFilter(const std::string& type, const std::shared_ptr<TypeFilter>& filter) noexcept = 0;
 
         /// Removes a type filter.
-        /// @param type The type to register this filter with.
+        /// @param type The type the filter is registered with.
         /// @param filter The filter implementation.
-        /// @return `true` of the filter was removed, `false` otherwise.
+        /// @return `true` if the filter was removed, `false` otherwise.
         virtual bool removeTypeFilter(const std::string& type, const std::shared_ptr<TypeFilter>& filter) noexcept = 0;
     };
 

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -39,13 +39,13 @@ module DataStormContract
         long id;
 
         /// The unique identifier for the associated key.
-        /// A negative value (`keyId < 0`) indicates a key filter.
+        /// A value of 0 indicates the key is marshaled inline in `keyValue`.
         long keyId;
 
-        /// The encoded key value, used when `keyId < 0` (key filter).
+        /// The encoded key value. Set when `keyId` is 0; empty otherwise.
         Ice::ByteSeq keyValue;
 
-        /// The timestamp when the sample was written, in milliseconds since the epoch.
+        /// The timestamp when the sample was written, in microseconds since the epoch.
         long timestamp;
 
         /// An update tag, used for PartialUpdate sample events.
@@ -292,7 +292,7 @@ module DataStormContract
 
         /// Attaches a local topic to a remote topic after receiving a topic announcement from the peer.
         ///
-        /// This operation is invoked if the session is interested in the announced topic. Which occurs when:
+        /// This operation is invoked if the session is interested in the announced topic, which occurs when:
         ///
         /// - The session has a reader for a topic that the peer writes, or
         /// - The session has a writer for a topic that the peer reads.
@@ -386,8 +386,8 @@ module DataStormContract
     {
         /// Queue a sample with the subscribers of the topic element.
         ///
-        /// @param topicId The unique identifier for the topic to which the sample belong.
-        /// @param elementId The unique identifier for the element to which the sample belong.
+        /// @param topicId The unique identifier for the topic to which the sample belongs.
+        /// @param elementId The unique identifier for the element to which the sample belongs.
         /// @param sample The sample to queue.
         void s(long topicId, long elementId, DataSample sample);
     }
@@ -430,7 +430,7 @@ module DataStormContract
         ///
         /// @param publisher The publisher node initiating the session. The proxy is never null.
         /// @throws SessionCreationException Thrown when the session cannot be created.
-        /// @see Lookup::announceTopicReader
+        /// @see Lookup#announceTopicReader
         void initiateCreateSession(Node* publisher) throws SessionCreationException;
 
         /// Initiates the creation of a subscriber session with a node. The subscriber node sends this request to a

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -53,7 +53,7 @@ DataElementI::DataElementI(TopicI* parent, string name, int64_t id, const DataSt
       _id(id),
       _config(make_shared<ElementConfig>()),
       _executor(parent->instance()->getCallbackExecutor()),
-      // The collocated forwarder is initalized here to avoid using a nullable proxy. The forwarder is only used by
+      // The collocated forwarder is initialized here to avoid using a nullable proxy. The forwarder is only used by
       // the instance that owns it and is removed in destroy implementation.
       _forwarder{parent->instance()->getCollocatedForwarder()->add<SessionPrx>(
           [this](const ByteSeq& inParams, const Current& current) { forward(inParams, current); })},
@@ -124,7 +124,7 @@ DataElementI::attach(
         name = os.str();
     }
 
-    // Attach the key or filter, and if attach success compute the ACK data to send to the peer.
+    // Attach the key or filter, and if the attach succeeds compute the ACK data to send to the peer.
     if ((id > 0 &&
          attachKey(topicId, data.id, key, sampleFilter, session, std::move(prx), facet, id, name, priority)) ||
         (id < 0 &&
@@ -676,10 +676,10 @@ DataElementI::forward(const ByteSeq& inParams, const Current& current) const
 {
     for (const auto& [_, listener] : _listeners)
     {
-        // If we are forwarding a sample check if at least once of the listeners is interested in the sample.
+        // If we are forwarding a sample check if at least one of the listeners is interested in the sample.
         if (!_sample || listener.matchOne(_sample, false))
         {
-            // Forward the call using the listener's session proxy don't need to wait for the result.
+            // Forward the call using the listener's session proxy, don't need to wait for the result.
             listener.proxy
                 ->ice_invokeAsync(current.operation, current.mode, inParams, nullptr, nullptr, nullptr, current.ctx);
         }
@@ -1507,7 +1507,7 @@ KeyDataWriterI::getSamples(
         cleanOldSamples(_samples, now, *_config->sampleLifetime);
     }
 
-    // Compute the stale time, according to the callers sample lifetime configuration.
+    // Compute the stale time, according to the caller's sample lifetime configuration.
     chrono::time_point<chrono::system_clock> staleTime = chrono::time_point<chrono::system_clock>::min();
     if (config->sampleLifetime && *config->sampleLifetime > 0)
     {

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -47,7 +47,7 @@ namespace
 NodeI::NodeI(const shared_ptr<Instance>& instance, std::string name)
     : _instance(instance),
       _proxy{instance->getObjectAdapter()->createProxy<NodePrx>(Identity{.name = std::move(name), .category = ""})},
-      // The subscriber and publisher collocated forwarders are initalized here to avoid using a nullable proxy. These
+      // The subscriber and publisher collocated forwarders are initialized here to avoid using a nullable proxy. These
       // objects are only used after the node is initialized and are removed in destroy implementation.
       _publisherForwarder{instance->getCollocatedForwarder()->add<PublisherSessionPrx>(
           [this](const ByteSeq& inParams, const Current& current) { forwardToPublishers(inParams, current); })},

--- a/cpp/src/DataStorm/NodeI.h
+++ b/cpp/src/DataStorm/NodeI.h
@@ -119,7 +119,7 @@ namespace DataStormI
         // A map of all publisher sessions, indexed by the identity of the peer node.
         std::map<Ice::Identity, std::shared_ptr<PublisherSessionI>> _publishers;
 
-        // A proxy to a colocated publisher session object that forwards requests to all active publisher sessions.
+        // A proxy to a collocated publisher session object that forwards requests to all active publisher sessions.
         DataStormContract::PublisherSessionPrx _publisherForwarder;
 
         // A map of all publisher sessions, indexed by the identity of each session.
@@ -128,7 +128,7 @@ namespace DataStormI
         // A map of all subscriber sessions, indexed by the identity of the peer node.
         std::map<Ice::Identity, std::shared_ptr<SubscriberSessionI>> _subscribers;
 
-        // A proxy to a colocated subscriber session object that forwards requests to all active subscriber sessions.
+        // A proxy to a collocated subscriber session object that forwards requests to all active subscriber sessions.
         DataStormContract::SubscriberSessionPrx _subscriberForwarder;
 
         // A map of all subscriber sessions, indexed by the identity of each session.

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -15,10 +15,10 @@ namespace
 {
     // The NodeForwarder class forwards calls to a Node that lacks a public endpoint.
     //
-    // This class implements the Slice DataContract::Node interface by forwarding calls to the target Node object
+    // This class implements the Slice DataStormContract::Node interface by forwarding calls to the target Node object
     // using the connection established during the creation of the NodeSession object.
     //
-    // The NodeForwarder wraps the node and session proxy parameters passed to the DataContract::Node operations
+    // The NodeForwarder wraps the node and session proxy parameters passed to the DataStormContract::Node operations
     // in forwarder proxies, which handle forwarding to the corresponding target objects.
     class NodeForwarder : public AsyncNode, public enable_shared_from_this<NodeForwarder>
     {

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -71,9 +71,9 @@ NodeSessionManager::init()
 {
     auto instance = _instance.lock();
     assert(instance);
-    auto sessionForwader = make_shared<SessionForwarder>(shared_from_this());
-    instance->getObjectAdapter()->addDefaultServant(sessionForwader, "sf");
-    instance->getObjectAdapter()->addDefaultServant(sessionForwader, "pf");
+    auto sessionForwarder = make_shared<SessionForwarder>(shared_from_this());
+    instance->getObjectAdapter()->addDefaultServant(sessionForwarder, "sf");
+    instance->getObjectAdapter()->addDefaultServant(sessionForwarder, "pf");
 
     auto communicator = instance->getCommunicator();
     const string connectTo = communicator->getProperties()->getIceProperty("DataStorm.Node.ConnectTo");
@@ -561,7 +561,7 @@ NodeSessionManager::destroySession(const ConnectionPtr& connection, const NodePr
     // Drop any announcements received over this connection; they can no longer be reached or refreshed.
     removeAnnouncements(connection);
 
-    // Destroy the connection if the session is still using it, otherwise the node has already
+    // Destroy the session if it is still using this connection, otherwise the node has already
     // replaced its NodeSession and it is using a new connection.
     auto p = _sessions.find(node->ice_getIdentity());
     if (p != _sessions.end() && p->second->getConnection() == connection)

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -51,7 +51,7 @@ SessionI::SessionI(shared_ptr<Instance> instance, shared_ptr<NodeI> parent, Node
 void
 SessionI::init()
 {
-    // Even though the node register a default servant for sessions, we still need to register the session servant
+    // Even though the node registers a default servant for sessions, we still need to register the session servant
     // explicitly here to ensure collocation works. The default servant from the node is used for facet calls.
     _instance->getObjectAdapter()->add(
         make_shared<DispatchInterceptorI>(shared_from_this(), _instance->getCallbackExecutor()),
@@ -961,7 +961,7 @@ SessionI::checkSession()
             if (_connection)
             {
                 // Make sure the connection is still established. It's possible that the connection got closed and we
-                // were not notified yet by the connection manager. Check session explicitly check for the connection
+                // were not notified yet by the connection manager. checkSession explicitly checks for the connection
                 // to make sure that if we get a session creation request from a peer (which might detect the connection
                 // closure before), it doesn't get ignored.
                 try

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -196,7 +196,7 @@ namespace DataStormI
         class TopicSubscribers
         {
         public:
-            // Add the give topic as a subscriber, if a subscription already exists, update the session instance id.
+            // Add the given topic as a subscriber, if a subscription already exists, update the session instance id.
             void addSubscriber(TopicI* topic, int sessionInstanceId)
             {
                 _sessionInstanceId = sessionInstanceId;

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -61,7 +61,7 @@ TopicI::TopicI(
       _instance(std::move(instance)),
       _traceLevels(_instance->getTraceLevels()),
       _id(id),
-      // The collocated forwarder is initalized here to avoid using a nullable proxy. The forwarder is only used by
+      // The collocated forwarder is initialized here to avoid using a nullable proxy. The forwarder is only used by
       // the instance that owns it and is removed in destroy implementation.
       _forwarder{_instance->getCollocatedForwarder()->add<SessionPrx>(
           [this](const ByteSeq& inParams, const Current& current) { forward(inParams, current); })}
@@ -151,7 +151,7 @@ ElementSpecSeq
 TopicI::getElementSpecs(int64_t topicId, const ElementInfoSeq& infos, const shared_ptr<SessionI>& session)
 {
     ElementSpecSeq specs;
-    // Iterate over the element infos representing the remote keys, and filters and compute the element spec for local
+    // Iterate over the element infos representing the remote keys and filters, and compute the element spec for local
     // keys and filters that match. Positive IDs represent keys and negative IDs represent filters.
     for (const auto& info : infos)
     {
@@ -781,7 +781,7 @@ TopicI::forward(const ByteSeq& inParams, const Current& current) const
     // Forwarder proxy must be called with the mutex locked!
     for (const auto& [_, listener] : _listeners)
     {
-        // Forward the call to all listeners using its session proxy, passing nullptr for the callbacks because we
+        // Forward the call to all listeners using their session proxy, passing nullptr for the callbacks because we
         // don't need to check the result.
         listener.proxy
             ->ice_invokeAsync(current.operation, current.mode, inParams, nullptr, nullptr, nullptr, current.ctx);

--- a/cpp/src/Glacier2/Instrumentation.h
+++ b/cpp/src/Glacier2/Instrumentation.h
@@ -57,7 +57,7 @@ namespace Glacier2::Instrumentation
             const std::shared_ptr<SessionObserver>& old) = 0;
 
         /// Glacier2 calls this method on initialization. The add-in implementing this interface can use this object
-        /// to get Glacier2 to re-obtain observers for topics and subscribers.
+        /// to get Glacier2 to re-obtain observers for its sessions.
         /// @param updater The observer updater object.
         virtual void setObserverUpdater(const std::shared_ptr<ObserverUpdater>& updater) = 0;
     };

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -307,7 +307,7 @@ namespace Glacier2
                     }
                     else
                     {
-                        ostr << ", or";
+                        ostr << ", or ";
                     }
                     ostr << range.start << " up to " << range.end;
                 }
@@ -1032,7 +1032,7 @@ Glacier2::ProxyVerifier::ProxyVerifier(CommunicatorPtr communicator, int traceLe
       _traceLevel(traceLevel)
 {
     //
-    // Evaluation order is dependant on how the rules are stored to the
+    // Evaluation order is dependent on how the rules are stored to the
     // rules vectors.
     //
     string s = _communicator->getProperties()->getIceProperty("Glacier2.Filter.Address.Accept");

--- a/cpp/src/Glacier2/RoutingTable.cpp
+++ b/cpp/src/Glacier2/RoutingTable.cpp
@@ -51,7 +51,7 @@ Glacier2::RoutingTable::add(
     size_t sz = _map.size();
 
     //
-    // We 'pre-scan' the list, applying our validation rules. The
+    // We 'pre-scan' the list, applying our validation rules. This
     // ensures that our state is not modified if this operation results
     // in a rejection.
     //

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -1104,7 +1104,7 @@ SessionRouterI::startCreateSession(const shared_ptr<CreateSession>& cb, const Co
         //
         // No session exists yet, so we will try to create one. To
         // avoid that other threads try to create sessions for the
-        // same connection, we add our endpoints to _pending.
+        // same connection, we add our connection to _pending.
         //
         _pending.insert(make_pair(connection, cb));
         return true;

--- a/cpp/src/Ice/AddDefaultPluginFactories_all.cpp
+++ b/cpp/src/Ice/AddDefaultPluginFactories_all.cpp
@@ -9,7 +9,7 @@ using namespace std;
 void
 IceInternal::addDefaultPluginFactories(vector<Ice::PluginFactory>& pluginFactories)
 {
-    // These built-in plug-ins are always available and not returned by a Ice::namePluginFactory function.
+    // These built-in plug-ins are always available and not returned by an Ice::namePluginFactory function.
     vector<Ice::PluginFactory> defaultPluginFactories{{Ice::tcpPluginFactory(), Ice::sslPluginFactory()}};
 
     Ice::PluginFactory udpPluginFactory{Ice::udpPluginFactory()};

--- a/cpp/src/Ice/ConnectRequestHandler.cpp
+++ b/cpp/src/Ice/ConnectRequestHandler.cpp
@@ -64,7 +64,7 @@ ConnectRequestHandler::getConnection()
     lock_guard lock(_mutex);
     //
     // First check for the connection, it's important otherwise the user could first get a connection
-    // and then the exception if he tries to obtain the proxy cached connection mutiple times (the
+    // and then the exception if he tries to obtain the proxy cached connection multiple times (the
     // exception can be set after the connection is set if the flush of pending requests fails).
     //
     if (_connection)

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -387,7 +387,7 @@ IceInternal::OutgoingConnectionFactory::incPendingConnectCount()
     //
     // Keep track of the number of pending connects. The outgoing connection factory
     // waitUntilFinished() method waits for all the pending connects to terminate before
-    // to return. This ensures that the communicator client thread pool isn't destroyed
+    // returning. This ensures that the communicator client thread pool isn't destroyed
     // too soon and will still be available to execute the ice_exception() callbacks for
     // the asynchronous requests waiting on a connection to be established.
     //
@@ -426,7 +426,7 @@ IceInternal::OutgoingConnectionFactory::getConnection(
             throw Ice::CommunicatorDestroyedException(__FILE__, __LINE__);
         }
 
-        // Search for an existing connections matching one of the given endpoints.
+        // Search for existing connections matching one of the given endpoints.
         Ice::ConnectionIPtr connection = findConnection(connectors, compress);
         if (connection)
         {
@@ -903,9 +903,9 @@ IceInternal::OutgoingConnectionFactory::ConnectCallback::getConnection()
         {
             //
             // A null return value from getConnection indicates that the connection
-            // is being established and that everthing has been done to ensure that
+            // is being established and that everything has been done to ensure that
             // the callback will be notified when the connection establishment is
-            // done or that the callback already obtain the connection.
+            // done or that the callback already obtained the connection.
             //
             return;
         }

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -643,7 +643,7 @@ Ice::ConnectionI::sendAsyncRequest(const OutgoingAsyncBasePtr& out, bool compres
 
     std::lock_guard lock(_mutex);
     //
-    // If the exception is closed before we even have a chance
+    // If the connection is closed before we even have a chance
     // to send our request, we always try to send the request
     // again.
     //
@@ -1591,7 +1591,7 @@ Ice::ConnectionI::finished(ThreadPoolCurrent& current, bool close)
     }
 
     // If there are no callbacks to call, we don't call ioCompleted() since we're not going to call code that will
-    // potentially block (this avoids promoting a new leader and unecessary thread creation, especially if this is
+    // potentially block (this avoids promoting a new leader and unnecessary thread creation, especially if this is
     // called on shutdown).
     if (!_connectionStartCompleted && !_connectionStartFailed && _sendStreams.empty() && _asyncRequests.empty() &&
         !_closeCallback)
@@ -2169,7 +2169,7 @@ Ice::ConnectionI::setState(State state)
 
                 //
                 // Don't need to close now for connections so only close the transceiver
-                // if the selector request it.
+                // if the selector requests it.
                 //
                 if (_threadPool->finish(shared_from_this(), false))
                 {
@@ -2396,7 +2396,7 @@ Ice::ConnectionI::sendHeartbeat() noexcept
         }
 
         // We send a heartbeat to the peer to generate a "write" on the connection. This write in turns creates
-        // a read on the peer, and resets the peer's idle check timer. When _sendStream is not empty, there is
+        // a read on the peer, and resets the peer's idle check timer. When _sendStreams is not empty, there is
         // already an outstanding write, so we don't need to send a heartbeat. It's possible the first message
         // of _sendStreams was already sent but not yet removed from _sendStreams: it means the last write
         // occurred very recently, which is good enough with respect to the idle check.

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -288,12 +288,12 @@ namespace Ice
         bool validate(IceInternal::SocketOperation = IceInternal::SocketOperationNone);
 
         /// Sends the next queued messages. This method is called by message() once the message which is being sent
-        /// (_sendStreams.First) is fully sent. Before sending the next message, this message is removed from
-        /// _sendsStream. If any, its sent callback is also queued in given callback queue.
+        /// (_sendStreams.front()) is fully sent. Before sending the next message, this message is removed from
+        /// _sendStreams. If any, its sent callback is also queued in given callback queue.
         ///
         /// @param callbacks The sent callbacks to call for the messages that were sent.
         /// @return The socket operation to register with the thread pool's selector to send the remainder of the
-        /// pending message being sent (_sendStreams.First).
+        /// pending message being sent (_sendStreams.front()).
         IceInternal::SocketOperation sendNextMessages(std::vector<OutgoingMessage>& callbacks);
 
         /// Sends or queues the given message.

--- a/cpp/src/Ice/ConsoleUtil.cpp
+++ b/cpp/src/Ice/ConsoleUtil.cpp
@@ -16,7 +16,7 @@ using namespace std;
 namespace
 {
     mutex consoleMutex;
-    // We leak consoleUtil object to ensure that is available during static destruction.
+    // We leak consoleUtil object to ensure that it is available during static destruction.
     ConsoleUtil* consoleUtil = 0;
 }
 

--- a/cpp/src/Ice/EndpointI.h
+++ b/cpp/src/Ice/EndpointI.h
@@ -64,7 +64,7 @@ namespace IceInternal
         [[nodiscard]] virtual EndpointIPtr connectionId(const std::string&) const = 0;
 
         //
-        // Return true if the endpoints support bzip2 compress, or false
+        // Return true if the endpoint supports bzip2 compression, or false
         // otherwise.
         //
         [[nodiscard]] virtual bool compress() const = 0;

--- a/cpp/src/Ice/FileUtil.cpp
+++ b/cpp/src/Ice/FileUtil.cpp
@@ -38,8 +38,8 @@ IceInternal::isAbsolutePath(const string& path)
     }
 
 #ifdef _WIN32
-    // We need at least 3 non whitespace character to have
-    // and absolute path
+    // We need at least 3 non whitespace characters to have
+    // an absolute path
     if (i + 3 > size)
     {
         return false;
@@ -199,7 +199,7 @@ int
 IceInternal::getcwd(string& cwd)
 {
     //
-    // Don't need to use a wide string converter, the wide string come
+    // Don't need to use a wide string converter, the wide string comes
     // from Windows API.
     //
     wchar_t cwdbuf[_MAX_PATH];
@@ -363,7 +363,7 @@ IceInternal::FileLock::FileLock(const std::string& path) : _path(path)
     //
 
     //
-    // Now that we have acquire an exclusive write lock,
+    // Now that we have acquired an exclusive write lock,
     // write the process pid there.
     //
     ostringstream os;

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -446,7 +446,7 @@ Ice::InputStream::readAndCheckSeqSize(int minSize)
     //
     // If there isn't enough data to read on the stream for the sequence (and
     // possibly enclosed sequences), something is wrong with the marshaled
-    // data: it's claiming having more data that what is possible to read.
+    // data: it's claiming having more data than what is possible to read.
     //
     if (_startSeq + minSeqSize > static_cast<int64_t>(b.size()))
     {
@@ -1143,7 +1143,7 @@ Ice::InputStream::readOptImpl(int32_t readTag, OptionalFormat expectedFormat)
         auto tag = static_cast<int32_t>(v >> 3);
         if (tag > 30)
         {
-            // We check for '> 30' instead of '> 29' because 30 is special sentinel tag, handled by the next block.
+            // We check for '> 30' instead of '> 29' because 30 is a special sentinel tag, handled by the next block.
             ostringstream os;
             os << "invalid tag '" << tag << "': tags larger than 29 must be encoded as a size";
             throw MarshalException(__FILE__, __LINE__, os.str());
@@ -1486,7 +1486,7 @@ Ice::InputStream::EncapsDecoder10::throwException(UserExceptionFactory exception
     assert(_sliceType == NoSlice);
 
     //
-    // User exception with the 1.0 encoding start with a boolean flag
+    // User exceptions with the 1.0 encoding start with a boolean flag
     // that indicates whether or not the exception has classes.
     //
     // This allows reading the pending values even if some part of
@@ -2102,7 +2102,7 @@ Ice::InputStream::EncapsDecoder11::readInstance(int32_t index, const PatchFunc& 
 
     //
     // Get the object ID before we start reading slices. If some
-    // slices are skiped, the indirect object table are still read and
+    // slices are skipped, the indirect object table is still read and
     // might read other instances.
     //
     index = ++_valueIdIndex;

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -617,7 +617,7 @@ IceInternal::Instance::createAdmin(const ObjectAdapterPtr& adminAdapter, const I
         catch (...)
         {
             //
-            // We clean it up, even through this error is not recoverable
+            // We clean it up, even though this error is not recoverable
             // (can't call again createAdmin after fixing the problem since all the facets
             // in the adapter are lost)
             //
@@ -676,7 +676,7 @@ IceInternal::Instance::getAdmin()
         catch (...)
         {
             //
-            // We clean it up, even through this error is not recoverable
+            // We clean it up, even though this error is not recoverable
             // (can't call again createAdmin after fixing the problem since all the facets
             // in the adapter are lost)
             //

--- a/cpp/src/Ice/LocatorInfo.cpp
+++ b/cpp/src/Ice/LocatorInfo.cpp
@@ -810,7 +810,7 @@ IceInternal::LocatorInfo::finishRequest(
     {
         //
         // Remove the cached references of well-known objects for which we tried
-        // to resolved the endpoints if these endpoints are empty.
+        // to resolve the endpoints if these endpoints are empty.
         //
         for (const auto& wellKnownRef : wellKnownRefs)
         {

--- a/cpp/src/Ice/LoggerI.cpp
+++ b/cpp/src/Ice/LoggerI.cpp
@@ -179,7 +179,7 @@ Ice::LoggerI::write(const string& message, bool indent)
                     _nextRetry = chrono::steady_clock::now() + retryTimeout;
 
                     //
-                    // We temporarily set the maximum size to 0 to ensure there isn't more rename attempts
+                    // We temporarily set the maximum size to 0 to ensure there aren't more rename attempts
                     // in the nested error call.
                     //
                     size_t sizeMax = _sizeMax;

--- a/cpp/src/Ice/LoggerI.h
+++ b/cpp/src/Ice/LoggerI.h
@@ -36,8 +36,8 @@ namespace Ice
         std::size_t _sizeMax;
 
         //
-        // In case of a log file rename failure is set to the time in milliseconds
-        // after which rename could be attempted again. Otherwise is set to zero.
+        // In case of a log file rename failure, set to the time point after which
+        // the rename can be attempted again. Otherwise, set to the epoch (zero).
         //
         std::chrono::steady_clock::time_point _nextRetry;
     };

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -242,7 +242,7 @@ namespace
         if (pos != string::npos)
         {
             //
-            // If it's a link-local address, use the zone indice.
+            // If it's a link-local address, use the zone index.
             //
             isAddr = false;
             name = intf.substr(pos + 1);
@@ -387,7 +387,7 @@ namespace
                 while (paddrs)
                 {
                     //
-                    // Don't need to pass a wide string converter as the wide string come
+                    // Don't need to pass a wide string converter as the wide string comes
                     // from Windows API.
                     //
                     if (wstringToString(paddrs->FriendlyName, getProcessStringConverter()) == name)
@@ -580,7 +580,7 @@ IceInternal::getAddresses(const string& host, int port, ProtocolSupport protocol
     } while (info == nullptr && rs == EAI_AGAIN && --retry >= 0);
 
     // In theory, getaddrinfo should only return EAI_NONAME if
-    // AI_NUMERICHOST is specified and the host name is not a IP
+    // AI_NUMERICHOST is specified and the host name is not an IP
     // address. However on some platforms (e.g. macOS 10.4.x)
     // EAI_NODATA is also returned so we also check for it.
 #ifdef EAI_NODATA
@@ -1826,7 +1826,7 @@ void
 IceInternal::doConnectAsync(SOCKET fd, const Address& addr, const Address& sourceAddr, AsyncInfo& info)
 {
     //
-    // NOTE: It's the caller's responsability to close the socket upon
+    // NOTE: It's the caller's responsibility to close the socket upon
     // failure to connect. The socket isn't closed by this method.
     //
     Address bindAddr;

--- a/cpp/src/Ice/NetworkProxy.cpp
+++ b/cpp/src/Ice/NetworkProxy.cpp
@@ -233,7 +233,7 @@ HTTPNetworkProxy::endRead(Buffer& buf)
     {
         //
         // Read one more byte, we can't easily read bytes in advance
-        // since the transport implementation might be be able to read
+        // since the transport implementation might be able to read
         // the data from the memory instead of the socket. This is for
         // instance the case with the OpenSSL transport (or we would
         // have to use a buffering BIO).

--- a/cpp/src/Ice/NetworkProxy.h
+++ b/cpp/src/Ice/NetworkProxy.h
@@ -39,7 +39,7 @@ namespace IceInternal
         // If the proxy host needs to be resolved, this should return
         // a new NetworkProxy containing the IP address of the proxy.
         // This is called from the endpoint host resolver thread, so
-        // it's safe if this this method blocks.
+        // it's safe if this method blocks.
         //
         [[nodiscard]] virtual NetworkProxyPtr resolveHost(ProtocolSupport) const = 0;
 

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -95,7 +95,7 @@ Ice::ObjectAdapterI::activate()
         //
         // One off initializations of the adapter: update the
         // locator registry and print the "adapter ready"
-        // message. We set set state to StateActivating to prevent
+        // message. We set state to StateActivating to prevent
         // deactivation from other threads while these one off
         // initializations are done.
         //
@@ -121,7 +121,7 @@ Ice::ObjectAdapterI::activate()
             //
             // If we couldn't update the locator registry, we let the
             // exception go through and don't activate the adapter to
-            // allow to user code to retry activating the adapter
+            // allow user code to retry activating the adapter
             // later.
             //
             {

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -1006,7 +1006,7 @@ void
 Ice::OutputStream::EncapsEncoder10::write(const UserException& v)
 {
     //
-    // User exception with the 1.0 encoding start with a boolean
+    // User exceptions with the 1.0 encoding start with a boolean
     // flag that indicates whether or not the exception uses
     // classes.
     //
@@ -1398,7 +1398,7 @@ Ice::OutputStream::EncapsEncoder11::writeInstance(const shared_ptr<Value>& v)
     assert(v);
 
     //
-    // If the instance was already marshaled, just write it's ID.
+    // If the instance was already marshaled, just write its ID.
     //
     auto q = _marshaledMap.find(v);
     if (q != _marshaledMap.end())

--- a/cpp/src/Ice/PropertyUtil.cpp
+++ b/cpp/src/Ice/PropertyUtil.cpp
@@ -82,7 +82,7 @@ IceInternal::validatePropertiesWithPrefix(
     PropertyDict props = properties->getPropertiesForPrefix(string{prefix} + ".");
     for (const auto& p : props)
     {
-        // Plus one to include the dot.
+        // Plus one to skip the dot.
         if (!findProperty(p.first.substr(prefix.size() + 1), propertyArray))
         {
             unknownProps.push_back(p.first);

--- a/cpp/src/Ice/ProtocolInstance.h
+++ b/cpp/src/Ice/ProtocolInstance.h
@@ -59,7 +59,7 @@ namespace IceInternal
         ProtocolInstance(const InstancePtr&, std::int16_t, std::string, bool);
         friend class Instance;
         // Use a weak pointer to avoid circular references. The communicator owns the endpoint factory, which in
-        // turn own this protocol instance.
+        // turn owns this protocol instance.
         const std::weak_ptr<Instance> _instance;
         const int _traceLevel;
         const std::string _traceCategory;

--- a/cpp/src/Ice/RetryQueue.cpp
+++ b/cpp/src/Ice/RetryQueue.cpp
@@ -26,8 +26,8 @@ IceInternal::RetryTask::runTimerTask()
     _outAsync->retry(); // Retry again the invocation.
 
     //
-    // NOTE: this must be called last, destroy() blocks until all task
-    // are removed to prevent the client thread pool to be destroyed
+    // NOTE: this must be called last, destroy() blocks until all tasks
+    // are removed to prevent the client thread pool from being destroyed
     // (we still need the client thread pool at this point to call
     // exception callbacks with CommunicatorDestroyedException).
     //

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -214,7 +214,7 @@ OpenSSL::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal::
         rethrow_exception(_verificationException);
     }
 
-    // Retrieve the certificate chain if the verification callback has not already fill it.
+    // Retrieve the certificate chain if the verification callback has not already filled it.
     if (!_peerCertificate)
     {
         // When calling on the server side the peer certificate is not included in SSL_get_peer_cert_chain and must be

--- a/cpp/src/Ice/SSL/RFC2253.cpp
+++ b/cpp/src/Ice/SSL/RFC2253.cpp
@@ -242,7 +242,7 @@ parseAttributeType(const string& data, size_t& pos)
     eatWhite(data, pos);
     if (pos >= data.size())
     {
-        throw Ice::ParseException(__FILE__, __LINE__, "invalid attribute type (expected end of data)");
+        throw Ice::ParseException(__FILE__, __LINE__, "invalid attribute type (unexpected end of data)");
     }
 
     string result;

--- a/cpp/src/Ice/SSL/SchannelEngine.cpp
+++ b/cpp/src/Ice/SSL/SchannelEngine.cpp
@@ -697,7 +697,7 @@ namespace
         }
         else
         {
-            // If subjectAlt is empty compare it to the subject CN, otherwise compare it to the to the subject alt
+            // If subjectAlt is empty compare it to the subject CN, otherwise compare it to the subject alt
             // name dnsNames.
             if (dnsNames.empty())
             {
@@ -1353,7 +1353,7 @@ Schannel::SSLEngine::createServerAuthenticationOptions() const
                     .cCreds = static_cast<DWORD>(_allCerts.size()),
                     .paCred = const_cast<PCCERT_CONTEXT*>(_allCerts.size() > 0 ? &_allCerts[0] : nullptr),
                     // Don't set SCH_SEND_ROOT_CERT as it seems to cause problems with Java certificate validation and
-                    // Schannel doesn't seems to send the root certificate either way.
+                    // Schannel doesn't seem to send the root certificate either way.
                     .dwFlags = SCH_CRED_NO_SYSTEM_MAPPER | SCH_USE_STRONG_CRYPTO};
             }
         },

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -93,7 +93,7 @@ namespace
         return SCH_CREDENTIALS{
             .dwVersion = SCH_CREDENTIALS_VERSION,
             // Don't set SCH_SEND_ROOT_CERT as it seems to cause problems with Java certificate validation and
-            // Schannel doesn't seems to send the root certificate either way.
+            // Schannel doesn't seem to send the root certificate either way.
             .dwFlags = SCH_CRED_NO_SYSTEM_MAPPER | SCH_USE_STRONG_CRYPTO};
     }
 }
@@ -1105,8 +1105,8 @@ Schannel::TransceiverI::TransceiverI(
                 false);       // Whether or not revocation checks only uses cached information.
         };
     }
-    // If the user provides a validation callback is up to the callback to validate the certificate chain.
-    // If the user doesn't set the trusted root certificates, we use Schannel default behavior, with uses the system
+    // If the user provides a validation callback, it is up to the callback to validate the certificate chain.
+    // If the user doesn't set the trusted root certificates, we use Schannel default behavior, which uses the system
     // trusted root certificates.
 }
 

--- a/cpp/src/Ice/SSL/SecureTransportEngine.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportEngine.cpp
@@ -34,8 +34,8 @@ namespace
     //
     // Retrieve the name of a cipher, SSLCipherSuite includes duplicated values for TLS/SSL
     // protocol ciphers, for example SSL_RSA_WITH_RC4_128_MD5/TLS_RSA_WITH_RC4_128_MD5
-    // are represented by the same SSLCipherSuite value, the names return by this method
-    // doesn't include a protocol prefix.
+    // are represented by the same SSLCipherSuite value, the names returned by this method
+    // don't include a protocol prefix.
     //
     string cipherName(SSLCipherSuite cipher)
     {

--- a/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
@@ -229,7 +229,7 @@ Ice::SSL::SecureTransport::TransceiverI::initialize(IceInternal::Buffer& readBuf
                     continue; // Call SSLHandshake to resume the handshake.
                 }
             }
-            // Let it fall through, this will raise a SecurityException with the SSLCopyPeerTrust error.
+            // Let it fall through, this will raise a ProtocolException with the SSLCopyPeerTrust error.
         }
         else if (err == errSSLClosedGraceful || err == errSSLClosedAbort)
         {
@@ -351,7 +351,7 @@ Ice::SSL::SecureTransport::TransceiverI::write(IceInternal::Buffer& buf)
             }
 
             //
-            // SSL protocol errors are defined in SecureTransport.h are in the range
+            // SSL protocol errors defined in SecureTransport.h are in the range
             // -9800 to -9849
             //
             if (err <= -9800 && err >= -9849)
@@ -424,7 +424,7 @@ Ice::SSL::SecureTransport::TransceiverI::read(IceInternal::Buffer& buf)
             }
 
             //
-            // SSL protocol errors are defined in SecureTransport.h are in the range
+            // SSL protocol errors defined in SecureTransport.h are in the range
             // -9800 to -9849
             //
             if (err <= -9800 && err >= -9849)

--- a/cpp/src/Ice/Selector.cpp
+++ b/cpp/src/Ice/Selector.cpp
@@ -127,7 +127,7 @@ Selector::getNextHandler(SocketOperation& status, DWORD& count, int& error, int 
             }
             else
             {
-                // This indicates a internal error with the IOCP completion port, we log the error and abort.
+                // This indicates an internal error with the IOCP completion port, we log the error and abort.
                 Ice::SocketException ex(__FILE__, __LINE__, err);
                 Ice::Error out(_instance->initializationData().logger);
                 out << "could not dequeue packet from completion port:\n" << ex;
@@ -478,7 +478,7 @@ Selector::startSelect()
 
     //
     // If there are ready handlers, don't block in select, just do a non-blocking
-    // select to retrieve new ready handlers from the Java selector.
+    // select to retrieve new ready handlers from the selector.
     //
     _selectNow = !_readyHandlers.empty();
 }
@@ -556,7 +556,7 @@ Selector::select(int timeout)
     }
     else if (timeout > 0)
     {
-        // kqueue use seconds, epoll use milliseconds
+        // kqueue uses seconds, epoll uses milliseconds
 #    ifdef ICE_USE_EPOLL
         timeout = timeout * 1000;
 #    endif
@@ -591,7 +591,7 @@ Selector::select(int timeout)
                 continue;
             }
 
-            // This indicates a internal error with the selector, we log the error and abort.
+            // This indicates an internal error with the selector, we log the error and abort.
             Ice::SocketException ex(__FILE__, __LINE__, IceInternal::getSocketErrno());
             Ice::Error out(_instance->initializationData().logger);
             out << "selector failed:\n" << ex;

--- a/cpp/src/Ice/ServantManager.cpp
+++ b/cpp/src/Ice/ServantManager.cpp
@@ -184,7 +184,7 @@ IceInternal::ServantManager::findServant(const Identity& ident, const string_vie
     lock_guard lock(_mutex);
 
     //
-    // This assert is not valid if the adapter dispatch incoming
+    // This assert is not valid if the adapter dispatches incoming
     // requests from bidir connections. This method might be called if
     // requests are received over the bidir connection after the
     // adapter was deactivated.
@@ -277,7 +277,7 @@ IceInternal::ServantManager::hasServant(const Identity& ident) const
     lock_guard lock(_mutex);
 
     //
-    // This assert is not valid if the adapter dispatch incoming
+    // This assert is not valid if the adapter dispatches incoming
     // requests from bidir connections. This method might be called if
     // requests are received over the bidir connection after the
     // adapter was deactivated.
@@ -360,7 +360,7 @@ IceInternal::ServantManager::findServantLocator(const string_view category) cons
     lock_guard lock(_mutex);
 
     //
-    // This assert is not valid if the adapter dispatch incoming
+    // This assert is not valid if the adapter dispatches incoming
     // requests from bidir connections. This method might be called if
     // requests are received over the bidir connection after the
     // adapter was deactivated.

--- a/cpp/src/Ice/StringConverter.cpp
+++ b/cpp/src/Ice/StringConverter.cpp
@@ -483,7 +483,7 @@ namespace
         wstring wbuffer;
 
         //
-        // The following code pages doesn't support MB_ERR_INVALID_CHARS flag
+        // The following code pages don't support the MB_ERR_INVALID_CHARS flag
         // see http://msdn.microsoft.com/en-us/library/windows/desktop/dd319072(v=vs.85).aspx
         //
         DWORD flags = (_cp == 50220 || _cp == 50221 || _cp == 50222 || _cp == 50225 || _cp == 50227 || _cp == 50229 ||

--- a/cpp/src/Ice/ThreadPool.cpp
+++ b/cpp/src/Ice/ThreadPool.cpp
@@ -548,7 +548,7 @@ IceInternal::ThreadPool::run(const EventHandlerThreadPtr& thread)
                 {
                     //
                     // If the handler called ioCompleted(), we re-enable the handler in
-                    // case it was disabled and we decrease the number of thread in use.
+                    // case it was disabled and we decrease the number of threads in use.
                     //
                     if (_serialize && current._handler.get() != _workQueue.get())
                     {

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -699,8 +699,8 @@ IceInternal::UdpTransceiver::UdpTransceiver(
     }
 
     //
-    // In general, connecting a datagram socket should be non-blocking as this just setups
-    // the default destination address for the socket. However, on some OS, connect sometime
+    // In general, connecting a datagram socket should be non-blocking as this just sets up
+    // the default destination address for the socket. However, on some OS, connect sometimes
     // returns EWOULDBLOCK. If that's the case, we keep the state as StateNeedConnect. This
     // will make sure the transceiver is notified when the socket is ready for sending (see
     // the initialize() implementation).

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -420,10 +420,10 @@ IceInternal::WSTransceiver::closing(bool initiator, exception_ptr reason)
     {
         //
         // If we initiated a close connection but also received a
-        // close connection, we assume we didn't initiated the
+        // close connection, we assume we didn't initiate the
         // connection and we send the close frame now. This is to
         // ensure that if both peers close the connection at the same
-        // time we don't hang having both peer waiting for the close
+        // time we don't hang having both peers waiting for the close
         // frame of the other.
         //
         assert(!initiator);
@@ -575,8 +575,8 @@ IceInternal::WSTransceiver::read(Buffer& buf)
     }
 
     //
-    // If we read the full Ice message, handle it before trying
-    // reading anymore data from the WS connection.
+    // If we read the full Ice message, handle it before trying to
+    // read any more data from the WS connection.
     //
     if (buf.i == buf.b.end())
     {
@@ -1654,7 +1654,7 @@ IceInternal::WSTransceiver::preWrite(Buffer& buf)
         // 32-bit value, so we copy the entire message into the internal buffer
         // for writing. For incoming connections, we just copy the start of the
         // message in the internal buffer after the header. If the message is
-        // larger, the reminder is sent directly from the message buffer to avoid
+        // larger, the remainder is sent directly from the message buffer to avoid
         // copying.
         //
 

--- a/cpp/src/IceBT/Engine.cpp
+++ b/cpp/src/IceBT/Engine.cpp
@@ -1088,7 +1088,7 @@ namespace IceBT
             // 2) After we find the remote device, we have to register a client profile
             //    for the given UUID.
             //
-            // 3) After registering the profile, we have to invoke ConnectDevice on the
+            // 3) After registering the profile, we have to invoke ConnectProfile on the
             //    local device object corresponding to the target address. The Bluetooth
             //    service will attempt to establish a connection to the remote device.
             //    If the connection succeeds, our profile object will receive a

--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -50,7 +50,7 @@ IceBT::TransceiverI::closing(bool initiator, exception_ptr)
 {
     //
     // If we are initiating the connection closure, wait for the peer
-    // to close the TCP/IP connection. Otherwise, close immediately.
+    // to close the Bluetooth connection. Otherwise, close immediately.
     //
     return initiator ? IceInternal::SocketOperationRead : IceInternal::SocketOperationNone;
 }

--- a/cpp/src/IceBox/IceBoxService.cpp
+++ b/cpp/src/IceBox/IceBoxService.cpp
@@ -129,7 +129,7 @@ main(int argc, char* argv[])
 
     InitializationData initData;
     // Initialize the service with a Properties object with the correct property prefix enabled.
-    // Since IceStorm is an IceBox service, we need to enable the IceBox property prefix as we allow configuring
+    // Since IceStorm is an IceBox service, we need to enable the IceStorm property prefix as we allow configuring
     // IceStorm properties through IceBox properties.
     initData.properties = make_shared<Properties>("IceBox", "IceStorm");
     initData.properties->setProperty("Ice.Admin.DelayCreation", "1");

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -889,7 +889,7 @@ Ice::PropertiesPtr
 IceBox::ServiceManagerI::createServiceProperties(const string& service)
 {
     // We don't want to clone the properties object as we don't want to copy the opt-in prefix list.
-    // NOTE: We always enable the "IceStorm" prefix as there's currently no way  to distinguish it.
+    // NOTE: We always enable the "IceStorm" prefix as there's currently no way to distinguish it.
     PropertiesPtr properties = make_shared<Properties>("IceStorm");
     PropertiesPtr communicatorProperties = _communicator->getProperties();
     if (communicatorProperties->getIcePropertyAsInt("IceBox.InheritProperties") > 0)

--- a/cpp/src/IceDB/IceDB.h
+++ b/cpp/src/IceDB/IceDB.h
@@ -68,8 +68,8 @@ namespace IceDB
     // write returns true on success, and false if the provided
     // array is too small.
     // On failure, MDB_val.mv_size contains the marshaled key
-    // size if known, and 0 if not know.
-    // static bool write(const T&, MDB_val&, H&);
+    // size if known, and 0 if not known.
+    // static bool write(const T&, MDB_val&);
     //
     template<typename T, typename C, typename H> struct Codec;
 
@@ -375,7 +375,7 @@ namespace IceDB
     //
     // Returns computed mapSize in bytes.
     // When the input parameter is <= 0, returns a platform-dependent default
-    // (currently 0 on Windows and 100 MB on other platforms).
+    // (currently 10 MB on Windows and 100 MB on other platforms).
     // Otherwise, returns input parameter * 1 MB.
     //
 

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -78,7 +78,7 @@ namespace IceGrid
         if (sz == -1)
         {
             Ice::Warning out(traceLevels->logger);
-            out << "error rerporting child error msg: '" << msg << "'";
+            out << "error reporting child error msg: '" << msg << "'";
         }
         close(fd);
 
@@ -690,7 +690,7 @@ Activator::activate(
     }
 
     //
-    // Don't print the following trace, this might interfer with the
+    // Don't print the following trace, this might interfere with the
     // output of the started process if it fails with an error message.
     //
     //     if(_traceLevels->activator > 0)

--- a/cpp/src/IceGrid/DescriptorBuilder.cpp
+++ b/cpp/src/IceGrid/DescriptorBuilder.cpp
@@ -429,7 +429,7 @@ void
 ServerInstanceDescriptorBuilder::addPropertySet(const string& service, const PropertySetDescriptor& desc)
 {
     //
-    // Allow re-opening of unamed property sets.
+    // Allow re-opening of unnamed property sets.
     //
     PropertySetDescriptor& p = service.empty() ? _descriptor.propertySet : _descriptor.servicePropertySets[service];
     p.references.insert(p.references.end(), desc.references.begin(), desc.references.end());
@@ -625,7 +625,7 @@ void
 CommunicatorDescriptorBuilder::addPropertySet(const PropertySetDescriptor& desc)
 {
     //
-    // Allow re-opening of unamed property sets.
+    // Allow re-opening of unnamed property sets.
     //
     PropertySetDescriptor& p = _descriptor->propertySet;
     p.references.insert(p.references.end(), desc.references.begin(), desc.references.end());
@@ -736,7 +736,7 @@ void
 ServiceInstanceDescriptorBuilder::addPropertySet(const PropertySetDescriptor& desc)
 {
     //
-    // Allow re-opening of unamed property sets.
+    // Allow re-opening of unnamed property sets.
     //
     PropertySetDescriptor& p = _descriptor.propertySet;
     p.references.insert(p.references.end(), desc.references.begin(), desc.references.end());

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -2034,7 +2034,7 @@ NodeHelper::NodeHelper(string name, NodeDescriptor descriptor, const Resolver& a
         //
         // Set the named property sets on the resolver. We use the
         // instantiated named property sets here -- named property sets
-        // must be fully definied at the node level.
+        // must be fully defined at the node level.
         //
         resolve.addPropertySets(_instance.propertySets);
     }
@@ -2526,7 +2526,7 @@ ApplicationHelper::ApplicationHelper(
         //
         // Set the named property sets on the resolver. We use the
         // instantiated named property sets here -- named property sets
-        // must be fully definied at the application level.
+        // must be fully defined at the application level.
         //
         resolve.addPropertySets(_instance.propertySets);
     }

--- a/cpp/src/IceGrid/FileCache.cpp
+++ b/cpp/src/IceGrid/FileCache.cpp
@@ -59,7 +59,7 @@ FileCache::getOffsetFromEnd(const string& file, int originalCount)
         }
         else
         {
-            is.seekg(0, ios::beg); // We've reach the beginning of the file.
+            is.seekg(0, ios::beg); // We've reached the beginning of the file.
         }
 
         //
@@ -93,7 +93,7 @@ FileCache::getOffsetFromEnd(const string& file, int originalCount)
         else if (totalCount < originalCount)
         {
             //
-            // Otherwise, it we still didn't find the required number of lines,
+            // Otherwise, if we still didn't find the required number of lines,
             // read another block of text before this block.
             //
             lastBlockOffset -= blockSize; // Position of the block we just read.

--- a/cpp/src/IceGrid/IceGridNode.cpp
+++ b/cpp/src/IceGrid/IceGridNode.cpp
@@ -675,7 +675,7 @@ NodeService::stop()
     }
 
     //
-    // Break cylic reference counts.
+    // Break cyclic reference counts.
     //
     if (_node)
     {

--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -18,7 +18,7 @@ module IceGrid
 
     class InternalAdapterDescriptor
     {
-        /// The identifier of the server.
+        /// The adapter ID.
         string id;
 
         /// Specifies if the lifetime of the adapter is the same as the server.
@@ -100,7 +100,7 @@ module IceGrid
     {
         /// Activate this adapter. If this adapter can be activated, this will activate the adapter and return the
         /// direct proxy of the adapter once it's active. If this adapter can be activated on demand, this will return
-        /// `null` if the adapter is inactive or the adapter direct proxy it's active.
+        /// `null` if the adapter is inactive or the adapter direct proxy if it's active.
         ["amd"] Object* activate();
 
         /// Get the adapter's direct proxy. The adapter's direct proxy is a proxy created with the object adapter.
@@ -171,7 +171,7 @@ module IceGrid
         /// @return The server state.
         ["cpp:const"] idempotent ServerState getState();
 
-        /// Get the server's pid. Note that the value returned by this method is system dependant. On Unix operating
+        /// Get the server's pid. Note that the value returned by this method is system dependent. On Unix operating
         /// systems, it's the pid value returned by the `fork()` system call and converted to an integer.
         ["cpp:const"] idempotent int getPid();
 
@@ -345,10 +345,10 @@ module IceGrid
         /// The network name of the host running this node (as defined in `uname()`).
         string hostname;
 
-        /// The operation system release level (as defined in `uname()`).
+        /// The operating system release level (as defined in `uname()`).
         string release;
 
-        /// The operation system version (as defined in `uname()`).
+        /// The operating system version (as defined in `uname()`).
         string version;
 
         /// The machine hardware type (as defined in `uname()`).
@@ -387,8 +387,8 @@ module IceGrid
         NodeSession* registerNode(InternalNodeInfo info, Node* prx, LoadInfo loadInf)
             throws NodeActiveException, PermissionDeniedException;
 
-        /// Register a replica with the registry. If a replica with the same name is already registered,
-        /// this operation overrides the existing registration only when the previously registered node is not active.
+        /// Register a replica with the registry. If a replica with the same name is already registered, this
+        /// operation overrides the existing registration only when the previously registered replica is not active.
         /// @param info Some information on the replica.
         /// @param prx The proxy of the replica.
         /// @return The replica session proxy.

--- a/cpp/src/IceGrid/NodeCache.cpp
+++ b/cpp/src/IceGrid/NodeCache.cpp
@@ -292,7 +292,7 @@ NodeEntry::canRemove()
 {
     lock_guard lock(_mutex);
 
-    // The cache mutex must be locked to acesss _selfRemovingRefCount
+    // The cache mutex must be locked to access _selfRemovingRefCount
     return _servers.empty() && !_session && _descriptors.empty() && _selfRemovingRefCount == 0;
 }
 
@@ -759,13 +759,13 @@ NodeEntry::getInternalServerDescriptor(const ServerInfo& info) const
 
         if (hasProperty(info.descriptor->propertySet.properties, "Ice.Admin.Enabled"))
         {
-            // Ice.Admin.Enabled explicitely set, leave Ice.Admin.Endpoints alone
+            // Ice.Admin.Enabled explicitly set, leave Ice.Admin.Endpoints alone
             server->processRegistered =
                 getPropertyAsInt(info.descriptor->propertySet.properties, "Ice.Admin.Enabled") > 0;
         }
         else if (hasProperty(info.descriptor->propertySet.properties, "Ice.Admin.Endpoints"))
         {
-            // Ice.Admin.Endpoints explicitely set, check if not ""
+            // Ice.Admin.Endpoints explicitly set, check if not ""
             server->processRegistered =
                 getProperty(info.descriptor->propertySet.properties, "Ice.Admin.Endpoints") != "";
         }

--- a/cpp/src/IceGrid/Parser.cpp
+++ b/cpp/src/IceGrid/Parser.cpp
@@ -49,7 +49,7 @@ namespace
          "                          Print the differences between the application\n"
          "                          described in DESC and the current deployment.\n"
          "                          If -s or --servers is specified, print the\n"
-         "                          the list of servers affected by the differences.\n"},
+         "                          list of servers affected by the differences.\n"},
         {"application",
          "update",
          "application update [-n | --no-restart] DESC [TARGET ... ] [NAME=VALUE ... ]\n"
@@ -103,7 +103,7 @@ namespace
         {"server", "describe", "server describe ID        Describe server ID.\n"},
         {"server", "properties", "server properties ID      Get the runtime properties of server ID.\n"},
         {"server", "property", "server property ID NAME   Get the runtime property NAME of server ID.\n"},
-        {"server", "status", "server status ID           Get the status of server ID.\n"},
+        {"server", "status", "server status ID          Get the status of server ID.\n"},
         {"server", "pid", "server pid ID             Get the process id of server ID.\n"},
         {"server", "start", "server start ID           Start server ID.\n"},
         {"server", "stop", "server stop ID            Stop server ID.\n"},
@@ -1676,7 +1676,7 @@ Parser::propertiesService(const list<string>& args, bool single)
     }
     else if (!single && args.size() != 2)
     {
-        invalidCommand("service properties", "requires exactly two argument");
+        invalidCommand("service properties", "requires exactly two arguments");
         return;
     }
 
@@ -2403,7 +2403,7 @@ Parser::showWarranty()
 
 //
 // With older flex version <= 2.5.35 YY_INPUT second
-// paramenter is of type int&, in newer versions it
+// parameter is of type int&, in newer versions it
 // changes to size_t&
 //
 void

--- a/cpp/src/IceGrid/Parser.h
+++ b/cpp/src/IceGrid/Parser.h
@@ -85,7 +85,7 @@ namespace IceGrid
 
         //
         // With older flex version <= 2.5.35 YY_INPUT second
-        // paramenter is of type int&, in newer versions it
+        // parameter is of type int&, in newer versions it
         // changes to size_t&
         //
         void getInput(char*, int&, size_t);

--- a/cpp/src/IceGrid/PlatformInfo.cpp
+++ b/cpp/src/IceGrid/PlatformInfo.cpp
@@ -68,8 +68,8 @@ namespace
         if (!glpi)
         {
             Ice::Warning out(logger);
-            out << "Unable to figure out the number of process sockets:\n";
-            out << "GetLogicalProcessInformation not supported on this OS;";
+            out << "Unable to figure out the number of processor sockets:\n";
+            out << "GetLogicalProcessorInformation not supported on this OS;";
             return 0;
         }
 
@@ -88,7 +88,7 @@ namespace
                 else
                 {
                     Ice::Warning out(logger);
-                    out << "Unable to figure out the number of process sockets:\n";
+                    out << "Unable to figure out the number of processor sockets:\n";
                     out << IceInternal::lastErrorToString();
                     return 0;
                 }
@@ -146,7 +146,7 @@ PlatformInfo::PlatformInfo(
     //
 #if defined(_WIN32)
     _terminated = false;
-    _usages1.insert(_usages1.end(), 1 * 60 / 5, 0);    // 1 sample every 5 seconds during 1 minutes.
+    _usages1.insert(_usages1.end(), 1 * 60 / 5, 0);    // 1 sample every 5 seconds during 1 minute.
     _usages5.insert(_usages5.end(), 5 * 60 / 5, 0);    // 1 sample every 5 seconds during 5 minutes.
     _usages15.insert(_usages15.end(), 15 * 60 / 5, 0); // 1 sample every 5 seconds during 15 minutes.
     _last1Total = 0;

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -1220,7 +1220,7 @@ RegistryI::getSSLInfo(const ConnectionPtr& connection, string& userDN)
 NodePrxSeq
 RegistryI::registerReplicas(const InternalRegistryPrx& internalRegistry, const NodePrxSeq& dbNodes)
 {
-    // Get proxies for slaves that we we connected with on last  shutdown.
+    // Get proxies for slaves that we were connected with on last shutdown.
     //
     // We first get the internal registry proxies and then also check
     // the public registry proxies. If we find public registry

--- a/cpp/src/IceGrid/ReplicaCache.cpp
+++ b/cpp/src/IceGrid/ReplicaCache.cpp
@@ -193,7 +193,7 @@ ReplicaCache::subscribe(const ReplicaObserverPrx& observer)
         if (traceLevels)
         {
             Ice::Warning out(traceLevels->logger);
-            out << "unexpected exception while subscribing observer from replica observer topic:\n" << ex;
+            out << "unexpected exception while subscribing observer to replica observer topic:\n" << ex;
         }
     }
 }

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -1512,7 +1512,7 @@ ServerI::activate()
         transform(desc->envs.begin(), desc->envs.end(), back_inserter(envs), environmentEval);
 
         //
-        // Clear the adapters direct proxy (this is usefull if the server
+        // Clear the adapters direct proxy (this is useful if the server
         // was manually activated).
         //
         for (const auto& adpt : adpts)

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -542,7 +542,7 @@ LocatorI::foundLocator(const Ice::LocatorPrx& locator)
             out << "received Ice locator with different instance name:\n";
             out << "using = '" << _locator->ice_getIdentity().category << "'\n";
             out << "received = '" << locator->ice_getIdentity().category << "'\n";
-            out << "This is typically the case if multiple Ice locators with different";
+            out << "This is typically the case if multiple Ice locators with different ";
             out << "instance names are deployed and the property 'IceLocatorDiscovery.InstanceName' ";
             out << "is not set.";
         }

--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -11,7 +11,7 @@
 
 module IceStormElection
 {
-    /// The contents of topic.
+    /// The contents of a topic.
     struct TopicContent
     {
         /// The topic identity.
@@ -123,10 +123,10 @@ module IceStormElection
         /// The node id.
         int id;
 
-        /// The nodes coordinator.
+        /// The node's coordinator.
         int coord;
 
-        /// The nodes group name.
+        /// The node's group name.
         string group;
 
         /// The replica the node is managing.
@@ -135,7 +135,7 @@ module IceStormElection
         /// The node state.
         NodeState state;
 
-        /// The sequence of nodes in this nodes group.
+        /// The sequence of nodes in this node's group.
         GroupInfoSeq up;
 
         /// The highest priority node that this node has seen.

--- a/cpp/src/IceStorm/Instrumentation.h
+++ b/cpp/src/IceStorm/Instrumentation.h
@@ -39,7 +39,7 @@ namespace IceStorm::Instrumentation
         /// Notification of some events being queued.
         virtual void queued(int count) = 0;
 
-        /// Notification of a some events being sent.
+        /// Notification of some events being sent.
         virtual void outstanding(int count) = 0;
 
         /// Notification of some events being delivered.
@@ -55,7 +55,7 @@ namespace IceStorm::Instrumentation
     public:
         virtual ~ObserverUpdater() = default;
 
-        /// Update topic observers associated with each topics.
+        /// Update topic observers associated with each topic.
         /// When called, this method goes through all the topics and for each topic
         /// TopicManagerObserver::getTopicObserver is called. The implementation of getTopicObserver has the
         /// possibility to return an updated observer if necessary.

--- a/cpp/src/IceStorm/NodeI.cpp
+++ b/cpp/src/IceStorm/NodeI.cpp
@@ -437,7 +437,7 @@ NodeI::merge(const set<int>& coordinatorSet)
             return;
         }
 
-        // Add each of the invited nodes in the invites issed set.
+        // Add each of the invited nodes in the invites issued set.
         _invitesIssued.insert(invited.begin(), invited.end());
 
         if (_traceLevels->election > 0)
@@ -540,7 +540,7 @@ NodeI::mergeContinue()
         out << "node id=" << _id << " llu=" << myLlu.generation << "/" << myLlu.iteration;
     }
 
-    // If its not us then we have to get the latest database data from
+    // If it's not us then we have to get the latest database data from
     // the replica with the latest set.
     // if(maxllu > _replica->getLastLogUpdate())
     if (maxllu > myLlu)
@@ -1072,7 +1072,7 @@ NodeI::destroy()
 }
 
 // A node should only receive an observer init call if the node is
-// reorganizing and its not the coordinator.
+// reorganizing and it's not the coordinator.
 void
 NodeI::checkObserverInit(int64_t)
 {
@@ -1095,7 +1095,7 @@ NodeI::startUpdate(int64_t& generation, const char* file, int line)
 
     unique_lock<mutex> lock(_mutex);
 
-    // If we've actively replicating & lost the majority of our replicas then recover.
+    // If we're actively replicating & lost the majority of our replicas then recover.
     if (!_coordinatorProxy && !_destroy && _state == NodeState::NodeStateNormal && !majority)
     {
         recovery(lock);

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -362,7 +362,7 @@ Parser::showBanner()
 
 //
 // With older flex version <= 2.5.35 YY_INPUT second
-// paramenter is of type int&, in newer versions it
+// parameter is of type int&, in newer versions it
 // changes to size_t&
 //
 void

--- a/cpp/src/IceStorm/Parser.h
+++ b/cpp/src/IceStorm/Parser.h
@@ -31,7 +31,7 @@ namespace IceStorm
 
         //
         // With older flex version <= 2.5.35 YY_INPUT second
-        // paramenter is of type int&, in newer versions it
+        // parameter is of type int&, in newer versions it
         // changes to size_t&
         //
         void getInput(char*, int&, size_t);

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -656,7 +656,7 @@ Subscriber::queue(bool forwarded, EventDataSeq events)
 {
     lock_guard lock(_mutex);
 
-    // If this is a link subscriber if the set of events were
+    // If this is a link subscriber and the set of events were
     // forwarded from another IceStorm instance then do not queue the
     // events.
     if (forwarded && _rec.link)
@@ -863,8 +863,8 @@ Subscriber::error(bool dec, exception_ptr e)
 
     //
     // A twoway subscriber can queue multiple send events and
-    // therefore its possible to get multiple error'd replies. Ignore
-    // replies if we're retrying and its not yet time to process the
+    // therefore it's possible to get multiple error'd replies. Ignore
+    // replies if we're retrying and it's not yet time to process the
     // next request.
     //
     auto now = std::chrono::steady_clock::now();

--- a/cpp/src/IceStorm/Subscriber.h
+++ b/cpp/src/IceStorm/Subscriber.h
@@ -74,7 +74,7 @@ namespace IceStorm
         const std::shared_ptr<Instance> _instance;
         const IceStorm::SubscriberRecord _rec;             // The subscriber record.
         const int _retryCount;                             // The retryCount.
-        const int _maxOutstanding;                         // The maximum number of oustanding events.
+        const int _maxOutstanding;                         // The maximum number of outstanding events.
         const std::optional<Ice::ObjectPrx> _proxy;        // The per subscriber object proxy, if any.
         const std::optional<Ice::ObjectPrx> _proxyReplica; // The replicated per subscriber object proxy, if any.
 

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -1310,7 +1310,7 @@ TopicImpl::removeSubscribers(const Ice::IdentitySeq& ids)
 
     if (found)
     {
-        // Then remove the subscriber from the subscribers list. Its
+        // Then remove the subscriber from the subscribers list. It's
         // possible that some of these subscribers have already been
         // removed (consider, for example, a concurrent reap call from two
         // replicas on the same subscriber). To avoid sending unnecessary

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -205,7 +205,7 @@ TransientTopicImpl::unsubscribe(optional<Ice::ObjectPrx> subscriber, const Ice::
     lock_guard lock(_mutex);
 
     // First remove the subscriber from the subscribers list. Note
-    // that its possible that the subscriber isn't in the list, but is
+    // that it's possible that the subscriber isn't in the list, but is
     // in the database if the subscriber was locally reaped.
     auto p = find(_subscribers.begin(), _subscribers.end(), id);
     if (p != _subscribers.end())
@@ -304,7 +304,7 @@ TransientTopicImpl::unlink(optional<TopicPrx> topic, const Ice::Current& current
     }
 
     // Remove the subscriber from the subscribers list. Note
-    // that its possible that the subscriber isn't in the list, but is
+    // that it's possible that the subscriber isn't in the list, but is
     // in the database if the subscriber was locally reaped.
     auto p = find(_subscribers.begin(), _subscribers.end(), id);
     if (p != _subscribers.end())
@@ -455,7 +455,7 @@ TransientTopicImpl::publish(bool forwarded, const EventDataSeq& events)
         for (const auto& id : ids)
         {
             //
-            // Its possible for the subscriber to already have been
+            // It's possible for the subscriber to already have been
             // removed since the copy is iterated over outside of
             // mutex protection.
             //

--- a/cpp/src/IceStorm/TransientTopicManagerI.cpp
+++ b/cpp/src/IceStorm/TransientTopicManagerI.cpp
@@ -87,7 +87,7 @@ void
 TransientTopicManagerImpl::reap()
 {
     //
-    // Must be called called with mutex locked.
+    // Must be called with mutex locked.
     //
     for (const string& topic : _instance->topicReaper()->consumeReapedTopics())
     {

--- a/cpp/src/iceserviceinstall/ServiceInstaller.cpp
+++ b/cpp/src/iceserviceinstall/ServiceInstaller.cpp
@@ -557,7 +557,7 @@ IceServiceInstaller::grantPermissions(const string& path, SE_OBJECT_TYPE type, b
         GetNamedSecurityInfoW(const_cast<wchar_t*>(stringToWstring(path).c_str()), type, flags, 0, 0, &acl, 0, &sd);
     if (res != ERROR_SUCCESS)
     {
-        throw runtime_error("Could not retrieve securify info for " + path + ": " + IceInternal::errorToString(res));
+        throw runtime_error("Could not retrieve security info for " + path + ": " + IceInternal::errorToString(res));
     }
 
     //
@@ -567,7 +567,7 @@ IceServiceInstaller::grantPermissions(const string& path, SE_OBJECT_TYPE type, b
     {
         if (!AuthzInitializeResourceManager(AUTHZ_RM_FLAG_NO_AUDIT, 0, 0, 0, 0, &manager))
         {
-            throw runtime_error("AutzInitializeResourceManager failed: " + IceInternal::lastErrorToString());
+            throw runtime_error("AuthzInitializeResourceManager failed: " + IceInternal::lastErrorToString());
         }
 
         LUID unusedId = {0};


### PR DESCRIPTION
Comment, doc-comment, and message-string typo fixes across the C++ runtime, transports, and services (Ice, IceGrid, IceStorm, Glacier2, IceBox, IceBT, DataStorm). No behavior changes.

The edits that are not comment-only, and so are worth actually reading:

- `Glacier2/SessionRouterI.cpp` — renamed the local `sessionForwader` to `sessionForwarder` (declaration and its two uses).
- `Glacier2/ProxyVerifier.cpp` — the address-filter description joined ranges with `", or"`, producing `10.0.0.1 up to 10.0.0.5, or10.0.0.9`. Added the missing space.
- `Ice/SSL/RFC2253.cpp` — `"expected end of data"` to `"unexpected end of data"`; the guard is `pos >= data.size()`, and the three neighbouring messages in the same file already say "unexpected".
- `IceGrid/PlatformInfo.cpp` — `GetLogicalProcessInformation` to `GetLogicalProcessorInformation` in a diagnostic, matching the actual Win32 API name resolved a few lines above, plus "process sockets" to "processor sockets".
- `IceGrid/Parser.cpp` — one help-table entry was indented one column past the other 38; realigned.
- `IceStorm/TransientTopicManagerI.cpp`, `IceBox/ServiceManagerI.cpp` — message string typos (`rerporting`, and a dropped article).

Everything else is comments and doc comments. Where a comment is mirrored in the other language mappings, only the C++ copy is touched here.