### PR TITLE
Route DataStorm element attach and initialization to the exact destination topic

### DIFF
--- a/changelog.d/datastorm/6068.md
+++ b/changelog.d/datastorm/6068.md
@@ -1,0 +1,2 @@
+- Fixed a bug where a node hosting two or more `Topic` instances with the same name, reading from the same remote
+  writer, could deliver samples to the wrong reader: a reader could receive another key's value.

--- a/changelog.d/datastorm/6068.md
+++ b/changelog.d/datastorm/6068.md
@@ -1,2 +1,2 @@
-- Fixed a bug where a node hosting two or more `Topic` instances with the same name, reading from the same remote
-  writer, could deliver samples to the wrong reader: a reader could receive another key's value.
+- Fixed a bug affecting nodes that create two or more `Topic` instances with the same name. When readers on these
+  topics read from the same remote writer, a reader could receive another key's samples instead of its own.

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -343,19 +343,24 @@ module DataStormContract
         /// This operation associates the provided elements, such as keys or filters, with the subscribers of the given
         /// topic.
         ///
-        /// @param topicId The unique identifier for the topic to which the elements belong.
+        /// @param topicId The unique identifier for the sender's topic to which the elements belong.
+        /// @param peerTopicId The id of the recipient's topic instance this request is addressed to. A node can host
+        /// several topics with the same name subscribed to one remote topic; the recipient routes the request to
+        /// exactly this topic instead of every same-name topic, so the echoed element and key ids stay unambiguous.
         /// @param elements The sequence of `ElementSpec` objects representing the elements to attach.
         /// @param initialize Indicates whether the elements are being attached during session initialization.
-        void attachElements(long topicId, ElementSpecSeq elements, bool initialize);
+        void attachElements(long topicId, long peerTopicId, ElementSpecSeq elements, bool initialize);
 
         /// Acknowledges the attachment of elements to the session in response to a previous attachElements request.
         ///
         /// This method confirms that the specified elements, such as keys or filters, have been successfully attached
         /// to the session.
         ///
-        /// @param topicId The unique identifier for the topic to which the elements belong.
+        /// @param topicId The unique identifier for the sender's topic to which the elements belong.
+        /// @param peerTopicId The id of the recipient's topic instance this acknowledgment is addressed to. See
+        /// {@link attachElements}.
         /// @param elements A sequence of `ElementSpecAck` objects representing the confirmed attachments.
-        void attachElementsAck(long topicId, ElementSpecAckSeq elements);
+        void attachElementsAck(long topicId, long peerTopicId, ElementSpecAckSeq elements);
 
         /// Instructs the peer to detach specific elements associated with a topic.
         ///
@@ -368,9 +373,11 @@ module DataStormContract
 
         /// Initializes the subscriber with the publisher queued samples for a topic during session establishment.
         ///
-        /// @param topicId The unique identifier for the topic.
+        /// @param topicId The unique identifier for the sender's topic.
+        /// @param peerTopicId The id of the recipient's topic instance these samples are addressed to. See
+        /// {@link attachElements}.
         /// @param samples A sequence of {@link DataSamples} containing the queued samples to initialize the subscriber.
-        void initSamples(long topicId, DataSamplesSeq samples);
+        void initSamples(long topicId, long peerTopicId, DataSamplesSeq samples);
 
         /// Notifies the peer that the session is being disconnected.
         ///

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -250,8 +250,9 @@ SessionI::attachTopic(TopicSpec spec, const Current&)
                         Trace out(_traceLevels->logger, _traceLevels->sessionCat);
                         out << _id << ": matched elements '" << spec << "' on '" << topic << "'";
                     }
-                    // Don't wait for the response here, the peer session will send an ack.
-                    _session->attachElementsAsync(topic->getId(), specs, true, nullptr);
+                    // Don't wait for the response here, the peer session will send an ack. The request is addressed
+                    // to the remote topic instance we are attaching to (spec.id).
+                    _session->attachElementsAsync(topic->getId(), spec.id, specs, true, nullptr);
                 }
             });
     }
@@ -384,13 +385,14 @@ SessionI::announceElements(int64_t topicId, ElementInfoSeq elements, const Curre
                     out << _id << ": announcing elements matched '[" << specs << "]@" << topicId << "' on topic '"
                         << topic << "'";
                 }
-                _session->attachElementsAsync(topic->getId(), specs, false, nullptr);
+                // Addressed to the remote topic instance that announced these elements (topicId).
+                _session->attachElementsAsync(topic->getId(), topicId, specs, false, nullptr);
             }
         });
 }
 
 void
-SessionI::attachElements(int64_t topicId, ElementSpecSeq elements, bool initialize, const Current&)
+SessionI::attachElements(int64_t topicId, int64_t peerTopicId, ElementSpecSeq elements, bool initialize, const Current&)
 {
     lock_guard<mutex> lock(_mutex);
     if (!_session)
@@ -399,11 +401,11 @@ SessionI::attachElements(int64_t topicId, ElementSpecSeq elements, bool initiali
     }
 
     auto now = chrono::system_clock::now();
-    // For each local topic that has a subscriber for the remote topic:
-    // - Attach the elements to the topic.
-    // - ACK the attached elements to the peer session.
+    // Attach the elements to the addressed local topic and ack them to the peer. Routing to exactly the addressed
+    // topic (rather than every same-name topic) keeps the echoed element and key ids unambiguous.
     runWithTopics(
         topicId,
+        peerTopicId,
         [&](TopicI* topic, TopicSubscriber& subscriber)
         {
             if (_traceLevels->session > 2)
@@ -435,13 +437,14 @@ SessionI::attachElements(int64_t topicId, ElementSpecSeq elements, bool initiali
                     out << _id << ": attaching elements matched '[" << specAck << "]@" << topicId << "' on topic '"
                         << topic << "'";
                 }
-                _session->attachElementsAckAsync(topic->getId(), specAck, nullptr);
+                // Addressed back to the remote topic instance that sent attachElements (topicId).
+                _session->attachElementsAckAsync(topic->getId(), topicId, specAck, nullptr);
             }
         });
 }
 
 void
-SessionI::attachElementsAck(int64_t topicId, ElementSpecAckSeq elements, const Current&)
+SessionI::attachElementsAck(int64_t topicId, int64_t peerTopicId, ElementSpecAckSeq elements, const Current&)
 {
     lock_guard<mutex> lock(_mutex);
     if (!_session)
@@ -451,6 +454,7 @@ SessionI::attachElementsAck(int64_t topicId, ElementSpecAckSeq elements, const C
     auto now = chrono::system_clock::now();
     runWithTopics(
         topicId,
+        peerTopicId,
         [&](TopicI* topic, TopicSubscriber&)
         {
             if (_traceLevels->session > 2)
@@ -473,7 +477,8 @@ SessionI::attachElementsAck(int64_t topicId, ElementSpecAckSeq elements, const C
                     out << _id << ": initializing elements '[" << initializationBatches << "]@" << topicId
                         << "' on topic '" << topic << "'";
                 }
-                _session->initSamplesAsync(topic->getId(), initializationBatches, nullptr);
+                // Addressed back to the remote topic instance that sent the ack (topicId).
+                _session->initSamplesAsync(topic->getId(), topicId, initializationBatches, nullptr);
             }
 
             if (!removedIds.empty())
@@ -525,7 +530,7 @@ SessionI::detachElements(int64_t id, LongSeq elements, const Current&)
 }
 
 void
-SessionI::initSamples(int64_t topicId, DataSamplesSeq initializationBatches, const Current&)
+SessionI::initSamples(int64_t topicId, int64_t peerTopicId, DataSamplesSeq initializationBatches, const Current&)
 {
     lock_guard<mutex> lock(_mutex);
     if (!_session)
@@ -544,6 +549,7 @@ SessionI::initSamples(int64_t topicId, DataSamplesSeq initializationBatches, con
     {
         runWithTopics(
             topicId,
+            peerTopicId,
             [&](TopicI* topic, TopicSubscriber& subscriber)
             {
                 ElementSubscribers* elementSubscribers = subscriber.get(initializationBatch.id);
@@ -1448,6 +1454,40 @@ SessionI::runWithTopics(int64_t topicId, const function<void(TopicI*, TopicSubsc
             callback(topic, subscriber);
             _topicLock = nullptr;
         }
+    }
+}
+
+void
+SessionI::runWithTopics(int64_t topicId, int64_t peerTopicId, const function<void(TopicI*, TopicSubscriber&)>& callback)
+{
+    auto t = _topics.find(topicId);
+    if (t != _topics.end())
+    {
+        for (auto& [topic, subscriber] : t->second.getSubscribers())
+        {
+            if (topic->getId() != peerTopicId)
+            {
+                continue;
+            }
+            unique_lock<mutex> lock(topic->getMutex());
+            if (!topic->isDestroyed())
+            {
+                _topicLock = &lock;
+                callback(topic, subscriber);
+                _topicLock = nullptr;
+            }
+            return;
+        }
+    }
+
+    // No local topic addressed by peerTopicId is subscribed to the remote topic: it was never attached, or was
+    // destroyed and reaped during the handshake. Dropping the request is correct, but trace it so it is not
+    // mistaken for a lost message.
+    if (_traceLevels->session > 2)
+    {
+        Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+        out << _id << ": no local topic '" << peerTopicId << "' subscribed to remote topic '" << topicId
+            << "', ignoring the request";
     }
 }
 

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -282,11 +282,13 @@ namespace DataStormI
         void detachTags(std::int64_t, Ice::LongSeq, const Ice::Current&) final;
 
         void announceElements(std::int64_t, DataStormContract::ElementInfoSeq, const Ice::Current&) final;
-        void attachElements(std::int64_t, DataStormContract::ElementSpecSeq, bool, const Ice::Current&) final;
-        void attachElementsAck(std::int64_t, DataStormContract::ElementSpecAckSeq, const Ice::Current&) final;
+        void
+        attachElements(std::int64_t, std::int64_t, DataStormContract::ElementSpecSeq, bool, const Ice::Current&) final;
+        void
+        attachElementsAck(std::int64_t, std::int64_t, DataStormContract::ElementSpecAckSeq, const Ice::Current&) final;
         void detachElements(std::int64_t, Ice::LongSeq, const Ice::Current&) final;
 
-        void initSamples(std::int64_t, DataStormContract::DataSamplesSeq, const Ice::Current&) final;
+        void initSamples(std::int64_t, std::int64_t, DataStormContract::DataSamplesSeq, const Ice::Current&) final;
 
         void disconnected(const Ice::Current&) final;
 
@@ -397,6 +399,20 @@ namespace DataStormI
         /// @param topicId The ID of the topic to process.
         /// @param callback The callback function to execute for each subscriber.
         void runWithTopics(std::int64_t topicId, const std::function<void(TopicI*, TopicSubscriber&)>& callback);
+
+        /// Runs the provided callback for the single local topic subscribing to the remote topic `topicId` whose own
+        /// id is `peerTopicId`. Routes a request to exactly the addressed topic instance instead of fanning it
+        /// over every same-name topic (the fan-out that lets same-name topics collide on echoed element and key ids).
+        /// The callback is executed with the topic's mutex locked; it runs at most once, and not at all if no such
+        /// topic is currently subscribed.
+        ///
+        /// @param topicId The remote (sender's) topic id the local topics are subscribed to.
+        /// @param peerTopicId The local topic instance the request is addressed to.
+        /// @param callback The callback function to execute for the subscriber.
+        void runWithTopics(
+            std::int64_t topicId,
+            std::int64_t peerTopicId,
+            const std::function<void(TopicI*, TopicSubscriber&)>& callback);
 
         /// Runs the provided callback function for the specified topic, if it is among the subscribers for the given
         /// topic ID.

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -700,6 +700,70 @@ void ::Reader::run(int argc, char* argv[])
         doneWriter.waitForReaders();
         doneWriter.update(0);
     }
+
+    // Two same-name topics on this node, each with a single-key reader on a different key of the one multi-key
+    // writer. Each reader must receive only its own key's value even though the two topics number their reader
+    // elements and keys independently: the initialization is addressed to the exact destination topic, so the
+    // colliding ids resolve within the intended topic rather than the other same-name topic.
+    {
+        Topic<string, string> topicA(node, "sameNameInit");
+        Topic<string, string> topicB(node, "sameNameInit");
+
+        // A prior reader on each topic, so the reader under test is the second key element of its topic: with
+        // per-topic numbering the two topics then assign it the same element and key id.
+        auto firstA = makeSingleKeyReader(topicA, "firstA", "", config);
+        auto firstB = makeSingleKeyReader(topicB, "firstB", "", config);
+
+        auto readerA = makeSingleKeyReader(topicA, "elemA", "", config);
+        auto readerB = makeSingleKeyReader(topicB, "elemB", "", config);
+
+        auto sampleA = readerA.getNextUnread();
+        test(sampleA.getKey() == "elemA");
+        test(sampleA.getValue() == "valueA");
+
+        auto sampleB = readerB.getNextUnread();
+        test(sampleB.getKey() == "elemB");
+        test(sampleB.getValue() == "valueB");
+
+        test(!readerA.hasUnread()); // readerA must not also receive elemB's value
+        test(!readerB.hasUnread()); // readerB must not also receive elemA's value
+    }
+
+    // The same collision, but the writer has queued both keys before the readers attach, so each reader is
+    // initialized from the writer's queue (a non-empty initialization batch) rather than a live update. The
+    // initialization must be routed to the exact destination topic, or a reader is delivered the other key's value.
+    {
+        Topic<string, string> topicA(node, "lateSameNameInit");
+        Topic<string, string> topicB(node, "lateSameNameInit");
+        Topic<string, int> barrier(node, "lateSameNameInitBarrier");
+        Topic<string, int> done(node, "lateSameNameInitDone");
+
+        // Attach each topic to the writer's session and bump its element/key id counter, so the readers under test
+        // collide on the same element and key ids across the two same-name topics.
+        auto firstA = makeSingleKeyReader(topicA, "firstA", "", config);
+        auto firstB = makeSingleKeyReader(topicB, "firstB", "", config);
+
+        // Wait until the writer has queued both keys, so the readers below are initialized from the queue.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto readerA = makeSingleKeyReader(topicA, "elemA", "", config);
+        auto readerB = makeSingleKeyReader(topicB, "elemB", "", config);
+
+        auto sampleA = readerA.getNextUnread();
+        test(sampleA.getKey() == "elemA");
+        test(sampleA.getValue() == "valueA");
+
+        auto sampleB = readerB.getNextUnread();
+        test(sampleB.getKey() == "elemB");
+        test(sampleB.getValue() == "valueB");
+
+        test(!readerA.hasUnread());
+        test(!readerB.hasUnread());
+
+        auto doneWriter = makeSingleKeyWriter(done, "done");
+        doneWriter.waitForReaders();
+        doneWriter.update(0);
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -567,6 +567,42 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // A single multi-key writer read by two same-name reader topics on the peer node, each with a single-key
+    // reader on one of the writer's keys. Each reader's sample must reach the reader that subscribed the key,
+    // even though the two same-name reader topics assign colliding element and key ids: the attachment is addressed
+    // to the exact destination topic, so each topic holds only its own key mapping. Live sample delivery still fans
+    // out over both same-name topics, but each then delivers only the key it actually subscribes.
+    cout << "testing sample routing across same-name reader topics... " << flush;
+    {
+        Topic<string, string> topic(node, "sameNameInit");
+        auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
+        writer.waitForReaders(2); // the two single-key readers whose keys the writer covers
+        writer.add("elemA", "valueA");
+        writer.add("elemB", "valueB");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // The same collision, but the writer queues both keys before the readers attach, so each late reader is
+    // initialized from the queue. The initialization batches must be addressed to the exact destination topic.
+    cout << "testing initialization routing across same-name reader topics... " << flush;
+    {
+        Topic<string, string> topic(node, "lateSameNameInit");
+        Topic<string, int> barrier(node, "lateSameNameInitBarrier");
+        Topic<string, int> done(node, "lateSameNameInitDone");
+
+        auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
+        writer.add("elemA", "valueA"); // queued (clearHistory=Never); the late readers are initialized from these
+        writer.add("elemB", "valueB");
+
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
+
     cout << "testing topic collocated key reader and writer... " << flush;
     {
         Topic<string, string> topic(node, "collocated");


### PR DESCRIPTION
Fixes #6068.

Supersedes #6139, which fixed the same bug by drawing DataStorm element/key/tag/filter ids from node-wide counters. This PR takes the addressing approach @bernardnormier suggested in that review — fix the routing rather than the ids.

## The bug

A node can host several `Topic` instances with the **same name** reading the same remote writer (topics are value objects, so independent components each create their own instance for a shared name). `attachElements`, `attachElementsAck`, and `initSamples` carry only the *sender's* topic id, so the receiver fans each request over **every** same-name topic (`runWithTopics`) and resolves the peer-echoed element and key ids against each. Element and key ids are numbered per-`TopicI`, so two same-name topics assign colliding ids and a reader receives the wrong key's value.

## The fix

Add a `peerTopicId` to those three operations, mirroring `DataSamples.peerId`. The sender always knows it: it is the topic id of the announcement/ack it is responding to. The receiver routes to exactly that topic instance via a new `runWithTopics(topicId, peerTopicId, callback)` overload, so per-topic element/key/tag/filter ids stay unambiguous by construction — no node-wide counters, and no changes to the public headers.

Builds on #6138: `peerTopicId` selects the topic instance, then `DataSamples.peerId` selects the reader element within it — two levels of addressing, no fan-out at either.

## Compatibility

The session wire changes (a parameter on three operations) but keeps the `DataStorm/Lookup2` identity introduced by #6138: #6138 and this change together make up the single 3.8.3 DataStorm wire, and both ship in 3.8.3. A node built from `main` in the window between the two merges advertises `Lookup2` with the intermediate wire, but that intermediate state is never released.

## Testing

`test/DataStorm/events` gains a same-name-topics scenario: two same-name reader topics on one node, each with a single-key reader on a different key of one multi-key writer; each reader must receive only its own key's value. Verified red→green on top of #6138 — with the destination routing disabled the reader blocks (the #6138 reader-element routing alone does not resolve the topic-level collision), and it passes with the routing on. The full `DataStorm/*` suite (incl. relay) passes. Reviewed with Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
