### PR TITLE
Create the server thread pool before the incoming connection factories

### DIFF
--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -1035,20 +1035,20 @@ Ice::ObjectAdapterI::initialize(optional<RouterPrx> router)
             }
             else
             {
-                // Make sure the dispatch thread pool is created before we create the incoming connection
-                // factories: the on-demand creation of the server thread pool can throw (for example, when a
-                // thread pool property has an invalid value), and it must not fail once we start creating
-                // connections.
-                getThreadPool();
-            }
+                // An adapter with endpoints accepts incoming connections, and each connection needs the
+                // adapter's dispatch thread pool. Create it before the first connection factory: its
+                // on-demand creation reads the thread pool properties and can throw, and it must not fail
+                // once connections exist.
+                [[maybe_unused]] auto _ = getThreadPool();
 
-            for (const auto& endpoint : endpoints)
-            {
-                for (const auto& expanded : endpoint->expandHost())
+                for (const auto& endpoint : endpoints)
                 {
-                    auto factory = make_shared<IncomingConnectionFactory>(_instance, expanded, shared_from_this());
-                    factory->initialize();
-                    _incomingConnectionFactories.push_back(factory);
+                    for (const auto& expanded : endpoint->expandHost())
+                    {
+                        auto factory = make_shared<IncomingConnectionFactory>(_instance, expanded, shared_from_this());
+                        factory->initialize();
+                        _incomingConnectionFactories.push_back(factory);
+                    }
                 }
             }
         }

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -1024,15 +1024,6 @@ Ice::ObjectAdapterI::initialize(optional<RouterPrx> router)
             // fill in the real port number.
             //
             vector<EndpointIPtr> endpoints = parseEndpoints(properties->getProperty(_name + ".Endpoints"), true);
-            for (const auto& endpoint : endpoints)
-            {
-                for (const auto& expanded : endpoint->expandHost())
-                {
-                    auto factory = make_shared<IncomingConnectionFactory>(_instance, expanded, shared_from_this());
-                    factory->initialize();
-                    _incomingConnectionFactories.push_back(factory);
-                }
-            }
             if (endpoints.empty())
             {
                 TraceLevelsPtr tl = _instance->traceLevels();
@@ -1040,6 +1031,24 @@ Ice::ObjectAdapterI::initialize(optional<RouterPrx> router)
                 {
                     Trace out(_instance->initializationData().logger, tl->networkCat);
                     out << "created adapter '" << _name << "' without endpoints";
+                }
+            }
+            else
+            {
+                // Make sure the dispatch thread pool is created before we create the incoming connection
+                // factories: the on-demand creation of the server thread pool can throw (for example, when a
+                // thread pool property has an invalid value), and it must not fail once we start creating
+                // connections.
+                getThreadPool();
+            }
+
+            for (const auto& endpoint : endpoints)
+            {
+                for (const auto& expanded : endpoint->expandHost())
+                {
+                    auto factory = make_shared<IncomingConnectionFactory>(_instance, expanded, shared_from_this());
+                    factory->initialize();
+                    _incomingConnectionFactories.push_back(factory);
                 }
             }
         }

--- a/cpp/test/Ice/adapterDeactivation/AllTests.cpp
+++ b/cpp/test/Ice/adapterDeactivation/AllTests.cpp
@@ -321,6 +321,25 @@ allTests(Test::TestHelper* helper)
     }
     cout << "ok" << endl;
 
+    cout << "testing UDP object adapter creation with an invalid thread pool property... " << flush;
+    {
+        Ice::InitializationData initData;
+        initData.properties = Ice::createProperties();
+        initData.properties->setProperty("Ice.ServerIdleTime", "invalid");
+        Ice::CommunicatorHolder ich{Ice::initialize(initData)};
+        try
+        {
+            ich->createObjectAdapterWithEndpoints("UdpAdapter", "udp -h 127.0.0.1 -p 0");
+            test(false);
+        }
+        catch (const Ice::PropertyException&)
+        {
+            // Expected: the server thread pool is created on demand by the UDP adapter, and its creation reads
+            // Ice.ServerIdleTime.
+        }
+    }
+    cout << "ok" << endl;
+
     cout << "testing object adapter creation with port in use... " << flush;
     {
         Ice::ObjectAdapterPtr adapter1 =

--- a/cpp/test/Ice/adapterDeactivation/AllTests.cpp
+++ b/cpp/test/Ice/adapterDeactivation/AllTests.cpp
@@ -326,7 +326,12 @@ allTests(Test::TestHelper* helper)
         Ice::InitializationData initData;
         initData.properties = Ice::createProperties();
         initData.properties->setProperty("Ice.ServerIdleTime", "invalid");
-        Ice::CommunicatorHolder ich{Ice::initialize(initData)};
+        if (IceInternal::isMinBuild())
+        {
+            // In static builds, the Ice library does not register the IceUDP plug-in automatically.
+            initData.pluginFactories = {Ice::udpPluginFactory()};
+        }
+        Ice::CommunicatorHolder ich{Ice::initialize(std::move(initData))};
         try
         {
             ich->createObjectAdapterWithEndpoints("UdpAdapter", "udp -h 127.0.0.1 -p 0");

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1414,36 +1414,27 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         }
         _transceiver = transceiver;
 
-        try
+        if (connector is null)
         {
-            if (connector is null)
-            {
-                // adapter is always set for incoming connections
-                Debug.Assert(adapter is not null);
-                _threadPool = adapter.getThreadPool();
-            }
-            else
-            {
-                // we use the client thread pool for outgoing connections, even if there is an
-                // object adapter with its own thread pool.
-                _threadPool = instance.clientThreadPool();
-            }
-            // On Windows, async socket I/O initiated on a thread that subsequently terminates is cancelled by the OS
-            // with SocketError.OperationAborted. The Ice thread pool can reap workers idle past ThreadIdleTime when
-            // SizeMax > 1, so in that combination we hop the I/O onto the .NET ThreadPool (whose threads are managed
-            // by the runtime and not reaped while owning pending I/O). Other platforms and fixed-size Ice pools don't
-            // need the hop. See startAsync.
-            _threadHopRequired = AssemblyUtil.isWindows && _threadPool.canShrink;
-            _threadPool.initialize(this);
+            // adapter is always set for incoming connections
+            Debug.Assert(adapter is not null);
+            _threadPool = adapter.getThreadPool();
         }
-        catch (LocalException)
+        else
         {
-            throw;
+            // we use the client thread pool for outgoing connections, even if there is an
+            // object adapter with its own thread pool.
+            _threadPool = instance.clientThreadPool();
         }
-        catch (System.Exception ex)
-        {
-            throw new SyscallException(ex);
-        }
+        // On Windows, async socket I/O initiated on a thread that subsequently terminates is cancelled by the OS
+        // with SocketError.OperationAborted. The Ice thread pool can reap workers idle past ThreadIdleTime when
+        // SizeMax > 1, so in that combination we hop the I/O onto the .NET ThreadPool (whose threads are managed
+        // by the runtime and not reaped while owning pending I/O). Other platforms and fixed-size Ice pools don't
+        // need the hop. See startAsync.
+        _threadHopRequired = AssemblyUtil.isWindows && _threadPool.canShrink;
+
+        // initialize only resets the handler state; it doesn't throw.
+        _threadPool.initialize(this);
     }
 
     /// <summary>

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1161,19 +1161,19 @@ public sealed class ObjectAdapter
                 }
                 else
                 {
-                    // Make sure the dispatch thread pool is created before we create the incoming connection
-                    // factories: the on-demand creation of the server thread pool can throw (for example, when a
-                    // thread pool property has an invalid value), and it must not fail once we start creating
-                    // connections.
+                    // An adapter with endpoints accepts incoming connections, and each connection needs the
+                    // adapter's dispatch thread pool. Create it before the first connection factory: its
+                    // on-demand creation reads the thread pool properties and can throw, and it must not fail
+                    // once connections exist.
                     getThreadPool();
-                }
 
-                foreach (EndpointI endp in endpoints)
-                {
-                    foreach (EndpointI expanded in endp.expandHost())
+                    foreach (EndpointI endp in endpoints)
                     {
-                        var factory = new IncomingConnectionFactory(instance, expanded, this);
-                        _incomingConnectionFactories.Add(factory);
+                        foreach (EndpointI expanded in endp.expandHost())
+                        {
+                            var factory = new IncomingConnectionFactory(instance, expanded, this);
+                            _incomingConnectionFactories.Add(factory);
+                        }
                     }
                 }
             }

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1148,14 +1148,7 @@ public sealed class ObjectAdapter
                 // Parse the endpoints, but don't store them in the adapter. The connection
                 // factory might change it, for example, to fill in the real port number.
                 List<EndpointI> endpoints = parseEndpoints(properties.getProperty(_name + ".Endpoints"), true);
-                foreach (EndpointI endp in endpoints)
-                {
-                    foreach (EndpointI expanded in endp.expandHost())
-                    {
-                        var factory = new IncomingConnectionFactory(instance, expanded, this);
-                        _incomingConnectionFactories.Add(factory);
-                    }
-                }
+
                 if (endpoints.Count == 0)
                 {
                     TraceLevels tl = _instance.traceLevels();
@@ -1164,6 +1157,23 @@ public sealed class ObjectAdapter
                         _instance.initializationData().logger!.trace(
                             tl.networkCat,
                             $"created adapter '{_name}' without endpoints");
+                    }
+                }
+                else
+                {
+                    // Make sure the dispatch thread pool is created before we create the incoming connection
+                    // factories: the on-demand creation of the server thread pool can throw (for example, when a
+                    // thread pool property has an invalid value), and it must not fail once we start creating
+                    // connections.
+                    getThreadPool();
+                }
+
+                foreach (EndpointI endp in endpoints)
+                {
+                    foreach (EndpointI expanded in endp.expandHost())
+                    {
+                        var factory = new IncomingConnectionFactory(instance, expanded, this);
+                        _incomingConnectionFactories.Add(factory);
                     }
                 }
             }

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -330,6 +330,28 @@ public class AllTests : global::Test.AllTests
         }
         output.WriteLine("ok");
 
+        output.Write("testing UDP object adapter creation with an invalid thread pool property... ");
+        output.Flush();
+        {
+            var initData = new Ice.InitializationData()
+            {
+                properties = new Ice.Properties(),
+            };
+            initData.properties.setProperty("Ice.ServerIdleTime", "invalid");
+            using var ic = new Ice.Communicator(initData);
+            try
+            {
+                ic.createObjectAdapterWithEndpoints("UdpAdapter", "udp -h 127.0.0.1 -p 0");
+                test(false);
+            }
+            catch (Ice.PropertyException)
+            {
+                // Expected: the server thread pool is created on demand by the UDP adapter, and its creation
+                // reads Ice.ServerIdleTime.
+            }
+        }
+        output.WriteLine("ok");
+
         output.Write("testing object adapter creation with port in use... ");
         output.Flush();
         {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -1097,19 +1097,15 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
         _transceiver = transceiver;
 
-        try {
-            if (connector == null) { // server connection
-                assert adapter != null;
-                _threadPool = adapter.getThreadPool();
-            } else { // client connection
-                _threadPool = _instance.clientThreadPool();
-            }
-            _threadPool.initialize(this);
-        } catch (LocalException ex) {
-            throw ex;
-        } catch (Exception ex) {
-            throw new SyscallException(ex);
+        if (connector == null) { // server connection
+            assert adapter != null;
+            _threadPool = adapter.getThreadPool();
+        } else { // client connection
+            _threadPool = _instance.clientThreadPool();
         }
+
+        // initialize only queues the handler registration with the selector; it doesn't throw.
+        _threadPool.initialize(this);
     }
 
     private static final int StateNotInitialized = 0;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -1131,16 +1131,23 @@ public final class ObjectAdapter {
                 // The connection factory might change it, for example, to fill in the real port number.
                 List<EndpointI> endpoints = parseEndpoints(properties.getProperty(_name + ".Endpoints"), true);
 
-                for (EndpointI endpoint : endpoints) {
-                    for (EndpointI expanded : endpoint.expandHost()) {
-                        _incomingConnectionFactories.add(new IncomingConnectionFactory(instance, expanded, this));
-                    }
-                }
                 if (endpoints.isEmpty()) {
                     TraceLevels tl = _instance.traceLevels();
                     if (tl.network >= 2) {
                         String msg = "created adapter '" + name + "' without endpoints";
                         _instance.initializationData().logger.trace(tl.networkCat, msg);
+                    }
+                } else {
+                    // Make sure the dispatch thread pool is created before we create the incoming connection
+                    // factories: the on-demand creation of the server thread pool can throw (for example, when a
+                    // thread pool property has an invalid value), and it must not fail once we start creating
+                    // connections.
+                    getThreadPool();
+                }
+
+                for (EndpointI endpoint : endpoints) {
+                    for (EndpointI expanded : endpoint.expandHost()) {
+                        _incomingConnectionFactories.add(new IncomingConnectionFactory(instance, expanded, this));
                     }
                 }
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -1138,16 +1138,16 @@ public final class ObjectAdapter {
                         _instance.initializationData().logger.trace(tl.networkCat, msg);
                     }
                 } else {
-                    // Make sure the dispatch thread pool is created before we create the incoming connection
-                    // factories: the on-demand creation of the server thread pool can throw (for example, when a
-                    // thread pool property has an invalid value), and it must not fail once we start creating
-                    // connections.
+                    // An adapter with endpoints accepts incoming connections, and each connection needs the
+                    // adapter's dispatch thread pool. Create it before the first connection factory: its
+                    // on-demand creation reads the thread pool properties and can throw, and it must not fail
+                    // once connections exist.
                     getThreadPool();
-                }
 
-                for (EndpointI endpoint : endpoints) {
-                    for (EndpointI expanded : endpoint.expandHost()) {
-                        _incomingConnectionFactories.add(new IncomingConnectionFactory(instance, expanded, this));
+                    for (EndpointI endpoint : endpoints) {
+                        for (EndpointI expanded : endpoint.expandHost()) {
+                            _incomingConnectionFactories.add(new IncomingConnectionFactory(instance, expanded, this));
+                        }
                     }
                 }
             }

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
@@ -17,6 +17,7 @@ import com.zeroc.Ice.ObjectAdapterDestroyedException;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.OperationNotExistException;
 import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.PropertyException;
 import com.zeroc.Ice.RouterPrx;
 
 import test.Ice.adapterDeactivation.Test.TestIntfPrx;
@@ -367,6 +368,24 @@ public class AllTests {
                 communicator.createObjectAdapterWithRouter("AdapterWithRouter", router);
                 test(false);
             } catch (InitializationException ex) {}
+        }
+        out.println("ok");
+
+        out.print("testing UDP object adapter creation with an invalid thread pool property... ");
+        out.flush();
+        {
+            InitializationData initData = new InitializationData();
+            initData.properties = new Properties();
+            initData.properties.setProperty("Ice.ServerIdleTime", "invalid");
+            try (Communicator ic = new Communicator(initData)) {
+                try {
+                    ic.createObjectAdapterWithEndpoints("UdpAdapter", "udp -h 127.0.0.1 -p 0");
+                    test(false);
+                } catch (PropertyException ex) {
+                    // Expected: the server thread pool is created on demand by the UDP adapter, and its
+                    // creation reads Ice.ServerIdleTime.
+                }
+            }
         }
         out.println("ok");
 


### PR DESCRIPTION
The server thread pool is created on demand, and its creation reads `Ice.ServerIdleTime` and the `Ice.ThreadPool.Server.*` properties. For a UDP object adapter in C++, that first read happened inside `ConnectionI::create`, after the `ConnectionI` constructor had returned: an invalid property value threw `PropertyException` at that point, and unwinding destroyed the connection with `_state == StateNotInitialized`, tripping the `assert(_state == StateFinished)` in `~ConnectionI` on debug builds. Release builds already reported the `PropertyException` cleanly, as do Java and C#, where the thread pool is acquired inside the connection constructor.

The object adapter now resolves its dispatch thread pool before creating the incoming connection factories, in all three mappings: the on-demand creation of the server thread pool — and any exception from it — happens before any acceptor or connection exists. The pool is still created by the same `createObjectAdapter` call as before, just a few steps earlier (for TCP, before the acceptor binds and listens instead of after); adapters without endpoints don't create the server thread pool, same as before.

This also removes a platform inconsistency: on iOS, `IncomingConnectionFactory::initialize` defers the acceptor creation until the app is foregrounded, so even a TCP adapter used to create the server thread pool outside `createObjectAdapter` — potentially on a notification callback, which is also where an invalid property value would have surfaced. The pool now exists from `createObjectAdapter` on every platform and transport.

With the thread pool guaranteed to exist by the time a connection is created, the try/catch around the thread pool wiring in the C# and Java `ConnectionI` constructors had no remaining live path (their `ThreadPool.initialize` doesn't throw); it is removed. C++ keeps its handling: `ThreadPool::initialize` registers with the selector, which can fail on Windows.

Each mapping's `Ice/adapterDeactivation` test now verifies that creating a UDP object adapter with an invalid `Ice.ServerIdleTime` throws `PropertyException`.

Fixes #6188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)