### PR TITLE
Avoid pointer arithmetic past the end of the buffer in InputStream bounds checks

### DIFF
--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -625,7 +625,7 @@ namespace Ice
         /// @param size The number of bytes to skip.
         void skip(size_type size)
         {
-            if (i + size > b.end())
+            if (size > static_cast<size_type>(b.end() - i))
             {
                 throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
             }

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -243,7 +243,8 @@ Ice::InputStream::startEncapsulation()
     {
         throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
-    if (i - sizeof(std::int32_t) + sz > b.end())
+    // sz includes the 4 bytes of the size itself, which we've already read.
+    if (sz - 4 > b.end() - i)
     {
         throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
@@ -305,7 +306,8 @@ Ice::InputStream::skipEmptyEncapsulation()
     {
         throw MarshalException{__FILE__, __LINE__, to_string(sz) + " is not a valid encapsulation size"};
     }
-    if (i - sizeof(std::int32_t) + sz > b.end())
+    // sz includes the 4 bytes of the size itself, which we've already read.
+    if (sz - 4 > b.end() - i)
     {
         throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
@@ -342,7 +344,8 @@ Ice::InputStream::readEncapsulation(const std::byte*& v, std::int32_t& sz)
     {
         throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
-    if (i - sizeof(std::int32_t) + sz > b.end())
+    // sz includes the 4 bytes of the size itself, which we've already read.
+    if (sz - 4 > b.end() - i)
     {
         throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
@@ -368,7 +371,8 @@ Ice::InputStream::skipEncapsulation()
     {
         throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
-    if (i - sizeof(int32_t) + sz > b.end())
+    // sz includes the 4 bytes of the size itself, which we've already read.
+    if (sz - 4 > b.end() - i)
     {
         throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }


### PR DESCRIPTION
`InputStream::skip` and the four encapsulation bounds checks (`startEncapsulation`, `skipEmptyEncapsulation`, `readEncapsulation`, `skipEncapsulation`) computed `i + size` — with a peer-controlled size of up to `INT32_MAX` — before comparing the result to `b.end()`. Forming a pointer past one-past-the-end is undefined behavior.

In practice the check still throws as intended on every configuration we build: 64-bit platforms can't wrap, and on 32-bit Windows the addition could only wrap with a buffer above `0x80000001`, which requires a large-address-aware process — our Win32 builds are not, so the address space tops out at 2GB. The fix removes undefined behavior rather than a reachable out-of-bounds read.

This PR rewrites these five checks to compare sizes using pointer subtraction (`b.end() - i`), the well-defined idiom already used by all the other bounds checks in `InputStream`. Behavior is unchanged: the same inputs throw the same `MarshalException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)