### PR TITLE
Remove closed-connection sessions from the IceGrid reaper's session list

### DIFF
--- a/changelog.d/service-icegrid/6129.md
+++ b/changelog.d/service-icegrid/6129.md
@@ -1,0 +1,2 @@
+- Fixed a memory leak in the IceGrid registry: the resources associated with a client or admin session were sometimes
+  retained until registry shutdown.

--- a/cpp/src/IceGrid/ReapThread.cpp
+++ b/cpp/src/IceGrid/ReapThread.cpp
@@ -183,6 +183,10 @@ ReapThread::connectionClosed(const Ice::ConnectionPtr& con)
         }
         reapables.swap(p->second);
         _connections.erase(p);
+
+        // Also erase the matching _sessions entries: the run thread can sleep forever when all remaining sessions
+        // have a 0s timeout, so it can't be relied upon to erase them.
+        _sessions.remove_if([&con](const ReapableItem& item) { return item.connection == con; });
     }
 
     // Destroy the reapables outside the lock, like run() and terminate().

--- a/cpp/src/IceGrid/ReapThread.h
+++ b/cpp/src/IceGrid/ReapThread.h
@@ -68,11 +68,13 @@ namespace IceGrid
     // by the IceGrid registry: admin sessions, client sessions (aka resource allocation sessions), internal node
     // sessions and internal replica sessions.
     // It supports two modes:
-    // - 0s timeout + non-null connection: the session is bound to the connection and is destroyed/reaped either
-    // explicitly (via a call to a Slice-defined destroy operation) or when the connection is closed
-    // - a null connection with usually a non-0 timeout: the session's lifetime is independent of the connection, and
-    // the reaper destroys the session when it doesn't receive a keepAlive call within timeout. If the timeout is 0s,
-    // the reaper only reaps the session when it's destroyed explicitly, or when the IceGrid registry shuts down.
+    // - 0s timeout + non-null connection (used by admin sessions and client sessions): the session is bound to the
+    // connection and is destroyed/reaped either explicitly (via a call to a Slice-defined destroy operation) or when
+    // the connection is closed
+    // - a null connection with usually a non-0 timeout (used by internal node sessions and internal replica sessions):
+    // the session's lifetime is independent of the connection, and the reaper destroys the session when it doesn't
+    // receive a keepAlive call within timeout. If the timeout is 0s, the reaper only reaps the session when it's
+    // destroyed explicitly, or when the IceGrid registry shuts down.
     class ReapThread final
     {
     public:


### PR DESCRIPTION
Fixes #6129.

When the connection bound to zero-timeout sessions closes, `ReapThread::connectionClosed` destroys the session servants and erases the `_connections` entry, but leaves the corresponding `ReapableItem`s in `_sessions`. The run loop would normally sweep these destroyed entries, but when every remaining session has a 0s timeout, `_wakeInterval` is 0s and the reaper thread waits forever. As a result, in a registry with no node or replica sessions (which have positive timeouts), each closed client/admin session connection leaves a destroyed servant and a closed connection in `_sessions` until the registry shuts down.

The fix: `connectionClosed` now also erases the matching `_sessions` entries while holding the lock. No notify or wake-interval recalculation is needed, since connection-bound reapables always have a 0s timeout and their removal can't change the minimum wake interval.

Explicitly destroying a zero-timeout session while its connection stays open still leaves the entry in place, but it's now cleaned up when the connection closes (the second `destroy()` is swallowed by the `ObjectNotExistException` catch in `SessionReapable`), so retention in that case is bounded by the connection's lifetime.

### 3.7 comparison

The same omission exists in 3.7's `connectionClosed`, but in practice this is a 3.8 regression. In 3.7, client and admin sessions were registered with `IceGrid.Registry.SessionTimeout` (default 30s) alongside their connection, so merely having any client/admin session made the reaper wake at least every 30 seconds, and each wake swept the stale entries (`timestamp()` throws for a destroyed session in 3.7, which the run loop treats as "remove"). Retention was bounded to ~30s even in a nodeless registry; the unbounded leak was reachable only by explicitly setting `IceGrid.Registry.SessionTimeout=0`. 3.8 removed the session-timeout/keepAlive model and hard-coded connection-bound sessions to 0s, making the wait-forever state the norm for a standalone registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)