### PR TITLE
Fix IcePy servant reference leaks from ServantWrapper::getObject

### DIFF
--- a/changelog.d/python/6127.md
+++ b/changelog.d/python/6127.md
@@ -1,0 +1,3 @@
+- Fixed a memory leak in Ice for Python: the object adapter leaked a reference to the servant on each request
+  dispatched through a servant locator, and a reference to each servant returned by `findAllFacets` and
+  `removeAllFacets`.

--- a/python/modules/IcePy/Logger.h
+++ b/python/modules/IcePy/Logger.h
@@ -23,6 +23,8 @@ namespace IcePy
         void error(const std::string&) final;
         std::string getPrefix() final;
         Ice::LoggerPtr cloneWithPrefix(std::string) final;
+
+        /// Returns a borrowed reference to the Python logger.
         PyObject* getObject();
 
     private:

--- a/python/modules/IcePy/ObjectAdapter.cpp
+++ b/python/modules/IcePy/ObjectAdapter.cpp
@@ -53,6 +53,7 @@ namespace IcePy
 
         void deactivate(string_view) final;
 
+        /// Returns a new reference to the Python servant locator.
         PyObject* getObject();
 
     private:
@@ -207,7 +208,9 @@ IcePy::ServantLocatorWrapper::finished(const Ice::Current&, const Ice::ObjectPtr
 
     ServantWrapperPtr wrapper{dynamic_pointer_cast<ServantWrapper>(c->servant)};
 
-    PyObjectHandle res{PyObject_CallMethod(_locator, "finished", "OOO", c->current, wrapper->getObject(), c->cookie)};
+    // Adopt the new reference returned by getObject: the "O" format increfs the argument on its own.
+    PyObjectHandle servant{wrapper->getObject()};
+    PyObjectHandle res{PyObject_CallMethod(_locator, "finished", "OOO", c->current, servant.get(), c->cookie)};
     if (PyErr_Occurred())
     {
         // Retrieve the exception before another Python API call clears it.
@@ -834,7 +837,9 @@ adapterRemoveAllFacets(ObjectAdapterObject* self, PyObject* args)
     {
         auto wrapper = dynamic_pointer_cast<ServantWrapper>(obj);
         assert(wrapper);
-        if (PyDict_SetItemString(result.get(), facet.c_str(), wrapper->getObject()) < 0)
+        // Adopt the new reference returned by getObject: PyDict_SetItemString increfs the value on its own.
+        PyObjectHandle servant{wrapper->getObject()};
+        if (PyDict_SetItemString(result.get(), facet.c_str(), servant.get()) < 0)
         {
             return nullptr;
         }
@@ -1006,7 +1011,9 @@ adapterFindAllFacets(ObjectAdapterObject* self, PyObject* args)
     {
         auto wrapper = dynamic_pointer_cast<ServantWrapper>(obj);
         assert(wrapper);
-        if (PyDict_SetItemString(result.get(), facet.c_str(), wrapper->getObject()) < 0)
+        // Adopt the new reference returned by getObject: PyDict_SetItemString increfs the value on its own.
+        PyObjectHandle servant{wrapper->getObject()};
+        if (PyDict_SetItemString(result.get(), facet.c_str(), servant.get()) < 0)
         {
             return nullptr;
         }

--- a/python/modules/IcePy/Operation.h
+++ b/python/modules/IcePy/Operation.h
@@ -73,6 +73,7 @@ namespace IcePy
         ServantWrapper(PyObject*);
         ~ServantWrapper() override;
 
+        /// Returns a new reference to the Python servant.
         PyObject* getObject();
 
     protected:


### PR DESCRIPTION
Fixes #6127.

`ServantWrapper::getObject()` returns a new reference, but three callers treated it as borrowed, leaking one
servant reference per servant-locator-dispatched request and one per facet returned by
`findAllFacets`/`removeAllFacets`.

- Adopt the returned reference in a `PyObjectHandle` at the three call sites: `ServantLocatorWrapper::finished`
  (the `"O"` format increfs on its own) and the two facet loops (`PyDict_SetItemString` increfs on its own).
- Documented the new-reference contract on the `getObject` declarations of `ServantWrapper` and
  `ServantLocatorWrapper`, whose siblings (`LoggerWrapper`, `ValueReader`) return borrowed references.

No test: the leak is only observable through `sys.getrefcount` deltas; verified with a refcount harness over all
three sites plus a non-leaking control, flat after the fix.
