### PR TITLE
Fix typos in the C++ test suite

### DIFF
--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -47,7 +47,7 @@ void ::Reader::run(int argc, char* argv[])
         test(sample.getUpdateTag() == "price");
         test(sample.getValue()->price == 18.0f);
 
-        // Late joining reader should still receive update events instead of partial updates
+        // Late joining reader with full history should still receive the partial update events
         auto reader2 = makeSingleKeyReader(topic, "AAPL");
         sample = reader2.getNextUnread();
         test(sample.getEvent() == SampleEvent::Add);

--- a/cpp/test/DataStorm/reliability/Writer.cpp
+++ b/cpp/test/DataStorm/reliability/Writer.cpp
@@ -53,9 +53,9 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
-    // Publish a batch of samples to a topic's key, follow by two consecutive session recovery events without writer
+    // Publish a batch of samples to a topic's key, followed by two consecutive session recovery events without writer
     // activity on the given key.
-    // Then send a second batch of samples to the same topic's key and ensure the reader continue reading from when it
+    // Then send a second batch of samples to the same topic's key and ensure the reader continues reading from when it
     // left off.
     cout << "testing reader multiple connection closure without writer activity... " << flush;
     {
@@ -77,11 +77,11 @@ void ::Writer::run(int argc, char* argv[])
         auto writerB = makeSingleKeyWriter(topic, "writer_barrier");
         writerB.update(0);
 
-        // Wait for a second control sample from the reader indicating the second session closure. The writer process
+        // Wait for a second control sample from the reader indicating the second session closure. The writer processes
         // this sample after the second session reestablishment.
         sample = readerB.getNextUnread();
 
-        // Session has been reestablish twice without activity in "element" key. Send the second batch of samples.
+        // Session has been reestablished twice without activity in "element" key. Send the second batch of samples.
         for (int i = 0; i < 100; ++i)
         {
             writer.update(i + 100);

--- a/cpp/test/Glacier2/router/Client.cpp
+++ b/cpp/test/Glacier2/router/Client.cpp
@@ -618,8 +618,8 @@ CallbackClient::run(int argc, char** argv)
     }
 
     //
-    // Send 3 twoway request to callback the receiver. The callback
-    // receiver only reply to the callback once it received the 3
+    // Send 3 twoway requests to callback the receiver. The callback
+    // receiver only replies to the callback once it received the 3
     // callbacks. This test ensures that Glacier2 doesn't serialize
     // twoway requests (see bug 337 for more information).
     //
@@ -755,7 +755,7 @@ CallbackClient::run(int argc, char** argv)
         //
         // Initiate few callbacks with a large payload. Because of
         // the buffered mode, this shouldn't block even though the
-        // misbehaved client are not answering their callback
+        // misbehaved clients are not answering their callback
         // requests.
         //
         Context context;

--- a/cpp/test/Glacier2/ssl/Client.cpp
+++ b/cpp/test/Glacier2/ssl/Client.cpp
@@ -26,7 +26,7 @@ Client::run(int argc, char** argv)
     communicator->setDefaultRouter(router);
 
     //
-    // First try to create a non ssl sessions.
+    // First try to create a non ssl session.
     //
     cout << "creating non-ssl session with tcp connection... ";
     try

--- a/cpp/test/Ice/ami/TestI.cpp
+++ b/cpp/test/Ice/ami/TestI.cpp
@@ -152,7 +152,7 @@ TestIntfI::finishDispatch(const Ice::Current&)
     {
         return;
     }
-    else if (_pending) // Pending might not be set yet if startDispatch is dispatch out-of-order
+    else if (_pending) // Pending might not be set yet if startDispatch is dispatched out-of-order
     {
         _pending();
         _pending = nullptr;

--- a/cpp/test/Ice/binding/AllTests.cpp
+++ b/cpp/test/Ice/binding/AllTests.cpp
@@ -887,7 +887,7 @@ allTests(Test::TestHelper* helper)
 
             // Ensure the published endpoints are actually valid. On
             // Fedora, binding to "localhost" with IPv6 only works but
-            // resolving localhost don't return the IPv6 address.
+            // resolving localhost doesn't return the IPv6 address.
             Ice::ObjectPrx prx = oa->createProxy(Ice::stringToIdentity("dummy"));
             try
             {

--- a/cpp/test/Ice/echo/BlobjectI.cpp
+++ b/cpp/test/Ice/echo/BlobjectI.cpp
@@ -108,7 +108,7 @@ BlobjectI::getConnection(const Ice::Current& current)
     }
     catch (const Ice::ConnectionLostException&)
     {
-        // If we lost the connection, wait 5 seconds for the server to re-establish it. Some tests,
+        // If we lost the connection, wait 5 seconds for the server to re-establish it. Some tests
         // involve connection closure and the server automatically re-establishes the connection with the echo server.
         _condition.wait_for(lock, chrono::seconds(5));
         if (!_connection)

--- a/cpp/test/Ice/inactivityTimeout/AllTests.cpp
+++ b/cpp/test/Ice/inactivityTimeout/AllTests.cpp
@@ -106,7 +106,7 @@ testWithOutstandingRequest(TestIntfPrx p, bool oneway)
     }
     else
     {
-        // With a two-way invocation, the inactivity timeout should not shutdown any connection.
+        // With a two-way invocation, the inactivity timeout should not shut down any connection.
         test(connection2 == connection);
     }
     connection2->close().get();

--- a/cpp/test/Ice/location/AllTests.cpp
+++ b/cpp/test/Ice/location/AllTests.cpp
@@ -521,7 +521,7 @@ allTests(Test::TestHelper* helper, const string& ref)
         }
         catch (const Ice::LocalException&)
         {
-            // Expected to fail once they endpoints have been updated in the background.
+            // Expected to fail once the endpoints have been updated in the background.
         }
         try
         {
@@ -533,7 +533,7 @@ allTests(Test::TestHelper* helper, const string& ref)
         }
         catch (const Ice::LocalException&)
         {
-            // Expected to fail once they endpoints have been updated in the background.
+            // Expected to fail once the endpoints have been updated in the background.
         }
         ic->destroy();
     }
@@ -611,15 +611,15 @@ allTests(Test::TestHelper* helper, const string& ref)
         id.name = Ice::generateUUID();
         adapter->add(std::make_shared<HelloI>(), id);
 
-        // Ensure that calls on the well-known proxy is collocated.
+        // Ensure that calls on the well-known proxy are collocated.
         HelloPrx helloPrx(communicator, communicator->identityToString(id));
         test(!helloPrx->ice_getConnection());
 
-        // Ensure that calls on the indirect proxy (with adapter ID) is collocated
+        // Ensure that calls on the indirect proxy (with adapter ID) are collocated
         helloPrx = adapter->createIndirectProxy<HelloPrx>(id);
         test(!helloPrx->ice_getConnection());
 
-        // Ensure that calls on the direct proxy is collocated
+        // Ensure that calls on the direct proxy are collocated
         helloPrx = adapter->createDirectProxy<HelloPrx>(id);
         test(!helloPrx->ice_getConnection());
 

--- a/cpp/test/Ice/logger/Client5.cpp
+++ b/cpp/test/Ice/logger/Client5.cpp
@@ -80,7 +80,7 @@ Client5::run(int, char**)
 
     //
     // Run Client application configured to generate 1024 bytes, the application is configured
-    // to archive log files when size is greatert than 128 bytes, there should be 7 archived files
+    // to archive log files when size is greater than 128 bytes, there should be 7 archived files
     // and current log file, all files must have 128 bytes size.
     //
     {
@@ -98,7 +98,7 @@ Client5::run(int, char**)
 
     //
     // Same as above but maximum size is lower than the message size, in this case we should
-    // get the same result as messages are not trucated.
+    // get the same result as messages are not truncated.
     //
     {
         Ice::InitializationData id;

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -101,7 +101,7 @@ namespace
             }
 
             // Ensure that the previous updates were committed, the setProperties call returns before
-            // notifying the callbacks so to ensure all the update callbacks have be notified we call
+            // notifying the callbacks so to ensure all the update callbacks have been notified we call
             // a second time, this will block until all the notifications from the first update have
             // completed.
             _serverProps->setProperties(Ice::PropertyDict());

--- a/cpp/test/Ice/operations/Server.cpp
+++ b/cpp/test/Ice/operations/Server.cpp
@@ -17,7 +17,7 @@ Server::run(int argc, char** argv)
 {
     Ice::PropertiesPtr properties = createTestProperties(argc, argv);
     //
-    // Its possible to have batch oneway requests dispatched after
+    // It's possible to have batch oneway requests dispatched after
     // the adapter is deactivated due to thread scheduling so we
     // suppress this warning.
     //

--- a/cpp/test/Ice/operations/ServerAMD.cpp
+++ b/cpp/test/Ice/operations/ServerAMD.cpp
@@ -17,7 +17,7 @@ ServerAMD::run(int argc, char** argv)
 {
     Ice::PropertiesPtr properties = createTestProperties(argc, argv);
     //
-    // Its possible to have batch oneway requests dispatched after
+    // It's possible to have batch oneway requests dispatched after
     // the adapter is deactivated due to thread scheduling so we
     // suppress this warning.
     //

--- a/cpp/test/Ice/retry/AllTests.cpp
+++ b/cpp/test/Ice/retry/AllTests.cpp
@@ -191,7 +191,7 @@ allTests(const Ice::CommunicatorPtr& communicator, const Ice::CommunicatorPtr& c
         test(retry1->opIdempotent(4) == 4);
         testInvocationCount(1);
         testFailureCount(0);
-        // It succeeded after 3 retry because of the failed opIdempotent on the fixed proxy above
+        // It succeeded after 3 retries because of the failed opIdempotent on the fixed proxy above
         testRetryCount(3);
         cout << "ok" << endl;
     }

--- a/cpp/test/Ice/udp/AllTests.cpp
+++ b/cpp/test/Ice/udp/AllTests.cpp
@@ -74,7 +74,7 @@ allTests(Test::TestHelper* helper)
     if (communicator->getProperties()->getIcePropertyAsInt("Ice.Override.Compress") == 0)
     {
         //
-        // Only run this test if compression is disabled, the test expect fixed message size
+        // Only run this test if compression is disabled, the test expects fixed message size
         // to be sent over the wire.
         //
 

--- a/cpp/test/IceBridge/simple/AllTests.cpp
+++ b/cpp/test/IceBridge/simple/AllTests.cpp
@@ -122,7 +122,7 @@ allTests(Test::TestHelper* helper)
     cout << "testing ordering... " << flush;
     {
         //
-        // Make sure ordering is preserved on connection establishemnt.
+        // Make sure ordering is preserved on connection establishment.
         //
         int counter = 0;
         for (int i = 0; i < 10; ++i)

--- a/cpp/test/IceGrid/replicaGroup/AllTests.cpp
+++ b/cpp/test/IceGrid/replicaGroup/AllTests.cpp
@@ -851,7 +851,7 @@ allTests(Test::TestHelper* helper)
         }
         catch (const DeploymentException&)
         {
-            // The Random replica goup is used by Server1!
+            // The Random replica group is used by Server1!
         }
 
         //
@@ -1100,7 +1100,7 @@ allTests(Test::TestHelper* helper)
     }
     catch (const ServerStartException&)
     {
-        // Server should fail to start because it can't regsiter dynamically an OA
+        // Server should fail to start because it can't register dynamically an OA
         // with a deployed replica group.
     }
     catch (const Ice::Exception& ex)

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -655,7 +655,7 @@ testCertificateVerification(
         comm->destroy();
 
         // Target host matches the certificate Common Name and the certificate has a DNS altName that does not
-        // matches the target host.
+        // match the target host.
         initData.properties = createClientProps(defaultProps, p12, "ca1/client", "ca1/ca1");
         initData.properties->setProperty("IceSSL.CheckCertName", "1");
         comm = initialize(initData);
@@ -787,7 +787,7 @@ testFindCert(const string& factoryRef, const string& defaultDir, const Ice::Prop
         initData.properties->setProperty("IceSSL.CertStoreLocation", "CurrentUser");
         initData.properties->setProperty("IceSSL.FindCert", clientFindCertProperties[i]);
 
-        // Use TrustOnly to ensure the peer has pick the expected certificate.
+        // Use TrustOnly to ensure the peer has picked the expected certificate.
         initData.properties->setProperty("IceSSL.TrustOnly", "CN=ca1.server");
 
         CommunicatorPtr comm = initialize(initData);
@@ -798,7 +798,7 @@ testFindCert(const string& factoryRef, const string& defaultDir, const Ice::Prop
         d["IceSSL.CAs"] = "ca1/ca1_cert.pem";
         d["IceSSL.FindCert"] = serverFindCertProperties[i];
 
-        // Use TrustOnly to ensure the peer has pick the expected certificate.
+        // Use TrustOnly to ensure the peer has picked the expected certificate.
         d["IceSSL.TrustOnly"] = "CN=ca1.client";
 
         optional<Test::ServerPrx> server = fact->createServer(d);
@@ -845,7 +845,7 @@ testFindCert(const string& factoryRef, const string& defaultDir, const Ice::Prop
     import.cleanup();
 
     //
-    // These must fail because we have already remove the certificates.
+    // These must fail because we have already removed the certificates.
     //
     for (int i = 0; clientFindCertProperties[i] != 0; i++)
     {
@@ -911,7 +911,7 @@ testFindCert(const string& factoryRef, const string& defaultDir, const Ice::Prop
         initData.properties->setProperty("IceSSL.KeychainPassword", "password");
         initData.properties->setProperty("IceSSL.FindCert", clientFindCertProperties[i]);
 
-// Use TrustOnly to ensure the peer has pick the expected certificate.
+// Use TrustOnly to ensure the peer has picked the expected certificate.
 #    ifndef ICE_USE_SECURE_TRANSPORT_IOS
         initData.properties->setProperty("IceSSL.TrustOnly", "CN=ca1.server");
 #    endif
@@ -925,7 +925,7 @@ testFindCert(const string& factoryRef, const string& defaultDir, const Ice::Prop
         d["IceSSL.KeychainPassword"] = "password";
         d["IceSSL.FindCert"] = serverFindCertProperties[i];
 
-        // Use TrustOnly to ensure the peer has pick the expected certificate.
+        // Use TrustOnly to ensure the peer has picked the expected certificate.
 #    ifndef ICE_USE_SECURE_TRANSPORT_IOS
         d["IceSSL.TrustOnly"] = "CN=ca1.client";
 #    endif
@@ -2120,9 +2120,9 @@ testCrlRevocation(const string& factoryRef, const string& defaultDir, const Ice:
     CommunicatorPtr comm;
     InitializationData initData;
 
-    // First test with non revoked certificate that include CRL distribution point
+    // First test with non revoked certificate that includes CRL distribution point
     initData.properties = createClientProps(defaultProps, p12, "", "ca3/ca3");
-    // CLR file used by OpenSSL, OpenSSL doesn't check the CRL distribution points.
+    // CRL file used by OpenSSL, OpenSSL doesn't check the CRL distribution points.
     initData.properties->setProperty("IceSSL.CertificateRevocationListFiles", "ca3/ca3.crl.pem");
     initData.properties->setProperty("IceSSL.RevocationCheck", "1");
     initData.properties->setProperty("IceSSL.RevocationCheckCacheOnly", "0");
@@ -2142,7 +2142,7 @@ testCrlRevocation(const string& factoryRef, const string& defaultDir, const Ice:
 
     // Repeat with RevocationCheck=2 to check whole chain
     initData.properties = createClientProps(defaultProps, p12, "", "ca3/ca3");
-    // CLR file used by OpenSSL, OpenSSL doesn't check the CRL distribution points.
+    // CRL file used by OpenSSL, OpenSSL doesn't check the CRL distribution points.
     initData.properties->setProperty("IceSSL.CertificateRevocationListFiles", "ca3/ca3.crl.pem");
     initData.properties->setProperty("IceSSL.RevocationCheck", "2");
     initData.properties->setProperty("IceSSL.RevocationCheckCacheOnly", "0");
@@ -2162,7 +2162,7 @@ testCrlRevocation(const string& factoryRef, const string& defaultDir, const Ice:
     // Repeat with revoked certificate
     initData.properties = createClientProps(defaultProps, p12, "", "ca3/ca3");
     initData.properties->setProperty("IceSSL.RevocationCheck", "0");
-    // CLR file used by OpenSSL, OpenSSL doesn't check the CRL distribution points.
+    // CRL file used by OpenSSL, OpenSSL doesn't check the CRL distribution points.
     initData.properties->setProperty("IceSSL.CertificateRevocationListFiles", "ca3/ca3.crl.pem");
     comm = initialize(initData);
     fact = Test::ServerFactoryPrx{comm, factoryRef};
@@ -2171,7 +2171,7 @@ testCrlRevocation(const string& factoryRef, const string& defaultDir, const Ice:
     d["IceSSL.VerifyPeer"] = "0";
     server = fact->createServer(d);
 
-    // Revoked certificate is accepted because IceSSL.RevocationCheck=0 disable revocation checks
+    // Revoked certificate is accepted because IceSSL.RevocationCheck=0 disables revocation checks
     server->ice_ping();
     info = dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(server->ice_getConnection()->getInfo());
     fact->destroyServer(server);
@@ -2210,7 +2210,7 @@ testCrlRevocation(const string& factoryRef, const string& defaultDir, const Ice:
     initData.properties = createClientProps(defaultProps, p12, "", "ca3/ca3");
     initData.properties->setProperty("IceSSL.RevocationCheck", "2");
     initData.properties->setProperty("IceSSL.RevocationCheckCacheOnly", "0");
-    // CLR file used by OpenSSL, OpenSSL doesn't check the CRL distribution points.
+    // CRL file used by OpenSSL, OpenSSL doesn't check the CRL distribution points.
     initData.properties->setProperty("IceSSL.CertificateRevocationListFiles", "ca3/i1/i1.crl.pem");
     initData.properties->setProperty("IceSSL.VerifyPeer", "0");
     comm = initialize(initData);
@@ -2237,7 +2237,7 @@ testCrlRevocation(const string& factoryRef, const string& defaultDir, const Ice:
     initData.properties = createClientProps(defaultProps, p12, "", "ca3/ca3");
     initData.properties->setProperty("IceSSL.RevocationCheck", "1");
     initData.properties->setProperty("IceSSL.RevocationCheckCacheOnly", "0");
-    // CLR file used by OpenSSL, OpenSSL doesn't check the CRL distribution points.
+    // CRL file used by OpenSSL, OpenSSL doesn't check the CRL distribution points.
     initData.properties->setProperty("IceSSL.CertificateRevocationListFiles", "ca3/i1/i1.crl.pem");
     initData.properties->setProperty("IceSSL.VerifyPeer", "0");
 
@@ -2272,7 +2272,7 @@ testOcspRevocation(const string& factoryRef, const string& defaultDir, const Ice
     CommunicatorPtr comm;
     InitializationData initData;
 
-    // First test with non revoked certificate that include AIA info
+    // First test with non revoked certificate that includes AIA info
     initData.properties = createClientProps(defaultProps, p12, "", "ca4/ca4");
     initData.properties->setProperty("IceSSL.RevocationCheck", "1");
     initData.properties->setProperty("IceSSL.RevocationCheckCacheOnly", "0");
@@ -2352,7 +2352,7 @@ testOcspRevocation(const string& factoryRef, const string& defaultDir, const Ice
 
     // Repeat with RevocationCheck=1 to only check the end cert
 #    ifndef ICE_USE_SECURE_TRANSPORT
-    // SecureTransport always check the whole chain for revocation
+    // SecureTransport always checks the whole chain for revocation
     initData.properties = createClientProps(defaultProps, p12, "", "ca4/ca4");
     initData.properties->setProperty("IceSSL.RevocationCheck", "1");
     initData.properties->setProperty("IceSSL.RevocationCheckCacheOnly", "0");
@@ -2371,7 +2371,7 @@ testOcspRevocation(const string& factoryRef, const string& defaultDir, const Ice
     comm->destroy();
 #    endif
 
-    // Repeat with a certificate that is unknow for the OCSP responder
+    // Repeat with a certificate that is unknown for the OCSP responder
     initData.properties = createClientProps(defaultProps, p12, "", "ca4/ca4");
     initData.properties->setProperty("IceSSL.RevocationCheck", "1");
     initData.properties->setProperty("IceSSL.RevocationCheckCacheOnly", "0");

--- a/cpp/test/IceSSL/configuration/OpenSSLTests.cpp
+++ b/cpp/test/IceSSL/configuration/OpenSSLTests.cpp
@@ -181,7 +181,7 @@ clientRejectsServerUsingCAFile(Test::TestHelper* helper, const string& testDir)
     SSL_CTX_use_PrivateKey_file(serverSSLContext, serverKeyFile.c_str(), SSL_FILETYPE_PEM);
     SSL_CTX_set_default_passwd_cb(serverSSLContext, passwordCallback);
 
-    // The CAs used by the client doesn't trust the server certificate.
+    // The CAs used by the client don't trust the server certificate.
     const string clientCAFile = testDir + "/ca2/ca2_cert.pem";
     SSL_CTX* clientSSLContext = SSL_CTX_new(TLS_client_method());
     SSL_CTX_load_verify_file(clientSSLContext, clientCAFile.c_str());
@@ -335,7 +335,7 @@ serverValidatesClientUsingCAFile(Test::TestHelper* helper, const string& testDir
 {
     cout << "server validates client certificate using a CAFile... " << flush;
 
-    // The CA used by the server trust the client certificate.
+    // The CA used by the server trusts the client certificate.
     const string serverCertFile = testDir + "/ca1/server_cert.pem";
     const string serverKeyFile = testDir + "/ca1/server_key.pem";
     const string serverCAFile = testDir + "/ca1/ca1_cert.pem";
@@ -458,7 +458,7 @@ serverRejectsClientUsingCAFile(Test::TestHelper* helper, const string& testDir)
 {
     cout << "server rejects client certificate using a CAFile... " << flush;
 
-    // The CAs used by the server doesn't trust the certificate used by the client.
+    // The CAs used by the server don't trust the certificate used by the client.
     const string serverCertFile = testDir + "/ca1/server_cert.pem";
     const string serverKeyFile = testDir + "/ca1/server_key.pem";
     const string serverCAFile = testDir + "/ca2/ca2_cert.pem";

--- a/cpp/test/IceStorm/stress/Publisher.cpp
+++ b/cpp/test/IceStorm/stress/Publisher.cpp
@@ -83,7 +83,7 @@ Publisher::run(int argc, char** argv)
     {
         if (maxQueueTest && i == 10)
         {
-            // Sleep one seconds to give some time to IceStorm to connect to the subscriber
+            // Sleep one second to give some time to IceStorm to connect to the subscriber
             this_thread::sleep_for(1s);
         }
         proxy->pub(i);

--- a/cpp/test/IceUtil/unicode/Client.cpp
+++ b/cpp/test/IceUtil/unicode/Client.cpp
@@ -24,7 +24,7 @@ using namespace std;
 
 //
 // Note that each file starts with a BOM; stringToWstring and wstringToString
-// converts these BOMs back and forth.
+// convert these BOMs back and forth.
 //
 
 #if defined(_WIN32)


### PR DESCRIPTION
Comment and message typo fixes in the C++ tests — `its`/`it's`, subject-verb agreement, missing articles, and a few misspellings.

Test data, expected-output strings, and assertions are unchanged; the only non-comment edit is a `dispatch` to `dispatched` inside a trailing comment in `Ice/ami/TestI.cpp`.

Deliberately left alone: the intentionally misspelled `"Overrided"` property values in `IceGrid/deployer`, which must keep matching the XML descriptors and the assertions that read them.