### PR TITLE
Resolve a DataStorm partial update against each reader's own value

### DIFF
--- a/changelog.d/datastorm/6174.md
+++ b/changelog.d/datastorm/6174.md
@@ -2,6 +2,3 @@
   the current value of whichever reader was served first, instead of against each reader's own current value. Readers
   that hold different values for a key, for example because only some of them use a discard policy, now each resolve
   the update against their own value.
-- Fixed a bug where a full value that the reader's `Decoder` rejected was dropped only by the first reader of the key
-  on the node. The other readers of that key took a default-constructed value for the published one. They now all
-  drop the value.

--- a/changelog.d/datastorm/6174.md
+++ b/changelog.d/datastorm/6174.md
@@ -1,0 +1,7 @@
+- Fixed a bug where a partial update delivered to several readers of the same key on one node was resolved against
+  the current value of whichever reader was served first, instead of against each reader's own current value. Readers
+  that hold different values for a key, for example because only some of them use a discard policy, now each resolve
+  the update against their own value.
+- Fixed a bug where a full value that the reader's `Decoder` rejected was dropped only by the first reader of the key
+  on the node. The other readers of that key took a default-constructed value for the published one. They now all
+  drop the value.

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -400,11 +400,6 @@ namespace DataStormI
             }
 
             // A custom Encoder may encode a value to zero bytes; the Decoder defines the meaning of empty input.
-            //
-            // The sample is only marked as having a value once the Decoder returned one. A received sample is shared
-            // by all the elements subscribed to the writer element that published it, so marking it beforehand would
-            // let a Decoder that throws leave the sample claiming a value it never got, and the elements that decode
-            // it after the first one would take that default-constructed value for the published one.
             _value = DecoderT<Value>::decode(communicator, _encodedValue);
             _hasValue = true;
             _encodedValue.clear();

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -400,8 +400,13 @@ namespace DataStormI
             }
 
             // A custom Encoder may encode a value to zero bytes; the Decoder defines the meaning of empty input.
-            _hasValue = true;
+            //
+            // The sample is only marked as having a value once the Decoder returned one. A received sample is shared
+            // by all the elements subscribed to the writer element that published it, so marking it beforehand would
+            // let a Decoder that throws leave the sample claiming a value it never got, and the elements that decode
+            // it after the first one would take that default-constructed value for the published one.
             _value = DecoderT<Value>::decode(communicator, _encodedValue);
+            _hasValue = true;
             _encodedValue.clear();
         }
 

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1610,24 +1610,39 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
                 }
                 assert(key);
 
-                auto sample = topic->getSampleFactory()->create(
-                    _id,
-                    elementSubscribers->name,
-                    dataSample.id,
-                    dataSample.event,
-                    key,
-                    topicSubscriber.tags[dataSample.tag],
-                    dataSample.value,
-                    dataSample.timestamp);
+                auto createSample = [&]
+                {
+                    return topic->getSampleFactory()->create(
+                        _id,
+                        elementSubscribers->name,
+                        dataSample.id,
+                        dataSample.event,
+                        key,
+                        topicSubscriber.tags[dataSample.tag],
+                        dataSample.value,
+                        dataSample.timestamp);
+                };
+
+                // A full value is decoded into the sample the same way whatever element receives it, so the elements
+                // subscribed to this writer element share a single sample, decoded once. A partial update is not: each
+                // element resolves it against its own current value for the key and the resolved value is written into
+                // the sample, so each element gets a sample of its own. Sharing one would let the value resolved by
+                // whichever element is served first surface in all the others.
+                shared_ptr<Sample> sharedSample;
+                if (dataSample.event != DataStorm::SampleEvent::PartialUpdate)
+                {
+                    sharedSample = createSample();
+                }
 
                 for (auto& [element, elementSubscriber] : elementSubscribers->getSubscribers())
                 {
                     if (elementSubscriber.initialized &&
                         (dataSample.keyId <= 0 || elementSubscriber.keys.find(key) != elementSubscriber.keys.end()))
                     {
+                        auto elementSample = sharedSample ? sharedSample : createSample();
                         elementSubscriber.lastId = dataSample.id;
                         element->queue(
-                            sample,
+                            elementSample,
                             elementSubscribers->priority,
                             shared_from_this(),
                             current.facet,

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1626,8 +1626,7 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
                 // A full value is decoded into the sample the same way whatever element receives it, so the elements
                 // subscribed to this writer element share a single sample, decoded once. A partial update is not: each
                 // element resolves it against its own current value for the key and the resolved value is written into
-                // the sample, so each element gets a sample of its own. Sharing one would let the value resolved by
-                // whichever element is served first surface in all the others.
+                // the sample, so each element gets a sample of its own.
                 shared_ptr<Sample> sharedSample;
                 if (dataSample.event != DataStorm::SampleEvent::PartialUpdate)
                 {

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -45,6 +45,10 @@ namespace DataStorm
     {
         static Counter decode(const Ice::CommunicatorPtr&, const Ice::ByteSeq& data)
         {
+            if (!data.empty() && data[0] == std::byte{0xFF})
+            {
+                throw std::runtime_error("undecodable counter");
+            }
             return Counter{data.empty() ? 0 : static_cast<int>(data[0])};
         }
     };
@@ -470,6 +474,60 @@ void ::Reader::run(int argc, char* argv[])
         test(sample.getEvent() == SampleEvent::PartialUpdate);
         test(sample.getUpdateTag() == "increment");
         test(sample.getValue().value == 5); // resolved against the empty-encoded base
+    }
+
+    // Two readers of the same key on one node hold different values for it, because only one of them applies the
+    // priority discard policy. A partial update accepted by both is resolved against each reader's own value.
+    Topic<string, StockPtr> perReaderTopic(node, "perReaderTopic");
+    perReaderTopic.setReaderDefaultConfig(config);
+    perReaderTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    {
+        auto noDiscardReader = makeSingleKeyReader(perReaderTopic, "AAPL", "noDiscard");
+
+        ReaderConfig priorityConfig = config;
+        priorityConfig.discardPolicy = DiscardPolicy::Priority;
+        auto priorityReader = makeSingleKeyReader(perReaderTopic, "AAPL", "priority", priorityConfig);
+
+        auto sample = noDiscardReader.getNextUnread();
+        test(sample.getValue()->price == 12.0f); // the high-priority full value
+
+        sample = noDiscardReader.getNextUnread();
+        test(sample.getValue()->price == 100.0f); // the low-priority full value, accepted by this reader
+
+        sample = noDiscardReader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::PartialUpdate);
+        test(sample.getValue()->price == 15.0f);
+        test(sample.getValue()->lastBid == 101.0f); // resolved against the low-priority value
+        test(sample.getValue()->lastAsk == 102.0f);
+
+        // The priority reader discarded the low-priority full value, so it still holds the high-priority one.
+        sample = priorityReader.getNextUnread();
+        test(sample.getValue()->price == 12.0f);
+
+        sample = priorityReader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::PartialUpdate);
+        test(sample.getValue()->price == 15.0f);
+        test(sample.getValue()->lastBid == 13.0f); // resolved against the high-priority value, not the other reader's
+        test(sample.getValue()->lastAsk == 14.0f);
+    }
+
+    // A full value that the Decoder rejects is dropped by every reader of the key on the node: each of them keeps the
+    // value it had and resynchronizes on the next full value that decodes.
+    Topic<string, Counter> decodeErrorTopic(node, "decodeErrorTopic");
+    decodeErrorTopic.setReaderDefaultConfig(config);
+    {
+        auto reader1 = makeSingleKeyReader(decodeErrorTopic, "key", "reader1");
+        auto reader2 = makeSingleKeyReader(decodeErrorTopic, "key", "reader2");
+
+        auto sample = reader1.getNextUnread();
+        test(sample.getValue().value == 1);
+        sample = reader1.getNextUnread();
+        test(sample.getValue().value == 2); // the undecodable value was dropped, not delivered as a default value
+
+        sample = reader2.getNextUnread();
+        test(sample.getValue().value == 1);
+        sample = reader2.getNextUnread();
+        test(sample.getValue().value == 2);
     }
 }
 

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -49,6 +49,10 @@ namespace DataStorm
     {
         static Counter decode(const Ice::CommunicatorPtr&, const Ice::ByteSeq& data)
         {
+            if (!data.empty() && data[0] == std::byte{0xFF})
+            {
+                throw std::runtime_error("undecodable counter");
+            }
             return Counter{data.empty() ? 0 : static_cast<int>(data[0])};
         }
     };
@@ -405,6 +409,52 @@ void ::Writer::run(int argc, char* argv[])
         writer.waitForReaders();
         writer.add(Counter{0}); // the full value 0 encodes to zero bytes
         writer.partialUpdate<int>("increment")(5);
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // Two readers of the same key on one node hold different values for it: the reader without a discard policy
+    // accepts the low-priority writer's full value, the reader using the priority discard policy discards it and keeps
+    // the high-priority writer's value. The partial update published next must be resolved against each reader's own
+    // value. Both writers deliver through the node's single session connection and the reader node dispatches samples
+    // serialized, so the reader processes the three samples in the order they are published here.
+    Topic<string, StockPtr> perReaderTopic(node, "perReaderTopic");
+    perReaderTopic.setWriterDefaultConfig(config);
+    perReaderTopic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
+    cout << "testing partial update resolved against each reader's own value... " << flush;
+    {
+        WriterConfig highPriority = config;
+        highPriority.priority = 10;
+        auto high = makeSingleKeyWriter(perReaderTopic, "AAPL", "high", highPriority);
+
+        WriterConfig lowPriority = config;
+        lowPriority.priority = 1;
+        auto low = makeSingleKeyWriter(perReaderTopic, "AAPL", "low", lowPriority);
+
+        high.waitForReaders(2);
+        low.waitForReaders(2);
+
+        high.add(make_shared<Stock>(12.0f, 13.0f, 14.0f));      // accepted by both readers
+        low.update(make_shared<Stock>(100.0f, 101.0f, 102.0f)); // discarded by the priority reader
+        high.partialUpdate<float>("price")(15.0f);
+
+        high.waitForNoReaders();
+        low.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // A full value that the reader's Decoder rejects is dropped by every reader of the key on the node, and none of
+    // them keeps it as the key's value: they all carry on with the value they had and resynchronize on the next full
+    // value that decodes.
+    Topic<string, Counter> decodeErrorTopic(node, "decodeErrorTopic");
+    decodeErrorTopic.setWriterDefaultConfig(config);
+    cout << "testing full value that fails to decode... " << flush;
+    {
+        auto writer = makeSingleKeyWriter(decodeErrorTopic, "key");
+        writer.waitForReaders(2);
+        writer.add(Counter{1});
+        writer.update(Counter{0xFF}); // the reader's Decoder throws on this value
+        writer.update(Counter{2});
         writer.waitForNoReaders();
     }
     cout << "ok" << endl;


### PR DESCRIPTION
Closes #6174

A subscriber session decoded a received sample once and queued that same object to every element subscribed to the
writer element that published it. `DataReaderI::queue` resolves a partial update in place on the sample, against the
element's own current value for the key, so the first element served wrote its result into the shared object and every
other element reused it. Elements that hold different values for the key — for instance because only some of them use a
discard policy — therefore delivered, and kept as their own value, an update resolved against another element's value.
It also bypassed the discard of a partial update that has no base value (#6083), resurrecting a key the element should
have had no value for.

`SubscriberSessionI::s` now creates a sample per element for a partial update, and keeps the single decoded sample only
for the events that no element mutates. That is the one place that knows a wire sample is about to fan out over several
elements, so the fix stays at the source of the sharing rather than in each consumer.

Decoding a full value shares the same defect, which came up while auditing the fix: `SampleT::decode` marked the sample
as having a value *before* calling the `Decoder`, so a `Decoder` that threw left the shared sample claiming a value it
never got, and the elements decoding it afterwards took the default-constructed value for the published one. The sample
is now marked only once the `Decoder` returned a value.

## Tests

Two cases at the end of `cpp/test/DataStorm/partial/{Writer,Reader}.cpp`:

- two writers (priority 10 and 1) and two readers of the same key, one with `DiscardPolicy::Priority` and one without,
  so the readers hold different values for the key when a partial update arrives;
- two co-subscribed readers and a full value the `Decoder` rejects, which both must drop.

Each fails for its own reason without its half of the fix, and the full `DataStorm` suite passes.
