### PR TITLE
Fix sub-second truncation in the C++ ice_locatorCacheTimeout chrono overload

### DIFF
--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -184,7 +184,7 @@ namespace Ice
         [[nodiscard]] Prx ice_locatorCacheTimeout(const std::chrono::duration<Rep, Period>& timeout) const
         {
             return fromReference(
-                asPrx()._locatorCacheTimeout(std::chrono::duration_cast<std::chrono::seconds>(timeout)));
+                asPrx()._locatorCacheTimeout(std::chrono::duration_cast<std::chrono::milliseconds>(timeout)));
         }
 
         /// Creates a proxy that is identical to this proxy, but uses oneway invocations.

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -669,6 +669,10 @@ allTests(TestHelper* helper)
     test(base->ice_locatorCacheTimeout(-2)->ice_getLocatorCacheTimeout() == -2s);
     test(base->ice_locatorCacheTimeout(-2s)->ice_getLocatorCacheTimeout() == -2s);
 
+    test(base->ice_locatorCacheTimeout(2000ms)->ice_getLocatorCacheTimeout() == 2s);
+    test(base->ice_locatorCacheTimeout(1500ms)->ice_getLocatorCacheTimeout() == 1500ms);
+    test(base->ice_locatorCacheTimeout(-500ms)->ice_getLocatorCacheTimeout() == -500ms);
+
     cout << "ok" << endl;
 
     cout << "testing proxy comparison... " << flush;


### PR DESCRIPTION
The `ice_locatorCacheTimeout` overload that accepts a `std::chrono::duration` cast the supplied duration to whole seconds, although the private setter, the `Reference` storage, the `ice_getLocatorCacheTimeout` getter, and the locator cache TTL check all use milliseconds — and the sibling `ice_invocationTimeout` overload already casts to milliseconds. The truncation silently turned `1500ms` into `1s`, and converted a negative sub-second timeout (an infinite locator cache timeout) into 0 (no locator cache).

The overload now casts to milliseconds, like the other duration-based proxy setters. This also aligns C++ with the C# and Java duration overloads, which store the supplied `TimeSpan`/`Duration` unchanged.

The property round-trip for sub-second locator cache timeouts is tracked separately in #6180.

Fixes #6120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)