### PR TITLE
Improve IceBT/IceGrid/IceStorm startup and error-path diagnostics

### DIFF
--- a/cpp/src/IceBT/Engine.cpp
+++ b/cpp/src/IceBT/Engine.cpp
@@ -525,6 +525,9 @@ namespace IceBT
             }
             catch (const DBus::Exception& ex)
             {
+                // Always remove the local service so we don't leak the profile and its callback chain on the
+                // long-lived DBus connection. removeService is a no-op if the service was already removed.
+                _dbusConnection->removeService(path);
                 throw BluetoothException{__FILE__, __LINE__, ex.reason};
             }
         }

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -752,7 +752,7 @@ Resolver::setVersion(const string& version)
         else if (_version > ICE_INT_VERSION && warningEnabled())
         {
             Ice::Warning out(_communicator->getLogger());
-            out << "invalid Ice version: " << _version << " is greater than the IceGrid ";
+            out << "Ice version " << v << " is greater than the IceGrid ";
             out << "registry version (" << ICE_STRING_VERSION << ")";
         }
     }

--- a/cpp/src/IceStorm/Service.cpp
+++ b/cpp/src/IceStorm/Service.cpp
@@ -193,9 +193,9 @@ ServiceI::start([[maybe_unused]] const string& serviceName, const CommunicatorPt
             // Validate first that the adapter ids match for the node and the topic manager otherwise some other
             // deployment is being used.
             const string suffix = ".TopicManager";
-            if (topicManagerAdapterId.empty() || nodeAdapterId.empty() ||
-                topicManagerAdapterId.replace(topicManagerAdapterId.find(suffix), suffix.size(), ".Node") !=
-                    nodeAdapterId)
+            string::size_type suffixPos = topicManagerAdapterId.find(suffix);
+            if (topicManagerAdapterId.empty() || nodeAdapterId.empty() || suffixPos == string::npos ||
+                string{topicManagerAdapterId}.replace(suffixPos, suffix.size(), ".Node") != nodeAdapterId)
             {
                 Ice::Error error(communicator->getLogger());
                 error << "deployment error: '" << topicManagerAdapterId << "' prefix does not match '" << nodeAdapterId
@@ -218,7 +218,14 @@ ServiceI::start([[maybe_unused]] const string& serviceName, const CommunicatorPt
                 string adapterId = replica->ice_getAdapterId();
 
                 // Replace TopicManager with the node endpoint.
-                adapterId = adapterId.replace(adapterId.find(suffix), suffix.size(), ".Node");
+                string::size_type replicaSuffixPos = adapterId.find(suffix);
+                if (replicaSuffixPos == string::npos)
+                {
+                    Ice::Error error(communicator->getLogger());
+                    error << "deployment error: '" << adapterId << "' does not contain '" << suffix << "'";
+                    throw IceBox::FailureException(__FILE__, __LINE__, "IceGrid deployment is incorrect");
+                }
+                adapterId.replace(replicaSuffixPos, suffix.size(), ".Node");
 
                 // The adapter id must start with the instance name.
                 if (adapterId.find(instanceName) != 0)
@@ -262,6 +269,13 @@ ServiceI::start([[maybe_unused]] const string& serviceName, const CommunicatorPt
             Ice::Error error(communicator->getLogger());
             error << "Replication requires at least 3 Nodes";
             throw IceBox::FailureException(__FILE__, __LINE__, "Replication requires at least 3 Nodes");
+        }
+
+        if (nodes.find(id) == nodes.end())
+        {
+            Ice::Error error(communicator->getLogger());
+            error << "invalid value for IceStorm.NodeId: no node with id " << id;
+            throw IceBox::FailureException(__FILE__, __LINE__, "invalid value for IceStorm.NodeId");
         }
 
         try

--- a/cpp/src/IceStorm/Service.cpp
+++ b/cpp/src/IceStorm/Service.cpp
@@ -274,7 +274,11 @@ ServiceI::start([[maybe_unused]] const string& serviceName, const CommunicatorPt
         if (nodes.find(id) == nodes.end())
         {
             Ice::Error error(communicator->getLogger());
-            error << "invalid value for IceStorm.NodeId: no node with id " << id;
+            error << "invalid value for IceStorm.NodeId: no node with id " << id << "; the node ids are:";
+            for (const auto& node : nodes)
+            {
+                error << " " << node.first;
+            }
             throw IceBox::FailureException(__FILE__, __LINE__, "invalid value for IceStorm.NodeId");
         }
 


### PR DESCRIPTION
This PR fixes the four service-side issues reported in #6134:

- **IceBT**: `unregisterProfile` now removes the local D-Bus service when the unregister call throws, mirroring the register path, so a send-side D-Bus exception no longer leaks the `ServerProfile` and its callback chain on the long-lived D-Bus connection.
- **IceGrid**: the descriptor warning for an Ice version newer than the registry now prints the dotted version string instead of the encoded integer, and no longer calls the version "invalid" (the warning now reads "Ice version 3.9.0 is greater than the IceGrid registry version (...)" instead of "invalid Ice version: 30900 ...").
- **IceStorm**: the `.TopicManager` adapter-id validations guard against a missing suffix before calling `replace`, and the initial comparison works on a copy — a malformed IceGrid deployment now produces the intended "deployment error" message and `IceBox::FailureException` (with the original, unmutated adapter id) instead of an uncaught `std::out_of_range`.
- **IceStorm**: the configured `IceStorm.NodeId` is validated against the node map before use; a node id that doesn't match any node now produces a clear error instead of an uncaught `std::out_of_range` that bypassed the `Ice::LocalException` handler.

All four changes only affect how misconfiguration and error paths are reported, so there are no changelog entries.

Fixes #6134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)