### PR TITLE
Improve robustness of plug-in specification and Options parsing

### DIFF
--- a/cpp/src/Ice/PluginManagerI.cpp
+++ b/cpp/src/Ice/PluginManagerI.cpp
@@ -279,7 +279,10 @@ Ice::PluginManagerI::loadPlugin(PluginFactoryFunc factoryFunc, const string& nam
                 "invalid arguments for plug-in '" + name + "':\n" + string{ex.what()});
         }
 
-        assert(!args.empty());
+        if (args.empty())
+        {
+            throw PluginInitializationException(__FILE__, __LINE__, "invalid arguments for plug-in '" + name + "'");
+        }
 
         //
         // Shift the arguments.

--- a/cpp/src/Ice/PluginManagerI.cpp
+++ b/cpp/src/Ice/PluginManagerI.cpp
@@ -281,7 +281,10 @@ Ice::PluginManagerI::loadPlugin(PluginFactoryFunc factoryFunc, const string& nam
 
         if (args.empty())
         {
-            throw PluginInitializationException(__FILE__, __LINE__, "invalid arguments for plug-in '" + name + "'");
+            throw PluginInitializationException(
+                __FILE__,
+                __LINE__,
+                "no entry point specified for plug-in '" + name + "'");
         }
 
         //

--- a/cpp/src/Ice/StringUtil.cpp
+++ b/cpp/src/Ice/StringUtil.cpp
@@ -586,7 +586,7 @@ IceInternal::unescapeString(
         {
             checkChar(s, p++);
         }
-        return s.substr(start, end);
+        return s.substr(start, end - start);
     }
     else
     {
@@ -606,7 +606,7 @@ IceInternal::unescapeString(
 
             if (!inputIsPureASCII)
             {
-                u8s = nativeToUTF8(s.substr(start, end), stringConverter);
+                u8s = nativeToUTF8(s.substr(start, end - start), stringConverter);
                 inputStringPtr = &u8s;
                 start = 0;
                 end = u8s.size();

--- a/cpp/src/Ice/StringUtil.cpp
+++ b/cpp/src/Ice/StringUtil.cpp
@@ -354,6 +354,10 @@ namespace
 
         if (s[start] != '\\')
         {
+            if (static_cast<unsigned char>(s[start]) > 127)
+            {
+                pureASCII = false;
+            }
             result.push_back(checkChar(s, start++));
         }
         else if (start + 1 == end)

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -38,7 +38,13 @@ namespace
                     "ServiceManager: invalid arguments for service '" + name + "':\n" + string{ex.what()});
             }
 
-            assert(!args.empty());
+            if (args.empty())
+            {
+                throw FailureException(
+                    __FILE__,
+                    __LINE__,
+                    "ServiceManager: invalid arguments for service '" + name + "'");
+            }
 
             //
             // Shift the arguments.

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -43,7 +43,7 @@ namespace
                 throw FailureException(
                     __FILE__,
                     __LINE__,
-                    "ServiceManager: invalid arguments for service '" + name + "'");
+                    "ServiceManager: no entry point specified for service '" + name + "'");
             }
 
             //

--- a/cpp/test/Ice/plugin/Client.cpp
+++ b/cpp/test/Ice/plugin/Client.cpp
@@ -130,6 +130,17 @@ Client::run(int argc, char** argv)
     try
     {
         Ice::PropertiesPtr properties = createTestProperties(argc, argv);
+        properties->setProperty("Ice.Plugin.Test", " ");
+        Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
+        test(false);
+    }
+    catch (const Ice::PluginInitializationException&)
+    {
+    }
+
+    try
+    {
+        Ice::PropertiesPtr properties = createTestProperties(argc, argv);
         properties->setProperty(
             "Ice.Plugin.Test",
             pluginDir + "TestPlugin:createPluginWithArgs 'C:\\Program Files\\' --DatabasePath "

--- a/cpp/test/Ice/stringConverter/Client.cpp
+++ b/cpp/test/Ice/stringConverter/Client.cpp
@@ -3,6 +3,7 @@
 #include "../../../src/Ice/Endian.h"
 #include "Ice/Ice.h"
 #include "Ice/IconvStringConverter.h"
+#include "Ice/StringUtil.h"
 #include "Test.h"
 #include "TestHelper.h"
 
@@ -127,6 +128,20 @@ Client::run(int argc, char** argv)
         identStr = identityToString(ident, Ice::ToStringMode::Compat);
         test(identStr == "cat/tu me fends le c\\305\\223ur!");
         test(Ice::stringToIdentity(identStr) == ident);
+
+        cout << "ok" << endl;
+
+        cout << "testing unescapeString subranges... " << flush;
+
+        // unescapeString(s, start, end, special) must return exactly the [start, end) subrange.
+        test(IceInternal::unescapeString("abcdef", 2, 4, "") == "cd");
+
+        // Same with a subrange that contains an escape sequence and a non-ASCII character, which takes
+        // the string-converter path.
+        string escaped = "xx\\t";
+        escaped += char(0xE9); // é in ISO Latin 9
+        escaped += "zz";
+        test(IceInternal::unescapeString(escaped, 2, 5, "") == string("\t") + char(0xE9));
 
         cout << "ok" << endl;
 

--- a/csharp/src/Ice/PluginManagerI.cs
+++ b/csharp/src/Ice/PluginManagerI.cs
@@ -276,7 +276,7 @@ internal sealed class PluginManagerI : PluginManager
 
             if (args.Length == 0)
             {
-                throw new PluginInitializationException($"Invalid arguments for plug-in '{name}'.");
+                throw new PluginInitializationException($"No entry point specified for plug-in '{name}'.");
             }
 
             entryPoint = args[0];

--- a/csharp/src/Ice/PluginManagerI.cs
+++ b/csharp/src/Ice/PluginManagerI.cs
@@ -274,7 +274,10 @@ internal sealed class PluginManagerI : PluginManager
                 throw new PluginInitializationException($"Invalid arguments for plug-in '{name}'.", ex);
             }
 
-            Debug.Assert(args.Length > 0);
+            if (args.Length == 0)
+            {
+                throw new PluginInitializationException($"Invalid arguments for plug-in '{name}'.");
+            }
 
             entryPoint = args[0];
 

--- a/csharp/src/Ice/UtilInternal/Options.cs
+++ b/csharp/src/Ice/UtilInternal/Options.cs
@@ -313,6 +313,14 @@ public sealed class Options
                                 //
                                 case 'c':
                                 {
+                                    if (i == l.Length - 1)
+                                    {
+                                        // Nothing after the \c: keep it unchanged. The missing closing quote is
+                                        // reported after the loop.
+                                        arg += "\\c";
+                                        break;
+                                    }
+
                                     c = l[++i];
                                     if (
                                         (char.ToUpper(c, CultureInfo.InvariantCulture) >= 'A' &&

--- a/csharp/src/iceboxnet/ServiceManagerI.cs
+++ b/csharp/src/iceboxnet/ServiceManagerI.cs
@@ -867,7 +867,7 @@ internal class ServiceManagerI : ServiceManagerDisp_, IDisposable
 
             if (args.Length == 0)
             {
-                throw new FailureException($"ServiceManager: invalid arguments for service '{name}'.");
+                throw new FailureException($"ServiceManager: no entry point specified for service '{name}'.");
             }
 
             entryPoint = args[0];

--- a/csharp/src/iceboxnet/ServiceManagerI.cs
+++ b/csharp/src/iceboxnet/ServiceManagerI.cs
@@ -865,7 +865,10 @@ internal class ServiceManagerI : ServiceManagerDisp_, IDisposable
                 throw new FailureException($"ServiceManager: invalid arguments for service '{name}'.", ex);
             }
 
-            Debug.Assert(args.Length > 0);
+            if (args.Length == 0)
+            {
+                throw new FailureException($"ServiceManager: invalid arguments for service '{name}'.");
+            }
 
             entryPoint = args[0];
 

--- a/csharp/test/Ice/plugin/Client.cs
+++ b/csharp/test/Ice/plugin/Client.cs
@@ -32,6 +32,22 @@ public class Client : Test.TestHelper
         }
 
         {
+            Console.Write("testing a whitespace-only plug-in specification... ");
+            Console.Out.Flush();
+            try
+            {
+                var properties = new Ice.Properties();
+                properties.setProperty("Ice.Plugin.Test", " ");
+                using Communicator _ = initialize(properties);
+                test(false);
+            }
+            catch (Ice.PluginInitializationException)
+            {
+            }
+            Console.WriteLine("ok");
+        }
+
+        {
             Console.Write("testing a simple plug-in that fails to initialize... ");
             Console.Out.Flush();
             try

--- a/csharp/test/IceUtil/inputUtil/Client.cs
+++ b/csharp/test/IceUtil/inputUtil/Client.cs
@@ -79,9 +79,10 @@ public class Client : Test.TestHelper
             "-Dir=\"test",
             "-Dir='test",
             "-Dir=$'test",
+            "-Dir=$'test\\c", // trailing \c inside an unterminated $'...' quote
         ];
 
-        for (int i = 0; i < 6; ++i)
+        for (int i = 0; i < badQuoteCommands.Length; ++i)
         {
             try
             {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
@@ -171,19 +171,25 @@ public final class Options {
 
                                 // Process control-chars.
                                 case 'c' -> {
-                                    c = line.charAt(++i);
-                                    if ((Character.toUpperCase(c) >= 'A'
-                                        && Character.toUpperCase(c) <= 'Z') || c == '@' || (c >= '[' && c <= '_')) {
-                                        arg.append((char) (Character.toUpperCase(c) - '@'));
+                                    if (i == line.length() - 1) {
+                                        // Nothing after the \c: keep it unchanged. The missing closing quote is
+                                        // reported after the loop.
+                                        arg.append("\\c");
                                     } else {
-                                        // Bash does not define what should happen if a
-                                        // \c is not followed by a recognized control character.
-                                        // We simply treat this case like other
-                                        // unrecognized escape sequences, that is, we
-                                        // preserve the escape sequence unchanged.
-                                        arg.append('\\');
-                                        arg.append('c');
-                                        arg.append(c);
+                                        c = line.charAt(++i);
+                                        if ((Character.toUpperCase(c) >= 'A'
+                                            && Character.toUpperCase(c) <= 'Z') || c == '@' || (c >= '[' && c <= '_')) {
+                                            arg.append((char) (Character.toUpperCase(c) - '@'));
+                                        } else {
+                                            // Bash does not define what should happen if a
+                                            // \c is not followed by a recognized control character.
+                                            // We simply treat this case like other
+                                            // unrecognized escape sequences, that is, we
+                                            // preserve the escape sequence unchanged.
+                                            arg.append('\\');
+                                            arg.append('c');
+                                            arg.append(c);
+                                        }
                                     }
                                 }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManagerI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManagerI.java
@@ -199,11 +199,11 @@ final class PluginManagerI implements PluginManager {
             try {
                 args = Options.split(pluginSpec);
             } catch (ParseException ex) {
-                throw new PluginInitializationException("invalid arguments for plug-in `" + name + "'", ex);
+                throw new PluginInitializationException("invalid arguments for plug-in '" + name + "'", ex);
             }
 
             if (args.length == 0) {
-                throw new PluginInitializationException("invalid arguments for plug-in '" + name + "'");
+                throw new PluginInitializationException("no entry point specified for plug-in '" + name + "'");
             }
 
             entryPoint = args[0];

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManagerI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManagerI.java
@@ -202,7 +202,9 @@ final class PluginManagerI implements PluginManager {
                 throw new PluginInitializationException("invalid arguments for plug-in `" + name + "'", ex);
             }
 
-            assert (args.length > 0);
+            if (args.length == 0) {
+                throw new PluginInitializationException("invalid arguments for plug-in '" + name + "'");
+            }
 
             entryPoint = args[0];
 

--- a/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
+++ b/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
@@ -701,11 +701,11 @@ final class ServiceManagerI implements ServiceManager {
             try {
                 args = Options.split(value);
             } catch (ParseException ex) {
-                throw new FailureException("ServiceManager: invalid arguments for service `" + name + "'", ex);
+                throw new FailureException("ServiceManager: invalid arguments for service '" + name + "'", ex);
             }
 
             if (args.length == 0) {
-                throw new FailureException("ServiceManager: invalid arguments for service '" + name + "'");
+                throw new FailureException("ServiceManager: no entry point specified for service '" + name + "'");
             }
 
             final String entryPoint = args[0];

--- a/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
+++ b/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
@@ -704,7 +704,9 @@ final class ServiceManagerI implements ServiceManager {
                 throw new FailureException("ServiceManager: invalid arguments for service `" + name + "'", ex);
             }
 
-            assert (args.length > 0);
+            if (args.length == 0) {
+                throw new FailureException("ServiceManager: invalid arguments for service '" + name + "'");
+            }
 
             final String entryPoint = args[0];
 

--- a/java/test/src/main/java/test/Ice/plugin/Client.java
+++ b/java/test/src/main/java/test/Ice/plugin/Client.java
@@ -34,6 +34,18 @@ public class Client extends TestHelper {
         }
 
         {
+            printWriter.print("testing a whitespace-only plug-in specification... ");
+            printWriter.flush();
+            Properties properties = createTestProperties(args);
+            properties.setProperty("Ice.Plugin.Test", " ");
+            try (Communicator communicator = initialize(properties)) {
+                test(false);
+            } catch (PluginInitializationException ex) {
+            }
+            printWriter.println("ok");
+        }
+
+        {
             printWriter.print("testing a simple plug-in that fails to initialize... ");
             printWriter.flush();
             Properties properties = createTestProperties(args);

--- a/java/test/src/main/java/test/IceUtil/inputUtil/Client.java
+++ b/java/test/src/main/java/test/IceUtil/inputUtil/Client.java
@@ -115,14 +115,15 @@ public class Client extends TestHelper {
             test(false);
         }
 
-        String[] parseExceptionCommands = new String[6];
+        String[] parseExceptionCommands = new String[7];
         parseExceptionCommands[0] = "\"";
         parseExceptionCommands[1] = "'";
         parseExceptionCommands[2] = "\\$'";
         parseExceptionCommands[3] = "-Dir=\"test";
         parseExceptionCommands[4] = "-Dir='test";
         parseExceptionCommands[5] = "-Dir=$'test";
-        for (int i = 0; i < 6; i++) {
+        parseExceptionCommands[6] = "-Dir=$'test\\c"; // trailing \c inside an unterminated $'...' quote
+        for (int i = 0; i < parseExceptionCommands.length; i++) {
             try {
                 Options.split(parseExceptionCommands[i]);
                 test(false);


### PR DESCRIPTION
This PR fixes the parsing robustness issues reported in #6133, in C++, C#, and Java:

- A whitespace-only plug-in or IceBox service specification passed the not-empty guard (which checks the untrimmed value), then `Options.split` returned an empty array and the entry point was read after only an `assert` — an `IndexOutOfRangeException`/`ArrayIndexOutOfBoundsException` in C#/Java release builds, and undefined behavior in C++. The six sites (plug-in manager and IceBox service manager in each language) now throw the expected `PluginInitializationException`/`FailureException` with a `no entry point specified` message.
- In C# and Java, a trailing `\c` inside an unterminated `$'…'` quote made `Options.split` read one character past the end of the string, throwing `IndexOutOfRangeException`/`StringIndexOutOfBoundsException`. Such input now takes the same path as C++: the `\c` is preserved unchanged and the parser reports the "unterminated $' quote" `ParseException`.
- The C++ `IceInternal::unescapeString` passed an end index as the count argument of `substr`. All current callers pass ranges where the two coincide (start 0, or end at the end of the string), so this is a latent bug with no observable behavior change; the count is now computed correctly for arbitrary subranges.
- Writing a direct test for the `unescapeString` subrange fix exposed a fourth bug, also fixed here: `decodeChar` did not clear its pure-ASCII flag for an unescaped byte > 127, so when a process string converter is installed, an input mixing a non-ASCII character with an ASCII escape sequence (for example an identity such as `caté\t...`) skipped the final UTF-8 to native conversion and returned UTF-8 bytes in a native-encoded string. This one is observable through `stringToIdentity` and proxy parsing, but only in applications that install a process string converter, so it doesn't warrant a changelog entry either.

The first three fixes only change how invalid configuration input fails, so there are no changelog entries.

Fixes #6133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)