### PR TITLE
Fix two diagnostic defects in the JS and PHP mappings

### DIFF
--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -1538,6 +1538,8 @@ export class InputStream {
             this._encapsStack = this._encapsCache;
             if (this._encapsStack !== null) {
                 this._encapsCache = this._encapsCache.next;
+                // Detach the reused node from the cache: as the outermost encapsulation it has no next.
+                this._encapsStack.next = null;
             } else {
                 this._encapsStack = new ReadEncaps();
             }

--- a/js/packages/ice/src/Ice/OutputStream.js
+++ b/js/packages/ice/src/Ice/OutputStream.js
@@ -528,7 +528,7 @@ export class OutputStream {
 
     clear() {
         if (this._encapsStack !== null) {
-            console.assert(this._encapsStack.next);
+            console.assert(this._encapsStack.next === null);
             this._encapsStack.next = this._encapsCache;
             this._encapsCache = this._encapsStack;
             this._encapsCache.reset();
@@ -876,6 +876,8 @@ export class OutputStream {
             this._encapsStack = this._encapsCache;
             if (this._encapsStack) {
                 this._encapsCache = this._encapsCache.next;
+                // Detach the reused node from the cache: as the outermost encapsulation it has no next.
+                this._encapsStack.next = null;
             } else {
                 this._encapsStack = new WriteEncaps();
             }

--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -82,7 +82,7 @@ namespace
         if (ce != cls)
         {
             ostringstream os;
-            os << "expected an instance of " << ce->name->val;
+            os << "expected an instance of " << cls->name->val;
             invalidArgument(os.str());
             return false;
         }


### PR DESCRIPTION
Closes #6136.

### PHP

`getVersion` printed `ce->name->val` — the *received* class — after the words "expected an instance of", so a caller passing a subclass was told to pass the very class it had just passed. Print the expected class instead, matching the sibling `createVersion`, which already uses `cls->name->val`.

Only a subclass of `\Ice\EncodingVersion` can reach this branch: the sole caller, `ice_encodingVersion`, parses with `"O"` and the `\Ice\EncodingVersion` class entry, so Zend's `instanceof` check rejects unrelated types earlier, while `getVersion` requires exact class equality.

### JavaScript

The issue suggested either dropping the `OutputStream.clear` assertion or replacing it with a real invariant. This does the latter — C#, Java, and JS `InputStream.clear` all assert `next == null`, so that is the intended invariant.

Correcting the polarity alone is not enough, though. `initEncaps` pops a node off the encapsulation cache without clearing its link into the rest of the cache, unlike `startEncapsulation`, which always overwrites `next`. So the outermost encapsulation can keep a stale `next`, and the assertion — now correct — would fire in a different case instead:

| scenario | before | polarity fix only | this PR |
|---|---|---|---|
| single-level encapsulation | assert fires | clean | clean |
| nested encapsulations, then a node reused from the cache | clean | assert fires | clean |

Detaching the reused node in `initEncaps` makes the invariant actually hold. It also stops `endEncapsulation` from restoring a cache node instead of `null` on that path.

`InputStream.initEncaps` has the same missing detach. Its `clear` already asserted `next === null`, so that one logs "Assertion failed" today, unmodified — reading a nested encapsulation and then reusing a cached node is enough. Fixed the same way.

There is no functional impact from any of this: `clear()` on an `OutputStream` is only reached in-tree from `ConnectionI` for `_writeStream`, which is always swapped or reset beforehand and so never carries a nested stack. The stale link is otherwise transient and self-correcting.

### Notes

Verified by driving the real sources under Node for the sequences in the table above and for the `InputStream` case, and by running the `Ice/stream` suite (green before and after — it never calls `clear()`, so it does not cover this path).

No test: the only observable is a private field, since `console.assert` does not throw and the stale link has no black-box effect. No changelog fragment, matching comparable cosmetic fixes such as 1daa3781e2 and 6066dba5f9 — happy to add one if you'd rather.

C# and Java have the identical stale-`next` pattern in both `OutputStream.initEncaps` and `InputStream.initEncaps`; filed as #6216 to keep this PR to the JS and PHP scope of the issue. Their assertions are release-gated, so the impact there is debug-build only.
