### PR TITLE
Validate the invocation timeout passed to ice_invocationTimeout in C#

### DIFF
--- a/changelog.d/csharp/6102.md
+++ b/changelog.d/csharp/6102.md
@@ -1,0 +1,4 @@
+- Fixed `ice_invocationTimeout(TimeSpan)`: setting an invocation timeout greater than `int.MaxValue` milliseconds
+  (about 24.9 days) could crash the process with an unhandled exception in the Ice timer thread. Timeouts outside
+  the range of an `int` in milliseconds are now rejected with an `ArgumentOutOfRangeException`, and fractional
+  timeouts are rounded down to a whole number of milliseconds.

--- a/csharp/src/Ice/Internal/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/Internal/CollocatedRequestHandler.cs
@@ -87,7 +87,7 @@ public class CollocatedRequestHandler : RequestHandler
             }
 
             outAsync.attachCollocatedObserver(_adapter, requestId);
-            if (!synchronous || !_response || _reference.getInvocationTimeout() > TimeSpan.Zero)
+            if (!synchronous || !_response || _reference.getInvocationTimeoutMs() > 0)
             {
                 // Don't invoke from the user thread if async or invocation timeout is set
                 _adapter.getThreadPool().execute(

--- a/csharp/src/Ice/Internal/DefaultsAndOverrides.cs
+++ b/csharp/src/Ice/Internal/DefaultsAndOverrides.cs
@@ -82,7 +82,7 @@ public sealed class DefaultsAndOverrides
             {
                 throw new InitializationException($"invalid value for Ice.Default.InvocationTimeout: {value}");
             }
-            defaultInvocationTimeout = TimeSpan.FromMilliseconds(value);
+            defaultInvocationTimeoutMs = value;
         }
 
         val = properties.getIceProperty("Ice.Default.EncodingVersion");
@@ -99,7 +99,7 @@ public sealed class DefaultsAndOverrides
     public bool defaultCollocationOptimization;
     public Ice.EndpointSelectionType defaultEndpointSelection;
     public TimeSpan defaultLocatorCacheTimeout;
-    public TimeSpan defaultInvocationTimeout;
+    public int defaultInvocationTimeoutMs;
     public Ice.EncodingVersion defaultEncoding;
     public Ice.FormatType defaultFormat;
 

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -466,10 +466,10 @@ public abstract class ProxyOutgoingAsyncBase : OutgoingAsyncBase, TimerTask
         {
             if (userThread)
             {
-                TimeSpan invocationTimeout = proxy_.iceReference().getInvocationTimeout();
-                if (invocationTimeout > TimeSpan.Zero)
+                int invocationTimeoutMs = proxy_.iceReference().getInvocationTimeoutMs();
+                if (invocationTimeoutMs > 0)
                 {
-                    instance_.timer().schedule(this, (long)invocationTimeout.TotalMilliseconds);
+                    instance_.timer().schedule(this, invocationTimeoutMs);
                 }
             }
             else
@@ -550,7 +550,7 @@ public abstract class ProxyOutgoingAsyncBase : OutgoingAsyncBase, TimerTask
         _sent = true;
         if (done)
         {
-            if (proxy_.iceReference().getInvocationTimeout() > TimeSpan.Zero)
+            if (proxy_.iceReference().getInvocationTimeoutMs() > 0)
             {
                 instance_.timer().cancel(this);
             }
@@ -560,7 +560,7 @@ public abstract class ProxyOutgoingAsyncBase : OutgoingAsyncBase, TimerTask
 
     protected override bool exceptionImpl(Ice.Exception ex)
     {
-        if (proxy_.iceReference().getInvocationTimeout() > TimeSpan.Zero)
+        if (proxy_.iceReference().getInvocationTimeoutMs() > 0)
         {
             instance_.timer().cancel(this);
         }
@@ -569,7 +569,7 @@ public abstract class ProxyOutgoingAsyncBase : OutgoingAsyncBase, TimerTask
 
     protected override bool responseImpl(bool userThread, bool ok, bool invoke)
     {
-        if (proxy_.iceReference().getInvocationTimeout() > TimeSpan.Zero)
+        if (proxy_.iceReference().getInvocationTimeoutMs() > 0)
         {
             instance_.timer().cancel(this);
         }
@@ -954,7 +954,7 @@ public class OutgoingAsync : ProxyOutgoingAsyncBase
     public override int invokeCollocated(CollocatedRequestHandler handler)
     {
         // The stream cannot be cached if the proxy is not a twoway or there is an invocation timeout set.
-        if (!proxy_.ice_isTwoway() || proxy_.iceReference().getInvocationTimeout() > TimeSpan.Zero)
+        if (!proxy_.ice_isTwoway() || proxy_.iceReference().getInvocationTimeoutMs() > 0)
         {
             // Disable caching by marking the streams as cached!
             state_ |= StateCachedBuffers;

--- a/csharp/src/Ice/Internal/Reference.cs
+++ b/csharp/src/Ice/Internal/Reference.cs
@@ -66,8 +66,8 @@ public abstract class Reference : IEquatable<Reference>
 
     public Dictionary<string, string> getContext() => _context;
 
-    public TimeSpan
-    getInvocationTimeout() => _invocationTimeout;
+    public int
+    getInvocationTimeoutMs() => _invocationTimeoutMs;
 
     public bool?
     getCompress() => _compress;
@@ -138,10 +138,10 @@ public abstract class Reference : IEquatable<Reference>
         return r;
     }
 
-    public Reference changeInvocationTimeout(TimeSpan newTimeout)
+    public Reference changeInvocationTimeoutMs(int newTimeout)
     {
         Reference r = _instance.referenceFactory().copy(this);
-        r._invocationTimeout = newTimeout;
+        r._invocationTimeoutMs = newTimeout;
         return r;
     }
 
@@ -350,7 +350,7 @@ public abstract class Reference : IEquatable<Reference>
         hash.Add(_facet);
         hash.Add(_compress);
         // We don't hash protocol and encoding; they are usually "1.0" and "1.1" respectively.
-        hash.Add(_invocationTimeout);
+        hash.Add(_invocationTimeoutMs);
         return hash.ToHashCode();
     }
 
@@ -366,7 +366,7 @@ public abstract class Reference : IEquatable<Reference>
             _compress == other._compress &&
             _protocol == other._protocol &&
             _encoding == other._encoding &&
-            _invocationTimeout == other._invocationTimeout;
+            _invocationTimeoutMs == other._invocationTimeoutMs;
     }
 
     public override bool Equals(object obj) => Equals(obj as Reference);
@@ -384,7 +384,7 @@ public abstract class Reference : IEquatable<Reference>
     private string _facet;
     private Ice.ProtocolVersion _protocol;
     private Ice.EncodingVersion _encoding;
-    private TimeSpan _invocationTimeout;
+    private int _invocationTimeoutMs;
     private bool? _compress;
 
     protected Reference(
@@ -396,7 +396,7 @@ public abstract class Reference : IEquatable<Reference>
         bool? compress,
         Ice.ProtocolVersion protocol,
         Ice.EncodingVersion encoding,
-        TimeSpan invocationTimeout,
+        int invocationTimeoutMs,
         Dictionary<string, string> context)
     {
         // Validate string arguments.
@@ -410,7 +410,7 @@ public abstract class Reference : IEquatable<Reference>
         _facet = facet;
         _protocol = protocol;
         _encoding = encoding;
-        _invocationTimeout = invocationTimeout;
+        _invocationTimeoutMs = invocationTimeoutMs;
         _compress = compress;
     }
 
@@ -431,7 +431,7 @@ public class FixedReference : Reference
         Ice.ProtocolVersion protocol,
         Ice.EncodingVersion encoding,
         Ice.ConnectionI connection,
-        TimeSpan invocationTimeout,
+        int invocationTimeoutMs,
         Dictionary<string, string> context)
     : base(
         instance,
@@ -442,7 +442,7 @@ public class FixedReference : Reference
         compress,
         protocol,
         encoding,
-        invocationTimeout,
+        invocationTimeoutMs,
         context) =>
         _fixedConnection = connection;
 
@@ -707,7 +707,7 @@ public class RoutableReference : Reference
             getProtocol(),
             getEncoding(),
             connection,
-            getInvocationTimeout(),
+            getInvocationTimeoutMs(),
             getContext());
     }
 
@@ -795,7 +795,7 @@ public class RoutableReference : Reference
             [prefix + ".LocatorCacheTimeout"] =
                 _locatorCacheTimeout.TotalSeconds.ToString(CultureInfo.InvariantCulture),
             [prefix + ".InvocationTimeout"] =
-                getInvocationTimeout().TotalMilliseconds.ToString(CultureInfo.InvariantCulture)
+                getInvocationTimeoutMs().ToString(CultureInfo.InvariantCulture)
         };
 
         if (_routerInfo != null)
@@ -1028,7 +1028,7 @@ public class RoutableReference : Reference
         bool cacheConnection,
         Ice.EndpointSelectionType endpointSelection,
         TimeSpan locatorCacheTimeout,
-        TimeSpan invocationTimeout,
+        int invocationTimeoutMs,
         Dictionary<string, string> context)
     : base(
         instance,
@@ -1039,7 +1039,7 @@ public class RoutableReference : Reference
         compress,
         protocol,
         encoding,
-        invocationTimeout,
+        invocationTimeoutMs,
         context)
     {
         _endpoints = endpoints;

--- a/csharp/src/Ice/Internal/ReferenceFactory.cs
+++ b/csharp/src/Ice/Internal/ReferenceFactory.cs
@@ -68,7 +68,7 @@ internal class ReferenceFactory
             Protocol.Protocol_1_0,
             _instance.defaultsAndOverrides().defaultEncoding,
             connection,
-            TimeSpan.FromMilliseconds(-1),
+            invocationTimeoutMs: -1,
             null);
     }
 
@@ -659,7 +659,7 @@ internal class ReferenceFactory
         bool cacheConnection = true;
         Ice.EndpointSelectionType endpointSelection = defaultsAndOverrides.defaultEndpointSelection;
         TimeSpan locatorCacheTimeout = defaultsAndOverrides.defaultLocatorCacheTimeout;
-        TimeSpan invocationTimeout = defaultsAndOverrides.defaultInvocationTimeout;
+        int invocationTimeoutMs = defaultsAndOverrides.defaultInvocationTimeoutMs;
         Dictionary<string, string> context = null;
 
         //
@@ -734,8 +734,7 @@ internal class ReferenceFactory
                 properties.getPropertyAsIntWithDefault(property, (int)locatorCacheTimeout.TotalSeconds));
 
             property = propertyPrefix + ".InvocationTimeout";
-            invocationTimeout = TimeSpan.FromMilliseconds(
-                properties.getPropertyAsIntWithDefault(property, (int)invocationTimeout.TotalMilliseconds));
+            invocationTimeoutMs = properties.getPropertyAsIntWithDefault(property, invocationTimeoutMs);
 
             property = propertyPrefix + ".Context.";
             Dictionary<string, string> contexts = properties.getPropertiesForPrefix(property);
@@ -769,7 +768,7 @@ internal class ReferenceFactory
             cacheConnection,
             endpointSelection,
             locatorCacheTimeout,
-            invocationTimeout,
+            invocationTimeoutMs,
             context);
     }
 

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -235,7 +235,10 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
     /// </summary>
-    /// <param name="newTimeout">The new invocation timeout.</param>
+    /// <param name="newTimeout">The new invocation timeout. The timeout is rounded down to the nearest millisecond.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newTimeout"/> is not between
+    /// <see cref="int.MinValue"/> and <see cref="int.MaxValue"/> milliseconds.</exception>
     ObjectPrx ice_invocationTimeout(TimeSpan newTimeout);
 
     /// <summary>
@@ -1029,31 +1032,43 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// Gets the invocation timeout of this proxy.
     /// </summary>
     /// <returns>The invocation timeout value.</returns>
-    public TimeSpan ice_getInvocationTimeout() => _reference.getInvocationTimeout();
+    public TimeSpan ice_getInvocationTimeout() => TimeSpan.FromMilliseconds(_reference.getInvocationTimeoutMs());
 
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
     /// </summary>
     /// <param name="newTimeout">The new invocation timeout (in milliseconds).</param>
     /// <returns>The new proxy with the specified invocation timeout.</returns>
-    public ObjectPrx ice_invocationTimeout(int newTimeout) =>
-        ice_invocationTimeout(TimeSpan.FromMilliseconds(newTimeout));
-
-    /// <summary>
-    /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
-    /// </summary>
-    /// <param name="newTimeout">The new invocation timeout.</param>
-    /// <returns>The new proxy with the specified invocation timeout.</returns>
-    public ObjectPrx ice_invocationTimeout(TimeSpan newTimeout)
+    public ObjectPrx ice_invocationTimeout(int newTimeout)
     {
-        if (newTimeout == _reference.getInvocationTimeout())
+        if (newTimeout == _reference.getInvocationTimeoutMs())
         {
             return this;
         }
         else
         {
-            return iceNewInstance(_reference.changeInvocationTimeout(newTimeout));
+            return iceNewInstance(_reference.changeInvocationTimeoutMs(newTimeout));
         }
+    }
+
+    /// <summary>
+    /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
+    /// </summary>
+    /// <param name="newTimeout">The new invocation timeout. The timeout is rounded down to the nearest millisecond.
+    /// </param>
+    /// <returns>The new proxy with the specified invocation timeout.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newTimeout"/> is not between
+    /// <see cref="int.MinValue"/> and <see cref="int.MaxValue"/> milliseconds.</exception>
+    public ObjectPrx ice_invocationTimeout(TimeSpan newTimeout)
+    {
+        if (newTimeout > TimeSpan.FromMilliseconds(int.MaxValue) ||
+            newTimeout < TimeSpan.FromMilliseconds(int.MinValue))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(newTimeout),
+                $"The invocation timeout must be between {int.MinValue} and {int.MaxValue} milliseconds.");
+        }
+        return ice_invocationTimeout((int)newTimeout.TotalMilliseconds);
     }
 
     /// <summary>

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -583,6 +583,24 @@ public class AllTests : global::Test.AllTests
         test(baseProxy.ice_invocationTimeout(0).ice_getInvocationTimeout() == TimeSpan.Zero);
         test(baseProxy.ice_invocationTimeout(-1).ice_getInvocationTimeout() == TimeSpan.FromMilliseconds(-1));
         test(baseProxy.ice_invocationTimeout(-2).ice_getInvocationTimeout() == TimeSpan.FromMilliseconds(-2));
+        test(baseProxy.ice_invocationTimeout(int.MaxValue).ice_getInvocationTimeout() ==
+            TimeSpan.FromMilliseconds(int.MaxValue));
+        try
+        {
+            baseProxy.ice_invocationTimeout(TimeSpan.FromDays(30));
+            test(false);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+        }
+        try
+        {
+            baseProxy.ice_invocationTimeout(TimeSpan.FromDays(-30));
+            test(false);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+        }
 
         test(baseProxy.ice_locatorCacheTimeout(0).ice_getLocatorCacheTimeout() == TimeSpan.Zero);
         test(baseProxy.ice_locatorCacheTimeout(-1).ice_getLocatorCacheTimeout() == TimeSpan.FromSeconds(-1));


### PR DESCRIPTION
In C#, `ice_invocationTimeout(TimeSpan)` accepted any `TimeSpan` value. For a timeout greater than `int.MaxValue` milliseconds (about 24.9 days), the Ice timer thread narrowed the wait delay to `int` in `Monitor.Wait(_mutex, (int)(first.scheduledTime - now))` once that deadline became the earliest pending one; the wrapped negative value made `Monitor.Wait` throw `ArgumentOutOfRangeException` outside any try block, and the unhandled exception on the timer thread terminated the process.

This PR makes two changes:

- `ice_invocationTimeout(TimeSpan)` now throws `ArgumentOutOfRangeException` for timeouts outside the range of an `int` in milliseconds, and rounds fractional timeouts down to a whole number of milliseconds, so the stored timeout always matches the applied one (a sub-millisecond timeout previously scheduled with a 0 ms delay and timed out immediately). Values less than or equal to zero keep their existing "no timeout" semantics, consistent with the other language mappings and the existing tests.
- The invocation timeout is now stored internally as an `int` in milliseconds (`invocationTimeoutMs`) instead of a `TimeSpan`, matching how it is parsed from properties, compared, stringified, and scheduled on the timer. The public API is unchanged: `ice_invocationTimeout(int)`, `ice_invocationTimeout(TimeSpan)`, and `ice_getInvocationTimeout()` keep their signatures, with the `TimeSpan` overload converting once at the API boundary.

Fixes #6102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)