### PR TITLE
Fix typos and grammar in the Java mapping

### DIFF
--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/NodeEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/NodeEditor.java
@@ -126,7 +126,7 @@ class NodeEditor extends Editor {
             "<html>A floating point value.<br>"
                 + "When not specified, IceGrid uses 1.0 divided by the<br>"
                 + "<i>number of threads</i> on all platforms except Windows;<br>"
-                + "on Windows, IceGrid uses 1.0.<html>");
+                + "on Windows, IceGrid uses 1.0.</html>");
     }
 
     @Override

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertiesField.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertiesField.java
@@ -77,7 +77,7 @@ public class PropertiesField extends JTable {
         // since they already appear in the Adapter pages
         Set<String> hiddenPropertyNames = new HashSet<>();
 
-        // We also hide properties whose value match an object or allocatable
+        // We also hide properties whose value matches an object or allocatable
         Set<String> hiddenPropertyValues = new HashSet<>();
 
         _hiddenProperties.clear();

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ReplicaGroup.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ReplicaGroup.java
@@ -186,7 +186,7 @@ class ReplicaGroup extends TreeNode {
 
     void rebuild(ReplicaGroupDescriptor descriptor) {
         _descriptor = descriptor;
-        // And that's it since there is no children
+        // And that's it since there are no children
     }
 
     private ReplicaGroupDescriptor _descriptor;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ReplicaGroupEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ReplicaGroupEditor.java
@@ -175,7 +175,7 @@ class ReplicaGroupEditor extends Editor {
             "<html>IceGrid returns the endpoints of "
                 + "up to <i>number</i> adapters<br>"
                 + "when resolving a replica group ID.<br>"
-                + "Enter 0 to returns the endpoints of all adapters.</html>");
+                + "Enter 0 to return the endpoints of all adapters.</html>");
 
         _loadSample.setEditable(true);
         JTextField loadSampleTextField = (JTextField) _loadSample.getEditor().getEditorComponent();

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Root.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Root.java
@@ -729,7 +729,7 @@ public class Root extends ListTreeNode {
             JOptionPane.showMessageDialog(
                 _coordinator.getMainFrame(),
                 e.toString(),
-                "Bad Application Descriptor: Unable reload Application",
+                "Bad Application Descriptor: Unable to reload Application",
                 JOptionPane.ERROR_MESSAGE);
             return;
         }

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/TreeNode.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/TreeNode.java
@@ -30,7 +30,7 @@ public abstract class TreeNode extends TreeNodeBase {
 
     abstract void write(XMLWriter writer) throws IOException;
 
-    // Ephemeral objects are destroyed when discard their changes
+    // Ephemeral objects are destroyed when their changes are discarded
     public boolean isEphemeral() {
         return false;
     }
@@ -50,7 +50,7 @@ public abstract class TreeNode extends TreeNodeBase {
     }
 
     TreeNode findChildLike(TreeNode other) {
-        // Default implementation just use id; not always appropriate
+        // Default implementation just uses id; not always appropriate
         return (TreeNode) findChild(other.getId());
     }
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
@@ -1247,7 +1247,7 @@ public class Coordinator {
         _liveApplications.clear();
 
         //
-        // Close al graphs
+        // Close all graphs
         //
         List<IGraphView> views = new ArrayList<>(_graphViews);
         for (IGraphView v : views) {
@@ -1364,7 +1364,7 @@ public class Coordinator {
                     //
                     // Compare the server certificate with a previous accepted certificate if
                     // any, the transient certificate is reset by Coordinator.login, and is only
-                    // useful in case the connection is retry, because a timeout or ACM closed it
+                    // useful in case the connection is retried, because a timeout or ACM closed it
                     // while the certificate verifier was waiting for the user decision.
                     //
                     // This avoids to show the dialog again if the user already granted the cert for
@@ -2814,7 +2814,7 @@ public class Coordinator {
                                 (String)
                                     JOptionPane.showInputDialog(
                                         _mainFrame,
-                                        "Which application do you to display",
+                                        "Which application do you want to display",
                                         "Show details",
                                         JOptionPane.QUESTION_MESSAGE,
                                         null,
@@ -3528,7 +3528,7 @@ public class Coordinator {
     private MainPane _mainPane;
 
     //
-    // Keep tracks of serial number when viewing/editing application definitions (not used for
+    // Keep track of serial number when viewing/editing application definitions (not used for
     // displaying live deployment)
     //
     private int _latestSerial = -1;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
@@ -117,7 +117,7 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
         public synchronized String toString(Number timestamp) {
             Date date = new Date(timestamp.longValue());
             if (date.getTime() < 1000) {
-                // When the x axis is first draw we don't have times to display.
+                // When the x axis is first drawn we don't have times to display.
                 return "";
             } else {
                 return _dateFormat.format(date);
@@ -698,7 +698,7 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
     }
 
     // Added a new chart series to an existing row, the graph series will use the
-    // same configuration, the row cell field must be reset so calculations doesn't
+    // same configuration, the row cell field must be reset so calculations don't
     // take into account previous data. If we don't reset fields here, calculations
     // can be bogus in case the view was disabled and the data in the view was reset.
     void addSeries(final MetricsRow row) {
@@ -859,8 +859,8 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                     }
                     samples--;
 
-                    // Remove empty series not longer in use, if there is only one
-                    // series that is keep to add new values.
+                    // Remove empty series no longer in use, if there is only one
+                    // series that is kept to add new values.
                     if (series.getData().isEmpty() && row.series.size() > 1) {
                         row.series.remove(series);
                         i--;
@@ -1410,7 +1410,7 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
         };
 
     //
-    // The metrics view being graph
+    // The metrics view being graphed
     //
 
     //

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsViewEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsViewEditor.java
@@ -1249,8 +1249,8 @@ public class MetricsViewEditor extends Editor implements MetricsFieldContext {
             _deltas.put(m.id, d2);
 
             if (d1 == null) {
-                // Return null indicate the graph to ignore this measurement. We need two
-                // measurement to calculate the delta increments.
+                // Return null to indicate the graph should ignore this measurement. We need two
+                // measurements to calculate the delta increments.
                 return null;
             }
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Server.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Server.java
@@ -696,7 +696,7 @@ public class Server extends Communicator {
                     }
 
                     if (_serviceObserver != null) {
-                        // Add observer to service manager using AMI call Note that duplicate
+                        // Add observer to service manager using AMI call. Note that duplicate
                         // registrations are ignored
 
                         ServiceManagerPrx serviceManager = getServiceManager();

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
@@ -825,7 +825,7 @@ public class SessionKeeper {
         private boolean _isDefault;
     }
 
-    // FocusListener implementation that unselect the text
+    // FocusListener implementation that unselects the text
     // of a text component after focus gained.
     public class FocusListener implements java.awt.event.FocusListener {
         public FocusListener(JTextComponent field) {
@@ -2393,7 +2393,7 @@ public class SessionKeeper {
         }
 
         boolean validateConfiguration() {
-            // If there isn't secure endpoints, we must set auth type to username password
+            // If there are no secure endpoints, we must set auth type to username password
             // and use X509 certificate to false.
             if (!hasSecureEndpoints()) {
                 _x509CertificateNoButton.setSelected(true);
@@ -2674,7 +2674,7 @@ public class SessionKeeper {
         // Finish configuration panel components
         private boolean _connectNow;
 
-        // The wizard steps the user has walked throw.
+        // The wizard steps the user has walked through.
         Stack<WizardStep> _wizardSteps = new Stack<>();
 
         ConnectionInfo _conf;
@@ -3944,7 +3944,7 @@ public class SessionKeeper {
         builder.border(Borders.DIALOG);
         builder.rowGroupingEnabled(true);
         builder.lineGapSize(LayoutStyle.getCurrent().getLinePad());
-        builder.addSeparator("Subject Alternate Names");
+        builder.addSeparator("Subject Alternative Names");
         builder.nextLine();
 
         Collection<List<?>> altNames = cert.getSubjectAlternativeNames();
@@ -4533,7 +4533,7 @@ public class SessionKeeper {
                 .setText("Logged into Slave Registry '" + _replicaName + "'");
         }
 
-        // Create the session in its own thread as it made remote calls
+        // Create the session in its own thread as it makes remote calls
         _coordinator
             .getExecutor()
             .submit(

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SimpleInternalFrame.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SimpleInternalFrame.java
@@ -289,7 +289,7 @@ public class SimpleInternalFrame extends JPanel {
 
     /**
      * Determines and answers the header's text foreground color. Tries to lookup a special color
-     * from the L&amp;F. In case it is absent, it uses the standard internal frame forground.
+     * from the L&amp;F. In case it is absent, it uses the standard internal frame foreground.
      *
      * @param isSelected true to lookup the active color, false for the inactive
      * @return the color of the foreground text

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/TreeNodeBase.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/TreeNodeBase.java
@@ -18,7 +18,7 @@ import javax.swing.tree.TreeCellRenderer;
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 
-// This class behaves like a leaf; derived class that represent non-leaf nodes must override various methods.
+// This class behaves like a leaf; derived classes that represent non-leaf nodes must override various methods.
 public class TreeNodeBase implements TreeNode, TreeCellRenderer {
     public Coordinator getCoordinator() {
         return _parent.getCoordinator();

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/XMLWriter.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/XMLWriter.java
@@ -99,7 +99,7 @@ public class XMLWriter {
             }
         }
         if (hasReserved) {
-            // First convert all '&' to '&amp';
+            // First convert all '&' to '&amp;'.
             if (v.indexOf('&') != -1) {
                 v = v.replaceAll("&", "&amp;");
             }

--- a/java/src/IceGridGUI/src/main/resources/metrics.cfg
+++ b/java/src/IceGridGUI/src/main/resources/metrics.cfg
@@ -317,7 +317,7 @@ IceGridGUI.Metrics.Subscriber.queued.columnToolTip = <html>Queued event count<br
 
 IceGridGUI.Metrics.Subscriber.outstanding.dataField = outstanding
 IceGridGUI.Metrics.Subscriber.outstanding.columnName = Outstanding
-IceGridGUI.Metrics.Subscriber.outstanding.columnToolTip = <html>Outstanding event count<br><br><p style="width: 300px;">Outstanding event are event which were sent by not yet delivered to the subcriber.</p></html>
+IceGridGUI.Metrics.Subscriber.outstanding.columnToolTip = <html>Outstanding event count<br><br><p style="width: 300px;">Outstanding event are event which were sent by not yet delivered to the subscriber.</p></html>
 
 IceGridGUI.Metrics.Subscriber.delivered.fieldClass = IceGridGUI.LiveDeployment.MetricsViewEditor$DeltaAverageMetricsField
 IceGridGUI.Metrics.Subscriber.delivered.dataField = delivered

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -325,7 +325,7 @@ public final class Communicator implements AutoCloseable {
     /**
      * Gets the object adapter that is associated by default with new outgoing connections created
      * by this communicator. This method returns null unless you set a non-null default object
-     * adapter using {@link setDefaultObjectAdapter}.
+     * adapter using {@link #setDefaultObjectAdapter}.
      *
      * @return the object adapter associated by default with new outgoing connections
      * @throws CommunicatorDestroyedException if the communicator has been destroyed
@@ -493,7 +493,7 @@ public final class Communicator implements AutoCloseable {
     }
 
     private CommunicatorFlushBatch _iceI_flushBatchRequestsAsync(CompressBatch compressBatch) {
-        // This callback object receives the results of all invocations of Connection.begin_flushBatchRequests.
+        // This callback object receives the results of the batch flush performed on each connection.
         var f = new CommunicatorFlushBatch(this, _instance);
         f.invoke(compressBatch);
         return f;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -1008,7 +1008,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
             // We send a heartbeat to the peer to generate a "write" on the connection. This write
             // in turns creates a read on the peer, and resets the peer's idle check timer. When
-            // _sendStream is not empty, there is already an outstanding write, so we don't need to
+            // _sendStreams is not empty, there is already an outstanding write, so we don't need to
             // send a heartbeat. It's possible the first message of _sendStreams was already sent
             // but not yet removed from _sendStreams: it means the last write occurred very
             // recently, which is good enough with respect to the idle check.
@@ -1475,12 +1475,12 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
     /**
      * Sends the next queued messages. This method is called by message() once the message which is
-     * being sent (_sendStreams.First) is fully sent. Before sending the next message, this message
-     * is removed from _sendsStream. If any, its sent callback is also queued in given callback queue.
+     * being sent (_sendStreams.getFirst()) is fully sent. Before sending the next message, this message
+     * is removed from _sendStreams. If any, its sent callback is also queued in given callback queue.
      *
      * @param callbacks The sent callbacks to call for the messages that were sent.
      * @return The socket operation to register with the thread pool's selector to send the
-     *     remainder of the pending message being sent (_sendStreams.First).
+     *     remainder of the pending message being sent (_sendStreams.getFirst()).
      */
     private int sendNextMessage(List<OutgoingMessage> callbacks) {
         if (_sendStreams.isEmpty()) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ErrorObserverMiddleware.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ErrorObserverMiddleware.java
@@ -15,7 +15,7 @@ public final class ErrorObserverMiddleware implements Object {
     private final Consumer<Error> _errorObserver;
 
     /**
-     * Constructs a ErrorObserverMiddleware.
+     * Constructs an ErrorObserverMiddleware.
      *
      * @param next the next dispatcher in the chain
      * @param errorObserver the error observer. If the provided observer throws an exception while

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HTTPNetworkProxy.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HTTPNetworkProxy.java
@@ -62,7 +62,7 @@ final class HTTPNetworkProxy implements NetworkProxy {
 
         if (!buf.b.hasRemaining()) {
             // Read one more byte, we can't easily read bytes in advance
-            // since the transport implementation might be be able to read
+            // since the transport implementation might be able to read
             // the data from the memory instead of the socket.
             buf.resize(buf.size() + 1, true);
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -473,7 +473,7 @@ public final class InputStream {
         }
 
         // If there isn't enough data to read on the stream for the sequence (and possibly enclosed sequences),
-        // something is wrong with the marshaled data: it's claiming having more data that what is possible to read.
+        // something is wrong with the marshaled data: it's claiming having more data than what is possible to read.
         if (_startSeq + minSeqSize > _buf.size()) {
             throw new MarshalException(END_OF_BUFFER_MESSAGE);
         }
@@ -626,7 +626,7 @@ public final class InputStream {
     }
 
     /**
-     * Extracts a optional serializable Java object from the stream.
+     * Extracts an optional serializable Java object from the stream.
      *
      * @param <T> The serializable type.
      * @param tag The numeric tag associated with the value.
@@ -1333,7 +1333,8 @@ public final class InputStream {
             OptionalFormat format = OptionalFormat.valueOf(v & 0x07); // First 3 bits.
             int tag = v >> 3;
             if (tag > 30) {
-                // We check for '> 30' instead of '> 29' because 30 is special sentinel tag, handled by the next block.
+                // We check for '> 30' instead of '> 29' because 30 is a special sentinel tag, handled by the next
+                // block.
                 throw new MarshalException("invalid tag '" + tag + "': tags larger than 29 must be encoded as a size");
             }
             if (tag == 30) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -693,7 +693,7 @@ public final class Instance {
             boolean ipv6 = isIPv6Supported ? properties.getIcePropertyAsInt("Ice.IPv6") > 0 : false;
 
             if (!ipv4 && !ipv6) {
-                throw new InitializationException("Both IPV4 and IPv6 support cannot be disabled.");
+                throw new InitializationException("Both IPv4 and IPv6 support cannot be disabled.");
             } else if (ipv4 && ipv6) {
                 _protocolSupport = Network.EnableBoth;
             } else if (ipv4) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/ObserverUpdater.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/ObserverUpdater.java
@@ -11,7 +11,7 @@ package com.zeroc.Ice.Instrumentation;
  */
 public interface ObserverUpdater {
     /**
-     * Update connection observers associated with each of the Ice connection from the communicator
+     * Update connection observers associated with each of the Ice connections from the communicator
      * and its object adapters. When called, this method goes through all the connections and for
      * each connection {@link CommunicatorObserver#getConnectionObserver} is called. The
      * implementation of getConnectionObserver has the possibility to return an updated observer if necessary.
@@ -19,7 +19,7 @@ public interface ObserverUpdater {
     void updateConnectionObservers();
 
     /**
-     * Update thread observers associated with each of the Ice thread from the communicator and its
+     * Update thread observers associated with each of the Ice threads from the communicator and its
      * object adapters. When called, this method goes through all the threads and for each thread
      * {@link CommunicatorObserver#getThreadObserver} is called. The implementation of
      * getThreadObserver has the possibility to return an updated observer if necessary.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorInfo.java
@@ -510,7 +510,7 @@ final class LocatorInfo {
     private void finishRequest(Reference ref, List<Reference> wellKnownRefs, ObjectPrx proxy, boolean notRegistered) {
         if (proxy == null || ((_ObjectPrxI) proxy)._getReference().isIndirect()) {
             // Remove the cached references of well-known objects for which we tried
-            // to resolved the endpoints if these endpoints are empty.
+            // to resolve the endpoints if these endpoints are empty.
             for (Reference r : wellKnownRefs) {
                 _table.removeObjectReference(r.getIdentity());
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NetworkProxy.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NetworkProxy.java
@@ -23,7 +23,7 @@ interface NetworkProxy {
 
     // If the proxy host needs to be resolved, this should return
     // a new NetworkProxy containing the IP address of the proxy.
-    // This is called from the endpoint host resolver thread, so it's safe if this this method blocks.
+    // This is called from the endpoint host resolver thread, so it's safe if this method blocks.
     NetworkProxy resolveHost(int protocolSupport);
 
     // Returns the IP address of the network proxy. This method must not block.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Object.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Object.java
@@ -123,7 +123,7 @@ public interface Object {
     }
 
     /**
-     * Dispatches an incoming request and returns a corresponding outgoing response for the {@link ice_isA} operation.
+     * Dispatches an incoming request and returns a corresponding outgoing response for the {@link #ice_isA} operation.
      *
      * @param obj the object to dispatch the request to
      * @param request the incoming request
@@ -142,7 +142,7 @@ public interface Object {
     }
 
     /**
-     * Dispatches an incoming request and returns a corresponding outgoing response for the {@link ice_ping} operation.
+     * Dispatches an incoming request and returns a corresponding outgoing response for the {@link #ice_ping} operation.
      *
      * @param obj the object to dispatch the request to
      * @param request the incoming request
@@ -156,7 +156,7 @@ public interface Object {
     }
 
     /**
-     * Dispatches an incoming request and returns a corresponding outgoing response for the {@link ice_ids} operation.
+     * Dispatches an incoming request and returns a corresponding outgoing response for the {@link #ice_ids} operation.
      *
      * @param obj the object to dispatch the request to
      * @param request the incoming request
@@ -174,7 +174,7 @@ public interface Object {
     }
 
     /**
-     * Dispatches an incoming request and returns a corresponding outgoing response for the {@link ice_id} operation.
+     * Dispatches an incoming request and returns a corresponding outgoing response for the {@link #ice_id} operation.
      *
      * @param obj the object to dispatch the request to
      * @param request the incoming request
@@ -189,7 +189,7 @@ public interface Object {
                 ret, (ostr, value) -> ostr.writeString(value), FormatType.CompactFormat));
     }
 
-    /** Implements {@link ice_isA} by checking all interfaces recursively. */
+    /** Implements {@link #ice_isA} by checking all interfaces recursively. */
     private static boolean isA(Class<?> type, String typeId) {
         for (var directInterface : type.getInterfaces()) {
             var sliceTypeIdAnnotation = directInterface.getAnnotation(SliceTypeId.class);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -109,7 +109,7 @@ public final class ObjectAdapter {
 
             // One off initializations of the adapter:
             // update the locator registry and print the "adapter ready" message.
-            // We set set state to StateActivating to prevent deactivation from other threads
+            // We set state to StateActivating to prevent deactivation from other threads
             // while these one off initializations are done.
             _state = StateActivating;
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
@@ -1805,7 +1805,7 @@ public final class OutputStream {
         private void writeInstance(Value v) {
             assert (v != null);
 
-            // If the instance was already marshaled, just write it's ID.
+            // If the instance was already marshaled, just write its ID.
             Integer p = _marshaledMap.get(v);
             if (p != null) {
                 _stream.writeSize(p);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyOutgoingAsyncBase.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyOutgoingAsyncBase.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Base class for proxy based invocations. This class handles the retry for proxy invocations.
- * It also ensures the child observer is correct notified of failures and make sure the retry task is
+ * It also ensures the child observer is correctly notified of failures and makes sure the retry task is
  * correctly canceled when the invocation completes.
  */
 abstract class ProxyOutgoingAsyncBase<T> extends OutgoingAsyncBase<T> {
@@ -361,7 +361,7 @@ abstract class ProxyOutgoingAsyncBase<T> extends OutgoingAsyncBase<T> {
                 throw ex;
             }
         } else if (ex instanceof RequestFailedException) {
-            // For all other cases, we don't retry ObjectNotExistException
+            // We don't retry other *NotExistException, which are all derived from RequestFailedException.
             throw ex;
         }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ReferenceFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ReferenceFactory.java
@@ -255,7 +255,7 @@ final class ReferenceFactory {
 
                 case 'e': {
                     if (argument == null) {
-                        throw new ParseException("no argument provided for -e option in in proxy string '" + s + "'");
+                        throw new ParseException("no argument provided for -e option in proxy string '" + s + "'");
                     }
 
                     try {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/EndpointInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/EndpointInfo.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice.SSL;
 
-/** Provides access to an SSL endpoint information. */
+/** Provides access to SSL endpoint information. */
 public final class EndpointInfo extends com.zeroc.Ice.EndpointInfo {
     EndpointInfo(com.zeroc.Ice.EndpointInfo underlying) {
         super(underlying);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/RFC2253.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/RFC2253.java
@@ -100,7 +100,7 @@ class RFC2253 {
         p.key = parseAttributeType(state);
         eatWhite(state);
         if (state.pos >= state.data.length()) {
-            throw new ParseException("invalid attribute type/value pair (unexpected end of state.data)");
+            throw new ParseException("invalid attribute type/value pair (unexpected end of data)");
         }
         if (state.data.charAt(state.pos) != '=') {
             throw new ParseException("invalid attribute type/value pair (missing =)");
@@ -113,7 +113,7 @@ class RFC2253 {
     private static String parseAttributeType(ParseState state) throws ParseException {
         eatWhite(state);
         if (state.pos >= state.data.length()) {
-            throw new ParseException("invalid attribute type (expected end of state.data)");
+            throw new ParseException("invalid attribute type (unexpected end of data)");
         }
 
         StringBuffer result = new StringBuffer();
@@ -158,7 +158,7 @@ class RFC2253 {
                     ++state.pos;
                     // 1*DIGIT must follow "."
                     if (state.pos < state.data.length() && !Character.isDigit(state.data.charAt(state.pos))) {
-                        throw new ParseException("invalid attribute type (expected end of state.data)");
+                        throw new ParseException("invalid attribute type (expected end of data)");
                     }
                 } else {
                     break;
@@ -212,7 +212,7 @@ class RFC2253 {
             ++state.pos;
             while (true) {
                 if (state.pos >= state.data.length()) {
-                    throw new ParseException("invalid attribute value (unexpected end of state.data)");
+                    throw new ParseException("invalid attribute value (unexpected end of data)");
                 }
                 // final terminating "
                 if (state.data.charAt(state.pos) == '"') {
@@ -254,7 +254,7 @@ class RFC2253 {
         ++state.pos;
 
         if (state.pos >= state.data.length()) {
-            throw new ParseException("invalid escape format (unexpected end of state.data)");
+            throw new ParseException("invalid escape format (unexpected end of data)");
         }
 
         if (special.indexOf(state.data.charAt(state.pos)) != -1

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TCPEndpointInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TCPEndpointInfo.java
@@ -3,7 +3,7 @@
 package com.zeroc.Ice;
 
 /**
- * Provides access to a TCP endpoint information.
+ * Provides access to TCP endpoint information.
  *
  * @see Endpoint
  */

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
@@ -13,7 +13,7 @@ class TcpAcceptor implements Acceptor {
 
     @Override
     public void setReadyCallback(ReadyCallback callback) {
-        // No need to for the ready callback.
+        // No need for the ready callback.
     }
 
     @Override

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TwowayOnlyException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TwowayOnlyException.java
@@ -17,7 +17,7 @@ public final class TwowayOnlyException extends LocalException {
         super(
             "Cannot invoke operation '"
                 + operation
-                + "' with a oneway, batchOneway, datagram, of batchDatagram proxy.");
+                + "' with a oneway, batchOneway, datagram, or batchDatagram proxy.");
         this.operation = operation;
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UDPEndpointInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UDPEndpointInfo.java
@@ -3,7 +3,7 @@
 package com.zeroc.Ice;
 
 /**
- * Provides access to a UDP endpoint information.
+ * Provides access to UDP endpoint information.
  *
  * @see Endpoint
  */

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSAcceptor.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSAcceptor.java
@@ -29,7 +29,7 @@ final class WSAcceptor implements Acceptor {
 
     @Override
     public Transceiver accept() {
-        // WebSocket handshaking is performed in TransceiverI::initialize, since accept must not block.
+        // WebSocket handshaking is performed in WSTransceiver.initialize, since accept must not block.
         return new WSTransceiver(_instance, _delegate.accept(), _allowedOrigins);
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSEndpointInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSEndpointInfo.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** Provides access to a WebSocket endpoint information. */
+/** Provides access to WebSocket endpoint information. */
 public final class WSEndpointInfo extends EndpointInfo {
     /** The URI configured with the endpoint. */
     public final String resource;

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -77,7 +77,7 @@ class PluginI implements Plugin {
                     exception(ex);
                 }
             } else {
-                // The proxy didn't change, so retrying wont help.
+                // The proxy didn't change, so retrying won't help.
                 assert (_exception != null);
                 _future.completeExceptionally(_exception);
             }
@@ -259,7 +259,7 @@ class PluginI implements Plugin {
                                 + "'\n"
                                 + "This is typically the case if multiple Ice locators"
                                 + " with different instance names are deployed and the"
-                                + " property `IceLocatorDiscovery.InstanceName'is not"
+                                + " property `IceLocatorDiscovery.InstanceName' is not"
                                 + " set.");
                 }
                 return;

--- a/java/test/src/main/java/test/Ice/ami/TestI.java
+++ b/java/test/src/main/java/test/Ice/ami/TestI.java
@@ -157,7 +157,7 @@ public class TestI implements TestIntf {
     public synchronized CompletionStage<Void> startDispatchAsync(Current current) {
         if (_shutdown) {
             // Ignore, this can occur with the forceful connection close test, shutdown can be
-            // dispatch before start dispatch.
+            // dispatched before startDispatch.
             CompletableFuture<Void> v = new CompletableFuture<>();
             v.complete(null);
             return v;
@@ -173,7 +173,7 @@ public class TestI implements TestIntf {
         if (_shutdown) {
             return;
         } else if (_pending != null) {
-            // Pending might not be set yet if startDispatch is dispatch out-of-order
+            // Pending might not be set yet if startDispatch is dispatched out-of-order
             _pending.complete(null);
             _pending = null;
         }

--- a/java/test/src/main/java/test/Ice/background/Acceptor.java
+++ b/java/test/src/main/java/test/Ice/background/Acceptor.java
@@ -14,7 +14,7 @@ class Acceptor implements com.zeroc.Ice.Acceptor {
 
     @Override
     public void setReadyCallback(ReadyCallback callback) {
-        // No need to for the ready callback.
+        // No need for the ready callback.
     }
 
     @Override

--- a/java/test/src/main/java/test/Ice/hash/Client.java
+++ b/java/test/src/main/java/test/Ice/hash/Client.java
@@ -88,12 +88,12 @@ public class Client extends TestHelper {
                             seenEndpoint.put(endpoint.hashCode(), endpoint);
                         }
                         //
-                        // Check the same endpoint produce always the same hash
+                        // Check the same endpoint always produces the same hash
                         //
                         test(endpoint.hashCode() == endpoint.hashCode());
                     }
                     //
-                    // Check the same proxy produce always the same hash
+                    // Check the same proxy always produces the same hash
                     //
                     test(obj.hashCode() == obj.hashCode());
                 }
@@ -126,7 +126,7 @@ public class Client extends TestHelper {
                         seenProxy.put(obj.hashCode(), obj.getProxy());
                     }
                     //
-                    // Check the same proxy produce always the same hash
+                    // Check the same proxy always produces the same hash
                     //
                     test(obj.hashCode() == obj.hashCode());
                 }
@@ -159,7 +159,7 @@ public class Client extends TestHelper {
                         seenProxy.put(obj.hashCode(), obj.getProxy());
                     }
                     //
-                    // Check the same proxy produce always the same hash
+                    // Check the same proxy always produces the same hash
                     //
                     test(obj.hashCode() == obj.hashCode());
                 }
@@ -358,7 +358,7 @@ public class Client extends TestHelper {
                         seenPointF.put(pf.hashCode(), pf);
                     }
                     //
-                    // Check the same struct produce always the same hash
+                    // Check the same struct always produces the same hash
                     //
                     test(pf.hashCode() == pf.hashCode());
                 }
@@ -378,7 +378,7 @@ public class Client extends TestHelper {
                         seenPointD.put(pd.hashCode(), pd);
                     }
                     //
-                    // Check the same struct produce always the same hash
+                    // Check the same struct always produces the same hash
                     //
                     test(pd.hashCode() == pd.hashCode());
                 }
@@ -404,7 +404,7 @@ public class Client extends TestHelper {
                         seenPolyline.put(polyline.hashCode(), polyline);
                     }
                     //
-                    // Check the same struct produce always the same hash
+                    // Check the same struct always produces the same hash
                     //
                     test(polyline.hashCode() == polyline.hashCode());
                 }
@@ -434,7 +434,7 @@ public class Client extends TestHelper {
                         seenColorPalette.put(colorPalette.hashCode(), colorPalette);
                     }
                     //
-                    // Check the same struct produce always the same hash
+                    // Check the same struct always produces the same hash
                     //
                     test(colorPalette.hashCode() == colorPalette.hashCode());
                 }
@@ -459,7 +459,7 @@ public class Client extends TestHelper {
                         seenColor.put(c.hashCode(), c);
                     }
                     //
-                    // Check the same struct produce always the same hash
+                    // Check the same struct always produces the same hash
                     //
                     test(c.hashCode() == c.hashCode());
                 }
@@ -494,7 +494,7 @@ public class Client extends TestHelper {
                         seenDraw.put(draw.hashCode(), draw);
                     }
                     //
-                    // Check the same struct produce always the same hash
+                    // Check the same struct always produces the same hash
                     //
                     test(draw.hashCode() == draw.hashCode());
                 }

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
@@ -131,7 +131,7 @@ public class AllTests {
             // first connection.
             test(connection2 != connection);
         } else {
-            // With a two-way invocation, the inactivity timeout should not shutdown any connection.
+            // With a two-way invocation, the inactivity timeout should not shut down any connection.
             test(connection2 == connection);
         }
         connection2.close();

--- a/java/test/src/main/java/test/Ice/interrupt/AllTests.java
+++ b/java/test/src/main/java/test/Ice/interrupt/AllTests.java
@@ -158,7 +158,7 @@ public class AllTests {
                 //
                 // Test interrupt of waitForSent. Here hold the adapter and send a large payload.
                 // The
-                // thread is interrupted in 500ms which should result in a operation interrupted
+                // thread is interrupted in 500ms which should result in an operation interrupted
                 // exception.
                 //
                 executor.submit(

--- a/java/test/src/main/java/test/Ice/location/AllTests.java
+++ b/java/test/src/main/java/test/Ice/location/AllTests.java
@@ -493,7 +493,7 @@ public class AllTests {
                         Thread.sleep(10);
                     }
                 } catch (LocalException ex) {
-                    // Expected to fail once they endpoints have been updated in the background.
+                    // Expected to fail once the endpoints have been updated in the background.
                 }
 
                 try {
@@ -504,7 +504,7 @@ public class AllTests {
                         Thread.sleep(10);
                     }
                 } catch (LocalException ex) {
-                    // Expected to fail once they endpoints have been updated in the background.
+                    // Expected to fail once the endpoints have been updated in the background.
                 }
             }
         }
@@ -583,18 +583,18 @@ public class AllTests {
         id.name = UUID.randomUUID().toString();
         adapter.add(new HelloI(), id);
 
-        // Ensure that calls on the well-known proxy is collocated.
+        // Ensure that calls on the well-known proxy are collocated.
         HelloPrx helloPrx =
             HelloPrx.checkedCast(
                 communicator.stringToProxy(
                     "\"" + communicator.identityToString(id) + "\""));
         test(helloPrx.ice_getConnection() == null);
 
-        // Ensure that calls on the indirect proxy (with adapter ID) is collocated
+        // Ensure that calls on the indirect proxy (with adapter ID) are collocated
         helloPrx = HelloPrx.checkedCast(adapter.createIndirectProxy(id));
         test(helloPrx.ice_getConnection() == null);
 
-        // Ensure that calls on the direct proxy is collocated
+        // Ensure that calls on the direct proxy are collocated
         helloPrx = HelloPrx.checkedCast(adapter.createDirectProxy(id));
         test(helloPrx.ice_getConnection() == null);
 

--- a/java/test/src/main/java/test/Ice/plugin/Client.java
+++ b/java/test/src/main/java/test/Ice/plugin/Client.java
@@ -15,7 +15,7 @@ import java.io.PrintWriter;
 public class Client extends TestHelper {
     public void run(String[] args) {
         //
-        // Under Android the class comes from the communicators classloader which
+        // Under Android the class comes from the communicator's classloader which
         // is setup in the android test driver.
         //
         String jarFile = isAndroid() ? "" : "../../../../../../../lib/IceTestPlugins.jar";

--- a/java/test/src/main/java/test/Ice/retry/AllTests.java
+++ b/java/test/src/main/java/test/Ice/retry/AllTests.java
@@ -167,7 +167,7 @@ public class AllTests {
             test(retry1.opIdempotent(4) == 4);
             instrumentation.testInvocationCount(1);
             instrumentation.testFailureCount(0);
-            // It succeeded after 3 retry because of the failed opIdempotent on the fixed proxy
+            // It succeeded after 3 retries because of the failed opIdempotent on the fixed proxy
             // above
             instrumentation.testRetryCount(3);
             out.println("ok");

--- a/java/test/src/main/java/test/Ice/timeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/timeout/AllTests.java
@@ -188,7 +188,7 @@ public class AllTests {
                 Thread.sleep(50);
             } catch (InterruptedException ex) {}
 
-            // We set a connect timeout of '1s', so the connection should still be useable here.
+            // We set a connect timeout of '1s', so the connection should still be usable here.
             try {
                 connection.getInfo(); // getInfo() doesn't throw in the closing state.
             } catch (LocalException ex) {


### PR DESCRIPTION
Comment, doc-comment, and message-string typo fixes across the Java runtime, IceGridGUI, and test suite. No behavior changes.

The user-visible edits:

- `Ice/Instance.java` — `"Both IPV4 and IPv6..."` to `IPv4`.
- `Ice/ReferenceFactory.java` — `"no argument provided for -e option in in proxy string"` lost the doubled `in`.
- `Ice/SSL/RFC2253.java` — several parse messages leaked the internal field name as `end of state.data`; now `end of data`, matching the C++/C# copies.
- `Ice/TwowayOnlyException.java` — `"datagram, of batchDatagram"` to `"or batchDatagram"`.
- `IceLocatorDiscovery/PluginI.java` — missing space in a concatenated warning.
- IceGridGUI — an unterminated `<html>` tag closed as `</html>`, `"Enter 0 to returns"`, `"Unable reload Application"`, `"Which application do you to display"`, and `Subject Alternate Names` to `Subject Alternative Names` (RFC 5280 calls it the Subject Alternative Name extension). `metrics.cfg` fixes `subcriber` in a tooltip.
- `Ice/Object.java` — `{@link ice_isA}` and siblings were unresolvable without the `#`; now `{@link #ice_isA}`.

Everything else is comments and doc comments.