### PR TITLE
Fix typos in the build system, CI workflows, and repository docs

### DIFF
--- a/BLUETOOTH.md
+++ b/BLUETOOTH.md
@@ -82,6 +82,6 @@ On Android, go to Settings → About phone → Status (or Settings → System �
 - Ensure IP addresses and Bluetooth addresses are correct
 - Use `--debug` flag for verbose output to diagnose connection issues
 
-[Android test controller]: java/test//android/controller/
+[Android test controller]: java/test/android/controller/
 [cpp/BUILDING.md]: cpp/BUILDING.md
 [java/BUILDING.md]: java/BUILDING.md

--- a/NIGHTLY.md
+++ b/NIGHTLY.md
@@ -73,7 +73,7 @@ https://download.zeroc.com/nexus/repository/nuget-3.9-nightly/
 
 ### Ice for Java
 
-The nightly packages are available from the maven ZeroC maven-nightly repository.
+The nightly packages are available from the ZeroC maven-nightly repository.
 
 To use them, add the following Maven repository to your build configuration:
 
@@ -191,7 +191,7 @@ zeroc-ice
 
 #### Linux <!-- omit in toc -->
 
-Ice for Python is also available as a RPM or DEB package, depending on your distribution.
+Ice for Python is also available as an RPM or DEB package, depending on your distribution.
 
 First, enable the Ice nightly DNF or APT repository on your system as per [Linux Repositories](#linux-repositories).
 Then, install the Ice for Python package:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ GPLv2 terms and conditions. ZeroC also grants a few [exceptions](ICE_LICENSE) to
 If you purchase a commercial or closed-source license for Ice, you must comply with the terms and conditions listed in
 the associated license agreement; the GPLv2 terms and conditions do not apply.
 
-The Ice software itself remains the same: the only difference between an open-source Ice and a commercial Ice are the
+The Ice software itself remains the same: the only difference between an open-source Ice and a commercial Ice is the
 license terms.
 
 [ci-home]: https://github.com/zeroc-ice/ice/actions/workflows/ci.yml

--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -332,7 +332,7 @@ get-program-targets = $2/$1$(EXE_EXT)
 # $(call create-component-with-config-targets,$1=project,$2=component,$3=platform,$4=config,$5=comp[platform-config],
 #                                             $6=nobuild)
 #
-# Defines target variables for the given component/paltform/configuration
+# Defines target variables for the given component/platform/configuration
 #
 define create-component-with-config-targets
 
@@ -478,7 +478,7 @@ $$(foreach e,$$($1_component_with_config_extensions),$$(eval $$(call $$e,$1,$2,$
 endif
 
 #
-# Order only prerequisties to ensure the object directory is created
+# Order only prerequisites to ensure the object directory is created
 # before we start building the objects
 #
 $$($5_objdir)/$$(call source-to-dependency,$$($5_sources)): | $$($5_objdir)
@@ -593,7 +593,7 @@ endif
 
 #
 # If sources are not specified for the component, we search for them in
-# the source directory and eventualy the slice directory if set.
+# the source directory and eventually the slice directory if set.
 #
 ifeq ($$($2_sources),)
 $2_sources      := $$(foreach e,$(source-extensions),$$(wildcard $$($2_srcdir)/*.$$(e)))
@@ -629,7 +629,7 @@ $1_slices       += $$(filter-out $$($2_slicedir)/%,$$($2_slices))
 #
 ifneq ($$(and $$($2_components),$$($2_slicedir)),)
 
-# Add an order-only prerequisities on the directory to trigger its creation if it doesn't exist.
+# Add an order-only prerequisite on the directory to trigger its creation if it doesn't exist.
 $$($1_generated_srcdir)/$$(call source-to-dependency,$$($2_slices)): | $$($1_generated_srcdir)
 
 ifneq ($$($1_generated_includedir),$$($2_generated_includedir))
@@ -761,7 +761,7 @@ endif
 #
 ifneq ($$($1_slicedirs),)
 
-# Add an order-only prerequisities on the directory to trigger its creation if it doesn't exist.
+# Add an order-only prerequisite on the directory to trigger its creation if it doesn't exist.
 $$($1_generated_srcdir)/$$(call source-to-dependency,$$($1_slices)): | $$($1_generated_srcdir)
 
 # Create generated include directory if different from generated source directory
@@ -976,7 +976,7 @@ var-names  = $(if $2,$2[$3-$4]_$1 $2[$3]_$1 $(foreach c,$(call subconfigs,$4),$2
 #
 # $(call var-value,$1=varname,$2=project,$3=component,$4=platform,$5=config,$6=fn)
 #
-# Returns the value of the given varible name for the given project/component/platform/configuration.
+# Returns the value of the given variable name for the given project/component/platform/configuration.
 # It returns the first defined variable from the set of variables returned by var-names defined above.
 # This checks first for component[platform-config]_varname, next for component[platform]_varname,
 # component[subconfig]_varname, ...

--- a/config/Make.rules
+++ b/config/Make.rules
@@ -14,7 +14,7 @@ prefix                 ?= /opt/Ice-$(version)
 
 #
 # Define embedded_runpath as no if you don't want any runpath added to
-# the executables. If not set, defaults to to "yes"
+# the executables. If not set, defaults to "yes"
 #
 embedded_runpath       ?= yes
 

--- a/config/makeprops.py
+++ b/config/makeprops.py
@@ -47,7 +47,7 @@ class PropertyHandler(ContentHandler):
     def __init__(self, language):
         # The language we are generating properties for
         self.language = language
-        # The section section we are currently parsing
+        # The section we are currently parsing
         self.parentNodeName = None
         # Dictionary of section names to attr dicts
         self.propertyArrayDict: dict[str, PropertyArray] = dict()

--- a/doxygen/mainpage.md
+++ b/doxygen/mainpage.md
@@ -6,7 +6,7 @@ Ice is a complete RPC framework that helps you build networked applications, and
 [Interface Definition Language].
 
 Ice and Ice-based applications use the Slice language to describe remote APIs in a purely declarative manner. For
-instance, here the Slice definition for a simple Greeter API:
+instance, here is the Slice definition for a simple Greeter API:
 
 ```ice
 module VisitorCenter

--- a/man/man1/icegridregistry.1
+++ b/man/man1/icegridregistry.1
@@ -55,7 +55,7 @@ Do not change the current working directory.
 .br
 Start the master registry in read-only mode.
 
-TP
+.TP
 .BR \-\-initdb\-from\-replica " " REPLICA
 .br
 Initialize the registry database from the given replica.

--- a/man/man1/icestormdb.1
+++ b/man/man1/icestormdb.1
@@ -29,11 +29,6 @@ Show program help.
 Display the Ice version.
 
 .TP
-.BR \-v ", " \-\-version\fR
-.br
-Display the Ice version.
-
-.TP
 .BR \-\-import " " FILE\fR
 .br
 Import database from the specified file.

--- a/scripts/Controller.py
+++ b/scripts/Controller.py
@@ -40,7 +40,7 @@ class ControllerDriver(Driver):
     def usage(self):
         print("")
         print("Controller driver options:")
-        print("--id=<identity>       The identify of the controller object.")
+        print("--id=<identity>       The identity of the controller object.")
         print("--endpoints=<endpts>  The endpoints to listen on.")
         print("--clean               Remove trust settings (macOS).")
 

--- a/scripts/Expect.py
+++ b/scripts/Expect.py
@@ -616,7 +616,7 @@ class Expect(object):
         self.before = self.buf
         self.after = ""
         #
-        # Without this we get warnings when runing with python_d on Windows
+        # Without this we get warnings when running with python_d on Windows
         #
         # ResourceWarning: unclosed file <_io.TextIOWrapper name=3 encoding='cp1252'>
         #
@@ -701,7 +701,7 @@ class Expect(object):
         return self.buf if self.p is None else self.r.getbuf()
 
     def hasInterruptSupport(self):
-        """Return True if the application gracefully terminated, False otherwise."""
+        """Return True if the process can be terminated gracefully with a signal, False otherwise."""
         if win32 and self.mapping == "java":
             return False
         return True

--- a/scripts/IceStormUtil.py
+++ b/scripts/IceStormUtil.py
@@ -177,9 +177,9 @@ class IceStormProcess:
     def getProps(self, current):
         #
         # An IceStorm client is provided with the IceStormAdmin.TopicManager.Default property set
-        # to the "instance" topic manager proxy if "instance" is set. Otherwise, if a single it's
+        # to the "instance" topic manager proxy if "instance" is set. Otherwise, it's
         # set to the replicated topic manager if a specific "instance name" is provided or there's
-        # only one IceStorm instance name deployed. If IceStorm multiple instance names are set,
+        # only one IceStorm instance name deployed. If multiple IceStorm instance names are set,
         # the client is given an IceStormAdmin.<instance name> property for each instance containing
         # the replicated topic manager proxy.
         #

--- a/scripts/LocalDriver.py
+++ b/scripts/LocalDriver.py
@@ -69,7 +69,7 @@ class Executor:
         while True:
             item = self.get(total, mainThread)
             if not item:
-                results.put(None)  # Notify the main thread that there are not more tests to run
+                results.put(None)  # Notify the main thread that there are no more tests to run
                 break
 
             (testsuite, index) = item
@@ -132,7 +132,7 @@ class Executor:
             self.runTestSuites(driver, total, results, True)
 
             #
-            # Dequeue results and print out the testuite output for each test.
+            # Dequeue results and print out the testsuite output for each test.
             #
             count = len(threads) + 1
             while count > 0:
@@ -398,7 +398,7 @@ class LocalDriver(Driver):
         print("--all-cross           Run all sensible permutations of cross language tests.")
         print("--client=<proxy>      The endpoint of the controller to run the client side.")
         print("--server=<proxy>      The endpoint of the controller to run the server side.")
-        print("--show-durations      Print out the duration of each tests.")
+        print("--show-durations      Print out the duration of each test.")
         print("--export-xml=<file>   Export JUnit XML test report.")
 
     def __init__(self, options, *args, **kargs):
@@ -689,7 +689,7 @@ class LocalDriver(Driver):
         self.executor.setInterrupt(value)
 
     def getTestPort(self, portnum):
-        # Return a port number in the range 14100-14199 for the first thread, 14200-14299 for the
+        # Return a port number in the range 14000-14099 for the first thread, 14100-14199 for the
         # second thread, etc.
         assert portnum < 100
         baseport = 14000 + self.threadlocal.num * 100 if hasattr(self.threadlocal, "num") else 12010

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -621,7 +621,7 @@ class Mapping(object):
             self.cprops = []
             self.sprops = []
 
-            # Options bellow are not parsed by the base class by still initialized here for convenience (this
+            # Options below are not parsed by the base class but still initialized here for convenience (this
             # avoid having to check the configuration type)
             self.openssl = False
             self.browser = ""
@@ -1996,7 +1996,7 @@ class Result:
             except UnicodeEncodeError:
                 #
                 # The console doesn't support the encoding of the message, we convert the message
-                # to an UTF-8 byte sequence and print out the byte sequence. We replace all the
+                # to a UTF-8 byte sequence and print out the byte sequence. We replace all the
                 # double backslash from the byte sequence string representation to single back
                 # slash.
                 #
@@ -2011,7 +2011,7 @@ class Result:
             except UnicodeEncodeError:
                 #
                 # The console doesn't support the encoding of the message, we convert the message
-                # to an UTF-8 byte sequence and print out the byte sequence. We replace all the
+                # to a UTF-8 byte sequence and print out the byte sequence. We replace all the
                 # double backslash from the byte sequence string representation to single back
                 # slash.
                 #
@@ -3766,7 +3766,7 @@ class CSharpMapping(Mapping):
         cmd = "dotnet {}.dll {}".format(os.path.join(path, exe), args)
 
         if current.config.dotnetCoverageSession != "":
-            # escapign \" is requried for passing though from dotnet-coverage -> dotnet -> exe
+            # escaping \" is required for passing through from dotnet-coverage -> dotnet -> exe
             cmd = cmd.replace('\\"', '\\\\\\"')
             cmd = f"dotnet-coverage connect --nologo {current.config.dotnetCoverageSession} {cmd}"
 
@@ -3841,7 +3841,7 @@ class PythonMapping(CppBasedMapping):
         def usage(self):
             print("")
             print("Python mapping options:")
-            print("--python=<interpreter>   Choose the interperter used to run python tests")
+            print("--python=<interpreter>   Choose the interpreter used to run python tests")
             print("--load-slice             Use Ice.loadSlice instead of the slice2py static generated code.")
             print("--pip-package            Use the installed pip package instead of the local build.")
 

--- a/scripts/generate-cpp-code-coverage.sh
+++ b/scripts/generate-cpp-code-coverage.sh
@@ -10,7 +10,7 @@ export LDFLAGS="-fprofile-instr-generate"
 export LLVM_PROFILE_FILE="${PWD}/coverage/%m.profraw"
 export OPTIMIZE=no
 
-# Use llvm from homebrew if we're on macOS
+# The llvm tools used below come from the Xcode Command Line Tools, so this script is macOS only
 if [ "$(uname)" != "Darwin" ]; then
     echo "This script is only supported on macOS"
     exit 1

--- a/scripts/process_windows_crash_dumps.py
+++ b/scripts/process_windows_crash_dumps.py
@@ -8,7 +8,7 @@ process_windows_crash_dumps.py - gather binaries & PDBs referenced by crash dump
 For every *.dmp* file found in the specified dumps directory this script:
   1. Launches `cdb.exe` to generate a *modules.txt* file containing full module list corresponding
      to the dlls and executables loaded by the crashed process.
-  2. Parses the modules and filter outs any modules that are located outside the GitHub workspace,
+  2. Parses the modules and filters out any modules that are located outside the GitHub workspace,
      this is to avoid copying binaries not belonging to the current build.
   3. Copies each matching binary **and** its companion PDB (if found) to a dedicated sub-folder under
      specified reports directory.

--- a/scripts/tests/IceSSL/revocationutil.py
+++ b/scripts/tests/IceSSL/revocationutil.py
@@ -152,7 +152,7 @@ def createCRLServer(
 
 
 class ThreadedServer:
-    # run HTPPServer in its own thread
+    # run HTTPServer in its own thread
 
     def __init__(self, hostname, port, handler):
         self.handler = handler

--- a/scripts/ws_ping_probe.py
+++ b/scripts/ws_ping_probe.py
@@ -109,7 +109,7 @@ def ping_pong(host, port, payload=b"", timeout=10.0):
     Upgrade, send a PING with the given payload, and return the PONG payload.
 
     Non-PONG frames the server emits first (e.g. its Ice connection-validation
-    message) are skipped. Raises if the server sends CLOSE or never ponngs.
+    message) are skipped. Raises if the server sends CLOSE or never pongs.
     """
     with socket.create_connection((host, port), timeout=timeout) as sock:
         reader = _Reader(sock, _upgrade(sock, host, port))


### PR DESCRIPTION
Typo and grammar fixes in the make rules, helper scripts, GitHub workflows, Doxygen config, two man pages, and the top-level markdown. No behavior changes.

Worth noting:

- `man/man1/icestormdb.1` — a `.TP` macro had lost its leading dot, so `TP` rendered as literal body text and the paragraph lost its formatting.
- `man/man1/icegridregistry.1` — a duplicated `-v, --version` block removed.
- `README.md` — a broken relative link (`java/test//android/controller/`) and "here the Slice definition" to "here is".
- `NIGHTLY.md` — "the maven ZeroC maven-nightly repository" said maven twice.
- `scripts/Controller.py` — `--id` help text said "identify" for "identity".
- `scripts/generate-cpp-code-coverage.sh` — a comment described a Homebrew lookup the script no longer does; it hardcodes the Command Line Tools path.

The rest is comments and prose. The `slice2py`/`slice2php` man pages are deliberately not in this PR — their option lists are genuinely out of date and are handled separately.