### PR TITLE
Fix doc comment typos in DataStorm for C++

### DIFF
--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -235,7 +235,7 @@ namespace DataStorm
         [[nodiscard]] bool hasReaders() const noexcept;
 
         /// Waits for the given number of readers to be online.
-        /// @param count The number of readers to wait.
+        /// @param count The number of readers to wait for.
         /// @throws NodeShutdownException Thrown when the node is shut down while waiting.
         void waitForReaders(unsigned int count = 1) const;
 
@@ -365,7 +365,7 @@ namespace DataStorm
         [[nodiscard]] bool hasReaders() const noexcept;
 
         /// Waits for the given number of data readers to be online.
-        /// @param count The number of data readers to wait.
+        /// @param count The number of data readers to wait for.
         /// @throws NodeShutdownException Thrown when the node is shut down while waiting.
         void waitForReaders(unsigned int count = 1) const;
 

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -356,7 +356,7 @@ namespace DataStorm
         /// @throws NodeShutdownException Thrown when the node is shut down while waiting.
         void waitForNoWriters() const;
 
-        /// Sets the default configuration used to construct readers.
+        /// Sets the default configuration used to construct writers.
         /// @param config The default writer configuration.
         void setWriterDefaultConfig(const WriterConfig& config) noexcept;
 


### PR DESCRIPTION
- `Topic::setWriterDefaultConfig` was documented as setting the default configuration used to construct *readers*, copied from `setReaderDefaultConfig` right below it.
- The `count` parameter of `Topic::waitForReaders` and `Writer::waitForReaders` read "the number of readers to wait"; the writer-side twins read "to wait for".