### PR TITLE
Dispatch nightly-release.yml for the 3.8 nightly build

### DIFF
--- a/.github/workflows/dispatch-nightly-release.yml
+++ b/.github/workflows/dispatch-nightly-release.yml
@@ -34,10 +34,9 @@ jobs:
         uses: ./.github/actions/dispatch-workflow
         with:
           ref: 3.8
-          # Use the existing orchestrator until nightly-release.yml is backported.
-          workflow: build-release.yml
+          workflow: nightly-release.yml
           token: ${{ secrets.GITHUB_TOKEN }}
-          inputs: '{"quality": "nightly", "publish": true}'
+          inputs: '{"publish": true}'
 
       - name: Dispatch nightly build for 3.7 (4:00 UTC)
         if: github.event.schedule == '0 4 * * *'


### PR DESCRIPTION
The 3.8 nightly dispatch has failed every night since `nightly-release.yml` was backported to 3.8 in #6077. That backport dropped the `publish` input from 3.8's `build-release.yml`, so the 3:00 UTC step's `{"quality": "nightly", "publish": true}` now gets rejected with `HTTP 422: Unexpected inputs provided: ["publish"]` and no 3.8 nightly is built.

- Dispatch `nightly-release.yml` with `{"publish": true}` for 3.8, matching what main already does.

3.7 still uses `build-release.yml`, which is correct there — that branch has no `nightly-release.yml` and its `build-release.yml` still takes both inputs.