### PR TITLE
Fix a string-map leak and the Future timed wait in Ice for MATLAB

### DIFF
--- a/changelog.d/matlab/6118.md
+++ b/changelog.d/matlab/6118.md
@@ -1,0 +1,3 @@
+- Fixed a memory leak in `Communicator.proxyToProperty`, `ImplicitContext.getContext`, `ObjectPrx.ice_getContext`,
+  `Properties.getPropertiesForPrefix`, and `Connection.getInfo` on a WebSocket connection. Each call leaked memory
+  proportional to the size of the dictionary it returned.

--- a/matlab/lib/+Ice/Future.m
+++ b/matlab/lib/+Ice/Future.m
@@ -79,7 +79,8 @@ classdef Future < IceInternal.WrapperObject
             %     successfully or exceptionally.
             %     'running' | 'sent' | 'finished'
             %   timeout - If provided, wait blocks up to the given number of seconds while waiting for the future to
-            %     reach the desired state. If the timeout is negative or not provided, wait blocks indefinitely.
+            %     reach the desired state. If the timeout is negative, infinite, or not provided, wait blocks
+            %     indefinitely. NaN is not a valid timeout value.
             %     double | empty array (default)
             %
             %    Output Arguments

--- a/matlab/src/Future.cpp
+++ b/matlab/src/Future.cpp
@@ -4,6 +4,9 @@
 #include "Util.h"
 #include "ice.h"
 
+#include <algorithm>
+#include <cmath>
+
 using namespace std;
 using namespace IceMatlab;
 
@@ -20,16 +23,24 @@ IceMatlab::Future::token(function<void()> t)
 bool
 IceMatlab::Future::waitForState(State state, double timeout)
 {
+    if (std::isnan(timeout))
+    {
+        throw std::invalid_argument("timeout must be a number");
+    }
+
     unique_lock<mutex> lock(_mutex);
-    if (timeout < 0)
+    if (timeout < 0 || std::isinf(timeout))
     {
         _cond.wait(lock, [this, state] { return this->stateImpl() >= state; });
         return !_exception;
     }
     else
     {
-        auto now = chrono::system_clock::now();
-        auto stop = now + chrono::milliseconds(static_cast<long long>(timeout * 1000));
+        // Cap the delay well below the point where the conversion to milliseconds, or the addition to the current
+        // time, would overflow. The cap is over 30 years, so it's indistinguishable from an unlimited wait.
+        constexpr double maxTimeout = 1'000'000'000.0;
+        auto delay = chrono::milliseconds(static_cast<long long>(std::min(timeout, maxTimeout) * 1000));
+        auto stop = chrono::steady_clock::now() + delay;
         bool b = _cond.wait_until(lock, stop, [this, state] { return this->stateImpl() >= state; });
         return b && !_exception;
     }

--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -193,6 +193,8 @@ IceMatlab::createStringMap(const map<string, string, std::less<>>& m)
         mxDestroyArray(valuesCell);
 
         mexCallMATLAB(1, &r, 2, params, "dictionary");
+        mxDestroyArray(params[0]);
+        mxDestroyArray(params[1]);
     }
     return r;
 }


### PR DESCRIPTION
Fixes the two unrelated MATLAB defects reported together in #6118.

Fixes #6118.

### `createStringMap` leaked its arguments

`createStringMap` passed two string arrays to `mexCallMATLAB("dictionary", …)` without destroying them. `mexCallMATLAB` does not take ownership of `prhs`, and Ice for MATLAB is loaded with `loadlibrary` rather than called as a MEX function — so there is no MEX-call boundary for MATLAB to reclaim temporaries at, and the arrays leaked permanently. The empty-map branch already destroyed its argument.

Reachable from `Communicator.proxyToProperty`, `ImplicitContext.getContext`, `ObjectPrx.ice_getContext`, `Properties.getPropertiesForPrefix`, and `Connection.getInfo` on a WebSocket connection.

Measured with `getPropertiesForPrefix` on a three-entry map, reporting `MemUsedMATLAB` growth:

| calls | before | after |
| ----- | ------ | ----- |
| 20,000 | +39.9 MB | +2.7 MB |
| 40,000 | +81.9 MB | +2.7 MB |
| 60,000 | +124.0 MB | +2.7 MB |
| 80,000 | +166.0 MB | +2.1 MB |

Linear at ~2.1 KB per call, versus flat.

Note the issue also names `getProperties`, which does not leak: it returns a `Properties` object, not a dictionary, and never reaches `createStringMap`.

### `Future::waitForState` timed wait

The deadline came from `system_clock`, so a wall-clock adjustment lengthened or shortened the wait; it now uses `steady_clock`. The delay was computed as `static_cast<long long>(timeout * 1000)` with no validation, which is undefined for `NaN`, for infinity, and for values beyond the range of `long long`. An infinite timeout is now an unlimited wait, `NaN` is rejected, and the delay is capped at 1e9 seconds — over 30 years, so indistinguishable from an unlimited wait, but comfortably inside what the conversion and the addition to `now()` can represent.

Checked against the built MEX:

```
timeout 0.5  -> ok=0 elapsed=0.51s
timeout 0    -> ok=0 elapsed=0.00s
timeout NaN  -> Ice:CppException: timeout must be a number
timeout 1e16 -> RETURNED ok=0 elapsed=19.48s   (blocked until the TCP connect failed)
```

The 1e16 case is the one that matters: it saturates and blocks rather than expiring. The timed branch itself is already covered by `Ice/ami`, which suspends the adapter and asserts that `wait('finished', 0.1)` returns false.

### Changelog

Only the leak gets a fragment. The `wait` change is an internal cleanup: the clock swap only bites if the system clock steps during a bounded wait, and the validation only matters for arguments no working program passes.

Full MATLAB suite: 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
