### PR TITLE
Test DataStorm partial updates after reconnect

### DIFF
--- a/cpp/msbuild/ice.test.slnx
+++ b/cpp/msbuild/ice.test.slnx
@@ -52,6 +52,14 @@
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
     </Project>
   </Folder>
+  <Folder Name="/DataStorm/partialReconnect/">
+    <Project Path="../test/DataStorm/partialReconnect/msbuild/reader/reader.vcxproj">
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
+    </Project>
+    <Project Path="../test/DataStorm/partialReconnect/msbuild/writer/writer.vcxproj">
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
+    </Project>
+  </Folder>
   <Folder Name="/DataStorm/relayReconnect/">
     <Project Path="../test/DataStorm/relayReconnect/msbuild/reader/reader.vcxproj">
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />

--- a/cpp/test/DataStorm/partialReconnect/Makefile.mk
+++ b/cpp/test/DataStorm/partialReconnect/Makefile.mk
@@ -1,0 +1,9 @@
+# Copyright (c) ZeroC, Inc.
+
+$(project)_programs        = reader writer
+$(project)_dependencies    = DataStorm Ice TestCommon
+
+$(project)_reader_sources  = Reader.cpp
+$(project)_writer_sources  = Writer.cpp
+
+tests += $(project)

--- a/cpp/test/DataStorm/partialReconnect/Reader.cpp
+++ b/cpp/test/DataStorm/partialReconnect/Reader.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+
+using namespace DataStorm;
+using namespace std;
+
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Reader::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    Topic<string, string> topic(node, "partialUpdateGap");
+    Topic<string, int> barrier(node, "partialUpdateGapBarrier");
+    topic.setUpdater<string>("append", [](string& value, const string& suffix) { value += suffix; });
+
+    {
+        ReaderConfig config;
+        config.clearHistory = ClearHistoryPolicy::Never;
+        auto reader = makeSingleKeyReader(topic, "key", "", config);
+
+        auto sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Add);
+        test(sample.getValue() == "base");
+
+        // Tell the writer the base is established. It closes the session connection and, while the reader is
+        // disconnected, publishes a full value followed by a partial update, neither of which reaches the reader.
+        auto ready = makeSingleKeyWriter(barrier, "ready");
+        ready.waitForReaders();
+        ready.update(0);
+
+        // Both samples arrive as a single full update carrying the resolved value. Replaying the writer's history
+        // would instead deliver "second" as an update of its own, followed by the partial update.
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Update);
+        test(sample.getValue() == "second-tail");
+
+        // A partial update published after the reader resumed resolves against the value it resumed with.
+        auto resumed = makeSingleKeyWriter(barrier, "resumed");
+        resumed.waitForReaders();
+        resumed.update(0);
+
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::PartialUpdate);
+        test(sample.getValue() == "second-tail-live");
+    }
+}
+
+DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/partialReconnect/Writer.cpp
+++ b/cpp/test/DataStorm/partialReconnect/Writer.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+
+using namespace DataStorm;
+using namespace std;
+
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Writer::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    Topic<string, string> topic(node, "partialUpdateGap");
+    Topic<string, int> barrier(node, "partialUpdateGapBarrier");
+    topic.setUpdater<string>("append", [](string& value, const string& suffix) { value += suffix; });
+
+    cout << "testing partial update after a reconnect across a history gap... " << flush;
+    {
+        // This writer keeps no history, so the samples it publishes while the session is down cannot be replayed when
+        // the reader resumes from its last sample id. Only the per-key base, retained independently of history, can
+        // bring the reader back up to date.
+        WriterConfig config;
+        config.sampleCount = 0;
+        auto writer = makeSingleKeyWriter(topic, "key", "", config);
+        writer.waitForReaders();
+        writer.add("base");
+
+        // Wait until the reader has consumed the base value, then close the session connection and publish while it is
+        // down. The reader cannot learn of the closure before close completes, and reconnecting takes a full session
+        // handshake, so both samples land in the gap.
+        auto sample = makeSingleKeyReader(barrier, "ready").getNextUnread();
+        auto connection = node.getSessionConnection(sample.getSession());
+        test(connection);
+        connection->close().get();
+        writer.update("second");
+        writer.partialUpdate<string>("append")("-tail");
+
+        // Wait until the reader has consumed the value it resumed with, so this partial update is delivered live
+        // rather than folded into the initialization batch.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "resumed").getNextUnread();
+        writer.partialUpdate<string>("append")("-live");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+}
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/partialReconnect/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/partialReconnect/msbuild/reader/reader.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2E0EE4A1-F13B-4BCF-915A-107F59D51D84}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/partialReconnect/msbuild/reader/reader.vcxproj.filters
+++ b/cpp/test/DataStorm/partialReconnect/msbuild/reader/reader.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/partialReconnect/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/partialReconnect/msbuild/writer/writer.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3985A2B1-8483-4A74-B398-95E63467F918}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/partialReconnect/msbuild/writer/writer.vcxproj.filters
+++ b/cpp/test/DataStorm/partialReconnect/msbuild/writer/writer.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/partialReconnect/test.py
+++ b/cpp/test/DataStorm/partialReconnect/test.py
@@ -1,0 +1,51 @@
+# Copyright (c) ZeroC, Inc.
+
+#
+# A reader that already holds a partial-update base reconnects across a gap in the writer's history.
+#
+# The writer keeps no history (sampleCount = 0) and publishes a full value plus a partial update while the session is
+# down. Resuming from the reader's last sample id cannot replay them, so the writer re-seeds the reader from its
+# current per-key base instead, delivered as a single full update carrying the resolved value. The scenarios in
+# DataStorm/partial cover the same re-seeding for readers that join fresh, with a last sample id of 0.
+#
+# The writer opens the gap by closing the session connection and publishing immediately afterwards, which is only
+# reliable while the two nodes share a single connection. This test therefore pins the topology: multicast is disabled
+# and the writer runs as a client with no server endpoint, so the reader can never connect back to it. Given more than
+# one connection between the nodes - multicast, or a relay chain - DataStorm can route the writer's publisher session
+# and the barrier's subscriber session over different connections, and closing one would leave the other delivering.
+#
+
+from DataStormUtil import Reader, Writer
+from Util import ClientServerTestCase, TestSuite
+
+traceProps = {
+    "DataStorm.Trace.Topic": 1,
+    "DataStorm.Trace.Session": 3,
+    "DataStorm.Trace.Data": 2,
+}
+
+# The reader listens and never connects out; the writer only connects in. One connection carries every session between
+# them, so closing it interrupts the writer's data session.
+readerProps = {
+    "DataStorm.Node.Multicast.Enabled": 0,
+    "DataStorm.Node.Server.Endpoints": "tcp -p {port1}",
+    "DataStorm.Node.ConnectTo": "",
+}
+
+writerProps = {
+    "DataStorm.Node.Multicast.Enabled": 0,
+    "DataStorm.Node.Server.Enabled": 0,
+    "DataStorm.Node.ConnectTo": "tcp -p {port1}",
+}
+
+TestSuite(
+    __file__,
+    [
+        ClientServerTestCase(
+            name="partial update after reconnect across a history gap",
+            client=Writer(props=writerProps),
+            server=Reader(props=readerProps),
+            traceProps=traceProps,
+        )
+    ],
+)

--- a/cpp/test/DataStorm/reliability/Reader.cpp
+++ b/cpp/test/DataStorm/reliability/Reader.cpp
@@ -168,6 +168,41 @@ void ::Reader::run(int argc, char* argv[])
         writerB.waitForReaders();
         writerB.update(0);
     }
+
+    {
+        Topic<string, string> topic(node, "partialUpdateReconnect");
+        Topic<string, int> barrier(node, "partialUpdateReconnectBarrier");
+        topic.setUpdater<string>("append", [](string& value, const string& suffix) { value += suffix; });
+        auto reader = makeSingleKeyReader(topic, "key", "", config);
+
+        auto sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Add);
+        test(sample.getValue() == "base");
+
+        // Force a reconnect after the reader has established its partial-update base. Reconnection resumes from the
+        // reader's last sample id, so the writer does not resend the full value; the reader must retain its base.
+        auto connection = node.getSessionConnection(sample.getSession());
+        test(connection);
+        connection->close().get();
+
+        // Signal the writer after the session has reconnected, then expect a partial update followed by a full update.
+        // The trailing full update makes a dropped partial fail immediately instead of leaving this test blocked.
+        auto ready = makeSingleKeyWriter(barrier, "ready");
+        ready.waitForReaders();
+        ready.update(0);
+
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::PartialUpdate);
+        test(sample.getValue() == "base-after-reconnect");
+
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Update);
+        test(sample.getValue() == "done");
+
+        auto done = makeSingleKeyWriter(barrier, "done");
+        done.waitForReaders();
+        done.update(0);
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/reliability/Writer.cpp
+++ b/cpp/test/DataStorm/reliability/Writer.cpp
@@ -114,6 +114,28 @@ void ::Writer::run(int argc, char* argv[])
         sample = readerB.getNextUnread();
     }
     cout << "ok" << endl;
+
+    cout << "testing partial update after reconnect... " << flush;
+    {
+        Topic<string, string> topic(node, "partialUpdateReconnect");
+        Topic<string, int> barrier(node, "partialUpdateReconnectBarrier");
+        topic.setUpdater<string>("append", [](string& value, const string& suffix) { value += suffix; });
+        auto writer = makeSingleKeyWriter(topic, "key", "", config);
+        writer.waitForReaders();
+        writer.add("base");
+
+        // Wait until the reader consumes the full value, closes the connection, and reconnects. The reconnect resumes
+        // after the add, so this partial update must resolve against the reader's retained pre-disconnect base.
+        [[maybe_unused]] auto ready = makeSingleKeyReader(barrier, "ready").getNextUnread();
+        writer.waitForReaders();
+        writer.partialUpdate<string>("append")("-after-reconnect");
+        writer.update("done");
+
+        // Keep the writer alive until the reader verifies both post-reconnect samples.
+        [[maybe_unused]] auto done = makeSingleKeyReader(barrier, "done").getNextUnread();
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
 }
 
 DEFINE_TEST(::Writer)


### PR DESCRIPTION
## Summary

- force a session reconnect after the reader consumes a full value
- publish a partial update without resending the full value
- verify the reader retains its pre-disconnect base and receives no duplicate initialization sample
- follow the partial with a full sentinel so a dropped partial fails immediately instead of hanging

Related to #5661.

## Testing

- `make -C cpp -j8`
- `python3 allTests.py DataStorm/reliability` (all 16 topology variants passed)