### PR TITLE
Fix typos in the Slice compilers and Slice definitions

### DIFF
--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -285,12 +285,12 @@ namespace
         openingEnd = (openingEnd == string::npos ? line.size() : openingEnd);
         auto count = openingEnd - pos;
 
-        // Find the closing delimeter, starting for the end of the opening delimeter.
+        // Find the closing delimiter, starting for the end of the opening delimiter.
         auto delimiter = string(count, '`');
         auto closingStart = line.find(delimiter, openingEnd);
         if (closingStart == string::npos)
         {
-            // No matching delimeter was found. Emit a warning, then skip to the next line. This one is broken.
+            // No matching delimiter was found. Emit a warning, then skip to the next line. This one is broken.
             const string msg = "unterminated code span: missing closing backtick delimiter";
             p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
 

--- a/cpp/src/Slice/DocCommentParser.h
+++ b/cpp/src/Slice/DocCommentParser.h
@@ -30,7 +30,7 @@ namespace Slice
         /// @param paramName If @p paramPtr is non-null, this is the mapped name of the parameter being referenced.
         /// Otherwise, this is the identifier after '@p', taken verbatim from the doc-comment.
         /// @param paramPtr A pointer to the parameter that is being referenced, or `nullptr` if it doesn't exist.
-        /// @return A properly formatted parameters reference in the target language. The doc-comment parser will
+        /// @return A properly formatted parameter reference in the target language. The doc-comment parser will
         /// replace the entire "@p <rawParamName>" string with the returned value.
         //
         // By default we just emit the parameter's name in code formatting.
@@ -48,7 +48,7 @@ namespace Slice
 
         /// This function is called by the doc-comment parser to map see-also references ('@see <rawLink>') into each
         /// language's syntax.
-        /// @param rawLink The references's raw text, taken verbatim from the doc-comment.
+        /// @param rawLink The reference's raw text, taken verbatim from the doc-comment.
         /// @param source A pointer to the Slice element that the doc-comment (and reference) are written on.
         /// @param target A pointer to the Slice element that is being referenced, or `nullptr` if it doesn't exist.
         /// @return A properly formatted see-also-link in the target language. This value will be stored in the

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -3371,7 +3371,7 @@ yyreduce:
         EnumeratorList enumerators = cont->enumerators(scoped->v);
         if (enumerators.size() == 1)
         {
-            // We found the enumerator the user must of been referencing.
+            // We found the enumerator the user must have been referencing.
             cl.push_back(enumerators.front());
             scoped->v = enumerators.front()->scoped();
         }

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -1411,7 +1411,7 @@ integer_constant
         EnumeratorList enumerators = cont->enumerators(scoped->v);
         if (enumerators.size() == 1)
         {
-            // We found the enumerator the user must of been referencing.
+            // We found the enumerator the user must have been referencing.
             cl.push_back(enumerators.front());
             scoped->v = enumerators.front()->scoped();
         }

--- a/cpp/src/Slice/MetadataValidation.cpp
+++ b/cpp/src/Slice/MetadataValidation.cpp
@@ -108,7 +108,7 @@ Slice::validateMetadata(const UnitPtr& unit, string_view prefix, map<string, Met
             }
         }
         return nullopt;
-    },
+    };
     knownMetadata.emplace("deprecate", std::move(deprecatedInfo));
 
     // "format"
@@ -464,7 +464,8 @@ MetadataVisitor::isMetadataValid(const MetadataPtr& metadata, const SyntaxTreeBa
         {
             // We make a special exception to uniqueness for metadata on forward declarations, since there can be
             // multiple forward declarations for the same entity, but they all share a single backing `MetadataList`.
-            // So for these types, even 'unique' metadata to appear multiple times, but we require them to be identical.
+            // So for these types, we let even 'unique' metadata appear multiple times, but we require them to be
+            // identical.
             if (dynamic_pointer_cast<ClassDecl>(p) || dynamic_pointer_cast<InterfaceDecl>(p))
             {
                 const MetadataPtr& previousMetadata = _seenDirectives[directive];

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -79,10 +79,10 @@ namespace
     /// Reports any naming conflicts between @p name and @p definitions.
     /// This should only be called for Slice elements that are _not_ defined at module scope.
     /// For example, this is fine to use for operations, enumerators, data members, and parameters.
-    /// For elements that are defined within directly within modules, `findContents` must be used instead.
+    /// For elements that are defined directly within modules, `findContents` must be used instead.
     /// @param name The name to check for conflicts.
     /// @param kind The kind of element that we're checking (only used for error messages).
-    /// @param definitions A list of definitions check @p name against.
+    /// @param definitions A list of definitions to check @p name against.
     /// @return @c false if there are no name conflicts, @c true otherwise.
     bool doesNameConflict(string_view name, string_view kind, const ContainedList& definitions)
     {
@@ -865,8 +865,8 @@ Slice::Contained::Contained(const ContainerPtr& container, string name) : _conta
 void
 Slice::Container::destroyContents()
 {
-    // Container has pointers to all it's contents (since it logically owns them).
-    // But each Contained also keeps a pointer to it's parent, creating a cycle.
+    // Container has pointers to all its contents (since it logically owns them).
+    // But each Contained also keeps a pointer to its parent, creating a cycle.
     // We need to break this cycle.
     for (const auto& i : _contents)
     {
@@ -999,7 +999,7 @@ Slice::Container::createClassDef(const string& name, int32_t id, const ClassDefP
     def->_declaration = decl;
     decl->_definition = def;
 
-    // Patch forward declarations which may of been created in other openings of this class' module.
+    // Patch forward declarations which may have been created in other openings of this class' module.
     for (const auto& q : matches)
     {
         dynamic_pointer_cast<ClassDecl>(q)->_definition = def;
@@ -1135,7 +1135,7 @@ Slice::Container::createInterfaceDef(const string& name, const InterfaceList& ba
     def->_declaration = decl;
     decl->_definition = def;
 
-    // Patch forward declarations which may of been created in other openings of this interface's module.
+    // Patch forward declarations which may have been created in other openings of this interface's module.
     for (const auto& q : matches)
     {
         dynamic_pointer_cast<InterfaceDecl>(q)->_definition = def;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -401,7 +401,7 @@ namespace Slice
         /// @remark Equivalent to `mappedScope(separator, leading) + mappedName()`.
         [[nodiscard]] std::string mappedScoped(const std::string& separator, bool leading = false) const;
 
-        /// Returns the mapped scope that this element will be generated in in the target language.
+        /// Returns the mapped scope in which this element will be generated in the target language.
         /// @param separator This string will be used to separate scope segments.
         /// @param leading If true, the returned string will have a leading `separator` (defaults to false).
         [[nodiscard]] std::string mappedScope(const std::string& separator, bool leading = false) const;
@@ -510,7 +510,7 @@ namespace Slice
         /// The user should disambiguate by qualifying the type-reference as 'Outer::H'.
         void checkHasChangedMeaning(const std::string& name, ContainedPtr namedThing = nullptr);
 
-        /// Returns `true` if this container is the global scope (i.e. it's of type `Unit`), and `false` otherwise.
+        /// Returns `false` if this container is the global scope (i.e. it's of type `Unit`), and `true` otherwise.
         /// If false, we emit an error message. So this function should only be called for types which cannot appear at
         /// global scope... so everything except for `Module`s.
         bool checkForGlobalDefinition(const char* definitionKindPlural);
@@ -733,7 +733,7 @@ namespace Slice
         [[nodiscard]] ParameterPtr returnParameter(const std::string& name);
 
         /// Returns this operation's out parameters and return type sorted in this order: '(required..., optional...)'.
-        /// If the this operation's return type is non-void and non-optional, it is at the end of the 'required' list.
+        /// If this operation's return type is non-void and non-optional, it is at the end of the 'required' list.
         /// Otherwise, required parameters are kept in definition order and optional parameters are sorted by tag.
         ///
         /// For convenience, non-void return types are represented by a dummy `Parameter` in this list.

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -256,11 +256,11 @@ Slice::Preprocessor::preprocess(const string& languageArg)
         char* buf = mcpp_get_mem_buffer(Out);
 
         //
-        // First try to open temporay file in tmp directory.
+        // First try to open temporary file in tmp directory.
         //
 #ifdef _WIN32
         //
-        // We use an unique id as the tmp file name prefix to avoid problems with this code being called concurrently
+        // We use a unique id as the tmp file name prefix to avoid problems with this code being called concurrently
         // from several processes, otherwise there is a chance that two processes call _wtempnam before any of them
         // opens the file and they will end up using the same tmp file. We then open the file with O_EXCL to atomically
         // create it -- this closes the TOCTOU window between _wtempnam returning a name and our opening it. The

--- a/cpp/src/Slice/Scanner.cpp
+++ b/cpp/src/Slice/Scanner.cpp
@@ -1829,7 +1829,7 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 /* Matches the end of a double-quoted string literal, but only while scanning a string literal. Flex always prefers
-   * to match the longest string it can, so quotes preceeded with a literal '\' will match the rules above this one. */
+   * to match the longest string it can, so quotes preceded with a literal '\' will match the rules above this one. */
 case 18:
 YY_RULE_SETUP
 #line 261 "src/Slice/Scanner.l"
@@ -2233,7 +2233,7 @@ YY_RULE_SETUP
     return BAD_TOKEN;
 }
 	YY_BREAK
-/* Matches any valid character (except newlines) not matched by another rule and fowards it to the parser.
+/* Matches any valid character (except newlines) not matched by another rule and forwards it to the parser.
    * This is the lowest priority rule in the scanner, and is only active while not in a sub-scanner. */
 case 50:
 YY_RULE_SETUP
@@ -3390,7 +3390,7 @@ namespace
         keywordMap["Value"] = ICE_VALUE;
     }
 
-    // This function is always called directly after a match has been made, but directly before it's action block is run.
+    // This function is always called directly after a match has been made, but directly before its action block is run.
     void preAction()
     {
         yycolno += yyleng;

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -256,7 +256,7 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
 }
 
   /* Matches the end of a double-quoted string literal, but only while scanning a string literal. Flex always prefers
-   * to match the longest string it can, so quotes preceeded with a literal '\' will match the rules above this one. */
+   * to match the longest string it can, so quotes preceded with a literal '\' will match the rules above this one. */
 <STRING_LITERAL>"\"" {
     popState();
     endLocation(yylloc);
@@ -556,7 +556,7 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
     return BAD_TOKEN;
 }
 
-  /* Matches any valid character (except newlines) not matched by another rule and fowards it to the parser.
+  /* Matches any valid character (except newlines) not matched by another rule and forwards it to the parser.
    * This is the lowest priority rule in the scanner, and is only active while not in a sub-scanner. */
 . {
     setLocation(yylloc);
@@ -701,7 +701,7 @@ namespace
         keywordMap["Value"] = ICE_VALUE;
     }
 
-    // This function is always called directly after a match has been made, but directly before it's action block is run.
+    // This function is always called directly after a match has been made, but directly before its action block is run.
     void preAction()
     {
         yycolno += yyleng;

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -110,7 +110,7 @@ namespace Slice
         /// Writes the dependencies in XML format to the specified file. If 'dependFile' is empty, it writes the
         /// dependencies to standard output instead.
         ///
-        /// This method write the dependencies for all visited units in a single XML document.
+        /// This method writes the dependencies for all visited units in a single XML document.
         ///
         /// @param dependFile The file to write the dependencies to or empty to write to standard output.
         void writeXMLDependencies(const std::string& dependFile);
@@ -118,7 +118,7 @@ namespace Slice
         /// Writes the dependencies in JSON format to the specified file. If 'dependFile' is empty, it writes the
         /// dependencies to standard output instead.
         ///
-        /// This method write the dependencies for all visited units in a single JSON document.
+        /// This method writes the dependencies for all visited units in a single JSON document.
         ///
         /// @param dependFile The file to write the dependencies to or empty to write to standard output.
         void writeJSONDependencies(const std::string& dependFile);

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -112,7 +112,7 @@ namespace Slice::Java
         std::string& formalType);
 
     /// Converts a Slice-formatted link into a JavaDoc formatted link.
-    /// @param rawLink The references's raw text, taken verbatim from the doc-comment.
+    /// @param rawLink The reference's raw text, taken verbatim from the doc-comment.
     /// @param source A pointer to the Slice element that the doc-comment (and reference) are written on.
     /// @param target A pointer to the Slice element that is being referenced, or `nullptr` if it doesn't exist.
     /// @returns A pair containing:

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -928,7 +928,7 @@ Slice::ImportVisitor::writeImports(
 
         if (jsModule == jsImportedModule || jsImportedModule.empty())
         {
-            // For Slice modules mapped to the same JavaScript module, or Slice files that doesn't use "js:module".
+            // For Slice modules mapped to the same JavaScript module, or Slice files that don't use "js:module".
             // We import them using their Slice include relative path.
             string f = toRelativePath(removeExtension(included) + ".js", unit->topLevelFile());
             imports[f] = sliceTopLevelModules;

--- a/cpp/src/slice2rb/RubyUtil.h
+++ b/cpp/src/slice2rb/RubyUtil.h
@@ -31,13 +31,13 @@ namespace Slice::Ruby
     std::string getMappedName(const ContainedPtr& p, IdentStyle style = IdentNormal);
 
     /// Returns the fully-qualified mapped-identifier of the provided Slice element.
-    /// This is equivalent to calling `getMappedName` on @p p and all it's containers.
+    /// This is equivalent to calling `getMappedName` on @p p and all its containers.
     std::string getAbsolute(const ContainedPtr& p);
 
-    /// Equivalent to `getMappedName` but with "T_" preprended to the name.
+    /// Equivalent to `getMappedName` but with "T_" prepended to the name.
     std::string getMetaTypeName(const ContainedPtr& p);
 
-    /// Equivalent to `getAbsolute` but with "T_" preprended to the name.
+    /// Equivalent to `getAbsolute` but with "T_" prepended to the name.
     std::string getMetaTypeReference(const ContainedPtr& p);
 
     /// Emits a comment header for a generated file.

--- a/slice/Glacier2/Router.ice
+++ b/slice/Glacier2/Router.ice
@@ -64,8 +64,8 @@ module Glacier2
         /// @throws PermissionDeniedException Thrown when an authentication or authorization failure occurs.
         /// @throws CannotCreateSessionException Thrown when the session cannot be created.
         /// @see Session
-        /// @see SessionManager
-        /// @see PermissionsVerifier
+        /// @see SSLSessionManager
+        /// @see SSLPermissionsVerifier
         Session* createSessionFromSecureConnection()
             throws PermissionDeniedException, CannotCreateSessionException;
 

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -18,7 +18,7 @@ module IceMX
     /// A dictionary of strings to integers.
     dictionary<string, int> StringIntDict;
 
-    /// The base class for metrics. A metrics object represents a collection of measurements associated to a given a
+    /// The base class for metrics. A metrics object represents a collection of measurements associated to a given
     /// system.
     class Metrics
     {
@@ -32,7 +32,7 @@ module IceMX
         /// The number of objects currently observed by this metrics.
         int current = 0;
 
-        /// The sum of the lifetime of each observed objects. This does not include the lifetime of objects which are
+        /// The sum of the lifetime of each observed object. This does not include the lifetime of objects which are
         /// currently observed, only the objects observed in the past.
         long totalLifetime = 0;
 
@@ -71,7 +71,7 @@ module IceMX
     /// metrics of an application that enabled the Ice administrative facility and configured one or more metrics views.
     interface MetricsAdmin
     {
-        /// Gets the names of enabled and disabled metrics.
+        /// Gets the names of the enabled and disabled metrics views.
         /// @param disabledViews The names of the disabled views.
         /// @return The names of the enabled views.
         Ice::StringSeq getMetricsViewNames(out Ice::StringSeq disabledViews);
@@ -107,7 +107,7 @@ module IceMX
         MetricsFailuresSeq getMapMetricsFailures(string view, string map)
             throws UnknownMetricsView;
 
-        /// Gets the metrics failure associated for the given metrics.
+        /// Gets the metrics failures associated with the given metrics.
         /// @param view The name of the metrics view.
         /// @param map The name of the metrics map.
         /// @param id The ID of the metrics.
@@ -170,7 +170,8 @@ module IceMX
     {
     }
 
-    /// Provide measurements for proxy invocations. Proxy invocations can either be sent over the wire or be collocated.
+    /// Provides measurements for proxy invocations. Proxy invocations can either be sent over the wire or be
+    /// collocated.
     class InvocationMetrics extends Metrics
     {
         /// The number of retries for the invocations.

--- a/slice/Ice/RemoteLogger.ice
+++ b/slice/Ice/RemoteLogger.ice
@@ -110,13 +110,13 @@ module Ice
         /// Retrieves recently logged log messages.
         /// @param messageTypes The list of message types that the caller wishes to receive. An empty list means no
         /// filtering (send all message types).
-        /// @param traceCategories The categories of traces that caller wish to receive. This parameter is ignored if
-        /// @p messageTypes is not empty and does not include trace. An empty list means no filtering (send all trace
-        /// categories).
+        /// @param traceCategories The categories of traces that the caller wishes to receive. This parameter is
+        /// ignored if @p messageTypes is not empty and does not include trace. An empty list means no filtering (send
+        /// all trace categories).
         /// @param messageMax The maximum number of log messages (of all types) to be returned. A negative value
         /// requests all messages available.
         /// @param prefix The prefix of the associated local logger.
-        /// @return The Log messages.
+        /// @return The log messages.
         LogMessageSeq getLog(
             LogMessageTypeSeq messageTypes,
             StringSeq traceCategories,

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -120,10 +120,10 @@ module IceGrid
         /// The network name of the host running this node.
         string hostname;
 
-        /// The operation system release level.
+        /// The operating system release level.
         string release;
 
-        /// The operation system version.
+        /// The operating system version.
         string version;
 
         /// The machine hardware type.
@@ -349,9 +349,9 @@ module IceGrid
         void instantiateServer(string application, string node, ServerInstanceDescriptor desc)
             throws AccessDeniedException, ApplicationNotExistException, DeploymentException;
 
-        /// Gets an application descriptor.
+        /// Gets information about an application.
         /// @param name The application name.
-        /// @return The application descriptor.
+        /// @return The application information.
         /// @throws ApplicationNotExistException Thrown when the application doesn't exist.
         ["cpp:const"]
         idempotent ApplicationInfo getApplicationInfo(string name)
@@ -660,7 +660,7 @@ module IceGrid
         /// message doesn't exceed the given size.
         /// @param lines The lines read from the file. If there was nothing to read from the file since the last call to
         /// read, an empty sequence is returned. The last line of the sequence is always incomplete (and therefore no
-        /// newline character should be added when writing the last line to the to the output device).
+        /// newline character should be added when writing the last line to the output device).
         /// @return `true` if EOF is encountered.
         /// @throws FileNotAvailableException Thrown when the implementation failed to read from the file.
         bool read(int size, out Ice::StringSeq lines)
@@ -798,7 +798,7 @@ module IceGrid
         /// @param info The details of the new adapter.
         void adapterAdded(AdapterInfo info);
 
-        // Notifies the observer that a dynamically-registered adapter was updated.
+        /// Notifies the observer that a dynamically-registered adapter was updated.
         /// @param info The details of the updated adapter.
         void adapterUpdated(AdapterInfo info);
 
@@ -867,9 +867,9 @@ module IceGrid
         /// session.
         /// @param registryObs The registry observer identity.
         /// @param nodeObs The node observer identity.
-        /// @param appObs The application observer.
-        /// @param adptObs The adapter observer.
-        /// @param objObs The object observer.
+        /// @param appObs The application observer identity.
+        /// @param adptObs The adapter observer identity.
+        /// @param objObs The object observer identity.
         /// @throws ObserverAlreadyRegisteredException Thrown when an observer is already registered with this registry.
         idempotent void setObserversByIdentity(
             Ice::Identity registryObs,

--- a/slice/IceGrid/Descriptor.ice
+++ b/slice/IceGrid/Descriptor.ice
@@ -87,7 +87,7 @@ module IceGrid
         ["deprecated:This field is provided for schema compatibility. It is no longer used."]
         bool registerProcess = false;
 
-        /// When `true`, the lifetime of this object adapter is the same of the server lifetime. This information is
+        /// When `true`, the lifetime of this object adapter is the same as the server lifetime. This information is
         /// used by the IceGrid node to figure out the server state: the server is active when all its "server lifetime"
         /// adapters are active.
         bool serverLifetime;
@@ -265,7 +265,7 @@ module IceGrid
     /// A mapping of template identifier to template descriptor.
     dictionary<string, TemplateDescriptor> TemplateDescriptorDict;
 
-    /// Describes an IceBox service.
+    /// Describes an IceBox service instance.
     struct ServiceInstanceDescriptor
     {
         /// The template used by this instance. It's empty when this instance does not use a template.
@@ -425,7 +425,7 @@ module IceGrid
         /// The name of the node to update.
         string name;
 
-        /// The updated description (or null if the description wasn't updated.)
+        /// The updated description (or null if the description wasn't updated).
         BoxedString description;
 
         /// The variables to update.
@@ -501,13 +501,13 @@ module IceGrid
         /// The server templates to update.
         TemplateDescriptorDict serverTemplates;
 
-        /// The IDs of the server template to remove.
+        /// The IDs of the server templates to remove.
         Ice::StringSeq removeServerTemplates;
 
         /// The service templates to update.
         TemplateDescriptorDict serviceTemplates;
 
-        /// The IDs of the service template to remove.
+        /// The IDs of the service templates to remove.
         Ice::StringSeq removeServiceTemplates;
 
         /// The application nodes to update.

--- a/slice/IceStorm/Metrics.ice
+++ b/slice/IceStorm/Metrics.ice
@@ -35,7 +35,7 @@ module IceMX
         /// The number of outstanding events.
         int outstanding = 0;
 
-        /// The number of forwarded events.
+        /// The number of delivered events.
         long delivered = 0;
     }
 }


### PR DESCRIPTION
Comment and doc-comment typo fixes in the Slice parser, the ten `slice2*` generators, and the Slice definitions under `slice/`. No behavior changes.

Two things to look at:

- `Slice/MetadataValidation.cpp` — the `deprecatedInfo.extraValidation` lambda assignment ended with `,` instead of `;`, chaining it to the following `knownMetadata.emplace` through the comma operator. Same semantics, but it reads as a typo; changed to `;`.
- `Slice/Scanner.l` and `Slice/Grammar.y` — the `fowards` to `forwards` fix is applied to both the flex/bison sources and their checked-in generated output, so the two stay in sync.

The `slice/` changes are doc comments on the public Slice contract — they affect generated API documentation in every mapping, so they may deserve a closer read than the rest.