### PR TITLE
Add an optional bare Object* to the Ice/optional test schema

### DIFF
--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -314,6 +314,7 @@ allTests(Test::TestHelper* helper, const Ice::SliceLoaderPtr& sliceLoader)
     mo1->h = string("test");
     mo1->i = MyEnum::MyEnumMember;
     mo1->j = MyInterfacePrx(communicator, "test");
+    mo1->oprx = Ice::ObjectPrx(communicator, "test");
     mo1->bs = ByteSeq();
     (*mo1->bs).push_back(byte{5});
     mo1->ss = StringSeq();
@@ -371,6 +372,7 @@ allTests(Test::TestHelper* helper, const Ice::SliceLoaderPtr& sliceLoader)
     test(mo3->h == string("test"));
     test(mo3->i = MyEnum::MyEnumMember);
     test(mo3->j = MyInterfacePrx(communicator, "test"));
+    test(mo3->oprx == mo1->oprx);
     test(mo3->bs == mo1->bs);
     test(mo3->ss == mo1->ss);
     test(mo3->iid == mo1->iid);
@@ -431,6 +433,7 @@ allTests(Test::TestHelper* helper, const Ice::SliceLoaderPtr& sliceLoader)
     test(!mo4->h);
     test(!mo4->i);
     test(!mo4->j);
+    test(!mo4->oprx);
     test(!mo4->bs);
     test(!mo4->ss);
     test(!mo4->iid);
@@ -463,6 +466,7 @@ allTests(Test::TestHelper* helper, const Ice::SliceLoaderPtr& sliceLoader)
     test(mo5->h == mo1->h);
     test(mo5->i == mo1->i);
     test(mo5->j == mo1->j);
+    test(mo5->oprx == mo1->oprx);
     test(mo5->bs == mo1->bs);
     test(mo5->ss == mo1->ss);
     test(mo5->iid == mo1->iid);
@@ -500,6 +504,7 @@ allTests(Test::TestHelper* helper, const Ice::SliceLoaderPtr& sliceLoader)
     mo6->e = nullopt;
     mo6->g = nullopt;
     mo6->i = nullopt;
+    mo6->oprx = nullopt;
     mo6->ss = nullopt;
     mo6->sid = nullopt;
     mo6->vs = nullopt;
@@ -523,6 +528,7 @@ allTests(Test::TestHelper* helper, const Ice::SliceLoaderPtr& sliceLoader)
     test(mo7->h == mo1->h);
     test(!mo7->i);
     test(mo7->j == mo1->j);
+    test(!mo7->oprx);
     test(mo7->bs == mo1->bs);
     test(!mo7->ss);
     test(mo7->iid == mo1->iid);
@@ -568,6 +574,7 @@ allTests(Test::TestHelper* helper, const Ice::SliceLoaderPtr& sliceLoader)
     test(!mo9->h);
     test(mo9->i == mo1->i);
     test(!mo9->j);
+    test(mo9->oprx == mo1->oprx);
     test(!mo9->bs);
     test(mo9->ss == mo1->ss);
     test(!mo9->iid);

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -75,6 +75,7 @@ module Test
         optional(8) string h;
         optional(9) MyEnum i;
         optional(10) MyInterface* j;
+        optional(11) Object* oprx;
         optional(12) ByteSeq bs;
         optional(13) StringSeq ss;
         optional(14) IntIntDict iid;

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -48,6 +48,7 @@ public class AllTests : global::Test.AllTests
         mo1.h = "test";
         mo1.i = Test.MyEnum.MyEnumMember;
         mo1.j = Test.MyInterfacePrxHelper.uncheckedCast(communicator.stringToProxy("test"));
+        mo1.oprx = communicator.stringToProxy("test");
         mo1.bs = [5];
         mo1.ss = ["test", "test2"];
         mo1.iid = new Dictionary<int, int>
@@ -100,6 +101,7 @@ public class AllTests : global::Test.AllTests
         test(mo1.h == "test");
         test(mo1.i.Value == Test.MyEnum.MyEnumMember);
         test(mo1.j.Equals(communicator.stringToProxy("test")));
+        test(mo1.oprx.Equals(communicator.stringToProxy("test")));
         test(ArraysEqual(mo1.bs, [(byte)5]));
         test(ArraysEqual(mo1.ss, ["test", "test2"]));
         test(mo1.iid[4] == 3);
@@ -142,6 +144,7 @@ public class AllTests : global::Test.AllTests
         test(mo4.h is null);
         test(mo4.i is null);
         test(mo4.j is null);
+        test(mo4.oprx is null);
         test(mo4.bs is null);
         test(mo4.ss is null);
         test(mo4.iid is null);
@@ -173,6 +176,7 @@ public class AllTests : global::Test.AllTests
         test(mo5.h == mo1.h);
         test(mo5.i.Value == mo1.i.Value);
         test(mo5.j.Equals(mo1.j));
+        test(mo5.oprx.Equals(mo1.oprx));
         test(ArraysEqual(mo5.bs, mo1.bs));
         test(ArraysEqual(mo5.ss, mo1.ss));
         test(mo5.iid[4] == 3);
@@ -218,6 +222,7 @@ public class AllTests : global::Test.AllTests
         test(mo7.h == mo1.h);
         test(mo7.i is null);
         test(mo7.j.Equals(mo1.j));
+        test(mo7.oprx is null);
         test(ArraysEqual(mo7.bs, mo1.bs));
         test(mo7.ss is null);
         test(mo7.iid[4] == 3);
@@ -245,6 +250,7 @@ public class AllTests : global::Test.AllTests
         mo8.e = mo5.e;
         mo8.g = mo5.g;
         mo8.i = mo5.i;
+        mo8.oprx = mo5.oprx;
         mo8.ss = mo5.ss;
         mo8.sid = mo5.sid;
         mo8.vs = mo5.vs;
@@ -268,6 +274,7 @@ public class AllTests : global::Test.AllTests
         test(mo9.h is null);
         test(mo9.i.Equals(mo1.i));
         test(mo9.j is null);
+        test(mo9.oprx.Equals(mo1.oprx));
         test(mo9.bs is null);
         test(ArraysEqual(mo9.ss, mo1.ss));
         test(mo9.iid is null);

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -70,6 +70,7 @@ module Test
         optional(8) string h;
         optional(9) MyEnum i;
         optional(10) MyInterface* j;
+        optional(11) Object* oprx;
         optional(12) ByteSeq bs;
         optional(13) StringSeq ss;
         optional(14) IntIntDict iid;

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -104,6 +104,7 @@ public class AllTests {
         mo1.setH("test");
         mo1.setI(MyEnum.MyEnumMember);
         mo1.setJ(MyInterfacePrx.createProxy(communicator, "test"));
+        mo1.setOprx(ObjectPrx.createProxy(communicator, "test"));
         mo1.setBs(new byte[]{(byte) 5});
         mo1.setSs(new String[]{"test", "test2"});
         mo1.setIid(new HashMap<>());
@@ -147,6 +148,7 @@ public class AllTests {
         test("test".equals(mo1.getH()));
         test(mo1.getI() == MyEnum.MyEnumMember);
         test(mo1.getJ().equals(communicator.stringToProxy("test")));
+        test(mo1.getOprx().equals(communicator.stringToProxy("test")));
         test(Arrays.equals(mo1.getBs(), new byte[]{(byte) 5}));
         test(Arrays.equals(mo1.getSs(), new String[]{"test", "test2"}));
         test(mo1.getIid().get(4) == 3);
@@ -191,6 +193,7 @@ public class AllTests {
         test(!mo4.hasH());
         test(!mo4.hasI());
         test(!mo4.hasJ());
+        test(!mo4.hasOprx());
         test(!mo4.hasBs());
         test(!mo4.hasSs());
         test(!mo4.hasIid());
@@ -229,6 +232,7 @@ public class AllTests {
         test(mo5.getH().equals(mo1.getH()));
         test(mo5.getI() == mo1.getI());
         test(mo5.getJ().equals(mo1.getJ()));
+        test(mo5.getOprx().equals(mo1.getOprx()));
         test(Arrays.equals(mo5.getBs(), mo1.getBs()));
         test(Arrays.equals(mo5.getSs(), mo1.getSs()));
         test(mo5.getIid().get(4) == 3);
@@ -278,6 +282,7 @@ public class AllTests {
         test(mo7.getH().equals(mo1.getH()));
         test(!mo7.hasI());
         test(mo7.getJ().equals(mo1.getJ()));
+        test(!mo7.hasOprx());
         test(Arrays.equals(mo7.getBs(), mo1.getBs()));
         test(!mo7.hasSs());
         test(mo7.getIid().get(4) == 3);
@@ -305,6 +310,7 @@ public class AllTests {
         mo8.setE(mo5.getE());
         mo8.setG(mo5.getG());
         mo8.setI(mo5.getI());
+        mo8.setOprx(mo5.getOprx());
         mo8.setSs(mo5.getSs());
         mo8.setSid(mo5.getSid());
         mo8.setVs(mo5.getVs());
@@ -328,6 +334,7 @@ public class AllTests {
         test(!mo9.hasH());
         test(mo9.getI() == mo1.getI());
         test(!mo9.hasJ());
+        test(mo9.getOprx().equals(mo1.getOprx()));
         test(!mo9.hasBs());
         test(Arrays.equals(mo9.getSs(), mo1.getSs()));
         test(!mo9.hasIid());

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -72,6 +72,7 @@ module Test
         optional(8) string h;
         optional(9) MyEnum i;
         optional(10) MyInterface* j;
+        optional(11) Object* oprx;
         optional(12) ByteSeq bs;
         optional(13) StringSeq ss;
         optional(14) IntIntDict iid;

--- a/js/packages/test/Ice/optional/Client.ts
+++ b/js/packages/test/Ice/optional/Client.ts
@@ -36,6 +36,7 @@ export class Client extends TestHelper {
         test(mo4.h === undefined);
         test(mo4.i === undefined);
         test(mo4.j === undefined);
+        test(mo4.oprx === undefined);
         test(mo4.bs === undefined);
         test(mo4.ss === undefined);
         test(mo4.iid === undefined);
@@ -69,6 +70,7 @@ export class Client extends TestHelper {
         mo1.h = "test";
         mo1.i = Test.MyEnum.MyEnumMember;
         mo1.j = new Test.MyInterfacePrx(communicator, "test");
+        mo1.oprx = new Ice.ObjectPrx(communicator, "test");
         mo1.bs = new Uint8Array([5]);
         mo1.ss = ["test", "test2"];
         mo1.iid = new Map();
@@ -109,6 +111,7 @@ export class Client extends TestHelper {
         test(mo1.h == mo5.h);
         test(mo1.i == mo5.i);
         test(mo1.j.equals(mo5.j));
+        test(mo1.oprx.equals(mo5.oprx));
         test(ArrayUtil.equals(mo5.bs!, mo1.bs));
         test(ArrayUtil.equals(mo5.ss!, mo1.ss));
         test(mo5.iid!.get(4) == 3);
@@ -154,6 +157,7 @@ export class Client extends TestHelper {
         test(mo7.h == mo1.h);
         test(mo7.i === undefined);
         test(mo7.j!.equals(mo1.j));
+        test(mo7.oprx === undefined);
         test(ArrayUtil.equals(mo7.bs!, mo1.bs));
         test(mo7.ss === undefined);
         test(mo7.iid!.get(4) == 3);
@@ -180,6 +184,7 @@ export class Client extends TestHelper {
         mo8.e = mo1.e;
         mo8.g = mo1.g;
         mo8.i = mo1.i;
+        mo8.oprx = mo1.oprx;
         mo8.ss = mo1.ss;
         mo8.sid = mo1.sid;
         mo8.vs = mo1.vs;
@@ -204,6 +209,7 @@ export class Client extends TestHelper {
         test(mo9.h === undefined);
         test(mo9.i == mo1.i);
         test(mo9.j === undefined);
+        test(mo9.oprx!.equals(mo1.oprx));
         test(mo9.bs === undefined);
         test(ArrayUtil.equals(mo9.ss!, mo1.ss!));
         test(mo9.iid === undefined);

--- a/js/packages/test/Ice/optional/Test.ice
+++ b/js/packages/test/Ice/optional/Test.ice
@@ -71,6 +71,7 @@ module Test
         optional(8) string h;
         optional(9) MyEnum i;
         optional(10) MyInterface* j;
+        optional(11) Object* oprx;
         optional(12) ByteSeq bs;
         optional(13) StringSeq ss;
         optional(14) IntIntDict iid;

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -11,10 +11,6 @@ classdef AllTests
             AllTests.skipUnknownOptionals(communicator);
             fprintf('ok\n');
 
-            fprintf('testing optional proxies without a proxy type... ');
-            AllTests.bareOptionalProxies(communicator);
-            fprintf('ok\n');
-
             ref = ['initial:', helper.getTestEndpoint()];
             initial = InitialPrx(communicator, ref);
 
@@ -38,6 +34,7 @@ classdef AllTests
             assert(mo1.h == Ice.Unset);
             assert(mo1.i == Ice.Unset);
             assert(isempty(mo1.j));
+            assert(isempty(mo1.oprx));
             assert(mo1.bs == Ice.Unset);
             assert(mo1.ss == Ice.Unset);
             assert(mo1.iid == Ice.Unset);
@@ -75,6 +72,7 @@ classdef AllTests
             imipd{5} = MyInterfacePrx(communicator, 'test');
             mo1 = MultiOptional(15, true, 19, 78, 99, 5.5, 1.0, 'test', MyEnum.MyEnumMember, ...
                                      MyInterfacePrx(communicator, 'test'), ...
+                                     communicator.stringToProxy('test'), ...
                                      [5], {'test', 'test2'}, iid, sid, fs, vs, [1], ...
                                      [MyEnum.MyEnumMember, MyEnum.MyEnumMember], ...
                                      [ fs ], [ vs ], { MyInterfacePrx(communicator, 'test') }, ...
@@ -90,6 +88,7 @@ classdef AllTests
             assert(strcmp(mo1.h, 'test'));
             assert(mo1.i == MyEnum.MyEnumMember);
             assert(mo1.j == communicator.stringToProxy('test'));
+            assert(mo1.oprx == communicator.stringToProxy('test'));
             assert(mo1.bs == [5])
             assert(isequal(mo1.ss, {'test', 'test2'}));
             assert(mo1.iid(4) == 3);
@@ -139,6 +138,7 @@ classdef AllTests
             assert(mo4.h == Ice.Unset);
             assert(mo4.i == Ice.Unset);
             assert(isempty(mo4.j)); % we don't use Unset for optional proxies
+            assert(isempty(mo4.oprx));
             assert(mo4.bs == Ice.Unset);
             assert(mo4.ss == Ice.Unset);
             assert(mo4.iid == Ice.Unset);
@@ -170,6 +170,7 @@ classdef AllTests
             assert(strcmp(mo5.h, mo1.h));
             assert(mo5.i == mo1.i);
             assert(mo5.j == mo1.j);
+            assert(mo5.oprx == mo1.oprx);
             assert(mo5.bs(1) == 5);
             assert(isequal(mo5.ss, mo1.ss));
             assert(mo5.iid(4) == 3);
@@ -215,6 +216,7 @@ classdef AllTests
             assert(strcmp(mo7.h, mo1.h));
             assert(mo7.i == Ice.Unset);
             assert(mo7.j == mo1.j);
+            assert(isempty(mo7.oprx));
             assert(mo7.bs(1) == 5);
             assert(mo7.ss == Ice.Unset);
             assert(mo7.iid(4) == 3);
@@ -242,6 +244,7 @@ classdef AllTests
             mo8.e = mo5.e;
             mo8.g = mo5.g;
             mo8.i = mo5.i;
+            mo8.oprx = mo5.oprx;
             mo8.ss = mo5.ss;
             mo8.sid = mo5.sid;
             mo8.vs = mo5.vs;
@@ -265,6 +268,7 @@ classdef AllTests
             assert(mo9.h == Ice.Unset);
             assert(mo9.i == mo1.i);
             assert(isempty(mo9.j)); % optional proxy
+            assert(mo9.oprx == mo1.oprx);
             assert(mo9.bs == Ice.Unset);
             assert(isequal(mo9.ss, mo1.ss));
             assert(mo9.iid == Ice.Unset);
@@ -800,29 +804,6 @@ classdef AllTests
             assert(is.readOptional(1, Ice.OptionalFormat.F4), 'tag 1 should be present');
             assert(is.readInt() == 11111, 'tag 1 value mismatch');
             % Tags 30, 50 and 300 are left unread; endEncapsulation must skip them cleanly.
-            is.endEncapsulation();
-        end
-
-        function bareOptionalProxies(communicator)
-            % Marshal a set and an unset optional proxy, and read them back with the untyped form of
-            % readProxyOpt - the form generated for `optional(N) Object*`, which yields an Ice.ObjectPrx.
-            encoding = Ice.EncodingVersion(1, 1);
-            prx = communicator.stringToProxy('test:tcp -h 127.0.0.1 -p 10000');
-
-            os = Ice.OutputStream(encoding);
-            os.startEncapsulation(Ice.FormatType.SlicedFormat);
-            os.writeProxyOpt(1, prx);
-            os.writeProxyOpt(2, Ice.ObjectPrx.empty); % unset: nothing is written for tag 2
-            os.endEncapsulation();
-            data = os.finished();
-
-            is = Ice.InputStream(communicator, encoding, data);
-            is.startEncapsulation();
-            p1 = is.readProxyOpt(1);
-            assert(isa(p1, 'Ice.ObjectPrx'), 'tag 1 should be an Ice.ObjectPrx');
-            assert(p1 == prx, 'tag 1 proxy mismatch');
-            p2 = is.readProxyOpt(2);
-            assert(isa(p2, 'Ice.ObjectPrx') && isempty(p2), 'tag 2 should be an empty Ice.ObjectPrx');
             is.endEncapsulation();
         end
     end

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -71,6 +71,7 @@ module Test
         optional(8) string h;
         optional(9) MyEnum i;
         optional(10) MyInterface* j;
+        optional(11) Object* oprx;
         optional(12) ByteSeq bs;
         optional(13) StringSeq ss;
         optional(14) IntIntDict iid;

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -45,6 +45,7 @@ function allTests($helper)
     test($mo1->h == Ice\None);
     test($mo1->i == Ice\None);
     test($mo1->j == Ice\None);
+    test($mo1->oprx == Ice\None);
     test($mo1->bs == Ice\None);
     test($mo1->ss == Ice\None);
     test($mo1->iid == Ice\None);
@@ -70,7 +71,7 @@ function allTests($helper)
     $vs = new Test\VarStruct("hello");
     $prx = Test\MyInterfacePrxHelper::createProxy($communicator, "test");
     $mo1 = new Test\MultiOptional(15, true, 19, 78, 99, 5.5, 1.0, 'test', Test\MyEnum::MyEnumMember,
-                      $prx, array(5), array('test', 'test2'), array(4=>3), array('test'=>10),
+                      $prx, $communicator->stringToProxy('test'), array(5), array('test', 'test2'), array(4=>3), array('test'=>10),
                       $fs, $vs, array(1), array(Test\MyEnum::MyEnumMember, Test\MyEnum::MyEnumMember), array($fs), array($vs),
                       array($prx), array(4=>Test\MyEnum::MyEnumMember), array(4=>$fs), array(5=>$vs),
                       array(5=>$prx), array(false, true, false));
@@ -85,6 +86,7 @@ function allTests($helper)
     test($mo1->h == "test");
     test($mo1->i == Test\MyEnum::MyEnumMember);
     test($mo1->j == $prx);
+    test($mo1->oprx == $communicator->stringToProxy('test'));
     test($mo1->bs == array(5));
     test($mo1->ss == array("test", "test2"));
     test($mo1->iid[4] == 3);
@@ -135,6 +137,7 @@ function allTests($helper)
     test($mo4->h == Ice\None);
     test($mo4->i == Ice\None);
     test($mo4->j == Ice\None);
+    test($mo4->oprx == Ice\None);
     test($mo4->bs == Ice\None);
     test($mo4->ss == Ice\None);
     test($mo4->iid == Ice\None);
@@ -166,6 +169,7 @@ function allTests($helper)
     test($mo5->h == $mo1->h);
     test($mo5->i == $mo1->i);
     test($mo5->j == $mo1->j);
+    test($mo5->oprx == $mo1->oprx);
     test($mo5->bs[0] == 5);
     test($mo5->ss == $mo1->ss);
     test($mo5->iid[4] == 3);
@@ -211,6 +215,7 @@ function allTests($helper)
     test($mo7->h == $mo1->h);
     test($mo7->i == Ice\None);
     test($mo7->j == $mo1->j);
+    test($mo7->oprx == Ice\None);
     test($mo7->bs[0] == 5);
     test($mo7->ss == Ice\None);
     test($mo7->iid[4] == 3);
@@ -238,6 +243,7 @@ function allTests($helper)
     $mo8->e = $mo5->e;
     $mo8->g = $mo5->g;
     $mo8->i = $mo5->i;
+    $mo8->oprx = $mo5->oprx;
     $mo8->ss = $mo5->ss;
     $mo8->sid = $mo5->sid;
     $mo8->vs = $mo5->vs;
@@ -261,6 +267,7 @@ function allTests($helper)
     test($mo9->h == Ice\None);
     test($mo9->i == $mo1->i);
     test($mo9->j == Ice\None);
+    test($mo9->oprx == $mo1->oprx);
     test($mo9->bs == Ice\None);
     test($mo9->ss == $mo1->ss);
     test($mo9->iid == Ice\None);

--- a/php/test/Ice/optional/Test.ice
+++ b/php/test/Ice/optional/Test.ice
@@ -71,6 +71,7 @@ module Test
         optional(8) string h;
         optional(9) MyEnum i;
         optional(10) MyInterface* j;
+        optional(11) Object* oprx;
         optional(12) ByteSeq bs;
         optional(13) StringSeq ss;
         optional(14) IntIntDict iid;

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -33,6 +33,7 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
     test(mo1.h is None)
     test(mo1.i is None)
     test(mo1.j is None)
+    test(mo1.oprx is None)
     test(mo1.bs is None)
     test(mo1.ss is None)
     test(mo1.iid is None)
@@ -67,6 +68,7 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
         "test",
         Test.MyEnum.MyEnumMember,
         Test.MyInterfacePrx(communicator, "test"),
+        Ice.ObjectPrx(communicator, "test"),
         bytes([5]),
         ["test", "test2"],
         {4: 3},
@@ -95,6 +97,7 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
     test(mo1.h == "test")
     test(mo1.i == Test.MyEnum.MyEnumMember)
     test(mo1.j == Test.MyInterfacePrx(communicator, "test"))
+    test(mo1.oprx == Ice.ObjectPrx(communicator, "test"))
     test(mo1.bs == bytes([5]))
     test(mo1.ss == ["test", "test2"])
     assert mo1.iid is not None
@@ -161,6 +164,7 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
     test(mo4.h is None)
     test(mo4.i is None)
     test(mo4.j is None)
+    test(mo4.oprx is None)
     test(mo4.bs is None)
     test(mo4.ss is None)
     test(mo4.iid is None)
@@ -193,6 +197,7 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
     test(mo5.h == mo1.h)
     test(mo5.i == mo1.i)
     test(mo5.j == mo1.j)
+    test(mo5.oprx == mo1.oprx)
     assert mo5.bs is not None
     test(mo5.bs[0] == 5)
     test(mo5.ss == mo1.ss)
@@ -250,6 +255,7 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
     test(mo7.h == mo1.h)
     test(mo7.i is None)
     test(mo7.j == mo1.j)
+    test(mo7.oprx is None)
     assert mo7.bs is not None
     test(mo7.bs[0] == 5)
     test(mo7.ss is None)
@@ -281,6 +287,7 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
     mo8.e = mo5.e
     mo8.g = mo5.g
     mo8.i = mo5.i
+    mo8.oprx = mo5.oprx
     mo8.ss = mo5.ss
     mo8.sid = mo5.sid
     mo8.vs = mo5.vs
@@ -305,6 +312,7 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
     test(mo9.h is None)
     test(mo9.i == mo1.i)
     test(mo9.j is None)
+    test(mo9.oprx == mo1.oprx)
     test(mo9.bs is None)
     test(mo9.ss == mo1.ss)
     test(mo9.iid is None)

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -72,6 +72,7 @@ module Test
         optional(8) string h;
         optional(9) MyEnum i;
         optional(10) MyInterface* j;
+        optional(11) Object* oprx;
         optional(12) ByteSeq bs;
         optional(13) StringSeq ss;
         optional(14) IntIntDict iid;

--- a/ruby/test/Ice/optional/AllTests.rb
+++ b/ruby/test/Ice/optional/AllTests.rb
@@ -25,6 +25,7 @@ def allTests(helper, communicator)
     test(mo1.h == nil)
     test(mo1.i == nil)
     test(mo1.j == nil)
+    test(mo1.oprx == nil)
     test(mo1.bs == nil)
     test(mo1.ss == nil)
     test(mo1.iid == nil)
@@ -50,6 +51,7 @@ def allTests(helper, communicator)
     vs = Test::VarStruct.new("hello")
     mo1 = Test::MultiOptional.new(15, true, 19, 78, 99, 5.5, 1.0, "test", Test::MyEnum::MyEnumMember, \
                                   Test::MyInterfacePrx.new(communicator, "test"), \
+                                  communicator.stringToProxy("test"), \
                                   [5], ["test", "test2"], {4=>3}, {"test"=>10}, fs, vs, [1], \
                                   [Test::MyEnum::MyEnumMember, Test::MyEnum::MyEnumMember], [ fs ], [ vs ], \
                                   [ Test::MyInterfacePrx.new(communicator, "test") ], \
@@ -67,6 +69,7 @@ def allTests(helper, communicator)
     test(mo1.h == "test")
     test(mo1.i == Test::MyEnum::MyEnumMember)
     test(mo1.j == communicator.stringToProxy("test"))
+    test(mo1.oprx == communicator.stringToProxy("test"))
     test(mo1.bs == [5])
     test(mo1.ss == ["test", "test2"])
     test(mo1.iid[4] == 3)
@@ -117,6 +120,7 @@ def allTests(helper, communicator)
     test(mo4.h == nil)
     test(mo4.i == nil)
     test(mo4.j == nil)
+    test(mo4.oprx == nil)
     test(mo4.bs == nil)
     test(mo4.ss == nil)
     test(mo4.iid == nil)
@@ -148,6 +152,7 @@ def allTests(helper, communicator)
     test(mo5.h == mo1.h)
     test(mo5.i == mo1.i)
     test(mo5.j == mo1.j)
+    test(mo5.oprx == mo1.oprx)
     test(mo5.bs.unpack("C*") == [0x05])
     test(mo5.ss == mo1.ss)
     test(mo5.iid[4] == 3)
@@ -193,6 +198,7 @@ def allTests(helper, communicator)
     test(mo7.h == mo1.h)
     test(mo7.i == nil)
     test(mo7.j == mo1.j)
+    test(mo7.oprx == nil)
     test(mo7.bs.unpack("C*") == [0x05])
     test(mo7.ss == nil)
     test(mo7.iid[4] == 3)
@@ -220,6 +226,7 @@ def allTests(helper, communicator)
     mo8.e = mo5.e
     mo8.g = mo5.g
     mo8.i = mo5.i
+    mo8.oprx = mo5.oprx
     mo8.ss = mo5.ss
     mo8.sid = mo5.sid
     mo8.vs = mo5.vs
@@ -243,6 +250,7 @@ def allTests(helper, communicator)
     test(mo9.h == nil)
     test(mo9.i == mo1.i)
     test(mo9.j == nil)
+    test(mo9.oprx == mo1.oprx)
     test(mo9.bs == nil)
     test(mo9.ss == mo1.ss)
     test(mo9.iid == nil)

--- a/ruby/test/Ice/optional/Test.ice
+++ b/ruby/test/Ice/optional/Test.ice
@@ -71,6 +71,7 @@ module Test
         optional(8) string h;
         optional(9) MyEnum i;
         optional(10) MyInterface* j;
+        optional(11) Object* oprx;
         optional(12) ByteSeq bs;
         optional(13) StringSeq ss;
         optional(14) IntIntDict iid;

--- a/swift/test/Ice/optional/AllTests.swift
+++ b/swift/test/Ice/optional/AllTests.swift
@@ -213,6 +213,7 @@ func allTests(_ helper: TestHelper, customSliceLoader: CustomSliceLoader) async 
     mo1.h = "test"
     mo1.i = .MyEnumMember
     mo1.j = try uncheckedCast(prx: communicator.stringToProxy("test")!, type: MyInterfacePrx.self)
+    mo1.oprx = try communicator.stringToProxy("test")
     mo1.bs = ByteSeq([5])
     mo1.ss = ["test", "test2"]
     mo1.iid = [4: 3]
@@ -251,6 +252,7 @@ func allTests(_ helper: TestHelper, customSliceLoader: CustomSliceLoader) async 
     try test(mo1.h! == "test")
     try test(mo1.i! == .MyEnumMember)
     try test(mo1.j! == communicator.stringToProxy("test"))
+    try test(mo1.oprx! == communicator.stringToProxy("test"))
     try test(mo1.bs! == ByteSeq([5]))
     try test(mo1.ss! == ["test", "test2"])
     try test(mo1.iid![4]! == 3)
@@ -299,6 +301,7 @@ func allTests(_ helper: TestHelper, customSliceLoader: CustomSliceLoader) async 
         try test(mo4.h == nil)
         try test(mo4.i == nil)
         try test(mo4.j == nil)
+        try test(mo4.oprx == nil)
         try test(mo4.bs == nil)
         try test(mo4.ss == nil)
         try test(mo4.iid == nil)
@@ -338,6 +341,7 @@ func allTests(_ helper: TestHelper, customSliceLoader: CustomSliceLoader) async 
         try test(mo5.h == mo1.h)
         try test(mo5.i == mo1.i)
         try test(mo5.j == mo1.j)
+        try test(mo5.oprx == mo1.oprx)
         try test(mo5.bs == mo1.bs)
         try test(mo5.ss == mo1.ss)
         try test(mo5.iid![4] == 3)
@@ -377,6 +381,7 @@ func allTests(_ helper: TestHelper, customSliceLoader: CustomSliceLoader) async 
         mo8.e = mo5.e
         mo8.g = mo5.g
         mo8.i = mo5.i
+        mo8.oprx = mo5.oprx
         mo8.ss = mo5.ss
         mo8.sid = mo5.sid
         mo8.vs = mo5.vs
@@ -403,6 +408,7 @@ func allTests(_ helper: TestHelper, customSliceLoader: CustomSliceLoader) async 
         try test(mo7.h == mo1.h)
         try test(mo7.i == nil)
         try test(mo7.j == mo1.j)
+        try test(mo7.oprx == nil)
         try test(mo7.bs == mo1.bs)
         try test(mo7.ss == nil)
         try test(mo7.iid![4] == 3)
@@ -438,6 +444,7 @@ func allTests(_ helper: TestHelper, customSliceLoader: CustomSliceLoader) async 
         try test(mo9.h == nil)
         try test(mo9.i == mo1.i)
         try test(mo9.j == nil)
+        try test(mo9.oprx == mo1.oprx)
         try test(mo9.bs == nil)
         try test(mo9.ss == mo1.ss)
         try test(mo9.iid == nil)

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -74,6 +74,7 @@ module Test
         optional(8) string h;
         optional(9) MyEnum i;
         optional(10) MyInterface* j;
+        optional(11) Object* oprx;
         optional(12) ByteSeq bs;
         optional(13) StringSeq ss;
         optional(14) IntIntDict iid;


### PR DESCRIPTION
`MultiOptional` in the `Ice/optional` test schema had an optional proxy of an interface type (`optional(10) MyInterface* j`) but no bare `Object*` field. That gap hid #6125: MATLAB's untyped `readProxyOpt` branch was never exercised by any test.

This PR adds `optional(11) Object* oprx;` to `MultiOptional` in all eight copies of the test schema (C++, C#, Java, MATLAB, PHP, Python, Ruby, Swift) — tag 11 was unused in every copy, so no renumbering — and sets/asserts the field alongside the existing `j` assertions, including the all-unset round-trip and the alternating clear-half rounds (tag 11 is odd, so it lands in the opposite half from `j`).

The `bareOptionalProxies` stream-level helper added to the MATLAB test by #6167 is removed: it was a stand-in for schema coverage and is now redundant.

Verified by running `Ice/optional` in C++, C#, Java, Python, Ruby, PHP, and Swift, plus a C++/C# cross run; the MATLAB mapping is not buildable on this platform and relies on CI.

Fixes #6168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)