### PR TITLE
Update the slice2py and slice2php man pages to match the compilers

### DIFF
--- a/man/man1/slice2php.1
+++ b/man/man1/slice2php.1
@@ -86,11 +86,6 @@ generate any code.
 .br
 Generate code for all Slice definitions, including those from included files.
 
-.TP
-.BR \-\-no\-namespace\fR
-.br
-Generate code without support for PHP namespaces (deprecated).
-
 .SH SEE ALSO
 
 .BR slice2cpp (1),

--- a/man/man1/slice2py.1
+++ b/man/man1/slice2py.1
@@ -79,24 +79,20 @@ Directs dependency information to the specified file. The output
 format depends on whether --depend or --depend-xml is also specified.
 
 .TP
-.BR \-\-all\fR
+.BR \-\-build " " modules|index|all\fR
 .br
-Generate code for all Slice definitions, including those from included files.
+Control which types of Python files are generated from the Slice definitions:
+modules generates only the Python module files, index generates only the Python
+package index files (__init__.py), and all generates both (the default).
 
 .TP
-.BR \-\-prefix " " PREFIX\fR
+.BR \-\-list\-generated " " modules|index|all\fR
 .br
-Use PREFIX as the prefix for generated file names.
-
-.TP
-.BR \-\-no-package\fR
-.br
-Do not generate Python package hierarchy.
-
-.TP
-.BR \-\-build-package\fR
-.br
-Only generate Python package hierarchy.
+List the Python files that would be generated for the given Slice definitions,
+without producing any output files: modules lists only the Python module files,
+index lists only the Python package index files (__init__.py), and all lists
+both. All paths are relative to the directory specified with --output-dir, and
+each file is listed on a separate line.
 
 .SH SEE ALSO
 


### PR DESCRIPTION
The man pages document options the compilers no longer accept, and omit ones they do. Verified against the option tables in the sources rather than from the help text.

- `slice2py.1` — `--all`, `--prefix`, `--no-package`, and `--build-package` are gone; `--build` and `--list-generated` (both taking `modules|index|all`) were undocumented. See the `addOpt` list and usage block in `cpp/src/slice2py/PythonUtil.cpp`.
- `slice2php.1` — `--no-namespace` is gone. See `cpp/src/slice2php/Main.cpp`.

Split out of the typo PRs because this rewrites documentation content rather than fixing spelling.