### PR TITLE
Report the PSK prefix in the TLS_PSK_WITH_NULL_SHA256 cipher name

### DIFF
--- a/cpp/src/Ice/SSL/SecureTransportEngine.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportEngine.cpp
@@ -337,7 +337,7 @@ namespace
             case TLS_PSK_WITH_AES_256_CBC_SHA384:
                 return "PSK_WITH_AES_256_CBC_SHA384";
             case TLS_PSK_WITH_NULL_SHA256:
-                return "WITH_NULL_SHA256";
+                return "PSK_WITH_NULL_SHA256";
             case TLS_PSK_WITH_NULL_SHA384:
                 return "PSK_WITH_NULL_SHA384";
 


### PR DESCRIPTION
`cipherName()` in the SecureTransport engine strips only the `SSL_`/`TLS_` protocol prefix — that is what its own header comment says, and every neighbouring PSK case keeps the `PSK_` prefix (`PSK_WITH_AES_128_CBC_SHA256`, `PSK_WITH_NULL_SHA384`, …). This one case returned `WITH_NULL_SHA256`, dropping it.

The name appears in SSL trace output and is matched against the `IceSSL.Ciphers` filter expression, so a rule written as `PSK_WITH_NULL_SHA256` currently would not match this suite. Nothing in the repository matches the old string.

Separate from the typo PRs because it changes a returned value.