### PR TITLE
Fix unmarshaling of optional bare Object* proxies in MATLAB

### DIFF
--- a/changelog.d/matlab/6125.md
+++ b/changelog.d/matlab/6125.md
@@ -1,0 +1,2 @@
+- Fixed the unmarshaling of optional `Object*` parameters and fields. Reading such a proxy always failed with a MATLAB
+  error, whether or not the sender set the optional value.

--- a/matlab/lib/+Ice/InputStream.m
+++ b/matlab/lib/+Ice/InputStream.m
@@ -673,12 +673,12 @@ classdef InputStream < handle
         function r = readProxyOpt(obj, tag, cls)
             if obj.readOptional(tag, Ice.OptionalFormat.FSize)
                 obj.skip(4);
-                if nargin == 1
+                if nargin == 2
                     r = obj.readProxy();
                 else
                     r = obj.readProxy(cls);
                 end
-            elseif nargin == 1
+            elseif nargin == 2
                 r = Ice.ObjectPrx.empty;
             else
                 emptyFunc = str2func(strcat(cls, '.empty'));

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -11,6 +11,10 @@ classdef AllTests
             AllTests.skipUnknownOptionals(communicator);
             fprintf('ok\n');
 
+            fprintf('testing optional proxies without a proxy type... ');
+            AllTests.bareOptionalProxies(communicator);
+            fprintf('ok\n');
+
             ref = ['initial:', helper.getTestEndpoint()];
             initial = InitialPrx(communicator, ref);
 
@@ -796,6 +800,29 @@ classdef AllTests
             assert(is.readOptional(1, Ice.OptionalFormat.F4), 'tag 1 should be present');
             assert(is.readInt() == 11111, 'tag 1 value mismatch');
             % Tags 30, 50 and 300 are left unread; endEncapsulation must skip them cleanly.
+            is.endEncapsulation();
+        end
+
+        function bareOptionalProxies(communicator)
+            % Marshal a set and an unset optional proxy, and read them back with the untyped form of
+            % readProxyOpt - the form generated for `optional(N) Object*`, which yields an Ice.ObjectPrx.
+            encoding = Ice.EncodingVersion(1, 1);
+            prx = communicator.stringToProxy('test:tcp -h 127.0.0.1 -p 10000');
+
+            os = Ice.OutputStream(encoding);
+            os.startEncapsulation(Ice.FormatType.SlicedFormat);
+            os.writeProxyOpt(1, prx);
+            os.writeProxyOpt(2, Ice.ObjectPrx.empty); % unset: nothing is written for tag 2
+            os.endEncapsulation();
+            data = os.finished();
+
+            is = Ice.InputStream(communicator, encoding, data);
+            is.startEncapsulation();
+            p1 = is.readProxyOpt(1);
+            assert(isa(p1, 'Ice.ObjectPrx'), 'tag 1 should be an Ice.ObjectPrx');
+            assert(p1 == prx, 'tag 1 proxy mismatch');
+            p2 = is.readProxyOpt(2);
+            assert(isa(p2, 'Ice.ObjectPrx') && isempty(p2), 'tag 2 should be an empty Ice.ObjectPrx');
             is.endEncapsulation();
         end
     end


### PR DESCRIPTION
`InputStream.readProxyOpt` detected its untyped call with `nargin == 1`, but a MATLAB method's `nargin` counts `obj`, so the form the generator emits for `optional(N) Object*` — `readProxyOpt(tag)` — arrives as `nargin == 2`. The typed form, `readProxyOpt(tag, 'Foo.FooPrx')`, is `nargin == 3`.

`nargin == 1` was therefore never true, and both the value-present and value-absent branches fell through to the `cls` path with `cls` unbound:

```
testing optional proxies without a proxy type... Not enough input arguments.
Error in Ice.InputStream/readProxyOpt (line 679)
                    r = obj.readProxy(cls);
```

So every optional bare `Object*` failed to unmarshal, whether or not the sender set the value. The sibling `readProxy(obj, cls)` correctly uses `nargin == 2`; `readProxyOpt` reused those constants without accounting for its extra `tag` parameter. It is the only `read*Opt` method taking an optional `cls`.

### Test

The optional test schema has no bare `Object*` — only `MyInterface*` — so this path had no coverage at all. The new `bareOptionalProxies` helper marshals a set and an unset optional proxy and reads both back through the untyped form. It is a local `OutputStream`/`InputStream` round-trip, modeled on the `skipUnknownOptionals` helper already in that file, so it needs no Slice change and no Python server change.

Verified it fails without the fix (at the line above) and passes with it. Full MATLAB suite: 16/16.

Closes #6125. A follow-up will add `optional(11) Object* oprx;` to `MultiOptional` for end-to-end coverage across mappings and drop this local test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
