### PR TITLE
Let PropertyException propagate from the ConnectionI constructor

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1878,7 +1878,7 @@ Ice::ConnectionI::ConnectionI(
     const EndpointIPtr& endpoint,
     const shared_ptr<ObjectAdapterI>& adapter,
     std::function<void(const ConnectionIPtr&)> removeFromFactory,
-    const ConnectionOptions& options) noexcept
+    const ConnectionOptions& options)
     : _communicator(std::move(communicator)),
       _instance(instance),
       _transceiver(transceiver),

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -249,7 +249,7 @@ namespace Ice
             const IceInternal::EndpointIPtr&,
             const std::shared_ptr<ObjectAdapterI>&,
             std::function<void(const ConnectionIPtr&)>,
-            const ConnectionOptions&) noexcept;
+            const ConnectionOptions&);
 
         static ConnectionIPtr create(
             const Ice::CommunicatorPtr&,

--- a/cpp/src/Ice/IdleTimeoutTransceiverDecorator.cpp
+++ b/cpp/src/Ice/IdleTimeoutTransceiverDecorator.cpp
@@ -70,15 +70,18 @@ IdleTimeoutTransceiverDecorator::initialize(Buffer& readBuffer, Buffer& writeBuf
 
 IdleTimeoutTransceiverDecorator::~IdleTimeoutTransceiverDecorator()
 {
-    // Since ConnectionI is noexcept, decoratorInit always sets _heartbeatTimerTask.
-    assert(_heartbeatTimerTask);
-    _timer->cancel(_heartbeatTimerTask);
+    // _heartbeatTimerTask remains null when the connection creation fails before decoratorInit is called.
+    if (_heartbeatTimerTask)
+    {
+        _timer->cancel(_heartbeatTimerTask);
+    }
     disableIdleCheck();
 }
 
 void
 IdleTimeoutTransceiverDecorator::close()
 {
+    assert(_heartbeatTimerTask); // close is only called on a connection that completed decoratorInit.
     _timer->cancel(_heartbeatTimerTask);
     disableIdleCheck();
     _decoratee->close();

--- a/cpp/test/Ice/properties/Client.cpp
+++ b/cpp/test/Ice/properties/Client.cpp
@@ -275,6 +275,25 @@ Client::run(int, char**)
         communicator->destroy();
         cout << " ok" << endl;
     }
+
+    {
+        cout << "testing that a connection attempt with an invalid connection property throws an exception... "
+             << flush;
+        Ice::InitializationData initData;
+        initData.properties = Ice::createProperties();
+        initData.properties->setProperty("Ice.Warn.Connections", "x");
+        Ice::CommunicatorHolder communicator = Ice::initialize(std::move(initData));
+        Ice::ObjectPrx p{communicator.communicator(), "test:tcp -h 127.0.0.1 -p 12345"};
+        try
+        {
+            p->ice_ping();
+            test(false);
+        }
+        catch (const Ice::PropertyException&)
+        {
+        }
+        cout << "ok" << endl;
+    }
 }
 
 DEFINE_TEST(Client)


### PR DESCRIPTION
In C++, the `ConnectionI` constructor is declared `noexcept` but reads integer properties (`Ice.Warn.Connections`, `Ice.Warn.Datagrams`, `Ice.Compression.Level`, and `Ice.UDP.SndSize` through the `BatchRequestQueue` it creates) whose parser throws `PropertyException` on a value that cannot be parsed. Property values are validated lazily at read time, so an invalid value passed communicator initialization and then aborted the process with `std::terminate` at the first connection.

This PR removes `noexcept` from the constructor. All three `ConnectionI::create` call sites already catch `LocalException`: an outgoing connection attempt now reports the `PropertyException` to the invocation, an incoming connection attempt logs a warning and refuses the connection, and the UDP bind-time path fails object-adapter creation with the exception. When the properties are read is unchanged.

The new test in `Ice/properties` establishes an outgoing connection with `Ice.Warn.Connections` set to an invalid value and expects `PropertyException`; without the fix, the client aborts with `SIGABRT`.

Fixes #6103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)