### PR TITLE
Fix NPE in discovery plug-ins' destroy after setDefaultLocator(null)

### DIFF
--- a/csharp/src/IceDiscovery/PluginI.cs
+++ b/csharp/src/IceDiscovery/PluginI.cs
@@ -120,10 +120,11 @@ public sealed class PluginI : Ice.Plugin
 
     public void destroy()
     {
+        // Called after initialize() completed successfully.
         _multicastAdapter?.destroy();
         _replyAdapter?.destroy();
         _locatorAdapter?.destroy();
-        if (_communicator.getDefaultLocator().Equals(_locator))
+        if (_locator.Equals(_communicator.getDefaultLocator()))
         {
             // Restore original default locator proxy, if the user didn't change it in the meantime
             _communicator.setDefaultLocator(_defaultLocator);

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -670,9 +670,10 @@ internal class PluginI : Ice.Plugin
     public void
     destroy()
     {
+        // Called after initialize() completed successfully.
         _replyAdapter?.destroy();
         _locatorAdapter?.destroy();
-        if (_communicator.getDefaultLocator().Equals(_locatorPrx))
+        if (_locatorPrx.Equals(_communicator.getDefaultLocator()))
         {
             // Restore original default locator proxy, if the user didn't change it in the meantime
             _communicator.setDefaultLocator(_defaultLocator);

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/PluginI.java
@@ -98,6 +98,7 @@ class PluginI implements Plugin {
 
     @Override
     public void destroy() {
+        // Called after initialize() completed successfully.
         if (_multicastAdapter != null) {
             _multicastAdapter.destroy();
         }
@@ -107,7 +108,7 @@ class PluginI implements Plugin {
         if (_locatorAdapter != null) {
             _locatorAdapter.destroy();
         }
-        if (_communicator.getDefaultLocator().equals(_locator)) {
+        if (_locator.equals(_communicator.getDefaultLocator())) {
             // Restore original default locator proxy, if the user didn't change it in the meantime
             _communicator.setDefaultLocator(_defaultLocator);
         }

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -610,13 +610,14 @@ class PluginI implements Plugin {
 
     @Override
     public void destroy() {
+        // Called after initialize() completed successfully.
         if (_replyAdapter != null) {
             _replyAdapter.destroy();
         }
         if (_locatorAdapter != null) {
             _locatorAdapter.destroy();
         }
-        if (_communicator.getDefaultLocator().equals(_locatorPrx)) {
+        if (_locatorPrx.equals(_communicator.getDefaultLocator())) {
             // Restore original default locator proxy, if the user didn't change it in the meantime
             _communicator.setDefaultLocator(_defaultLocator);
         }


### PR DESCRIPTION
In the Java and C# IceDiscovery and IceLocatorDiscovery plug-ins, `destroy()` compared the communicator's current default locator to the plug-in's locator with the nullable proxy as the receiver: `_communicator.getDefaultLocator().equals(...)`. When the application called `setDefaultLocator(null)` after plug-in initialization, this threw a `NullPointerException`/`NullReferenceException`, which `PluginManagerI.destroy` caught and logged as a spurious warning during communicator destruction.

This PR flips the operands: the receiver is now the plug-in's own locator proxy, which is always non-null when `destroy()` runs (the plug-in manager only destroys plug-ins whose `initialize()` completed — now documented with a comment in each `destroy()` implementation). Comparing against a null default locator correctly returns false: the user changed the default locator, so the plug-in does not restore the original one.

The C++ plug-ins are not affected: they compare `std::optional` values, which is null-safe.

Fixes #6135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)