### PR TITLE
Use weak ownership for DataStorm topic subscribers

### DIFF
--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -296,7 +296,7 @@ namespace DataStormI
         void waitForListeners(int count) const;
         [[nodiscard]] bool hasListeners() const;
 
-        [[nodiscard]] TopicI* getTopic() const { return _parent.get(); }
+        [[nodiscard]] const std::shared_ptr<TopicI>& getTopic() const { return _parent; }
 
     protected:
         virtual bool addConnectedKey(const std::shared_ptr<Key>& key, const std::shared_ptr<Subscriber>& subscriber);

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -158,16 +158,9 @@ SessionI::announceTopics(TopicInfoSeq topics, bool, const Current&)
         auto p = _topics.begin();
         while (p != _topics.end())
         {
-            auto detach = [this, topicId = p->first](TopicI* topic, TopicSubscriber& subscriber)
+            auto detach = [this, topicId = p->first](const shared_ptr<TopicI>& topic)
             {
-                if (subscriber.getAll().empty())
-                {
-                    // No element subscriptions: nothing to detach. The element subscribers are also what keeps the
-                    // topic alive (each element holds its parent topic), so the topic must not be dereferenced here.
-                    return;
-                }
                 unique_lock<mutex> topicLock(topic->getMutex());
-                _topicLock = &topicLock;
                 if (topic->isDestroyed())
                 {
                     // The topic is being destroyed: TopicI::disconnect detaches its elements only while the
@@ -181,7 +174,6 @@ SessionI::announceTopics(TopicInfoSeq topics, bool, const Current&)
                     // session from the topic's listeners.
                     topic->detach(topicId, shared_from_this());
                 }
-                _topicLock = nullptr;
             };
             if (p->second.reap(_sessionInstanceId, detach))
             {
@@ -226,7 +218,7 @@ SessionI::attachTopic(TopicSpec spec, const Current&)
                 // If the topic spec has tags, decode them and add them to the subscriber.
                 if (!spec.tags.empty())
                 {
-                    auto& subscriber = _topics.at(spec.id).getSubscriber(topic.get());
+                    auto& subscriber = _topics.at(spec.id).getSubscriber(topic);
                     for (const auto& tag : spec.tags)
                     {
                         subscriber.tags[tag.id] =
@@ -273,10 +265,15 @@ SessionI::detachTopic(int64_t id, const Current&)
         return;
     }
 
-    for (auto& [topic, _] : t->second.getSubscribers())
+    for (auto& [topicRef, _] : t->second.getSubscribers())
     {
+        auto topic = topicRef.lock();
+        if (!topic)
+        {
+            continue;
+        }
+
         unique_lock<mutex> topicLock(topic->getMutex());
-        _topicLock = &topicLock;
         if (topic->isDestroyed())
         {
             // The topic is being destroyed: TopicI::disconnect detaches its elements only while the subscriber
@@ -292,7 +289,6 @@ SessionI::detachTopic(int64_t id, const Current&)
             }
             topic->detach(id, shared_from_this());
         }
-        _topicLock = nullptr;
     }
 
     // Erase the topic
@@ -310,7 +306,7 @@ SessionI::attachTags(int64_t topicId, ElementInfoSeq tags, bool initialize, cons
 
     runWithTopics(
         topicId,
-        [&](TopicI* topic, TopicSubscriber& subscriber)
+        [&](const shared_ptr<TopicI>& topic, TopicSubscriber& subscriber)
         {
             if (_traceLevels->session > 2)
             {
@@ -341,7 +337,7 @@ SessionI::detachTags(int64_t topicId, LongSeq tags, const Current&)
 
     runWithTopics(
         topicId,
-        [&](TopicI* topic, TopicSubscriber& subscriber)
+        [&](const shared_ptr<TopicI>& topic, TopicSubscriber& subscriber)
         {
             if (_traceLevels->session > 2)
             {
@@ -367,7 +363,7 @@ SessionI::announceElements(int64_t topicId, ElementInfoSeq elements, const Curre
 
     runWithTopics(
         topicId,
-        [&](TopicI* topic, TopicSubscriber&)
+        [&](const shared_ptr<TopicI>& topic, TopicSubscriber&)
         {
             if (_traceLevels->session > 2)
             {
@@ -406,7 +402,7 @@ SessionI::attachElements(int64_t topicId, int64_t peerTopicId, ElementSpecSeq el
     runWithTopics(
         topicId,
         peerTopicId,
-        [&](TopicI* topic, TopicSubscriber& subscriber)
+        [&](const shared_ptr<TopicI>& topic, TopicSubscriber& subscriber)
         {
             if (_traceLevels->session > 2)
             {
@@ -455,7 +451,7 @@ SessionI::attachElementsAck(int64_t topicId, int64_t peerTopicId, ElementSpecAck
     runWithTopics(
         topicId,
         peerTopicId,
-        [&](TopicI* topic, TopicSubscriber&)
+        [&](const shared_ptr<TopicI>& topic, TopicSubscriber&)
         {
             if (_traceLevels->session > 2)
             {
@@ -499,7 +495,7 @@ SessionI::detachElements(int64_t id, LongSeq elements, const Current&)
 
     runWithTopics(
         id,
-        [&](TopicI* topic, TopicSubscriber& subscriber)
+        [&](const shared_ptr<TopicI>& topic, TopicSubscriber& subscriber)
         {
             if (_traceLevels->session > 2)
             {
@@ -550,7 +546,7 @@ SessionI::initSamples(int64_t topicId, int64_t peerTopicId, DataSamplesSeq initi
         runWithTopics(
             topicId,
             peerTopicId,
-            [&](TopicI* topic, TopicSubscriber& subscriber)
+            [&](const shared_ptr<TopicI>& topic, TopicSubscriber& subscriber)
             {
                 ElementSubscribers* elementSubscribers = subscriber.get(initializationBatch.id);
                 if (!elementSubscribers)
@@ -772,7 +768,9 @@ SessionI::disconnectedImpl(const ConnectionPtr& connection, exception_ptr ex)
         // The analyzer falsely flags the lambda's captures as undefined: it loses track of the closure once it
         // is stored in runWithTopics' std::function parameter.
         // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
-        runWithTopics(topicId, [topicId, self](TopicI* topic, TopicSubscriber&) { topic->detach(topicId, self); });
+        runWithTopics(
+            topicId,
+            [topicId, self](const shared_ptr<TopicI>& topic, TopicSubscriber&) { topic->detach(topicId, self); });
     }
 
     // The peer's wire disconnected() op is not a connection close, so unregister the session that connected()
@@ -959,10 +957,15 @@ SessionI::destroyImpl(const exception_ptr& ex)
         auto self = shared_from_this();
         for (auto& [topicId, subscribers] : _topics)
         {
-            for (auto& [topic, _] : subscribers.getSubscribers())
+            for (auto& [topicRef, _] : subscribers.getSubscribers())
             {
+                auto topic = topicRef.lock();
+                if (!topic)
+                {
+                    continue;
+                }
+
                 unique_lock<mutex> topicLock(topic->getMutex());
-                _topicLock = &topicLock;
                 if (topic->isDestroyed())
                 {
                     // The topic is being destroyed: TopicI::disconnect detaches its elements only while the
@@ -973,7 +976,6 @@ SessionI::destroyImpl(const exception_ptr& ex)
                 {
                     topic->detach(topicId, self);
                 }
-                _topicLock = nullptr;
             }
         }
         _topics.clear();
@@ -1071,7 +1073,7 @@ SessionI::setNode(NodePrx node)
 }
 
 void
-SessionI::subscribe(int64_t topicId, TopicI* topic)
+SessionI::subscribe(int64_t topicId, const shared_ptr<TopicI>& topic)
 {
     if (_traceLevels->session > 1)
     {
@@ -1083,7 +1085,7 @@ SessionI::subscribe(int64_t topicId, TopicI* topic)
 }
 
 void
-SessionI::unsubscribe(int64_t topicId, TopicI* topic)
+SessionI::unsubscribe(int64_t topicId, const shared_ptr<TopicI>& topic)
 {
     assert(_topics.find(topicId) != _topics.end());
     auto& subscriber = _topics.at(topicId).getSubscriber(topic);
@@ -1113,7 +1115,7 @@ SessionI::unsubscribe(int64_t topicId, TopicI* topic)
 }
 
 void
-SessionI::disconnect(int64_t topicId, TopicI* topic)
+SessionI::disconnect(int64_t topicId, const shared_ptr<TopicI>& topic)
 {
     lock_guard<mutex> lock(_mutex); // Called by TopicI::destroy
 
@@ -1131,12 +1133,10 @@ SessionI::disconnect(int64_t topicId, TopicI* topic)
     // disconnect() is called from TopicI::destroy() after the topic is marked destroyed, so detach the listeners
     // directly here instead of through runWithTopic, which skips destroyed topics. Skipping the unsubscribe (and the
     // element detachKey/detachFilter it drives) would leave TopicI::_listenerCount stale and trip a debug assert.
-    if (subscriber.getSubscribers().find(topic) != subscriber.getSubscribers().end())
+    if (subscriber.getSubscribers().find(weak_ptr<TopicI>{topic}) != subscriber.getSubscribers().end())
     {
         unique_lock<mutex> topicLock(topic->getMutex());
-        _topicLock = &topicLock;
         unsubscribe(topicId, topic);
-        _topicLock = nullptr;
     }
 
     subscriber.removeSubscriber(topic);
@@ -1431,50 +1431,66 @@ SessionI::runWithTopics(
         {
             continue;
         }
-        _topicLock = &lock;
         callback(topic);
-        _topicLock = nullptr;
     }
 }
 
 void
-SessionI::runWithTopics(int64_t topicId, const function<void(TopicI*, TopicSubscriber&)>& callback)
+SessionI::runWithTopics(int64_t topicId, const function<void(const shared_ptr<TopicI>&, TopicSubscriber&)>& callback)
 {
     auto t = _topics.find(topicId);
     if (t != _topics.end())
     {
-        for (auto& [topic, subscriber] : t->second.getSubscribers())
+        auto& subscribers = t->second.getSubscribers();
+        auto p = subscribers.begin();
+        while (p != subscribers.end())
         {
-            unique_lock<mutex> lock(topic->getMutex());
-            if (topic->isDestroyed())
+            auto topic = p->first.lock();
+            if (!topic)
             {
+                p = subscribers.erase(p);
                 continue;
             }
-            _topicLock = &lock;
-            callback(topic, subscriber);
-            _topicLock = nullptr;
+
+            unique_lock<mutex> lock(topic->getMutex());
+            if (!topic->isDestroyed())
+            {
+                callback(topic, p->second);
+            }
+            ++p;
         }
     }
 }
 
 void
-SessionI::runWithTopics(int64_t topicId, int64_t peerTopicId, const function<void(TopicI*, TopicSubscriber&)>& callback)
+SessionI::runWithTopics(
+    int64_t topicId,
+    int64_t peerTopicId,
+    const function<void(const shared_ptr<TopicI>&, TopicSubscriber&)>& callback)
 {
     auto t = _topics.find(topicId);
     if (t != _topics.end())
     {
-        for (auto& [topic, subscriber] : t->second.getSubscribers())
+        auto& subscribers = t->second.getSubscribers();
+        auto p = subscribers.begin();
+        while (p != subscribers.end())
         {
+            auto topic = p->first.lock();
+            if (!topic)
+            {
+                p = subscribers.erase(p);
+                continue;
+            }
+
             if (topic->getId() != peerTopicId)
             {
+                ++p;
                 continue;
             }
             unique_lock<mutex> lock(topic->getMutex());
             if (!topic->isDestroyed())
             {
-                _topicLock = &lock;
-                callback(topic, subscriber);
-                _topicLock = nullptr;
+                callback(topic, p->second);
             }
             return;
         }
@@ -1492,12 +1508,15 @@ SessionI::runWithTopics(int64_t topicId, int64_t peerTopicId, const function<voi
 }
 
 void
-SessionI::runWithTopic(int64_t topicId, TopicI* topic, const function<void(TopicSubscriber&)>& callback)
+SessionI::runWithTopic(
+    int64_t topicId,
+    const shared_ptr<TopicI>& topic,
+    const function<void(TopicSubscriber&)>& callback)
 {
     auto t = _topics.find(topicId);
     if (t != _topics.end())
     {
-        auto p = t->second.getSubscribers().find(topic);
+        auto p = t->second.getSubscribers().find(weak_ptr<TopicI>{topic});
         if (p != t->second.getSubscribers().end())
         {
             unique_lock<mutex> lock(topic->getMutex());
@@ -1505,9 +1524,7 @@ SessionI::runWithTopic(int64_t topicId, TopicI* topic, const function<void(Topic
             {
                 return;
             }
-            _topicLock = &lock;
             callback(p->second);
-            _topicLock = nullptr;
         }
     }
 }
@@ -1554,7 +1571,7 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
     auto now = chrono::system_clock::now();
     runWithTopics(
         topicId,
-        [&](TopicI* topic, TopicSubscriber& topicSubscriber)
+        [&](const shared_ptr<TopicI>& topic, TopicSubscriber& topicSubscriber)
         {
             auto elementSubscribers = topicSubscriber.get(elementId);
             if (elementSubscribers && !elementSubscribers->getSubscribers().empty())

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1477,8 +1477,8 @@ SessionI::runWithTopics(
         auto p = subscribers.begin();
         while (p != subscribers.end())
         {
-            // The shared_ptr returned by lock() can be the last owning reference. TopicI's destructor must remain
-            // callback-free because the caller holds the session mutex.
+            // lock() can return the last owning reference, so the topic can be destroyed at the end of
+            // this iteration, while the session mutex is held.
             auto topic = p->first.lock();
             if (!topic)
             {

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1445,8 +1445,8 @@ SessionI::runWithTopics(int64_t topicId, const function<void(const shared_ptr<To
         auto p = subscribers.begin();
         while (p != subscribers.end())
         {
-            // The shared_ptr returned by lock() can be the last owning reference. TopicI's destructor must remain
-            // callback-free because the caller holds the session mutex.
+            // lock() can return the last owning reference, so the topic can be destroyed at the end of
+            // this iteration, while the session mutex is held.
             auto topic = p->first.lock();
             if (!topic)
             {

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1445,6 +1445,8 @@ SessionI::runWithTopics(int64_t topicId, const function<void(const shared_ptr<To
         auto p = subscribers.begin();
         while (p != subscribers.end())
         {
+            // The shared_ptr returned by lock() can be the last owning reference. TopicI's destructor must remain
+            // callback-free because the caller holds the session mutex.
             auto topic = p->first.lock();
             if (!topic)
             {
@@ -1475,6 +1477,8 @@ SessionI::runWithTopics(
         auto p = subscribers.begin();
         while (p != subscribers.end())
         {
+            // The shared_ptr returned by lock() can be the last owning reference. TopicI's destructor must remain
+            // callback-free because the caller holds the session mutex.
             auto topic = p->first.lock();
             if (!topic)
             {

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -196,54 +196,54 @@ namespace DataStormI
         class TopicSubscribers
         {
         public:
+            using SubscriberMap = std::map<std::weak_ptr<TopicI>, TopicSubscriber, std::owner_less<>>;
+
             // Add the given topic as a subscriber, if a subscription already exists, update the session instance id.
-            void addSubscriber(TopicI* topic, int sessionInstanceId)
+            void addSubscriber(const std::shared_ptr<TopicI>& topic, int sessionInstanceId)
             {
                 _sessionInstanceId = sessionInstanceId;
-                auto p = _subscribers.find(topic);
+                auto p = _subscribers.find(std::weak_ptr<TopicI>{topic});
                 if (p != _subscribers.end())
                 {
                     p->second.sessionInstanceId = sessionInstanceId;
                 }
                 else
                 {
-                    _subscribers.emplace(topic, TopicSubscriber(sessionInstanceId));
+                    _subscribers.emplace(std::weak_ptr<TopicI>{topic}, TopicSubscriber(sessionInstanceId));
                 }
             }
 
-            [[nodiscard]] TopicSubscriber& getSubscriber(TopicI* topic)
+            [[nodiscard]] TopicSubscriber& getSubscriber(const std::shared_ptr<TopicI>& topic)
             {
-                assert(_subscribers.find(topic) != _subscribers.end());
-                return _subscribers.at(topic);
+                auto p = _subscribers.find(std::weak_ptr<TopicI>{topic});
+                assert(p != _subscribers.end());
+                return p->second;
             }
 
-            void removeSubscriber(TopicI* topic) { _subscribers.erase(topic); }
-
-            std::map<TopicI*, TopicSubscriber>& getSubscribers() { return _subscribers; }
-
-            // Determine if the subscriber should be reaped. The detach callback is called for each removed
-            // subscriber, before it is removed.
-            [[nodiscard]] bool reap(int sessionInstanceId, const std::function<void(TopicI*, TopicSubscriber&)>& detach)
+            void removeSubscriber(const std::shared_ptr<TopicI>& topic)
             {
-                if (sessionInstanceId != _sessionInstanceId)
-                {
-                    // If using a prior session instance id, we can remove all subscribers.
-                    for (auto& [topic, subscriber] : _subscribers)
-                    {
-                        detach(topic, subscriber);
-                    }
-                    _subscribers.clear();
-                    return true;
-                }
+                _subscribers.erase(std::weak_ptr<TopicI>{topic});
+            }
 
+            SubscriberMap& getSubscribers() { return _subscribers; }
+
+            // Reap subscribers from prior session instances and subscribers whose topics no longer exist. The detach
+            // callback is called for each live subscriber before it is removed.
+            [[nodiscard]] bool
+            reap(int sessionInstanceId, const std::function<void(const std::shared_ptr<TopicI>&)>& detach)
+            {
                 auto p = _subscribers.begin();
                 while (p != _subscribers.end())
                 {
-                    if (p->second.sessionInstanceId != sessionInstanceId)
+                    auto topic = p->first.lock();
+                    if (!topic || sessionInstanceId != _sessionInstanceId ||
+                        p->second.sessionInstanceId != sessionInstanceId)
                     {
-                        // Remove the subscriber if it is using a prior session instance id.
-                        detach(p->first, p->second);
-                        _subscribers.erase(p++);
+                        if (topic)
+                        {
+                            detach(topic);
+                        }
+                        p = _subscribers.erase(p);
                     }
                     else
                     {
@@ -257,13 +257,14 @@ namespace DataStormI
 
         private:
             // Each entry in the map represents a subscriber to the same remote topic.
-            // The key is a pointer to the local topic object subscribing to the remote topic, and the TopicSubscriber
-            // object contains the subscription details.
-            std::map<TopicI*, TopicSubscriber> _subscribers;
+            // The key is the non-owning identity of the local topic object subscribing to the remote topic, and the
+            // TopicSubscriber object contains the subscription details. A weak key avoids retaining the topic through
+            // the Topic -> Session listener relationship and remains unambiguous if a later topic reuses its address.
+            SubscriberMap _subscribers;
 
             // The session instance id is incremented each time a session is reconnected. Subscribers with a different
             // session instance id can be discarded.
-            int _sessionInstanceId;
+            int _sessionInstanceId{0};
         };
 
     public:
@@ -327,9 +328,9 @@ namespace DataStormI
         [[nodiscard]] DataStormContract::NodePrx getNode() const;
         void setNode(DataStormContract::NodePrx);
 
-        void subscribe(std::int64_t, TopicI*);
-        void unsubscribe(std::int64_t, TopicI*);
-        void disconnect(std::int64_t, TopicI*);
+        void subscribe(std::int64_t, const std::shared_ptr<TopicI>&);
+        void unsubscribe(std::int64_t, const std::shared_ptr<TopicI>&);
+        void disconnect(std::int64_t, const std::shared_ptr<TopicI>&);
 
         void subscribeToKey(
             std::int64_t topicId,
@@ -398,7 +399,9 @@ namespace DataStormI
         ///
         /// @param topicId The ID of the topic to process.
         /// @param callback The callback function to execute for each subscriber.
-        void runWithTopics(std::int64_t topicId, const std::function<void(TopicI*, TopicSubscriber&)>& callback);
+        void runWithTopics(
+            std::int64_t topicId,
+            const std::function<void(const std::shared_ptr<TopicI>&, TopicSubscriber&)>& callback);
 
         /// Runs the provided callback for the single local topic subscribing to the remote topic `topicId` whose own
         /// id is `peerTopicId`. Routes a request to exactly the addressed topic instance instead of fanning it
@@ -412,7 +415,7 @@ namespace DataStormI
         void runWithTopics(
             std::int64_t topicId,
             std::int64_t peerTopicId,
-            const std::function<void(TopicI*, TopicSubscriber&)>& callback);
+            const std::function<void(const std::shared_ptr<TopicI>&, TopicSubscriber&)>& callback);
 
         /// Runs the provided callback function for the specified topic, if it is among the subscribers for the given
         /// topic ID.
@@ -421,7 +424,10 @@ namespace DataStormI
         /// @param topicId The ID of the topic to process.
         /// @param topic The topic to process.
         /// @param callback The callback function to execute for the subscriber.
-        void runWithTopic(std::int64_t topicId, TopicI* topic, const std::function<void(TopicSubscriber&)>& callback);
+        void runWithTopic(
+            std::int64_t topicId,
+            const std::shared_ptr<TopicI>& topic,
+            const std::function<void(TopicSubscriber&)>& callback);
 
         /// Returns the topics that match the specified name.
         ///
@@ -467,9 +473,6 @@ namespace DataStormI
         // - Key: The topic ID on the remote node.
         // - Value: A `TopicSubscribers` object containing the subscribers for the remote topic.
         std::map<std::int64_t, TopicSubscribers> _topics;
-
-        // The lock of the topic being processed by the callback function. See runWithTopics.
-        std::unique_lock<std::mutex>* _topicLock;
 
         // The proxy to the peer session, or `std::nullopt` if the session is disconnected.
         std::optional<DataStormContract::SessionPrx> _session;

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -215,9 +215,7 @@ namespace DataStormI
 
             [[nodiscard]] TopicSubscriber& getSubscriber(const std::shared_ptr<TopicI>& topic)
             {
-                auto p = _subscribers.find(std::weak_ptr<TopicI>{topic});
-                assert(p != _subscribers.end());
-                return p->second;
+                return _subscribers.at(std::weak_ptr<TopicI>{topic});
             }
 
             void removeSubscriber(const std::shared_ptr<TopicI>& topic)

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -312,7 +312,7 @@ TopicI::attach(int64_t topicId, shared_ptr<SessionI> session, SessionPrx peerSes
     // If the topic ID is successfully added, instruct the session to subscribe to the topic.
     if (p->second.topics.insert(topicId).second)
     {
-        p->first->subscribe(topicId, this);
+        p->first->subscribe(topicId, shared_from_this());
     }
 }
 
@@ -323,7 +323,7 @@ TopicI::detach(int64_t topicId, const shared_ptr<SessionI>& session)
     if (p != _listeners.end() && p->second.topics.erase(topicId))
     {
         // If the topic ID is removed, instruct the session to unsubscribe from the topic.
-        session->unsubscribe(topicId, this);
+        session->unsubscribe(topicId, shared_from_this());
 
         // If the session has no remaining subscribed topics, remove its listener from the list.
         if (p->second.topics.empty())
@@ -761,6 +761,7 @@ void
 TopicI::disconnect()
 {
     map<shared_ptr<SessionI>, Listener> listeners;
+    auto self = shared_from_this();
     {
         unique_lock<mutex> lock(_mutex);
         listeners.swap(_listeners);
@@ -770,7 +771,7 @@ TopicI::disconnect()
     {
         for (const auto& id : listener.topics)
         {
-            session->disconnect(id, this);
+            session->disconnect(id, self);
         }
     }
 


### PR DESCRIPTION
Fixes #6088.

SessionI now keys each remote-topic subscriber map by weak TopicI ownership identity. Every map consumer locks the weak key before accessing the topic mutex or state and discards expired entries. This avoids both dangling dereferences and collisions when a later topic reuses the same address, without introducing a Topic-to-Session-to-Topic ownership cycle.

The topic attach, detach, and disconnect paths now pass shared topic identity into SessionI, and DataElementI exposes its retained parent for subscriber lookup. This keeps the existing destroyed-topic cleanup from #5872 and #6087 intact: destroyed topics that are still alive remain available for cleanup, while actually expired topics are skipped safely.

This also removes SessionI::_topicLock. Its only reader was removed by #5597, leaving the member write-only and not exception-safe.

The related reconnect key bookkeeping in #5781 is intentionally not included: it has separate refcount semantics and needs its own fix.

No changelog fragment is included because this is defensive hardening for an invariant violation with no currently confirmed normal-operation trigger.

Testing:

- make -C cpp -j8 DataStorm
- python3 allTests.py --filter=DataStorm (11/11 passed)