### PR TITLE
Remove the duplicate ZeroC.Ice DistPackage entry

### DIFF
--- a/csharp/msbuild/ice.proj
+++ b/csharp/msbuild/ice.proj
@@ -16,9 +16,6 @@
         <DistPackage Include="ZeroC.Glacier2">
             <ProjectDir>$(MSBuildThisFileDirectory)..\src\Glacier2</ProjectDir>
         </DistPackage>
-        <DistPackage Include="ZeroC.Ice">
-            <ProjectDir>$(MSBuildThisFileDirectory)..\src\Ice</ProjectDir>
-        </DistPackage>
         <DistPackage Include="ZeroC.IceBox">
             <ProjectDir>$(MSBuildThisFileDirectory)..\src\IceBox</ProjectDir>
         </DistPackage>


### PR DESCRIPTION
`ZeroC.Ice` is listed twice in the `DistPackage` item group in `csharp/msbuild/ice.proj`, with identical `ProjectDir` metadata.

Harmless either way — the `Publish` target consumes it via `%(DistPackage.ProjectDir)` batching, so the repeat is a no-op — but it should not ride along in a typo PR.