### PR TITLE
Use the documented mexCallMATLABWithTrap failure signal in createMatlabException

### DIFF
--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -290,9 +290,11 @@ namespace
         mxArray* ex;
 
         // keep going on error
-        mexCallMATLABWithTrap(1, &ex, static_cast<int>(params.size()), params.data(), className.c_str());
-        if (!ex)
+        mxArray* error =
+            mexCallMATLABWithTrap(1, &ex, static_cast<int>(params.size()), params.data(), className.c_str());
+        if (error)
         {
+            mxDestroyArray(error);
             mexCallMATLAB(1, &ex, static_cast<int>(params.size()), params.data(), "Ice.LocalException");
         }
 


### PR DESCRIPTION
In `createMatlabException`, the fallback to `Ice.LocalException` for C++ local exceptions with no MATLAB mapping class (e.g. `Ice::FileException`) was gated on `if (!ex)`, where `ex` is the `plhs` output of `mexCallMATLABWithTrap`. The documented failure signal of `mexCallMATLABWithTrap` is its return value — a pointer to the trapped `MException`, null on success — and the `plhs` contents are unspecified on failure. The code discarded the return value and read `ex`, which is only guaranteed to be set on success.

In practice MATLAB nulls `plhs[0]` when the trapped call fails, so the fallback worked — the existing `Ice/properties` test exercises exactly this path (`Properties.load` on a missing file → `Ice:FileException` identifier on an `Ice.LocalException`) and continues to pass unchanged. This change makes the code rely on the documented contract instead of that undocumented behavior, and destroys the trapped `MException` instead of leaking it. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)