### PR TITLE
Fail gracefully when decoding an encoding 1.0 object reference with index -2147483648

### DIFF
--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1460,7 +1460,7 @@ Ice::InputStream::EncapsDecoder10::read(PatchFunc patchFunc, void* patchAddr)
     //
     int32_t index;
     _stream->read(index);
-    if (index > 0)
+    if (index > 0 || index == INT32_MIN)
     {
         throw MarshalException(__FILE__, __LINE__, "invalid object id");
     }

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -1035,7 +1035,7 @@ private class EncapsDecoder10: EncapsDecoder {
         // Object references are encoded as a negative integer in 1.0.
         //
         var index: Int32 = try stream.read()
-        if index > 0 {
+        if index > 0 || index == Int32.min {
             throw MarshalException("invalid object id")
         }
         index = -index


### PR DESCRIPTION
In the encoding 1.0 class decoders, an object reference is a non-positive `Int32` that the decoder negates to obtain the instance index. The wire value `-2147483648` (`Int32.min`) passes the existing `index > 0` check, and negating it overflows.

This PR rejects this value with the existing `MarshalException("invalid object id")` in the two mappings where the overflow matters:

- **Swift**: integer arithmetic is checked, so `-index` was a deterministic runtime trap — a peer sending this crafted value in an encoding 1.0 encapsulation could abort the process.
- **C++**: `-index` was signed-overflow UB (an aborting trap under UBSan). In practice it wraps back to `INT32_MIN`, a negative patch-map key that no instance ever resolves, so decoding already failed gracefully with `MarshalException("index for class received, but no instance")` at the end of `readPendingValues`. This also covers the mappings that decode through the C++ stream (Python, Ruby, PHP).

The C#, Java, and JS decoders are intentionally left unchanged: their behavior for this value is well-defined (wrap in C#/Java, exact arithmetic in JS yielding `2^31`), and in all three the bogus index simply becomes an unresolved patch entry that fails at the end of decoding with the same `MarshalException`. Adding a guard there would only replace one `MarshalException` with another for input no conformant encoder produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)