### PR TITLE
Validate the delay passed to the C# timer and the invocation timeout

### DIFF
--- a/changelog.d/csharp/6102.md
+++ b/changelog.d/csharp/6102.md
@@ -1,0 +1,3 @@
+- Fixed `ice_invocationTimeout(TimeSpan)`: setting an invocation timeout greater than `int.MaxValue` milliseconds
+  (about 24.9 days) could crash the process with an unhandled exception in the Ice timer thread. Such timeouts are
+  now rejected with an `ArgumentOutOfRangeException`.

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -469,7 +469,7 @@ public abstract class ProxyOutgoingAsyncBase : OutgoingAsyncBase, TimerTask
                 TimeSpan invocationTimeout = proxy_.iceReference().getInvocationTimeout();
                 if (invocationTimeout > TimeSpan.Zero)
                 {
-                    instance_.timer().schedule(this, (long)invocationTimeout.TotalMilliseconds);
+                    instance_.timer().schedule(this, invocationTimeout);
                 }
             }
             else

--- a/csharp/src/Ice/Internal/RetryQueue.cs
+++ b/csharp/src/Ice/Internal/RetryQueue.cs
@@ -67,6 +67,7 @@ public class RetryQueue
 
     public void add(ProxyOutgoingAsyncBase outAsync, int interval)
     {
+        Debug.Assert(interval >= 0);
         lock (_mutex)
         {
             if (_instance == null)
@@ -75,7 +76,7 @@ public class RetryQueue
             }
             var task = new RetryTask(_instance, this, outAsync);
             outAsync.cancelable(task); // This will throw if the request is canceled.
-            _instance.timer().schedule(task, interval);
+            _instance.timer().schedule(task, TimeSpan.FromMilliseconds(interval));
             _requests.Add(task, null);
         }
     }

--- a/csharp/src/Ice/Internal/Timer.cs
+++ b/csharp/src/Ice/Internal/Timer.cs
@@ -36,8 +36,15 @@ public sealed class Timer
         _thread.Join();
     }
 
-    public void schedule(TimerTask task, long delay)
+    public void schedule(TimerTask task, TimeSpan delay)
     {
+        if (delay < TimeSpan.Zero || delay > TimeSpan.FromMilliseconds(int.MaxValue))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(delay),
+                $"The timer delay must be between 0 and {int.MaxValue} milliseconds.");
+        }
+
         lock (_mutex)
         {
             if (_instance == null)
@@ -45,7 +52,11 @@ public sealed class Timer
                 throw new Ice.CommunicatorDestroyedException();
             }
 
-            var token = new Token(Time.currentMonotonicTimeMillis() + delay, ++_tokenId, 0, task);
+            var token = new Token(
+                Time.currentMonotonicTimeMillis() + (long)delay.TotalMilliseconds,
+                ++_tokenId,
+                0,
+                task);
 
             try
             {
@@ -187,6 +198,9 @@ public sealed class Timer
                     }
 
                     _wakeUpTime = first.scheduledTime;
+                    // The wait duration fits in an int: schedule rejects delays larger than int.MaxValue, and the
+                    // monotonic clock only moves forward after that.
+                    Debug.Assert(first.scheduledTime - now <= int.MaxValue);
                     Monitor.Wait(_mutex, (int)(first.scheduledTime - now));
                 }
 

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -235,7 +235,10 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
     /// </summary>
-    /// <param name="newTimeout">The new invocation timeout.</param>
+    /// <param name="newTimeout">The new invocation timeout. A positive timeout is rounded down to the nearest
+    /// millisecond.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newTimeout"/> is greater than
+    /// <see cref="int.MaxValue"/> milliseconds.</exception>
     ObjectPrx ice_invocationTimeout(TimeSpan newTimeout);
 
     /// <summary>
@@ -1044,8 +1047,17 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// </summary>
     /// <param name="newTimeout">The new invocation timeout.</param>
     /// <returns>The new proxy with the specified invocation timeout.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newTimeout"/> is greater than
+    /// <see cref="int.MaxValue"/> milliseconds.</exception>
     public ObjectPrx ice_invocationTimeout(TimeSpan newTimeout)
     {
+        if (newTimeout > TimeSpan.FromMilliseconds(int.MaxValue))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(newTimeout),
+                $"The invocation timeout cannot be greater than {int.MaxValue} milliseconds.");
+        }
+
         if (newTimeout == _reference.getInvocationTimeout())
         {
             return this;

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -1045,7 +1045,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
     /// </summary>
-    /// <param name="newTimeout">The new invocation timeout.</param>
+    /// <param name="newTimeout">The new invocation timeout. A positive timeout is rounded down to the nearest
+    /// millisecond.</param>
     /// <returns>The new proxy with the specified invocation timeout.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newTimeout"/> is greater than
     /// <see cref="int.MaxValue"/> milliseconds.</exception>

--- a/csharp/src/IceDiscovery/LookupI.cs
+++ b/csharp/src/IceDiscovery/LookupI.cs
@@ -89,7 +89,7 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
         {
             // We only reach here with _proxies empty, i.e. no replica-group response arrived. _latency is set only
             // together with inserting into _proxies, so the latency timer is not running.
-            Debug.Assert(_latency == 0);
+            Debug.Assert(_latency == TimeSpan.Zero);
 
             // Restart the replica-group latency window so it's measured from this round rather than from request
             // creation.
@@ -104,12 +104,12 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
         if (isReplicaGroup)
         {
             _proxies.Add(proxy);
-            if (_latency == 0)
+            if (_latency == TimeSpan.Zero)
             {
                 // The aggregation window is the measured response time, scaled by IceDiscovery.LatencyMultiplier,
                 // with a 1ms floor so we never schedule a degenerate zero-length window.
                 double responseTimeMs = TimeSpan.FromTicks(DateTime.Now.Ticks - _start).TotalMilliseconds;
-                _latency = Math.Max(1, (long)(responseTimeMs * lookup_.latencyMultiplier()));
+                _latency = TimeSpan.FromMilliseconds(Math.Max(1, (long)(responseTimeMs * lookup_.latencyMultiplier())));
                 lookup_.timer().cancel(this);
                 lookup_.timer().schedule(this, _latency);
             }
@@ -178,7 +178,7 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
     //
     private readonly HashSet<Ice.ObjectPrx> _proxies = new HashSet<Ice.ObjectPrx>();
     private long _start;
-    private long _latency;
+    private TimeSpan _latency;
 }
 
 internal class ObjectRequest : Request<Ice.Identity>, Ice.Internal.TimerTask
@@ -226,7 +226,7 @@ internal class LookupI : LookupDisp_
     {
         _registry = registry;
         _lookup = lookup;
-        _timeout = properties.getIcePropertyAsInt("IceDiscovery.Timeout");
+        _timeout = TimeSpan.FromMilliseconds(properties.getIcePropertyAsInt("IceDiscovery.Timeout"));
         _retryCount = properties.getIcePropertyAsInt("IceDiscovery.RetryCount");
         _latencyMultiplier = properties.getIcePropertyAsInt("IceDiscovery.LatencyMultiplier");
         if (_latencyMultiplier < 1)
@@ -541,7 +541,7 @@ internal class LookupI : LookupDisp_
     private readonly LocatorRegistryI _registry;
     private readonly LookupPrx _lookup;
     private readonly Dictionary<LookupPrx, LookupReplyPrx> _lookups = new Dictionary<LookupPrx, LookupReplyPrx>();
-    private readonly int _timeout;
+    private readonly TimeSpan _timeout;
     private readonly int _retryCount;
     private readonly int _latencyMultiplier;
     private readonly string _domainId;

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -113,10 +113,10 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
     LocatorI(LookupPrx lookup, Ice.Properties properties, string instanceName, Ice.LocatorPrx voidLocator)
     {
         _lookup = lookup;
-        _timeout = properties.getIcePropertyAsInt("IceLocatorDiscovery.Timeout");
-        if (_timeout < 0)
+        _timeout = TimeSpan.FromMilliseconds(properties.getIcePropertyAsInt("IceLocatorDiscovery.Timeout"));
+        if (_timeout < TimeSpan.Zero)
         {
-            _timeout = 300;
+            _timeout = TimeSpan.FromMilliseconds(300);
         }
         _retryCount = properties.getIcePropertyAsInt("IceLocatorDiscovery.RetryCount");
         if (_retryCount < 0)
@@ -550,7 +550,7 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
 
     private readonly LookupPrx _lookup;
     private readonly Dictionary<LookupPrx, LookupReplyPrx> _lookups = new Dictionary<LookupPrx, LookupReplyPrx>();
-    private readonly int _timeout;
+    private readonly TimeSpan _timeout;
     private readonly Ice.Internal.Timer _timer;
     private readonly int _traceLevel;
     private readonly int _retryCount;

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -583,6 +583,16 @@ public class AllTests : global::Test.AllTests
         test(baseProxy.ice_invocationTimeout(0).ice_getInvocationTimeout() == TimeSpan.Zero);
         test(baseProxy.ice_invocationTimeout(-1).ice_getInvocationTimeout() == TimeSpan.FromMilliseconds(-1));
         test(baseProxy.ice_invocationTimeout(-2).ice_getInvocationTimeout() == TimeSpan.FromMilliseconds(-2));
+        test(baseProxy.ice_invocationTimeout(int.MaxValue).ice_getInvocationTimeout() ==
+            TimeSpan.FromMilliseconds(int.MaxValue));
+        try
+        {
+            baseProxy.ice_invocationTimeout(TimeSpan.FromDays(30));
+            test(false);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+        }
 
         test(baseProxy.ice_locatorCacheTimeout(0).ice_getLocatorCacheTimeout() == TimeSpan.Zero);
         test(baseProxy.ice_locatorCacheTimeout(-1).ice_getLocatorCacheTimeout() == TimeSpan.FromSeconds(-1));


### PR DESCRIPTION
In C#, `ice_invocationTimeout(TimeSpan)` accepted any `TimeSpan` value. For a timeout greater than `int.MaxValue` milliseconds (about 24.9 days), the Ice timer thread narrowed the wait delay to `int` in `Monitor.Wait(_mutex, (int)(first.scheduledTime - now))` once that deadline became the earliest pending one; the wrapped negative value made `Monitor.Wait` throw `ArgumentOutOfRangeException` outside any try block, and the unhandled exception on the timer thread terminated the process.

The root issue is that `Timer.schedule` accepted delays the timer cannot wait. `schedule` now takes a `TimeSpan` delay, performs the milliseconds conversion itself, and validates the delay against the range the timer supports (0 to `int.MaxValue` milliseconds), throwing `ArgumentOutOfRangeException` in the caller's thread — no caller can schedule a delay that would crash the timer thread. A `Debug.Assert` in the timer loop records why the narrowing to `int` is now safe.

`ice_invocationTimeout(TimeSpan)` also validates its argument against the same bound, so an unusable invocation timeout is rejected when it is set rather than at the next invocation. Values less than or equal to zero keep their existing "no timeout" semantics, consistent with the other language mappings and the existing tests, and a positive timeout is now documented to round down to the nearest millisecond.

Also adds a `Debug.Assert(interval >= 0)` in `RetryQueue.add` documenting the caller contract (0 is a valid interval, used for immediate retries).

Fixes #6102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)