### PR TITLE
Order the DistPackage entries to match the solution files

### DIFF
--- a/csharp/msbuild/ice.proj
+++ b/csharp/msbuild/ice.proj
@@ -10,11 +10,11 @@
 
     <ItemGroup>
         <!-- Packages produced by the source build -->
-        <DistPackage Include="ZeroC.Ice">
-            <ProjectDir>$(MSBuildThisFileDirectory)..\src\Ice</ProjectDir>
-        </DistPackage>
         <DistPackage Include="ZeroC.Glacier2">
             <ProjectDir>$(MSBuildThisFileDirectory)..\src\Glacier2</ProjectDir>
+        </DistPackage>
+        <DistPackage Include="ZeroC.Ice">
+            <ProjectDir>$(MSBuildThisFileDirectory)..\src\Ice</ProjectDir>
         </DistPackage>
         <DistPackage Include="ZeroC.IceBox">
             <ProjectDir>$(MSBuildThisFileDirectory)..\src\IceBox</ProjectDir>


### PR DESCRIPTION
Follow-up to #6151, addressing https://github.com/zeroc-ice/ice/pull/6151#issuecomment-5059835255.

`ice.proj` had `ZeroC.Ice` listed twice — once before `ZeroC.Glacier2` and once after. #6151 removed the second copy, which happened to be the one in the right place, leaving `Ice` ahead of `Glacier2`. Removing the first copy instead would have kept the usual ordering.

This swaps the two entries so the list reads `Glacier2, Ice, IceBox, iceboxnet, IceDiscovery, IceGrid, IceLocatorDiscovery, IceStorm, ZeroC.Ice.Slice.Tools` — identical to the `src` project order in both `ice.slnx` and `ice.dist.slnx`. The other seven entries were already in the right order.

No functional change: `DistPackage` is consumed through `%(DistPackage.ProjectDir)` batching in the `Publish` target, so the ordering is cosmetic.