### PR TITLE
Wait on the writer for the late reader in the DataStorm events test

### DIFF
--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -620,7 +620,6 @@ void ::Reader::run(int argc, char* argv[])
     {
         Topic<string, string> topic(node, "lateEmptyBatch");
         Topic<string, int> barrier(node, "lateEmptyBatchBarrier");
-        Topic<string, int> ready(node, "lateEmptyBatchReady");
 
         {
             auto probe = makeSingleKeyReader(topic, "elemA", "", config);
@@ -631,10 +630,6 @@ void ::Reader::run(int argc, char* argv[])
 
         auto reader = makeSingleKeyReader(topic, "elemB", "", config);
         reader.waitForWriters(1); // attached via the empty initialization batch; a live sample is now delivered
-
-        auto readyWriter = makeSingleKeyWriter(ready, "ready");
-        readyWriter.waitForReaders();
-        readyWriter.update(0);
 
         // elemB had no queued sample, so initialization delivered nothing; the live update is the first sample.
         auto sample = reader.getNextUnread();

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -509,7 +509,6 @@ void ::Writer::run(int argc, char* argv[])
     {
         Topic<string, string> topic(node, "lateEmptyBatch");
         Topic<string, int> barrier(node, "lateEmptyBatchBarrier");
-        Topic<string, int> ready(node, "lateEmptyBatchReady");
 
         auto writer = makeMultiKeyWriter(topic, {"elemA", "elemB"}, "", config);
         writer.add("elemA", "valueA"); // elemB is covered but never written
@@ -518,8 +517,12 @@ void ::Writer::run(int argc, char* argv[])
         barrierWriter.waitForReaders();
         barrierWriter.update(0);
 
+        // Wait for the late reader on this writer rather than for a signal published by the reader: the reader
+        // publishes on its publisher session while it acknowledges this writer's attachment on its subscriber
+        // session, and the two sessions are independent, so a signal can arrive before the acknowledgment.
+        writer.waitForReaders(1);
+
         // Delivered only if the empty initialization batch for elemB marked the reader initialized.
-        [[maybe_unused]] auto _ = makeSingleKeyReader(ready, "ready").getNextUnread();
         writer.update("elemB", "valueB");
         writer.waitForNoReaders();
     }

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -517,9 +517,8 @@ void ::Writer::run(int argc, char* argv[])
         barrierWriter.waitForReaders();
         barrierWriter.update(0);
 
-        // Wait for the late reader on this writer rather than for a signal published by the reader: the reader
-        // publishes on its publisher session while it acknowledges this writer's attachment on its subscriber
-        // session, and the two sessions are independent, so a signal can arrive before the acknowledgment.
+        // Wait for the late reader: its attachment queues the empty initialization batch, and the update below is
+        // delivered after that batch on the same session.
         writer.waitForReaders(1);
 
         // Delivered only if the empty initialization batch for elemB marked the reader initialized.


### PR DESCRIPTION
Fixes #6187.

## The hang

`cpp/DataStorm/events` hung for the full 6h job cap on `amzn2023-aarch64` ([run 30103774710](https://github.com/zeroc-ice/ice/actions/runs/30103774710/job/89516045816)). The `test-logs-amzn2023-aarch64` artifact has both nodes' trace logs, and they stop dead at the same millisecond in the `Writer/Reader multicast enabled` case:

- The reader attaches its late `elemB` reader and **sends** `attachElementsAck` at `.362` (`s/1: attaching elements matched '[e2:pe1:sz0:k3:pvk3]@24'`).
- It then creates the `ready` writer and publishes at `.363`.
- The writer **never logs `attaching elements ack`** for that element, but does process the `ready` sample at `.363`, runs `writer.update("elemB", "valueB")` with zero listeners, returns from `waitForNoReaders()` immediately, and destroys the topic.

So a message the reader sent *first* was overtaken by one it sent *second*: the reader blocks forever in `getNextUnread()`, the writer blocks in the next scenario's `barrierWriter.waitForReaders()`.

## Why the two messages are unordered

`reader.waitForWriters(1)` is satisfied purely reader-side, when the reader processes the writer's `attachElements` — before its acknowledgment reaches the writer. The acknowledgment travels on the reader's **subscriber** session; the `lateEmptyBatchReady` signal travels on its **publisher** session. DataStorm orders messages within a session, never across sessions, so the signal can arrive first.

That also explains why only the multicast case hangs:

| config | topology | ordered? |
|---|---|---|
| `Writer/Reader` | writer runs with `Node.Server.Enabled=0` + `ConnectTo`, so both sessions share the single connection and the writer dispatches them on its single-threaded client thread pool | incidentally |
| `Writer/Reader multicast enabled` | both nodes have adapters and each initiates, so the two sessions sit on different connections | no |

The default case is not a guarantee — nothing in DataStorm promises ordering across sessions, so it survives only as an accident of that topology and of `Ice.ThreadPool.Client.Size` defaulting to 1 (see #6195).

The sibling scenarios are not affected. `lateFilter` and `coalescedSameKey` gate on `waitForUnread(n)` over non-empty initialization samples, which can only exist after the writer processed the acknowledgment; `lateInterleaved` and `lateAnyKeyWriter` send `done` only after draining, and the writer publishes nothing afterwards. `lateEmptyBatch` is exposed precisely because its initialization batch is empty, so there is no sample to wait on.

## The change

Wait on the writer instead of on a signal from the reader, and drop the now-redundant `lateEmptyBatchReady` topic. The acknowledgment registers the reader and queues its empty initialization batch while holding the topic mutex that `waitForReaders` acquires, so the barrier cannot return in between, and the live sample then follows on the same session.

## Testing

`DataStorm/events` passes 25 consecutive runs and the full `DataStorm/*` suite passes (10/10).

I could not reproduce the hang locally: 50 runs of the pre-fix build under saturating CPU load all passed. The race needs the `ready` sample to overtake the acknowledgment across the two sessions, which does not happen readily on loopback on an unloaded machine. The evidence for the mechanism is the CI trace above rather than a local red run.

Test-only change, so no changelog fragment — matching #5892 and #5904, the previous flaky DataStorm test fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
