### PR TITLE
Fix typos and grammar in the Python, Ruby, PHP, and MATLAB mappings

### DIFF
--- a/matlab/lib/+Ice/InputStream.m
+++ b/matlab/lib/+Ice/InputStream.m
@@ -565,7 +565,7 @@ classdef InputStream < handle
                     format = bitand(v, uint8(7)); % First 3 bits.
                     tag = uint32(bitshift(v, -3));
                     if tag > 30
-                        % We check for '> 30' instead of '> 29' because 30 is special sentinel tag, handled by the next block.
+                        % We check for '> 30' instead of '> 29' because 30 is a special sentinel tag, handled by the next block.
                         throw(Ice.MarshalException(...
                             sprintf('invalid tag ''%d'': tags larger than 29 must be encoded as a size', tag)));
                     end

--- a/matlab/lib/+Ice/TCPEndpointInfo.m
+++ b/matlab/lib/+Ice/TCPEndpointInfo.m
@@ -1,5 +1,5 @@
 classdef (Sealed) TCPEndpointInfo < Ice.IPEndpointInfo
-    %TCPENDPOINTINFO Provides access to a TCP endpoint information.
+    %TCPENDPOINTINFO Provides access to TCP endpoint information.
     %
     %   TCPEndpointInfo Methods:
     %     type - Returns the type of the endpoint.

--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -312,7 +312,7 @@ IceMatlab::convertException(const std::exception_ptr exc)
         rethrow_exception(exc);
     }
     // We need to catch and convert:
-    // - local exceptions thrown from MATLAB code for which we provide a convience constructor (e.g. MarshalException)
+    // - local exceptions thrown from MATLAB code for which we provide a convenience constructor (e.g. MarshalException)
     // - local exceptions that define extra properties we want to expose to MATLAB users (e.g. ObjectNotExistException
     // via its base class, RequestFailedException)
     catch (const Ice::AlreadyRegisteredException& e)

--- a/php/src/Config.h
+++ b/php/src/Config.h
@@ -5,7 +5,7 @@
 
 #include "Ice/Ice.h"
 
-// Surpress various warnings emitted from including the PHP headers
+// Suppress various warnings emitted from including the PHP headers
 #if defined(__clang__)
 #    pragma clang diagnostic ignored "-Wconversion"
 #    pragma clang diagnostic ignored "-Wsign-conversion"
@@ -46,7 +46,7 @@ extern zend_module_entry ice_module_entry;
 #define phpext_ice_ptr &ice_module_entry
 
 #ifdef ZTS
-//  If building for thread-safe enviroment, include the Thread Safe Resource Manager.
+//  If building for thread-safe environment, include the Thread Safe Resource Manager.
 #    include "TSRM.h"
 #endif
 

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -3215,7 +3215,7 @@ IcePHP::ExceptionReader::ExceptionReader(const CommunicatorInfoPtr& communicator
 IcePHP::ExceptionReader::~ExceptionReader()
 {
 #ifdef NDEBUG
-    // BUGFIX: releasing this object trigers an assert in PHP objects_store
+    // BUGFIX: releasing this object triggers an assert in PHP objects_store
     // https://github.com/php/php-src/issues/10593
     if (!Z_ISUNDEF(_ex))
     {

--- a/php/src/Types.h
+++ b/php/src/Types.h
@@ -109,7 +109,7 @@ namespace IcePHP
     public:
         virtual std::string getId() const = 0;
 
-        virtual bool validate(zval*, bool) = 0; // Validate type data. Bool enables excpetion throwing.
+        virtual bool validate(zval*, bool) = 0; // Validate type data. Bool enables exception throwing.
 
         virtual bool variableLength() const = 0;
         virtual int wireSize() const = 0;

--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -366,7 +366,7 @@ namespace
 
     zend_class_entry* createPHPException(zval* ex, const char* typeId, bool fallbackToLocalException = false)
     {
-        // Convert the exception's typeId to its mapped Python type by replacing "::Ice::" with "\Ice\".
+        // Convert the exception's typeId to its mapped PHP type by replacing "::Ice::" with "\Ice\".
         // This function should only ever be called on Ice local exceptions which don't use 'php:identifier'.
         string result = typeId;
         assert(result.find("::Ice::") == 0);

--- a/php/test/Ice/exceptions/Client.php
+++ b/php/test/Ice/exceptions/Client.php
@@ -351,7 +351,7 @@ class Client extends TestHelper
             $properties = $this->createTestProperties($args);
             $properties->setProperty("Ice.MessageSizeMax", "10");
             //
-            // This property is set by the test suite, howerver we need to override it for this test.
+            // This property is set by the test suite, however we need to override it for this test.
             // Unlike C++, we can not pass $argv into Ice::createProperties, so we just set it after.
             //
             $properties->setProperty("Ice.Warn.Connections", "0");

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -26,7 +26,7 @@ namespace
 
 #ifndef _WIN64
     //
-    // COMPILERFIX: With Windows 64 the templates bellow will produce trucation warnings,
+    // COMPILERFIX: With Windows 64 the templates below will produce truncation warnings,
     // we ifdef them out as they are never used with Windows 64.
     //
     template<> struct Hasher<4, 4>
@@ -46,7 +46,7 @@ namespace
         {
             auto v = reinterpret_cast<intptr_t>(ptr);
 
-            // Eliminate lower 4 bits as objecs are usually aligned on 16 bytes boundaries,
+            // Eliminate lower 4 bits as objects are usually aligned on 16 bytes boundaries,
             // then eliminate upper bits
             return (v >> 4) & 0xFFFFFFFF;
         }

--- a/python/modules/IcePy/EndpointInfo.cpp
+++ b/python/modules/IcePy/EndpointInfo.cpp
@@ -274,7 +274,7 @@ namespace IcePy
         .tp_basicsize = sizeof(EndpointInfoObject),
         .tp_dealloc = reinterpret_cast<destructor>(endpointInfoDealloc),
         .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-        .tp_doc = PyDoc_STR("Provides access to a TCP endpoint information."),
+        .tp_doc = PyDoc_STR("Provides access to TCP endpoint information."),
         .tp_new = reinterpret_cast<newfunc>(endpointInfoNew),
     };
 
@@ -284,7 +284,7 @@ namespace IcePy
         .tp_basicsize = sizeof(EndpointInfoObject),
         .tp_dealloc = reinterpret_cast<destructor>(endpointInfoDealloc),
         .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-        .tp_doc = PyDoc_STR("Provides access to a UDP endpoint information."),
+        .tp_doc = PyDoc_STR("Provides access to UDP endpoint information."),
         .tp_getset = UDPEndpointInfoGetters,
         .tp_new = reinterpret_cast<newfunc>(endpointInfoNew),
     };
@@ -295,7 +295,7 @@ namespace IcePy
         .tp_basicsize = sizeof(EndpointInfoObject),
         .tp_dealloc = reinterpret_cast<destructor>(endpointInfoDealloc),
         .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-        .tp_doc = PyDoc_STR("Provides access to a WebSocket endpoint information."),
+        .tp_doc = PyDoc_STR("Provides access to WebSocket endpoint information."),
         .tp_getset = WSEndpointInfoGetters,
         .tp_new = reinterpret_cast<newfunc>(endpointInfoNew),
     };
@@ -306,7 +306,7 @@ namespace IcePy
         .tp_basicsize = sizeof(EndpointInfoObject),
         .tp_dealloc = reinterpret_cast<destructor>(endpointInfoDealloc),
         .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-        .tp_doc = PyDoc_STR("Provides access to an SSL endpoint information."),
+        .tp_doc = PyDoc_STR("Provides access to SSL endpoint information."),
         .tp_new = reinterpret_cast<newfunc>(endpointInfoNew),
     };
 

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -1679,7 +1679,7 @@ IcePy::AsyncTypedInvocation::handleResponse(PyObject* future, bool ok, pair<cons
             }
             else if (PyTuple_GET_SIZE(args.get()) == 1)
             {
-                // PyTuple_GET_ITEM steals a reference.
+                // PyTuple_GET_ITEM returns a borrowed reference.
                 PyObject* obj = PyTuple_GET_ITEM(args.get(), 0);
                 assert(obj);
                 r = PyObjectHandle{Py_NewRef(obj)};
@@ -1924,7 +1924,7 @@ Upcall::dispatchImpl(PyObject* servant, const string& dispatchName, PyObject* ar
     // lookupType() returns a borrowed reference.
     PyObject* dispatchMethod{lookupType("Ice.Dispatch.dispatch")};
     assert(dispatchMethod);
-    // Ensure we release the reference when this method exist.
+    // Ensure we release the reference when this method exits.
     PyObjectHandle dispatchMethodHandle{Py_NewRef(dispatchMethod)};
 
     PyObjectHandle dispatchArgs{PyTuple_New(3)};

--- a/python/modules/IcePy/Properties.cpp
+++ b/python/modules/IcePy/Properties.cpp
@@ -69,7 +69,7 @@ propertiesInit(PropertiesObject* self, PyObject* args, PyObject* /*kwds*/)
         }
         else if (defaultsObj != Py_None)
         {
-            PyErr_Format(PyExc_ValueError, "defaults must be None or a Ice.Properties");
+            PyErr_Format(PyExc_ValueError, "defaults must be None or an Ice.Properties");
             return -1;
         }
     }

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -37,7 +37,7 @@ namespace
 {
     //
     // This exception is raised if the factory specified in a sequence metadata
-    // cannot be load or is not valid
+    // cannot be loaded or is not valid
     //
     class InvalidSequenceFactoryException
     {

--- a/python/python/Ice/Properties.py
+++ b/python/python/Ice/Properties.py
@@ -49,6 +49,7 @@ class Properties:
         Examples
         --------
         .. code-block:: python
+
             # Create a new empty property set.
             properties = Ice.Properties()
 

--- a/python/python/Ice/Util.py
+++ b/python/python/Ice/Util.py
@@ -208,7 +208,7 @@ def getSliceDir() -> str | None:
         The absolute path of the directory containing the Ice Slice files, or ``None`` if the directory cannot be found.
     """
 
-    # Get the parent of the directory containing this file (__init__.py).
+    # Get the parent of the directory containing this file (Util.py).
     pyHome = os.path.join(os.path.dirname(__file__), "..")
 
     # Detect setup.py installation in site-packages. The slice files live one level above this file.

--- a/python/python/IcePy-stubs/__init__.pyi
+++ b/python/python/IcePy-stubs/__init__.pyi
@@ -659,7 +659,7 @@ class SSLConnectionInfo(ConnectionInfo):
     """str: The peer certificate, PEM-encoded, or an empty string if the peer did not provide one."""
 
 class SSLEndpointInfo(EndpointInfo):
-    """Provides access to an SSL endpoint information."""
+    """Provides access to SSL endpoint information."""
 
     ...
 
@@ -673,7 +673,7 @@ class TCPConnectionInfo(IPConnectionInfo):
     """int: The size of the send buffer."""
 
 class TCPEndpointInfo(IPEndpointInfo):
-    """Provides access to a TCP endpoint information."""
+    """Provides access to TCP endpoint information."""
 
     ...
 
@@ -693,7 +693,7 @@ class UDPConnectionInfo(IPConnectionInfo):
     """int: The size of the send buffer."""
 
 class UDPEndpointInfo(IPEndpointInfo):
-    """Provides access to a UDP endpoint information."""
+    """Provides access to UDP endpoint information."""
 
     mcastInterface: str
     """str: The multicast interface."""
@@ -709,7 +709,7 @@ class WSConnectionInfo(ConnectionInfo):
     connection, and the response headers for an outgoing connection."""
 
 class WSEndpointInfo(EndpointInfo):
-    """Provides access to a WebSocket endpoint information."""
+    """Provides access to WebSocket endpoint information."""
 
     resource: str
     """str: The URI configured with the endpoint."""

--- a/python/test/Ice/ami/TestI.py
+++ b/python/test/Ice/ami/TestI.py
@@ -78,8 +78,8 @@ class TestIntfI(Test.TestIntf):
     def startDispatch(self, current: Ice.Current):
         with self._cond:
             if self._shutdown:
-                # Ignore, this can occur with the forceful connection close test, shutdown can be dispatch
-                # before start dispatch.
+                # Ignore, this can occur with the forceful connection close test, shutdown can be dispatched
+                # before startDispatch.
                 v = Ice.Future()
                 v.set_result(None)
                 return v
@@ -93,7 +93,7 @@ class TestIntfI(Test.TestIntf):
         with self._cond:
             if self._shutdown:
                 return
-            elif self._pending:  # Pending might not be set yet if startDispatch is dispatch out-of-order
+            elif self._pending:  # Pending might not be set yet if startDispatch is dispatched out-of-order
                 self._pending.set_result(None)
                 self._pending = None
 

--- a/python/test/Ice/blobject/Server.py
+++ b/python/test/Ice/blobject/Server.py
@@ -39,7 +39,7 @@ class Server(TestHelper):
     def run(self, args: list[str]):
         properties = self.createTestProperties(args)
         #
-        # Its possible to have batch oneway requests dispatched after the
+        # It's possible to have batch oneway requests dispatched after the
         # adapter is deactivated due to thread scheduling so we suppress
         # this warning.
         #

--- a/python/test/Ice/operations/Server.py
+++ b/python/test/Ice/operations/Server.py
@@ -18,7 +18,7 @@ class Server(TestHelper):
     def run(self, args: list[str]):
         properties = self.createTestProperties(args)
         #
-        # Its possible to have batch oneway requests dispatched after the
+        # It's possible to have batch oneway requests dispatched after the
         # adapter is deactivated due to thread scheduling so we suppress
         # this warning.
         #

--- a/python/test/Ice/operations/ServerAMD.py
+++ b/python/test/Ice/operations/ServerAMD.py
@@ -18,7 +18,7 @@ class ServerAMD(TestHelper):
     def run(self, args: list[str]):
         properties = self.createTestProperties(args)
         #
-        # Its possible to have batch oneway requests dispatched after the
+        # It's possible to have batch oneway requests dispatched after the
         # adapter is deactivated due to thread scheduling so we suppress
         # this warning.
         #

--- a/python/test/Slice/escape/Client.py
+++ b/python/test/Slice/escape/Client.py
@@ -91,7 +91,7 @@ class Client(TestHelper):
     def run(self, args: list[str]):
         properties = self.createTestProperties(args)
         #
-        # Its possible to have batch oneway requests dispatched after the
+        # It's possible to have batch oneway requests dispatched after the
         # adapter is deactivated due to thread scheduling so we suppress
         # this warning.
         #

--- a/ruby/ice.gemspec
+++ b/ruby/ice.gemspec
@@ -17,7 +17,7 @@ install a full Ice distribution if you want to use other Ice language
 mappings, or Ice services such as IceGrid, IceStorm and Glacier2.
 
 We provide extensive online documentation for Ice, the Ruby extension,
-and the other Ice language mappings and servicespec.
+and the other Ice language mappings and services.
 
 Join us on our user forums if you have questions about Ice.
 eos

--- a/ruby/ruby/Ice/SliceUtil.rb
+++ b/ruby/ruby/Ice/SliceUtil.rb
@@ -8,8 +8,8 @@ module Ice
         # Get the grand-parent of the directory containing this file (Ice/SliceUtil.rb).
         rbHome = File::join(File::dirname(__FILE__), "../..")
 
-        # For an installation from a source distribution, a binary tarball, the "slice" directory is a sibling of the
-        # "ruby" directory.
+        # For an installation from a binary tarball, rbHome is the installation root and the "slice" directory is a
+        # sibling of the "ruby" directory.
         dir = File::join(rbHome, "slice")
         if File::exist?(dir)
             return File::expand_path(dir)

--- a/ruby/src/IceRuby/DefaultSliceLoader.h
+++ b/ruby/src/IceRuby/DefaultSliceLoader.h
@@ -8,7 +8,7 @@
 
 namespace IceRuby
 {
-    /// Instantiates generated Python classes/exceptions based on the Slice type ID.
+    /// Instantiates generated Ruby classes/exceptions based on the Slice type ID.
     class DefaultSliceLoader final : public Ice::SliceLoader
     {
     public:

--- a/ruby/src/IceRuby/Endpoint.cpp
+++ b/ruby/src/IceRuby/Endpoint.cpp
@@ -82,7 +82,7 @@ IceRuby_Endpoint_cmp(VALUE self, VALUE other)
         }
         if (!checkEndpoint(other))
         {
-            throw RubyException(rb_eTypeError, "argument must be a endpoint");
+            throw RubyException(rb_eTypeError, "argument must be an endpoint");
         }
         Ice::EndpointPtr p1 = Ice::EndpointPtr(*reinterpret_cast<Ice::EndpointPtr*>(DATA_PTR(self)));
         Ice::EndpointPtr p2 = Ice::EndpointPtr(*reinterpret_cast<Ice::EndpointPtr*>(DATA_PTR(other)));

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -469,7 +469,7 @@ IceRuby::OperationI::unmarshalResults(const vector<byte>& bytes, const Ice::Comm
 
     //
     // Unmarshal the results. If there is more than one value to be returned, then return them
-    // in a tuple of the form (result, outParam1, ...). Otherwise just return the value.
+    // in an array of the form [result, outParam1, ...]. Otherwise just return the value.
     //
     Ice::InputStream is{communicator, bytes, lookupSliceLoader(communicator)};
 


### PR DESCRIPTION
Comment, doc-comment, and message-string typo fixes across the C-extension bindings and the MATLAB toolbox. No behavior changes.

The non-comment edits:

- `IcePy/EndpointInfo.cpp` and `IcePy-stubs/__init__.pyi` — `"Provides access to a TCP endpoint information"` drops the article, in the `tp_doc` strings and the matching stubs. These are the docstrings users see from `help()`, and the stub file is required to stay in sync with the C source.
- `IcePy/Properties.cpp` — `"defaults must be None or a Ice.Properties"` to `an`.
- `IceRuby/Endpoint.cpp` — `"argument must be a endpoint"` to `an endpoint`.
- `php/src/Util.cpp` — a type-mismatch message named the received class where it meant the expected one.
- `matlab/lib/+Ice/TCPEndpointInfo.m` — same article fix as the Python docstrings, matching the other MATLAB endpoint-info classes.

Everything else is comments.