### PR TITLE
Fix C# multicast address detection, cancellation registration retention, and endpoint parse overflow

### DIFF
--- a/changelog.d/csharp/6113.md
+++ b/changelog.d/csharp/6113.md
@@ -1,0 +1,5 @@
+- Fixed UDP multicast address detection: IPv4 addresses in the unicast range `223.0.0.0/8` and IPv6 unicast
+  addresses such as `ff::1` were incorrectly classified as multicast addresses.
+- Fixed a leak in asynchronous proxy invocations that supply a cancellation token: each invocation remained
+  registered with this token after completing, so a long-lived token retained the memory of all its completed
+  invocations.

--- a/changelog.d/csharp/6113.md
+++ b/changelog.d/csharp/6113.md
@@ -1,5 +1,3 @@
-- Fixed UDP multicast address detection: IPv4 addresses in the unicast range `223.0.0.0/8` and IPv6 unicast
-  addresses such as `ff::1` were incorrectly classified as multicast addresses.
 - Fixed a leak in asynchronous proxy invocations that supply a cancellation token: each invocation remained
   registered with this token after completing, so a long-lived token retained the memory of all its completed
   invocations.

--- a/csharp/src/Ice/Internal/IPEndpointI.cs
+++ b/csharp/src/Ice/Internal/IPEndpointI.cs
@@ -290,7 +290,7 @@ public abstract class IPEndpointI : EndpointI
             {
                 port_ = int.Parse(argument, CultureInfo.InvariantCulture);
             }
-            catch (FormatException ex)
+            catch (System.Exception ex) when (ex is FormatException or OverflowException)
             {
                 throw new ParseException($"invalid port value '{argument}' in endpoint '{endpoint}'", ex);
             }

--- a/csharp/src/Ice/Internal/Network.cs
+++ b/csharp/src/Ice/Internal/Network.cs
@@ -81,32 +81,15 @@ internal sealed class Network
 
     internal static bool isMulticast(IPEndPoint addr)
     {
-        string ip = addr.Address.ToString().ToUpperInvariant();
         if (addr.AddressFamily == AddressFamily.InterNetwork)
         {
-            char[] splitChars = { '.' };
-            string[] arr = ip.Split(splitChars);
-            try
-            {
-                int i = int.Parse(arr[0], CultureInfo.InvariantCulture);
-                if (i >= 223 && i <= 239)
-                {
-                    return true;
-                }
-            }
-            catch (FormatException)
-            {
-                return false;
-            }
+            byte firstOctet = addr.Address.GetAddressBytes()[0];
+            return firstOctet >= 224 && firstOctet <= 239;
         }
         else // AddressFamily.InterNetworkV6
         {
-            if (ip.StartsWith("FF", StringComparison.Ordinal))
-            {
-                return true;
-            }
+            return addr.Address.IsIPv6Multicast;
         }
-        return false;
     }
 
     internal static bool isIPv6Supported()

--- a/csharp/src/Ice/Internal/OpaqueEndpointI.cs
+++ b/csharp/src/Ice/Internal/OpaqueEndpointI.cs
@@ -253,7 +253,7 @@ internal sealed class OpaqueEndpointI : EndpointI
                 {
                     t = int.Parse(argument, CultureInfo.InvariantCulture);
                 }
-                catch (FormatException ex)
+                catch (System.Exception ex) when (ex is FormatException or OverflowException)
                 {
                     throw new ParseException($"invalid type value '{argument}' in endpoint '{endpoint}'", ex);
                 }

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -1468,7 +1468,18 @@ public abstract class TaskCompletionCallback<T> : TaskCompletionSource<T>, Outgo
     {
         if (_cancellationToken.CanBeCanceled)
         {
-            _cancellationToken.Register(og.cancel);
+            CancellationTokenRegistration registration = _cancellationToken.Register(og.cancel);
+            _ = disposeRegistrationAsync();
+
+            // Dispose of the registration when the task of this TaskCompletionSource completes; otherwise, a
+            // long-lived cancellation token would retain a reference to every invocation created with it.
+            async Task disposeRegistrationAsync()
+            {
+                // SuppressThrowing requires a non-generic Task; the outcome of the invocation is observed by
+                // the application through the task of this TaskCompletionSource.
+                await ((Task)this.Task).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+                registration.Dispose();
+            }
         }
     }
 

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -1469,17 +1469,17 @@ public abstract class TaskCompletionCallback<T> : TaskCompletionSource<T>, Outgo
         if (_cancellationToken.CanBeCanceled)
         {
             CancellationTokenRegistration registration = _cancellationToken.Register(og.cancel);
-            _ = disposeRegistrationAsync();
 
             // Dispose of the registration when the task of this TaskCompletionSource completes; otherwise, a
-            // long-lived cancellation token would retain a reference to every invocation created with it.
-            async Task disposeRegistrationAsync()
-            {
-                // SuppressThrowing requires a non-generic Task; the outcome of the invocation is observed by
-                // the application through the task of this TaskCompletionSource.
-                await ((Task)this.Task).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
-                registration.Dispose();
-            }
+            // long-lived cancellation token would retain a reference to every invocation created with it. We
+            // continue with (and don't await) this task because awaiting it would mark its exception as observed,
+            // and a faulted invocation would no longer reach TaskScheduler.UnobservedTaskException.
+            _ = this.Task.ContinueWith(
+                static (_, state) => ((CancellationTokenRegistration)state!).Dispose(),
+                registration,
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
         }
     }
 

--- a/csharp/src/Ice/Internal/Protocol.cs
+++ b/csharp/src/Ice/Internal/Protocol.cs
@@ -157,7 +157,7 @@ public sealed class Protocol
             majVersion = int.Parse(majStr, CultureInfo.InvariantCulture);
             minVersion = int.Parse(minStr, CultureInfo.InvariantCulture);
         }
-        catch (FormatException ex)
+        catch (System.Exception ex) when (ex is FormatException or OverflowException)
         {
             throw new ParseException($"invalid version value in '{str}'", ex);
         }

--- a/csharp/src/Ice/Internal/TcpEndpointI.cs
+++ b/csharp/src/Ice/Internal/TcpEndpointI.cs
@@ -219,7 +219,7 @@ internal sealed class TcpEndpointI : IPEndpointI
                             throw new ParseException($"invalid timeout value '{argument}' in endpoint '{endpoint}'");
                         }
                     }
-                    catch (System.FormatException ex)
+                    catch (System.Exception ex) when (ex is System.FormatException or System.OverflowException)
                     {
                         throw new ParseException($"invalid timeout value '{argument}' in endpoint '{endpoint}'", ex);
                     }

--- a/csharp/src/Ice/Internal/UdpEndpointI.cs
+++ b/csharp/src/Ice/Internal/UdpEndpointI.cs
@@ -323,7 +323,7 @@ internal sealed class UdpEndpointI : IPEndpointI
             {
                 _mcastTtl = int.Parse(argument, CultureInfo.InvariantCulture);
             }
-            catch (FormatException ex)
+            catch (System.Exception ex) when (ex is FormatException or OverflowException)
             {
                 throw new ParseException($"invalid TTL value '{argument}' in endpoint '{endpoint}'", ex);
             }

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -252,6 +252,42 @@ public class AllTests : global::Test.AllTests
         {
         }
 
+        try
+        {
+            communicator.stringToProxy("test:tcp -h 127.0.0.1 -t 99999999999999"); // greater than int.MaxValue
+            test(false);
+        }
+        catch (ParseException)
+        {
+        }
+
+        try
+        {
+            communicator.stringToProxy("test:udp -h 127.0.0.1 --ttl 99999999999999"); // greater than int.MaxValue
+            test(false);
+        }
+        catch (ParseException)
+        {
+        }
+
+        try
+        {
+            communicator.stringToProxy("test:opaque -t 99999999999999 -v abcd"); // greater than short.MaxValue
+            test(false);
+        }
+        catch (ParseException)
+        {
+        }
+
+        try
+        {
+            communicator.stringToProxy("test -e 99999999999999.0"); // greater than byte.MaxValue
+            test(false);
+        }
+        catch (ParseException)
+        {
+        }
+
         //
         // Test invalid endpoint syntax
         //

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -243,6 +243,15 @@ public class AllTests : global::Test.AllTests
         {
         }
 
+        try
+        {
+            communicator.stringToProxy("test:tcp -p 99999999999999"); // greater than int.MaxValue
+            test(false);
+        }
+        catch (ParseException)
+        {
+        }
+
         //
         // Test invalid endpoint syntax
         //


### PR DESCRIPTION
This PR fixes the C# issues reported in #6113:

- `Network.isMulticast` classified IPv4 addresses in the unicast range `223.0.0.0/8` as multicast (the multicast range starts at `224.0.0.0`), and checked the textual form of IPv6 addresses, misclassifying unicast addresses such as `ff::1`. It now checks the first address byte for IPv4 and uses `IPAddress.IsIPv6Multicast` for IPv6.
- Asynchronous invocations registered their cancel action with the caller's cancellation token but never disposed of the returned registration, so a long-lived cancellation token retained a reference to every completed invocation created with it. The registration is now disposed of when the invocation's task completes.
- The endpoint option parsers caught `FormatException` but not `OverflowException`, so an out-of-range numeric value (e.g. `-p 99999999999999`) surfaced a raw `System.OverflowException` instead of `Ice.ParseException`.

Item 4 of #6113 (fractional-ms timeout round-trip) is now tracked by #6180.

Fixes #6113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)