### PR TITLE
Fail gracefully when a middleware factory throws during dispatch pipeline creation

### DIFF
--- a/changelog.d/cpp/middleware-factory-exception.md
+++ b/changelog.d/cpp/middleware-factory-exception.md
@@ -1,0 +1,4 @@
+- Improved the handling of exceptions thrown by middleware factories. A middleware factory should never throw; if it
+  does throw during the creation of an object adapter's dispatch pipeline (at first dispatch), the program previously
+  terminated. Now, the object adapter logs an error and all dispatches on this object adapter fail with an
+  `UnknownException`.

--- a/changelog.d/csharp/middleware-factory-exception.md
+++ b/changelog.d/csharp/middleware-factory-exception.md
@@ -1,0 +1,4 @@
+- Improved the handling of exceptions thrown by middleware factories. A middleware factory should never throw; if it
+  does throw during the creation of an object adapter's dispatch pipeline (at first dispatch), the exception previously
+  resurfaced in Ice's internal request processing, which could leave client invocations unanswered. Now, the object
+  adapter logs an error and all dispatches on this object adapter fail with an `UnknownException`.

--- a/changelog.d/java/middleware-factory-exception.md
+++ b/changelog.d/java/middleware-factory-exception.md
@@ -1,0 +1,4 @@
+- Improved the handling of exceptions thrown by middleware factories. A middleware factory should never throw; if it
+  does throw during the creation of an object adapter's dispatch pipeline (at first dispatch), the object adapter
+  previously kept an incomplete dispatch pipeline that was missing one or more middleware. Now, the object adapter logs
+  an error and all dispatches on this object adapter fail with an `UnknownException`.

--- a/changelog.d/js/middleware-factory-exception.md
+++ b/changelog.d/js/middleware-factory-exception.md
@@ -1,0 +1,4 @@
+- Improved the handling of exceptions thrown by middleware factories. A middleware factory should never throw; if it
+  does throw during the creation of an object adapter's dispatch pipeline (at first dispatch), the exception previously
+  escaped into the connection's incoming message processing, which could leave client invocations unanswered. Now, the
+  object adapter logs an error and all dispatches on this object adapter fail with an `UnknownException`.

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -55,10 +55,7 @@ namespace
     public:
         void dispatch(IncomingRequest&, std::function<void(OutgoingResponse)>) final
         {
-            throw UnknownException{
-                __FILE__,
-                __LINE__,
-                "the object adapter could not create its dispatch pipeline"};
+            throw UnknownException{__FILE__, __LINE__, "the object adapter could not create its dispatch pipeline"};
         }
     };
 }

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -48,6 +48,19 @@ namespace
     inline EndpointIPtr toEndpointI(const EndpointPtr& endp) { return dynamic_pointer_cast<EndpointI>(endp); }
 
     string emptyName{};
+
+    // Installed as the dispatch pipeline when the creation of the actual pipeline fails.
+    class FailedDispatchPipeline final : public Object
+    {
+    public:
+        void dispatch(IncomingRequest&, std::function<void(OutgoingResponse)>) final
+        {
+            throw UnknownException{
+                __FILE__,
+                __LINE__,
+                "the object adapter could not create its dispatch pipeline"};
+        }
+    };
 }
 
 Ice::ObjectAdapter::~ObjectAdapter() = default; // avoid weak vtable
@@ -535,11 +548,27 @@ Ice::ObjectAdapterI::dispatchPipeline() const noexcept
     lock_guard lock(_mutex);
     if (!_dispatchPipeline)
     {
-        _dispatchPipeline = _servantManager;
-        while (!_middlewareFactoryStack.empty())
+        try
         {
-            _dispatchPipeline = _middlewareFactoryStack.top()(std::move(_dispatchPipeline));
-            _middlewareFactoryStack.pop();
+            ObjectPtr dispatchPipeline = _servantManager;
+            while (!_middlewareFactoryStack.empty())
+            {
+                dispatchPipeline = _middlewareFactoryStack.top()(std::move(dispatchPipeline));
+                _middlewareFactoryStack.pop();
+            }
+            _dispatchPipeline = std::move(dispatchPipeline);
+        }
+        catch (const std::exception& ex)
+        {
+            Error out(_instance->initializationData().logger);
+            out << "failed to create the dispatch pipeline of object adapter '" << _name << "':\n" << ex;
+            _dispatchPipeline = make_shared<FailedDispatchPipeline>();
+        }
+        catch (...)
+        {
+            Error out(_instance->initializationData().logger);
+            out << "failed to create the dispatch pipeline of object adapter '" << _name << "': unknown c++ exception";
+            _dispatchPipeline = make_shared<FailedDispatchPipeline>();
         }
     }
     return _dispatchPipeline;

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -563,12 +563,14 @@ Ice::ObjectAdapterI::dispatchPipeline() const noexcept
             Error out(_instance->initializationData().logger);
             out << "failed to create the dispatch pipeline of object adapter '" << _name << "':\n" << ex;
             _dispatchPipeline = make_shared<FailedDispatchPipeline>();
+            _middlewareFactoryStack = {};
         }
         catch (...)
         {
             Error out(_instance->initializationData().logger);
             out << "failed to create the dispatch pipeline of object adapter '" << _name << "': unknown c++ exception";
             _dispatchPipeline = make_shared<FailedDispatchPipeline>();
+            _middlewareFactoryStack = {};
         }
     }
     return _dispatchPipeline;

--- a/cpp/test/Ice/middleware/AllTests.cpp
+++ b/cpp/test/Ice/middleware/AllTests.cpp
@@ -3,8 +3,21 @@
 #include "TestHelper.h"
 #include "TestI.h"
 
+#include <stdexcept>
+
 using namespace std;
 using namespace Test;
+
+class NullLogger final : public Ice::Logger, public enable_shared_from_this<NullLogger>
+{
+public:
+    void print(const string&) final {}
+    void trace(const string&, const string&) final {}
+    void warning(const string&) final {}
+    void error(const string&) final {}
+    string getPrefix() final { return "NullLogger"; }
+    Ice::LoggerPtr cloneWithPrefix(string) final { return shared_from_this(); }
+};
 
 class Middleware final : public Ice::Object
 {
@@ -69,8 +82,52 @@ testMiddlewareExecutionOrder(const Ice::CommunicatorPtr& communicator)
 }
 
 void
+testMiddlewareFactoryException()
+{
+    cout << "testing middleware factory exception... " << flush;
+
+    // Use a separate communicator with a null logger: the pipeline creation failure is logged as an error.
+    Ice::InitializationData initData;
+    initData.logger = make_shared<NullLogger>();
+    Ice::CommunicatorHolder communicatorHolder{Ice::initialize(initData)};
+    const Ice::CommunicatorPtr& communicator = communicatorHolder.communicator();
+
+    Ice::ObjectAdapterPtr oa = communicator->createObjectAdapter("");
+    oa->add(make_shared<MyObjectI>(), Ice::Identity{"test", ""});
+
+    oa->use([](Ice::ObjectPtr) -> Ice::ObjectPtr { throw runtime_error{"middleware factory exception"}; });
+
+    MyObjectPrx p(communicator, "test");
+
+    try
+    {
+        p->ice_ping();
+        test(false);
+    }
+    catch (const Ice::UnknownException& ex)
+    {
+        // The message does not reveal the middleware factory exception.
+        test(string_view{ex.what()}.find("middleware factory exception") == string_view::npos);
+    }
+
+    // The failure is permanent for this object adapter.
+    try
+    {
+        p->ice_ping();
+        test(false);
+    }
+    catch (const Ice::UnknownException&)
+    {
+    }
+
+    oa->destroy();
+    cout << "ok" << endl;
+}
+
+void
 allTests(Test::TestHelper* helper)
 {
     Ice::CommunicatorPtr communicator = helper->communicator();
     testMiddlewareExecutionOrder(communicator);
+    testMiddlewareFactoryException();
 }

--- a/cpp/test/Ice/middleware/AllTests.cpp
+++ b/cpp/test/Ice/middleware/AllTests.cpp
@@ -95,7 +95,7 @@ testMiddlewareFactoryException()
     Ice::ObjectAdapterPtr oa = communicator->createObjectAdapter("");
     oa->add(make_shared<MyObjectI>(), Ice::Identity{"test", ""});
 
-    oa->use([](Ice::ObjectPtr) -> Ice::ObjectPtr { throw runtime_error{"middleware factory exception"}; });
+    oa->use([](const Ice::ObjectPtr&) -> Ice::ObjectPtr { throw runtime_error{"middleware factory exception"}; });
 
     MyObjectPrx p(communicator, "test");
 

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1492,12 +1492,31 @@ public sealed class ObjectAdapter
 
     private Object createDispatchPipeline()
     {
-        Object dispatchPipeline = _servantManager; // the "final" dispatcher
-        foreach (Func<Object, Object> middleware in _middlewareStack)
+        try
         {
-            dispatchPipeline = middleware(dispatchPipeline);
+            Object dispatchPipeline = _servantManager; // the "final" dispatcher
+            foreach (Func<Object, Object> middleware in _middlewareStack)
+            {
+                dispatchPipeline = middleware(dispatchPipeline);
+            }
+            return dispatchPipeline;
         }
-        _middlewareStack.Clear(); // we no longer need these functions
-        return dispatchPipeline;
+        catch (System.Exception ex)
+        {
+            _instance.initializationData().logger!.error(
+                $"failed to create the dispatch pipeline of object adapter '{_name}':\n{ex}");
+            return new FailedDispatchPipeline();
+        }
+        finally
+        {
+            _middlewareStack.Clear(); // we no longer need these functions
+        }
+    }
+
+    // Installed as the dispatch pipeline when the creation of the actual pipeline fails.
+    private class FailedDispatchPipeline : Ice.Object
+    {
+        public ValueTask<OutgoingResponse> dispatchAsync(IncomingRequest request) =>
+            throw new UnknownException("The object adapter could not create its dispatch pipeline.");
     }
 }

--- a/csharp/test/Ice/middleware/AllTests.cs
+++ b/csharp/test/Ice/middleware/AllTests.cs
@@ -11,6 +11,7 @@ public class AllTests : global::Test.AllTests
         TextWriter output = helper.getWriter();
         Communicator communicator = helper.communicator();
         testMiddlewareExecutionOrder(communicator, output);
+        testMiddlewareFactoryException(output);
     }
 
     // Verifies the middleware execute in installation order.
@@ -43,6 +44,48 @@ public class AllTests : global::Test.AllTests
         oa.destroy();
     }
 
+    // Verifies a middleware factory exception makes all dispatches fail with a generic UnknownException.
+    private static void testMiddlewareFactoryException(TextWriter output)
+    {
+        output.Write("testing middleware factory exception... ");
+        output.Flush();
+
+        // Use a separate communicator with a null logger: the pipeline creation failure is logged as an error.
+        var initData = new InitializationData { logger = new NullLogger() };
+        using Communicator communicator = Util.initialize(initData);
+
+        ObjectAdapter oa = communicator.createObjectAdapter("");
+        oa.add(new MyObjectI(), new Identity { name = "test" });
+
+        oa.use(next => throw new InvalidOperationException("middleware factory exception"));
+
+        Test.MyObjectPrx p = Test.MyObjectPrxHelper.createProxy(communicator, "test");
+
+        try
+        {
+            p.ice_ping();
+            test(false);
+        }
+        catch (UnknownException ex)
+        {
+            // The message does not reveal the middleware factory exception.
+            test(!ex.Message.Contains("middleware factory exception"));
+        }
+
+        // The failure is permanent for this object adapter.
+        try
+        {
+            p.ice_ping();
+            test(false);
+        }
+        catch (UnknownException)
+        {
+        }
+
+        output.WriteLine("ok");
+        oa.destroy();
+    }
+
     private class Middleware : Object
     {
         private readonly Object _next;
@@ -64,6 +107,33 @@ public class AllTests : global::Test.AllTests
             _name = name;
             _inLog = inLog;
             _outLog = outLog;
+        }
+    }
+
+    private class NullLogger : Logger
+    {
+        public void print(string message)
+        {
+        }
+
+        public void trace(string category, string message)
+        {
+        }
+
+        public void warning(string message)
+        {
+        }
+
+        public void error(string message)
+        {
+        }
+
+        public string getPrefix() => "NullLogger";
+
+        public Logger cloneWithPrefix(string prefix) => new NullLogger();
+
+        public void Dispose()
+        {
         }
     }
 }

--- a/csharp/test/Ice/middleware/AllTests.cs
+++ b/csharp/test/Ice/middleware/AllTests.cs
@@ -69,7 +69,7 @@ public class AllTests : global::Test.AllTests
         catch (UnknownException ex)
         {
             // The message does not reveal the middleware factory exception.
-            test(!ex.Message.Contains("middleware factory exception"));
+            test(!ex.Message.Contains("middleware factory exception", StringComparison.Ordinal));
         }
 
         // The failure is permanent for this object adapter.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -5,6 +5,8 @@ package com.zeroc.Ice;
 import com.zeroc.Ice.Instrumentation.CommunicatorObserver;
 import com.zeroc.Ice.SSL.SSLEngineFactory;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -13,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 import java.util.UUID;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -703,9 +706,27 @@ public final class ObjectAdapter {
      */
     public synchronized Object dispatchPipeline() {
         if (_dispatchPipeline == null) {
-            _dispatchPipeline = _servantManager;
-            while (!_middlewareStack.isEmpty()) {
-                _dispatchPipeline = _middlewareStack.pop().apply(_dispatchPipeline);
+            try {
+                Object dispatchPipeline = _servantManager;
+                while (!_middlewareStack.isEmpty()) {
+                    dispatchPipeline = _middlewareStack.pop().apply(dispatchPipeline);
+                }
+                _dispatchPipeline = dispatchPipeline;
+            } catch (RuntimeException | Error ex) {
+                var sw = new StringWriter();
+                var pw = new PrintWriter(sw);
+                ex.printStackTrace(pw);
+                pw.flush();
+                _instance
+                    .initializationData()
+                    .logger
+                    .error(
+                        "failed to create the dispatch pipeline of object adapter '"
+                            + _name
+                            + "':\n"
+                            + sw.toString());
+                _middlewareStack.clear();
+                _dispatchPipeline = new FailedDispatchPipeline();
             }
         }
         return _dispatchPipeline;
@@ -1414,6 +1435,14 @@ public final class ObjectAdapter {
                 }
             }
             _instance.initializationData().logger.trace(_instance.traceLevels().locationCat, s.toString());
+        }
+    }
+
+    // Installed as the dispatch pipeline when the creation of the actual pipeline fails.
+    private static class FailedDispatchPipeline implements Object {
+        @Override
+        public CompletionStage<OutgoingResponse> dispatch(IncomingRequest request) {
+            throw new UnknownException("The object adapter could not create its dispatch pipeline.");
         }
     }
 }

--- a/java/test/src/main/java/test/Ice/middleware/AllTests.java
+++ b/java/test/src/main/java/test/Ice/middleware/AllTests.java
@@ -7,7 +7,9 @@ import com.zeroc.Ice.Current;
 import com.zeroc.Ice.ErrorObserverMiddleware;
 import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.IncomingRequest;
+import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.LocalException;
+import com.zeroc.Ice.Logger;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectPrx;
@@ -15,6 +17,7 @@ import com.zeroc.Ice.OutgoingResponse;
 import com.zeroc.Ice.ServantLocator;
 import com.zeroc.Ice.UnknownException;
 import com.zeroc.Ice.UserException;
+import com.zeroc.Ice.Util;
 
 import test.Ice.middleware.Test.MyException;
 import test.Ice.middleware.Test.MyObject;
@@ -146,6 +149,47 @@ public class AllTests {
         testErrorObserverMiddleware(communicator, output, true, true);
 
         testMiddlewareObservesLocatorDispatchError(communicator, output);
+        testMiddlewareFactoryException(output);
+    }
+
+    // Verifies a middleware factory exception makes all dispatches fail with a generic UnknownException.
+    private static void testMiddlewareFactoryException(PrintWriter output) {
+        output.write("testing middleware factory exception... ");
+        output.flush();
+
+        // Use a separate communicator with a null logger: the pipeline creation failure is logged as an error.
+        var initData = new InitializationData();
+        initData.logger = new NullLogger();
+
+        try (Communicator communicator = Util.initialize(initData)) {
+            ObjectAdapter oa = communicator.createObjectAdapter("");
+            ObjectPrx obj = oa.add(new MyObjectI(), new Identity("test", ""));
+
+            oa.use(
+                next -> {
+                    throw new IllegalStateException("middleware factory exception");
+                });
+
+            var p = MyObjectPrx.uncheckedCast(obj);
+
+            try {
+                p.ice_ping();
+                test(false);
+            } catch (UnknownException ex) {
+                // The message does not reveal the middleware factory exception.
+                test(!ex.getMessage().contains("middleware factory exception"));
+            }
+
+            // The failure is permanent for this object adapter.
+            try {
+                p.ice_ping();
+                test(false);
+            } catch (UnknownException ex) {}
+
+            oa.destroy();
+        }
+
+        output.println("ok");
     }
 
     private static void testMiddlewareExecutionOrder(
@@ -250,6 +294,33 @@ public class AllTests {
 
         output.println("ok");
         oa.destroy();
+    }
+
+    private static class NullLogger implements Logger {
+        @Override
+        public void print(String message) {}
+
+        @Override
+        public void trace(String category, String message) {}
+
+        @Override
+        public void warning(String message) {}
+
+        @Override
+        public void error(String message) {}
+
+        @Override
+        public String getPrefix() {
+            return "NullLogger";
+        }
+
+        @Override
+        public Logger cloneWithPrefix(String prefix) {
+            return new NullLogger();
+        }
+
+        @Override
+        public void close() {}
     }
 
     private static void test(boolean b) {

--- a/js/packages/ice/src/Ice/ObjectAdapter.js
+++ b/js/packages/ice/src/Ice/ObjectAdapter.js
@@ -275,10 +275,12 @@ export class ObjectAdapter {
                 }
                 this._dispatchPipeline = dispatchPipeline;
             } catch (ex) {
+                // A middleware factory can throw a value that is not an Error, such as null or a symbol.
+                const details = ex instanceof Error ? `${ex}\n${ex.stack}` : String(ex);
                 this._instance
                     .initializationData()
                     .logger.error(
-                        `failed to create the dispatch pipeline of object adapter '${this._name}':\n${ex}\n${ex.stack}`,
+                        `failed to create the dispatch pipeline of object adapter '${this._name}':\n${details}`,
                     );
                 this._middlewareStack.length = 0;
                 this._dispatchPipeline = new FailedDispatchPipeline();

--- a/js/packages/ice/src/Ice/ObjectAdapter.js
+++ b/js/packages/ice/src/Ice/ObjectAdapter.js
@@ -9,6 +9,7 @@ import {
     InitializationException,
     ObjectAdapterDestroyedException,
     ParseException,
+    UnknownException,
 } from "./LocalExceptions.js";
 import { Ice as Ice_Router } from "./Router.js";
 const { RouterPrx } = Ice_Router;
@@ -266,12 +267,22 @@ export class ObjectAdapter {
 
     get dispatchPipeline() {
         if (this._dispatchPipeline === null) {
-            let dispatchPipeline = this._servantManager; // the "final" dispatcher
-            while (this._middlewareStack.length > 0) {
-                const middleware = this._middlewareStack.pop();
-                dispatchPipeline = middleware(dispatchPipeline);
+            try {
+                let dispatchPipeline = this._servantManager; // the "final" dispatcher
+                while (this._middlewareStack.length > 0) {
+                    const middleware = this._middlewareStack.pop();
+                    dispatchPipeline = middleware(dispatchPipeline);
+                }
+                this._dispatchPipeline = dispatchPipeline;
+            } catch (ex) {
+                this._instance
+                    .initializationData()
+                    .logger.error(
+                        `failed to create the dispatch pipeline of object adapter '${this._name}':\n${ex}\n${ex.stack}`,
+                    );
+                this._middlewareStack.length = 0;
+                this._dispatchPipeline = new FailedDispatchPipeline();
             }
-            this._dispatchPipeline = dispatchPipeline;
         }
         return this._dispatchPipeline;
     }
@@ -407,5 +418,12 @@ export class ObjectAdapter {
             this._instance.initializationData().logger.trace(this._instance.traceLevels().networkCat, msg);
         }
         return endpoints;
+    }
+}
+
+// Installed as the dispatch pipeline when the creation of the actual pipeline fails.
+class FailedDispatchPipeline {
+    dispatch() {
+        throw new UnknownException("The object adapter could not create its dispatch pipeline.");
     }
 }

--- a/js/packages/test/Ice/middleware/Server.ts
+++ b/js/packages/test/Ice/middleware/Server.ts
@@ -30,6 +30,20 @@ class Middleware extends Ice.Object {
     private _outLog: string[];
 }
 
+class NullLogger implements Ice.Logger {
+    print(_message: string): void {}
+
+    trace(_category: string, _message: string): void {}
+
+    warning(_message: string): void {}
+
+    error(_message: string): void {}
+
+    cloneWithPrefix(_prefix: string): Ice.Logger {
+        return this;
+    }
+}
+
 class MyObjectI extends Test.MyObject {
     constructor() {
         super();
@@ -66,6 +80,8 @@ export class Server extends TestHelper {
                 .use((next: Ice.Object) => new Middleware(next, "B", inLog, outLog))
                 .use((next: Ice.Object) => new Middleware(next, "C", inLog, outLog));
             await communicator.waitForShutdown();
+
+            await this.testMiddlewareFactoryException(communicator, args);
         } finally {
             const out = this.getWriter();
             out.write("testing middleware execution order... ");
@@ -89,5 +105,50 @@ export class Server extends TestHelper {
                 await communicator.destroy();
             }
         }
+    }
+
+    // Verifies a middleware factory exception makes all dispatches fail with a generic UnknownException.
+    async testMiddlewareFactoryException(invokingCommunicator: Ice.Communicator, args: string[]) {
+        const out = this.getWriter();
+        out.write("testing middleware factory exception... ");
+
+        // Use a separate communicator with a null logger: the pipeline creation failure is logged as an error.
+        const initData = new Ice.InitializationData();
+        [initData.properties] = this.createTestProperties(args);
+        initData.logger = new NullLogger();
+        const [communicator] = this.initialize(initData);
+        try {
+            const echo = new Test.EchoPrx(communicator, `__echo:${this.getTestEndpoint()}`);
+            const adapter = await communicator.createObjectAdapter("");
+            await echo.setConnection();
+            echo.ice_getCachedConnection()!.setAdapter(adapter);
+
+            adapter.add(new MyObjectI(), new Ice.Identity("test"));
+            adapter.use(() => {
+                throw new Error("middleware factory exception");
+            });
+
+            const prx = new Test.MyObjectPrx(invokingCommunicator, `test: ${this.getTestEndpoint()}`);
+
+            try {
+                await prx.getName();
+                test(false);
+            } catch (ex) {
+                test(ex instanceof Ice.UnknownException);
+                // The message does not reveal the middleware factory exception.
+                test(!(ex as Ice.UnknownException).message.includes("middleware factory exception"));
+            }
+
+            // The failure is permanent for this object adapter.
+            try {
+                await prx.getName();
+                test(false);
+            } catch (ex) {
+                test(ex instanceof Ice.UnknownException);
+            }
+        } finally {
+            await communicator.destroy();
+        }
+        out.writeLine("ok");
     }
 }

--- a/js/packages/test/Ice/middleware/Server.ts
+++ b/js/packages/test/Ice/middleware/Server.ts
@@ -81,7 +81,7 @@ export class Server extends TestHelper {
                 .use((next: Ice.Object) => new Middleware(next, "C", inLog, outLog));
             await communicator.waitForShutdown();
 
-            await this.testMiddlewareFactoryException(communicator, args);
+            await this.testMiddlewareFactoryException(communicator);
         } finally {
             const out = this.getWriter();
             out.write("testing middleware execution order... ");
@@ -108,13 +108,13 @@ export class Server extends TestHelper {
     }
 
     // Verifies a middleware factory exception makes all dispatches fail with a generic UnknownException.
-    async testMiddlewareFactoryException(invokingCommunicator: Ice.Communicator, args: string[]) {
+    async testMiddlewareFactoryException(invokingCommunicator: Ice.Communicator) {
         const out = this.getWriter();
         out.write("testing middleware factory exception... ");
 
         // Use a separate communicator with a null logger: the pipeline creation failure is logged as an error.
         const initData = new Ice.InitializationData();
-        [initData.properties] = this.createTestProperties(args);
+        initData.properties = invokingCommunicator.getProperties().clone();
         initData.logger = new NullLogger();
         const [communicator] = this.initialize(initData);
         try {


### PR DESCRIPTION
An object adapter creates its dispatch pipeline lazily, at the first dispatch, by calling the middleware factories installed with `use`. A middleware factory should never throw. However, if one did throw, none of the mappings handled it well:

- **C++**: `dispatchPipeline()` is `noexcept`, so the program terminated.
- **C#**: the `Lazy<Object>` cached the exception and rethrew it at internal call sites, which could leave client invocations unanswered.
- **Java**: the object adapter cached a partial dispatch pipeline, and subsequent dispatches ran without the middleware that had already been applied.
- **JS**: the exception escaped into the connection's incoming message processing, and a subsequent dispatch could cache a partial pipeline.

With this PR, all four mappings handle a middleware factory exception the same way: the object adapter logs an error with the exception's details and installs a pipeline that fails every dispatch with a generic `UnknownException` that does not reveal the failure's cause. The failure is permanent for the object adapter — the pipeline creation is not retried.

Swift needs no change: its middleware factories are non-throwing closures returning a non-optional `Dispatcher`, and its pipeline construction already commits only on success.

Each mapping's middleware test gets a new case verifying both the generic exception and that the failure is permanent, plus changelog fragments for the four mappings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)