### PR TITLE
Read connection-related properties at communicator initialization

### DIFF
--- a/cpp/src/Ice/BatchRequestQueue.cpp
+++ b/cpp/src/Ice/BatchRequestQueue.cpp
@@ -12,8 +12,6 @@ using namespace IceInternal;
 
 namespace
 {
-    const int udpOverhead = 20 + 8;
-
     class BatchRequestI final : public Ice::BatchRequest
     {
     public:
@@ -53,8 +51,7 @@ BatchRequestQueue::BatchRequestQueue(const InstancePtr& instance, bool datagram)
     _maxSize = instance->batchAutoFlushSize();
     if (_maxSize > 0 && datagram)
     {
-        const Ice::InitializationData& initData = instance->initializationData();
-        int32_t udpSndSize = initData.properties->getPropertyAsIntWithDefault("Ice.UDP.SndSize", 65535 - udpOverhead);
+        int32_t udpSndSize = instance->udpSndSize();
         if (udpSndSize < _maxSize)
         {
             _maxSize = udpSndSize;

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -1496,7 +1496,7 @@ IceInternal::IncomingConnectionFactory::IncomingConnectionFactory(
               : instance->initializationData().properties->getPropertyAsInt(adapter->getName() + ".MaxConnections")),
       _endpoint(endpoint),
       _adapter(adapter),
-      _warn(_instance->initializationData().properties->getIcePropertyAsInt("Ice.Warn.Connections") > 0)
+      _warn(_instance->warnConnections())
 {
 }
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1897,26 +1897,15 @@ Ice::ConnectionI::ConnectionI(
       // suppress inactivity timeout for datagram connections
       _inactivityTimeout(endpoint->datagram() ? chrono::seconds::zero() : options.inactivityTimeout),
       _removeFromFactory(std::move(removeFromFactory)),
-      _warn(_instance->initializationData().properties->getIcePropertyAsInt("Ice.Warn.Connections") > 0),
-      _warnUdp(_instance->initializationData().properties->getIcePropertyAsInt("Ice.Warn.Datagrams") > 0),
+      _warn(_instance->warnConnections()),
+      _warnUdp(_instance->warnDatagrams()),
+      _compressionLevel(_instance->compressionLevel()),
       _asyncRequestsHint(_asyncRequests.end()),
       _messageSizeMax(connector ? _instance->messageSizeMax() : adapter->messageSizeMax()),
       _batchRequestQueue(new BatchRequestQueue(instance, endpoint->datagram())),
       _readStream{instance.get(), currentProtocolEncoding},
       _maxDispatches(options.maxDispatches)
 {
-    const Ice::PropertiesPtr& properties = _instance->initializationData().properties;
-
-    int& compressionLevel = const_cast<int&>(_compressionLevel);
-    compressionLevel = properties->getIcePropertyAsInt("Ice.Compression.Level");
-    if (compressionLevel < 1)
-    {
-        compressionLevel = 1;
-    }
-    else if (compressionLevel > 9)
-    {
-        compressionLevel = 9;
-    }
 }
 
 Ice::ConnectionIPtr

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -79,6 +79,8 @@ using namespace IceInternal;
 
 namespace
 {
+    const int udpOverhead = 20 + 8;
+
     mutex staticMutex;
     bool oneOffDone = false;
     std::list<IceInternal::Instance*>* instanceList = nullptr;
@@ -1143,6 +1145,15 @@ IceInternal::Instance::initialize(const Ice::CommunicatorPtr& communicator)
             // The property is specified in kibibytes (KiB); _batchAutoFlushSize is stored in bytes.
             const_cast<int32_t&>(_batchAutoFlushSize) = batchAutoFlushSize * 1024;
         }
+
+        const_cast<bool&>(_warnConnections) = _initData.properties->getIcePropertyAsInt("Ice.Warn.Connections") > 0;
+        const_cast<bool&>(_warnDatagrams) = _initData.properties->getIcePropertyAsInt("Ice.Warn.Datagrams") > 0;
+
+        const_cast<int32_t&>(_compressionLevel) =
+            std::clamp(_initData.properties->getIcePropertyAsInt("Ice.Compression.Level"), 1, 9);
+
+        const_cast<int32_t&>(_udpSndSize) =
+            _initData.properties->getPropertyAsIntWithDefault("Ice.UDP.SndSize", 65535 - udpOverhead);
 
         int32_t classGraphDepthMax = _initData.properties->getIcePropertyAsInt("Ice.ClassGraphDepthMax");
         if (classGraphDepthMax < 1)

--- a/cpp/src/Ice/Instance.h
+++ b/cpp/src/Ice/Instance.h
@@ -86,6 +86,10 @@ namespace IceInternal
         [[nodiscard]] Ice::PluginManagerPtr pluginManager() const;
         [[nodiscard]] std::int32_t messageSizeMax() const { return _messageSizeMax; }
         [[nodiscard]] std::int32_t batchAutoFlushSize() const { return _batchAutoFlushSize; }
+        [[nodiscard]] bool warnConnections() const { return _warnConnections; }
+        [[nodiscard]] bool warnDatagrams() const { return _warnDatagrams; }
+        [[nodiscard]] std::int32_t compressionLevel() const { return _compressionLevel; }
+        [[nodiscard]] std::int32_t udpSndSize() const { return _udpSndSize; }
         [[nodiscard]] std::int32_t classGraphDepthMax() const { return _classGraphDepthMax; }
         [[nodiscard]] Ice::ToStringMode toStringMode() const { return _toStringMode; }
         [[nodiscard]] bool acceptClassCycles() const { return _acceptClassCycles; }
@@ -155,6 +159,10 @@ namespace IceInternal
         const DefaultsAndOverridesPtr _defaultsAndOverrides;               // Immutable, not reset by destroy().
         const std::int32_t _messageSizeMax{0};                             // Immutable, not reset by destroy().
         const std::int32_t _batchAutoFlushSize{0};                         // Immutable, not reset by destroy().
+        const bool _warnConnections{false};                                // Immutable, not reset by destroy().
+        const bool _warnDatagrams{false};                                  // Immutable, not reset by destroy().
+        const std::int32_t _compressionLevel{1};                           // Immutable, not reset by destroy().
+        const std::int32_t _udpSndSize{0};                                 // Immutable, not reset by destroy().
         const std::int32_t _classGraphDepthMax{0};                         // Immutable, not reset by destroy().
         const Ice::ToStringMode _toStringMode{Ice::ToStringMode::Unicode}; // Immutable, not reset by destroy().
         const bool _acceptClassCycles{false};                              // Immutable, not reset by destroy().

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1380,8 +1380,8 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         _inactivityTimeout = endpoint.datagram() ? TimeSpan.Zero : options.inactivityTimeout;
         _maxDispatches = options.maxDispatches;
         _removeFromFactory = removeFromFactory;
-        _warn = initData.properties.getIcePropertyAsInt("Ice.Warn.Connections") > 0;
-        _warnUdp = initData.properties.getIcePropertyAsInt("Ice.Warn.Datagrams") > 0;
+        _warn = instance.warnConnections();
+        _warnUdp = instance.warnDatagrams();
         _nextRequestId = 1;
         _messageSizeMax = connector is null ? adapter.messageSizeMax() : instance.messageSizeMax();
         _batchRequestQueue = new BatchRequestQueue(instance, _endpoint.datagram());
@@ -1393,15 +1393,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         _upcallCount = 0;
         _state = StateNotInitialized;
 
-        _compressionLevel = initData.properties.getIcePropertyAsInt("Ice.Compression.Level");
-        if (_compressionLevel < 1)
-        {
-            _compressionLevel = 1;
-        }
-        else if (_compressionLevel > 9)
-        {
-            _compressionLevel = 9;
-        }
+        _compressionLevel = instance.compressionLevel();
 
         if (options.idleTimeout > TimeSpan.Zero && !endpoint.datagram())
         {

--- a/csharp/src/Ice/Internal/BatchRequestQueue.cs
+++ b/csharp/src/Ice/Internal/BatchRequestQueue.cs
@@ -46,9 +46,7 @@ internal sealed class BatchRequestQueue
         _maxSize = instance.batchAutoFlushSize();
         if (_maxSize > 0 && datagram)
         {
-            int udpSndSize = initData.properties.getPropertyAsIntWithDefault(
-                "Ice.UDP.SndSize",
-                65535 - _udpOverhead);
+            int udpSndSize = instance.udpSndSize();
             if (udpSndSize < _maxSize)
             {
                 _maxSize = udpSndSize;
@@ -227,5 +225,4 @@ internal sealed class BatchRequestQueue
     private readonly BatchRequestI _request;
     private LocalException _exception;
     private readonly int _maxSize;
-    private const int _udpOverhead = 20 + 8;
 }

--- a/csharp/src/Ice/Internal/ConnectionFactory.cs
+++ b/csharp/src/Ice/Internal/ConnectionFactory.cs
@@ -1290,7 +1290,7 @@ internal sealed class IncomingConnectionFactory : EventHandler, ConnectionI.Star
 
         _endpoint = endpoint;
         _adapter = adapter;
-        _warn = _instance.initializationData().properties!.getIcePropertyAsInt("Ice.Warn.Connections") > 0;
+        _warn = _instance.warnConnections();
         _connections = [];
         _state = StateHolding;
         _acceptorStarted = false;

--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -254,6 +254,22 @@ public sealed class Instance
         // No mutex lock, immutable.
         _batchAutoFlushSize;
 
+    public bool warnConnections() =>
+        // No mutex lock, immutable.
+        _warnConnections;
+
+    public bool warnDatagrams() =>
+        // No mutex lock, immutable.
+        _warnDatagrams;
+
+    public int compressionLevel() =>
+        // No mutex lock, immutable.
+        _compressionLevel;
+
+    public int udpSndSize() =>
+        // No mutex lock, immutable.
+        _udpSndSize;
+
     public int classGraphDepthMax() =>
         // No mutex lock, immutable.
         _classGraphDepthMax;
@@ -704,6 +720,13 @@ public sealed class Instance
                 // The property is specified in kibibytes (KiB); _batchAutoFlushSize is stored in bytes.
                 _batchAutoFlushSize = batchAutoFlushSize * 1024;
             }
+
+            _warnConnections = _initData.properties.getIcePropertyAsInt("Ice.Warn.Connections") > 0;
+            _warnDatagrams = _initData.properties.getIcePropertyAsInt("Ice.Warn.Datagrams") > 0;
+
+            _compressionLevel = Math.Clamp(_initData.properties.getIcePropertyAsInt("Ice.Compression.Level"), 1, 9);
+
+            _udpSndSize = _initData.properties.getPropertyAsIntWithDefault("Ice.UDP.SndSize", 65535 - udpOverhead);
 
             int classGraphDepthMax = _initData.properties.getIcePropertyAsInt("Ice.ClassGraphDepthMax");
             if (classGraphDepthMax < 1)
@@ -1435,6 +1458,12 @@ public sealed class Instance
     private DefaultsAndOverrides _defaultsAndOverrides; // Immutable, not reset by destroy().
     private int _messageSizeMax; // Immutable, not reset by destroy().
     private int _batchAutoFlushSize; // Immutable, not reset by destroy().
+    private const int udpOverhead = 20 + 8;
+
+    private bool _warnConnections; // Immutable, not reset by destroy().
+    private bool _warnDatagrams; // Immutable, not reset by destroy().
+    private int _compressionLevel; // Immutable, not reset by destroy().
+    private int _udpSndSize; // Immutable, not reset by destroy().
     private int _classGraphDepthMax; // Immutable, not reset by destroy().
     private Ice.ToStringMode _toStringMode; // Immutable, not reset by destroy().
     private int _cacheMessageBuffers; // Immutable, not reset by destroy().

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BatchRequestQueue.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BatchRequestQueue.java
@@ -54,7 +54,7 @@ class BatchRequestQueue {
 
         _maxSize = instance.batchAutoFlushSize();
         if (_maxSize > 0 && datagram) {
-            int udpSndSize = initData.properties.getPropertyAsIntWithDefault("Ice.UDP.SndSize", 65535 - _udpOverhead);
+            int udpSndSize = instance.udpSndSize();
             if (udpSndSize < _maxSize) {
                 _maxSize = udpSndSize;
             }
@@ -210,6 +210,4 @@ class BatchRequestQueue {
     private final BatchRequestI _request;
     private LocalException _exception;
     private int _maxSize;
-
-    private static final int _udpOverhead = 20 + 8;
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -1061,8 +1061,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         _maxDispatches = options.maxDispatches();
         _timer = instance.timer();
         _removeFromFactory = removeFromFactory;
-        _warn = initData.properties.getIcePropertyAsInt("Ice.Warn.Connections") > 0;
-        _warnUdp = instance.initializationData().properties.getIcePropertyAsInt("Ice.Warn.Datagrams") > 0;
+        _warn = instance.warnConnections();
+        _warnUdp = instance.warnDatagrams();
         _nextRequestId = 1;
         _messageSizeMax = connector == null ? adapter.messageSizeMax() : instance.messageSizeMax();
         _batchRequestQueue = new BatchRequestQueue(instance, _endpoint.datagram());
@@ -1074,13 +1074,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         _upcallCount = 0;
         _state = StateNotInitialized;
 
-        int compressionLevel = initData.properties.getIcePropertyAsInt("Ice.Compression.Level");
-        if (compressionLevel < 1) {
-            compressionLevel = 1;
-        } else if (compressionLevel > 9) {
-            compressionLevel = 9;
-        }
-        _compressionLevel = compressionLevel;
+        _compressionLevel = instance.compressionLevel();
 
         if (options.idleTimeout() > 0 && !endpoint.datagram()) {
             _idleTimeoutTransceiver =

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
@@ -261,7 +261,7 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
 
         _endpoint = endpoint;
         _adapter = adapter;
-        _warn = _instance.initializationData().properties.getIcePropertyAsInt("Ice.Warn.Connections") > 0;
+        _warn = _instance.warnConnections();
         _state = StateHolding;
         _acceptorStarted = false;
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -263,6 +263,26 @@ public final class Instance {
         return _batchAutoFlushSize;
     }
 
+    public boolean warnConnections() {
+        // No mutex lock, immutable.
+        return _warnConnections;
+    }
+
+    public boolean warnDatagrams() {
+        // No mutex lock, immutable.
+        return _warnDatagrams;
+    }
+
+    public int compressionLevel() {
+        // No mutex lock, immutable.
+        return _compressionLevel;
+    }
+
+    public int udpSndSize() {
+        // No mutex lock, immutable.
+        return _udpSndSize;
+    }
+
     public int classGraphDepthMax() {
         // No mutex lock, immutable.
         return _classGraphDepthMax;
@@ -597,6 +617,15 @@ public final class Instance {
                 // The property is specified in kibibytes (KiB); _batchAutoFlushSize is stored in bytes.
                 _batchAutoFlushSize = batchAutoFlushSize * 1024;
             }
+
+            _warnConnections = properties.getIcePropertyAsInt("Ice.Warn.Connections") > 0;
+            _warnDatagrams = properties.getIcePropertyAsInt("Ice.Warn.Datagrams") > 0;
+
+            _compressionLevel =
+                Math.min(Math.max(properties.getIcePropertyAsInt("Ice.Compression.Level"), 1), 9);
+
+            _udpSndSize =
+                properties.getPropertyAsIntWithDefault("Ice.UDP.SndSize", 65535 - _udpOverhead);
 
             int classGraphDepthMax = properties.getIcePropertyAsInt("Ice.ClassGraphDepthMax");
             if (classGraphDepthMax < 1) {
@@ -1303,6 +1332,12 @@ public final class Instance {
     private DefaultsAndOverrides _defaultsAndOverrides; // Immutable, not reset by destroy().
     private int _messageSizeMax; // Immutable, not reset by destroy().
     private int _batchAutoFlushSize; // Immutable, not reset by destroy().
+    private static final int _udpOverhead = 20 + 8;
+
+    private boolean _warnConnections; // Immutable, not reset by destroy().
+    private boolean _warnDatagrams; // Immutable, not reset by destroy().
+    private int _compressionLevel; // Immutable, not reset by destroy().
+    private int _udpSndSize; // Immutable, not reset by destroy().
     private int _classGraphDepthMax; // Immutable, not reset by destroy().
     private ToStringMode _toStringMode; // Immutable, not reset by destroy().
     private int _cacheMessageBuffers; // Immutable, not reset by destroy().

--- a/js/packages/ice/src/Ice/ConnectionI.js
+++ b/js/packages/ice/src/Ice/ConnectionI.js
@@ -84,7 +84,7 @@ export class ConnectionI {
 
         this._hasMoreData = { value: false };
 
-        this._warn = initData.properties.getIcePropertyAsInt("Ice.Warn.Connections") > 0;
+        this._warn = instance.warnConnections();
         this._nextRequestId = 1;
         this._messageSizeMax = instance.messageSizeMax();
         this._batchRequestQueue = new BatchRequestQueue(instance);

--- a/js/packages/ice/src/Ice/Instance.js
+++ b/js/packages/ice/src/Ice/Instance.js
@@ -19,6 +19,7 @@ export class Instance {
         this._clientConnectionOptions = null;
         this._messageSizeMax = 0;
         this._batchAutoFlushSize = 0;
+        this._warnConnections = false;
         this._classGraphDepthMax = 0;
         this._toStringMode = ToStringMode.Unicode;
         this._implicitContext = null;

--- a/js/packages/ice/src/Ice/InstanceExtensions.js
+++ b/js/packages/ice/src/Ice/InstanceExtensions.js
@@ -134,6 +134,11 @@ Instance.prototype.batchAutoFlushSize = function () {
     return this._batchAutoFlushSize;
 };
 
+Instance.prototype.warnConnections = function () {
+    // This value is immutable.
+    return this._warnConnections;
+};
+
 Instance.prototype.classGraphDepthMax = function () {
     // This value is immutable.
     return this._classGraphDepthMax;
@@ -224,6 +229,8 @@ Instance.prototype.finishSetup = function (communicator) {
             // The property is specified in kibibytes (KiB); _batchAutoFlushSize is stored in bytes.
             this._batchAutoFlushSize = batchAutoFlushSize * 1024;
         }
+
+        this._warnConnections = this._initData.properties.getIcePropertyAsInt("Ice.Warn.Connections") > 0;
 
         let classGraphDepthMax = this._initData.properties.getIcePropertyAsInt("Ice.ClassGraphDepthMax");
         if (classGraphDepthMax < 1) {


### PR DESCRIPTION
The `ConnectionI` constructor read `Ice.Warn.Connections`, `Ice.Warn.Datagrams`, and `Ice.Compression.Level`, and the `BatchRequestQueue` it creates read `Ice.UDP.SndSize`. Property values are validated lazily at read time, so a malformed value (for example `Ice.Warn.Connections=x`) passed communicator initialization and then made these reads throw at the first connection. In C++ the `ConnectionI` constructor is `noexcept`, so the escaping `PropertyException` aborted the process with `std::terminate`; in the other mappings the failure surfaced as a confusing per-connection exception.

`Instance` now reads, validates, and caches these values during communicator initialization — following the existing pattern for `Ice.MessageSizeMax` and `Ice.BatchAutoFlushSize` — and the connection code uses the cached values. A malformed value now fails `initialize()` with a clear exception, in every mapping, before any connection is established. The out-of-range handling of `Ice.Compression.Level` (clamp to [1, 9]) is unchanged; only where the properties are read has moved.

This change applies to C++, C#, Java, and JS (which only reads `Ice.Warn.Connections`). As a side effect, changing one of these properties at run time with `setProperty` no longer affects subsequently created connections — the value set at initialization is used for the communicator's lifetime, consistently across mappings.

Fixes #6103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)