### PR TITLE
Route DataStorm partial-update, sample-filter, and updater codecs through the EncoderT/DecoderT dispatcher

### DIFF
--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -1161,7 +1161,7 @@ namespace DataStorm
               std::move(name),
               config,
               sampleFilter.name,
-              Encoder<SampleFilterCriteria>::encode(topic.getCommunicator(), sampleFilter.criteria)))
+              DataStormI::EncoderT<SampleFilterCriteria>::encode(topic.getCommunicator(), sampleFilter.criteria)))
     {
     }
 
@@ -1206,7 +1206,7 @@ namespace DataStorm
               std::move(name),
               config,
               sampleFilter.name,
-              Encoder<SampleFilterCriteria>::encode(topic.getCommunicator(), sampleFilter.criteria)))
+              DataStormI::EncoderT<SampleFilterCriteria>::encode(topic.getCommunicator(), sampleFilter.criteria)))
     {
     }
 
@@ -1396,7 +1396,7 @@ namespace DataStorm
         auto updateTag = _tagFactory->create(tag);
         return [impl, updateTag](const UpdateValue& value)
         {
-            auto encoded = Encoder<UpdateValue>::encode(impl->getCommunicator(), value);
+            auto encoded = DataStormI::EncoderT<UpdateValue>::encode(impl->getCommunicator(), value);
             impl->publish(nullptr, std::make_shared<DataStormI::SampleT<Key, Value, UpdateTag>>(encoded, updateTag));
         };
     }
@@ -1464,7 +1464,7 @@ namespace DataStorm
         auto keyFactory = _keyFactory;
         return [impl, updateTag, keyFactory](const Key& key, const UpdateValue& value)
         {
-            auto encoded = Encoder<UpdateValue>::encode(impl->getCommunicator(), value);
+            auto encoded = DataStormI::EncoderT<UpdateValue>::encode(impl->getCommunicator(), value);
             impl->publish(
                 keyFactory->create(key),
                 std::make_shared<DataStormI::SampleT<Key, Value, UpdateTag>>(encoded, updateTag));
@@ -1651,7 +1651,7 @@ namespace DataStorm
                     value = Cloner<Value>::clone(
                         std::static_pointer_cast<DataStormI::SampleT<Key, Value, UpdateTag>>(previous)->getValue());
                 }
-                updater(value, Decoder<UpdateValue>::decode(communicator, next->getEncodedValue()));
+                updater(value, DataStormI::DecoderT<UpdateValue>::decode(communicator, next->getEncodedValue()));
                 std::static_pointer_cast<DataStormI::SampleT<Key, Value, UpdateTag>>(next)->setValue(std::move(value));
             } : std::function<void(const std::shared_ptr<DataStormI::Sample>&,
                                 const std::shared_ptr<DataStormI::Sample>&,

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -17,6 +17,31 @@ public:
     void run(int, char**) override;
 };
 
+namespace
+{
+    // A user type whose codec specializations provide only the communicator-less (one-arg) encode/decode form. The
+    // reader and writer API adapt such codecs to their two-arg internal calls through DataStormI::EncoderT and
+    // DataStormI::DecoderT; routing this type through the sample-filter, partial-update, and updater paths below
+    // exercises that dispatch.
+    struct CustomValue
+    {
+        int value = 0;
+    };
+}
+
+namespace DataStorm
+{
+    template<> struct Encoder<CustomValue>
+    {
+        static Ice::ByteSeq encode(const CustomValue& value) { return {static_cast<std::byte>(value.value)}; }
+    };
+
+    template<> struct Decoder<CustomValue>
+    {
+        static CustomValue decode(const Ice::ByteSeq& data) { return CustomValue{static_cast<int>(data[0])}; }
+    };
+}
+
 void ::Writer::run(int argc, char* argv[])
 {
     Node node(argc, argv);
@@ -260,6 +285,9 @@ void ::Writer::run(int argc, char* argv[])
         t2.setReaderDefaultConfig(ReaderConfig());
 
         tc1.setUpdater<string>("test", [](string&, const string&) {});
+
+        // A communicator-less update codec goes through the DecoderT dispatcher in the registered updater.
+        tc1.setUpdater<CustomValue>("customtag", [](string&, CustomValue) {});
     }
     cout << "ok" << endl;
 
@@ -295,6 +323,8 @@ void ::Writer::run(int argc, char* argv[])
         skwm.add("test");
         skwm.update(string("test"));
         skwm.partialUpdate<int>("updatetag")(10);
+        // A communicator-less update codec goes through the EncoderT dispatcher when publishing the partial update.
+        skwm.partialUpdate<CustomValue>("customtag")(CustomValue{5});
         skwm.remove();
 
         auto skws = make_shared<SingleKeyWriter<string, string>>(topic, "key");
@@ -309,6 +339,7 @@ void ::Writer::run(int argc, char* argv[])
         mkwm.add("key", "test");
         mkwm.update("key", string("test"));
         mkwm.partialUpdate<int>("updatetag")("key", 10);
+        mkwm.partialUpdate<CustomValue>("customtag")("key", CustomValue{5});
         mkwm.remove("key");
 
         auto mkws = make_shared<MultiKeyWriter<string, string>>(topic, vector<string>{"key"});
@@ -349,12 +380,15 @@ void ::Writer::run(int argc, char* argv[])
         testReader(skr);
         auto skrsf = makeSingleKeyReader(topic, "key", Filter<string>("_regex", ".*"));
         skrsf = makeSingleKeyReader(topic, "key", Filter<string>("_regex", ".*"), "", ReaderConfig());
+        // A communicator-less sample-filter codec goes through the EncoderT dispatcher when encoding the criteria.
+        skrsf = makeSingleKeyReader(topic, "key", Filter<CustomValue>("customFilter", CustomValue{1}));
 
         auto mkr = makeMultiKeyReader(topic, {"key"});
         mkr = makeMultiKeyReader(topic, {"key"}, "", ReaderConfig());
         testReader(mkr);
         auto mkrsf = makeMultiKeyReader(topic, {"key"}, Filter<string>("_regex", ".*"));
         mkrsf = makeMultiKeyReader(topic, {"key"}, Filter<string>("_regex", ".*"), "", ReaderConfig());
+        mkrsf = makeMultiKeyReader(topic, {"key"}, Filter<CustomValue>("customFilter", CustomValue{1}));
 
         auto akr = makeAnyKeyReader(topic);
         akr = makeAnyKeyReader(topic, "", ReaderConfig());
@@ -372,6 +406,10 @@ void ::Writer::run(int argc, char* argv[])
             Filter<string>("_regex", ".*"),
             "",
             ReaderConfig());
+        frsf = makeFilteredKeyReader(
+            topic,
+            Filter<string>("_regex", ".*"),
+            Filter<CustomValue>("customFilter", CustomValue{1}));
 
         auto skrs = make_shared<SingleKeyReader<string, string>>(topic, "key");
         skrs = make_shared<SingleKeyReader<string, string>>(topic, "key", "", ReaderConfig());


### PR DESCRIPTION
Closes #6131.

Five call sites in `cpp/include/DataStorm/DataStorm.h` invoked `DataStorm::Encoder<T>`/`Decoder<T>` directly with a communicator argument, bypassing the `EncoderT`/`DecoderT` dispatcher that adapts user codec specializations to either the one-arg `encode(value)`/`decode(data)` or two-arg `encode(communicator, value)`/`decode(communicator, data)` form:

- `MultiKeyReader` ctor and `FilteredKeyReader` ctor — `Encoder<SampleFilterCriteria>::encode`
- `SingleKeyWriter::partialUpdate` and `MultiKeyWriter::partialUpdate` — `Encoder<UpdateValue>::encode`
- `Topic::setUpdater` — `Decoder<UpdateValue>::decode`

For the default (unspecialized) codecs this is byte-for-byte identical, so there is **no runtime, wire-format, or interop change**. But a user who specialized `Encoder`/`Decoder` with the communicator-less one-arg form — which the dispatcher exists to support — failed to compile at these sites for partial updates and multi-key/filtered sample filters, unlike the rest of the API. The `SingleKeyReader` sample-filter constructor already routed through `EncoderT`, which is what made the inconsistency visible.

This routes the five sites through `DataStormI::EncoderT`/`DecoderT`, matching that constructor.

## Testing

Extends the `DataStorm/api` `Writer` test with a `CustomValue` type whose `Encoder`/`Decoder` specializations provide only the communicator-less one-arg form, routed through all five fixed paths plus the `SingleKeyReader` control. Without the fix the test file fails to compile (5 errors: 4 encode + 1 decode); with the fix it compiles and runs.