### PR TITLE
Unsubscribe each DataStorm key with its own remote key id

### DIFF
--- a/changelog.d/datastorm/inline-key-zero-bytes.md
+++ b/changelog.d/datastorm/inline-key-zero-bytes.md
@@ -1,0 +1,3 @@
+- Fixed the handling of a key that a custom `Encoder` encodes to an empty byte sequence. An any-key or filtered
+  writer marshals such a key inline like any other, but a reader mistook it for a key sent by id: it discarded the
+  sample, or delivered it without checking the key against the reader's own subscription.

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -296,11 +296,13 @@ DataElementI::detachKey(
         // Unsubscribe from the key being detached, not from whichever key created the subscriber: a multi-key
         // element attached to the same remote element shares a single subscriber across all its keys. attachKey
         // records an id for every key it connects, and this runs only for a key that was connected, so the entry
-        // is there. Key ids start at 1, so the 0 fallback would trip the assert in unsubscribeFromKey with a key
-        // id that was never subscribed to, pointing away from the break.
-        int64_t remoteKeyId = 0;
+        // is there.
         auto q = subscriber->keyIds.find(key);
         assert(q != subscriber->keyIds.end());
+
+        // Should the lookup ever miss, 0 is an id no key ever uses (key ids start at 1), so the unsubscribe below
+        // is a no-op rather than a decrement of another key's count.
+        int64_t remoteKeyId = 0;
         if (q != subscriber->keyIds.end())
         {
             remoteKeyId = q->second;

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -294,9 +294,14 @@ DataElementI::detachKey(
     if (removeConnectedKey(key, subscriber))
     {
         // Unsubscribe from the key being detached, not from whichever key created the subscriber: a multi-key
-        // element attached to the same remote element shares a single subscriber across all its keys.
+        // element attached to the same remote element shares a single subscriber across all its keys. attachKey
+        // records an id for every key it connects, and this runs only for a key that was connected, so the entry
+        // is there. Key ids start at 1, so the 0 fallback would trip the assert in unsubscribeFromKey with a key
+        // id that was never subscribed to, pointing away from the break.
         int64_t remoteKeyId = 0;
-        if (auto q = subscriber->keyIds.find(key); q != subscriber->keyIds.end())
+        auto q = subscriber->keyIds.find(key);
+        assert(q != subscriber->keyIds.end());
+        if (q != subscriber->keyIds.end())
         {
             remoteKeyId = q->second;
             subscriber->keyIds.erase(q);

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -129,7 +129,7 @@ DataElementI::attach(
     if ((id > 0 &&
          attachKey(topicId, data.id, key, sampleFilter, session, std::move(prx), facet, id, name, priority)) ||
         (id < 0 &&
-         attachFilter(topicId, data.id, key, sampleFilter, session, std::move(prx), facet, id, filter, name, priority)))
+         attachFilter(topicId, data.id, key, sampleFilter, session, std::move(prx), facet, filter, name, priority)))
     {
         auto q = data.lastIds.find(_id);
         int64_t lastId = q != data.lastIds.end() ? q->second : 0;
@@ -186,7 +186,7 @@ DataElementI::attach(
     if ((id > 0 &&
          attachKey(topicId, data.id, key, sampleFilter, session, std::move(prx), facet, id, name, priority)) ||
         (id < 0 &&
-         attachFilter(topicId, data.id, key, sampleFilter, session, std::move(prx), facet, id, filter, name, priority)))
+         attachFilter(topicId, data.id, key, sampleFilter, session, std::move(prx), facet, filter, name, priority)))
     {
         auto q = data.lastIds.find(_id);
         int64_t lastId = q != data.lastIds.end() ? q->second : 0;
@@ -231,7 +231,7 @@ DataElementI::attachKey(
     }
 
     bool added = false;
-    auto subscriber = p->second.addOrGet(topicId, elementId, keyId, nullptr, sampleFilter, name, priority, added);
+    auto subscriber = p->second.addOrGet(topicId, elementId, nullptr, sampleFilter, name, priority, added);
 
     if (_onConnectedElements && added)
     {
@@ -241,6 +241,7 @@ DataElementI::attachKey(
 
     if (addConnectedKey(key, subscriber))
     {
+        subscriber->keyIds.emplace(key, keyId);
         if (key)
         {
             subscriber->keys.insert(key);
@@ -292,6 +293,14 @@ DataElementI::detachKey(
 
     if (removeConnectedKey(key, subscriber))
     {
+        // Unsubscribe from the key being detached, not from whichever key created the subscriber: a multi-key
+        // element attached to the same remote element shares a single subscriber across all its keys.
+        int64_t remoteKeyId = 0;
+        if (auto q = subscriber->keyIds.find(key); q != subscriber->keyIds.end())
+        {
+            remoteKeyId = q->second;
+            subscriber->keyIds.erase(q);
+        }
         if (key)
         {
             subscriber->keys.erase(key);
@@ -323,7 +332,7 @@ DataElementI::detachKey(
         _parent->decListenerCount();
         if (unsubscribe)
         {
-            session->unsubscribeFromKey(topicId, elementId, shared_from_this(), subscriber->id);
+            session->unsubscribeFromKey(topicId, elementId, shared_from_this(), remoteKeyId);
         }
         notifyListenerWaiters();
     }
@@ -338,7 +347,6 @@ DataElementI::attachFilter(
     const shared_ptr<SessionI>& session,
     SessionPrx prx,
     const string& facet,
-    int64_t subscriberId,
     const shared_ptr<Filter>& filter,
     const string& name,
     int priority)
@@ -357,7 +365,7 @@ DataElementI::attachFilter(
     const int64_t filterId = -elementId;
 
     bool added = false;
-    auto subscriber = p->second.addOrGet(topicId, filterId, subscriberId, filter, sampleFilter, name, priority, added);
+    auto subscriber = p->second.addOrGet(topicId, filterId, filter, sampleFilter, name, priority, added);
     if (_onConnectedElements && added)
     {
         _executor->queue([callback = _onConnectedElements, name]
@@ -671,7 +679,12 @@ DataElementI::disconnect()
             }
             else
             {
-                listener.first.session->disconnectFromKey(k.first, k.second, shared_from_this(), ks.second->id);
+                // One subscription per key: a multi-key element attached to the same remote element shares a
+                // single subscriber, and the session counts its subscriptions per remote key.
+                for (const auto& [_, remoteKeyId] : ks.second->keyIds)
+                {
+                    listener.first.session->disconnectFromKey(k.first, k.second, shared_from_this(), remoteKeyId);
+                }
             }
         }
     }

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -30,13 +30,11 @@ namespace DataStormI
         struct Subscriber
         {
             Subscriber(
-                std::int64_t id,
                 const std::shared_ptr<Filter>& filter,
                 const std::shared_ptr<Filter>& sampleFilter,
                 std::string name,
                 int priority)
-                : id(id),
-                  filter(filter),
+                : filter(filter),
                   sampleFilter(sampleFilter),
                   name(std::move(name)),
                   priority(priority)
@@ -45,8 +43,12 @@ namespace DataStormI
 
             std::int64_t topicId;
             std::int64_t elementId;
-            std::int64_t id;
             std::set<std::shared_ptr<Key>> keys;
+            // The remote key id each key in `keys` was attached with. A local element attached to the same remote
+            // element under several keys shares a single Subscriber, so the ids are tracked per key: detaching one
+            // key with another key's id corrupts the session's per-key subscriber accounting. Empty for a filter
+            // subscription, which has no remote key id.
+            std::map<std::shared_ptr<Key>, std::int64_t> keyIds;
             std::shared_ptr<Filter> filter;
             std::shared_ptr<Filter> sampleFilter;
             std::string name;
@@ -106,7 +108,6 @@ namespace DataStormI
             [[nodiscard]] std::shared_ptr<Subscriber> addOrGet(
                 std::int64_t topicId,
                 std::int64_t elementId,
-                std::int64_t subscriberId,
                 const std::shared_ptr<Filter>& filter,
                 const std::shared_ptr<Filter>& sampleFilter,
                 const std::string& name,
@@ -118,10 +119,7 @@ namespace DataStormI
                 if (p == subscribers.end())
                 {
                     added = true;
-                    p = subscribers
-                            .emplace(
-                                k,
-                                std::make_shared<Subscriber>(subscriberId, filter, sampleFilter, name, priority))
+                    p = subscribers.emplace(k, std::make_shared<Subscriber>(filter, sampleFilter, name, priority))
                             .first;
                 }
                 return p->second;
@@ -238,7 +236,6 @@ namespace DataStormI
             const std::shared_ptr<SessionI>&,
             DataStormContract::SessionPrx,
             const std::string&,
-            std::int64_t,
             const std::shared_ptr<Filter>&,
             const std::string&,
             int);

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -41,8 +41,6 @@ namespace DataStormI
             {
             }
 
-            std::int64_t topicId;
-            std::int64_t elementId;
             std::set<std::shared_ptr<Key>> keys;
             // The remote key id each key in `keys` was attached with. A local element attached to the same remote
             // element under several keys shares a single Subscriber, so the ids are tracked per key: detaching one

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -586,16 +586,33 @@ SessionI::initSamples(int64_t topicId, int64_t peerTopicId, DataSamplesSeq initi
                 const auto& sampleFactory = topic->getSampleFactory();
                 for (const auto& sample : initializationBatch.samples)
                 {
+                    // A key id of 0 means the key is marshaled inline in keyValue, per DataSample. Don't infer
+                    // that from an empty keyValue: a custom key encoder can legitimately encode a key to zero
+                    // bytes, and key ids start at 1.
                     shared_ptr<Key> key;
-                    if (sample.keyValue.empty())
+                    if (sample.keyId != 0)
                     {
-                        key = subscriber.keys[sample.keyId].first;
+                        key = subscriber.findKey(sample.keyId);
                     }
                     else
                     {
                         key = topic->getKeyFactory()->decode(_instance->getCommunicator(), sample.keyValue);
                     }
+
                     assert(key);
+                    if (!key)
+                    {
+                        // The batch is addressed to a reader that subscribed to this key, so the session always
+                        // knows it. Abandon the batch rather than build a key-less sample, and leave the reader
+                        // uninitialized so a later redelivery can still initialize it.
+                        if (_traceLevels->session > 0)
+                        {
+                            Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+                            out << _id << ": discarding initialization batch from 'e" << initializationBatch.id << '@'
+                                << topicId << "': unknown key '" << sample.keyId << "'";
+                        }
+                        return;
+                    }
 
                     samplesI.push_back(sampleFactory->create(
                         _id,
@@ -1205,13 +1222,25 @@ SessionI::unsubscribeFromKey(
         }
     }
 
-    auto& elementSubscribersMap = topicSubscriber.keys[keyId].second;
-    if (--elementSubscribersMap[elementId] == 0)
+    // An unsubscribe always follows the subscribe for the same key id, so the entry is there. The count can be
+    // higher than the number of pending unsubscribes: a disconnect detaches the elements without decrementing,
+    // and the reattach increments again. Look the entry up rather than indexing it: indexing would insert an
+    // entry with a null key for a key id the session never subscribed to, and the sample paths resolve a
+    // sample's key through it.
+    auto k = topicSubscriber.keys.find(keyId);
+    assert(k != topicSubscriber.keys.end());
+    if (k != topicSubscriber.keys.end())
     {
-        elementSubscribersMap.erase(elementId);
-        if (elementSubscribersMap.empty())
+        auto& elementSubscribersMap = k->second.second;
+        auto e = elementSubscribersMap.find(elementId);
+        assert(e != elementSubscribersMap.end() && e->second > 0);
+        if (e != elementSubscribersMap.end() && --e->second == 0)
         {
-            topicSubscriber.keys.erase(keyId);
+            elementSubscribersMap.erase(e);
+            if (elementSubscribersMap.empty())
+            {
+                topicSubscriber.keys.erase(k);
+            }
         }
     }
 }
@@ -1327,17 +1356,22 @@ SessionI::getLastIds(int64_t topicId, int64_t keyOrFilterId, const std::shared_p
         else
         {
             // Key subscription: report this element's lastId for each remote element it's subscribed to under this
-            // key. Key subscriptions are indexed by remote key id, so look the key up directly. An element id can
-            // remain in the key map after its ElementSubscribers was removed (e.g. a multi-key element detaches
-            // under one key but its other keys are still counted), so skip ids with no live subscriber, like the
-            // filter branch above.
-            for (const auto& [elementId, _] : subscriber.keys[keyOrFilterId].second)
+            // key. Key subscriptions are indexed by remote key id, so look the key up directly. This runs for a
+            // key the peer just announced, before anything subscribed to it, so the lookup must not insert: an
+            // entry with a null key would then shadow the unknown-key check the sample paths rely on. An element
+            // id can also outlive its ElementSubscribers, so skip ids with no live subscriber, like the filter
+            // branch above.
+            auto k = subscriber.keys.find(keyOrFilterId);
+            if (k != subscriber.keys.end())
             {
-                if (auto* elementSubscribers = subscriber.get(elementId))
+                for (const auto& [elementId, _] : k->second.second)
                 {
-                    if (auto* s = elementSubscribers->getSubscriber(element))
+                    if (auto* elementSubscribers = subscriber.get(elementId))
                     {
-                        lastIds.emplace(elementId, s->lastId);
+                        if (auto* s = elementSubscribers->getSubscriber(element))
+                        {
+                            lastIds.emplace(elementId, s->lastId);
+                        }
                     }
                 }
             }
@@ -1396,10 +1430,10 @@ SessionI::subscriberInitialized(
         auto keyFactory = element->getTopic()->getKeyFactory();
         for (const auto& sample : samples)
         {
-            // An any-key writer marshals the key inline (keyId 0, keyValue set), as the live data path in s()
-            // handles; accept an inline-key sample for a key subscription too, rather than requiring keyId to map
-            // to the subscription key.
-            assert(!sample.keyValue.empty() || key == subscriber.keys[sample.keyId].first);
+            // An any-key writer marshals the key inline (keyId 0), as the live data path in s() handles; accept an
+            // inline-key sample for a key subscription too, rather than requiring keyId to map to the subscription
+            // key.
+            assert(sample.keyId == 0 || key == subscriber.findKey(sample.keyId));
 
             samplesI.push_back(sampleFactory->create(
                 _id,
@@ -1607,11 +1641,14 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
                     out << "]";
                 }
 
+                // A key id of 0 means the key is marshaled inline in keyValue, per DataSample. Don't infer that
+                // from an empty keyValue: a custom key encoder can legitimately encode a key to zero bytes, and
+                // key ids start at 1.
                 shared_ptr<Key> key;
-                if (dataSample.keyValue.empty())
+                if (dataSample.keyId != 0)
                 {
-                    auto q = topicSubscriber.keys.find(dataSample.keyId);
-                    if (q == topicSubscriber.keys.end())
+                    key = topicSubscriber.findKey(dataSample.keyId);
+                    if (!key)
                     {
                         // The session never subscribed to this key (a peer can forward a sample for a key none of
                         // this session's readers are subscribed to); no subscriber can match it.
@@ -1623,7 +1660,6 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
                         }
                         return;
                     }
-                    key = q->second.first;
                 }
                 else
                 {
@@ -1647,13 +1683,15 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
                         (dataSample.keyId <= 0 || elementSubscriber.keys.find(key) != elementSubscriber.keys.end()))
                     {
                         elementSubscriber.lastId = dataSample.id;
+                        // An inline key (keyId 0) was not matched against this element's subscription, so the
+                        // element has to check it itself.
                         element->queue(
                             sample,
                             elementSubscribers->priority,
                             shared_from_this(),
                             current.facet,
                             now,
-                            !dataSample.keyValue.empty());
+                            dataSample.keyId == 0);
                     }
                 }
             }

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -783,11 +783,13 @@ SessionI::disconnectedImpl(const ConnectionPtr& connection, exception_ptr ex)
     for (const auto& [topicId, _] : _topics)
     {
         // The analyzer falsely flags the lambda's captures as undefined: it loses track of the closure once it
-        // is stored in runWithTopics' std::function parameter.
-        // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
+        // is stored in runWithTopics' std::function parameter. The suppression spans the whole call because the
+        // analyzer reports the diagnostic inside the lambda body, not on the runWithTopics line.
+        // NOLINTBEGIN(clang-analyzer-core.NullDereference)
         runWithTopics(
             topicId,
             [topicId, self](const shared_ptr<TopicI>& topic, TopicSubscriber&) { topic->detach(topicId, self); });
+        // NOLINTEND(clang-analyzer-core.NullDereference)
     }
 
     // The peer's wire disconnected() op is not a connection close, so unregister the session that connected()

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -175,6 +175,16 @@ namespace DataStormI
                 }
             }
 
+            /// Returns the local key matching a remote key id, or `nullptr` when this session holds no subscription
+            /// for that id. Samples from a keyed writer carry only the key id, and the sample paths resolve it
+            /// through this method. It never inserts: an entry with a null key would be indistinguishable from a
+            /// real subscription and would defeat the callers' unknown-key checks.
+            [[nodiscard]] std::shared_ptr<Key> findKey(std::int64_t keyId) const
+            {
+                auto p = keys.find(keyId);
+                return p == keys.end() ? nullptr : p->second.first;
+            }
+
             // A map of remote keys to local keys and the number of local elements subscribing to a remote element.
             // - Key: The remote key ID.
             // - Value: A pair containing the local key and a map of remote element IDs to the number of local elements

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -126,9 +126,8 @@ void ::Reader::run(int argc, char* argv[])
         test(aapl->lastAsk == 14.0f); // AAPL's own ask, not GOOG's 102
     }
 
-    // A persistent multi-key reader attaches to writer 1 under both keys; writer 1's detach leaves a stale entry
-    // in the reader's per-key subscriber map, and writer 2's attach drives SessionI::getLastIds over it, which
-    // must not dereference null.
+    // A persistent multi-key reader attaches to writer 1 under both keys. After writer 1 is destroyed, the reader
+    // attaches to writer 2 under both keys again and reads its sample.
     Topic<string, int> detachTopic(node, "multiKeyDetach");
     detachTopic.setReaderDefaultConfig(config);
     Topic<string, int> detachBarrier(node, "multiKeyDetachBarrier");
@@ -137,14 +136,13 @@ void ::Reader::run(int argc, char* argv[])
         auto sample = reader.getNextUnread(); // from writer 1
         test(sample.getValue() == 1);
 
-        // Wait until writer 1's detach has been processed (this is what leaves the stale per-key entry), then
-        // tell the writer it can create writer 2.
+        // Wait until writer 1's detach has been processed, then tell the writer it can create writer 2.
         reader.waitForNoWriters();
         auto barrier = makeSingleKeyWriter(detachBarrier, "barrier");
         barrier.waitForReaders();
         barrier.update(0);
 
-        sample = reader.getNextUnread(); // from writer 2: attach runs getLastIds over the stale entry
+        sample = reader.getNextUnread(); // from writer 2
         test(sample.getValue() == 2);
     }
 

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -95,9 +95,9 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
-    // Destroying a multi-key writer leaves a stale entry in the reader's per-key subscriber map
-    // (DataElementI::detachKey detaches every key with the element's first key id). A later attach then drives
-    // SessionI::getLastIds over the stale entry, which must not crash the reader.
+    // A multi-key writer that is destroyed and replaced by a new one keeps delivering to a reader subscribed to
+    // both keys: the detach releases the subscription for each of the writer's keys, so the reattach starts from
+    // a clean per-key state.
     Topic<string, int> detachTopic(node, "multiKeyDetach");
     detachTopic.setWriterDefaultConfig(config);
     Topic<string, int> detachBarrier(node, "multiKeyDetachBarrier");
@@ -107,10 +107,10 @@ void ::Writer::run(int argc, char* argv[])
             auto writer = makeMultiKeyWriter(detachTopic, {"k1", "k2"});
             writer.waitForReaders();
             writer.add("k1", 1);
-        } // writer destroyed here -> detachElements -> stale per-key entry on the reader
+        } // writer destroyed here, detaching both of its keys on the reader
 
         // Wait for the reader to confirm it has processed the detach before creating the second writer, so the
-        // second attach is guaranteed to run getLastIds over the stale entry.
+        // second attach runs against the state the detach left behind.
         [[maybe_unused]] auto _ = makeSingleKeyReader(detachBarrier, "barrier").getNextUnread();
 
         auto writer = makeMultiKeyWriter(detachTopic, {"k1", "k2"});

--- a/cpp/test/DataStorm/types/Reader.cpp
+++ b/cpp/test/DataStorm/types/Reader.cpp
@@ -29,6 +29,17 @@ namespace
         red,
     };
 
+    // A key type with a custom encoding whose default value (0) encodes to zero bytes. The default Ice encoding
+    // never produces an empty byte sequence, so only a custom Encoder can, and an any-key writer marshals such a
+    // key inline like any other key.
+    struct Marker
+    {
+        int value = 0;
+
+        bool operator<(const Marker& other) const { return value < other.value; }
+        bool operator==(const Marker& other) const { return value == other.value; }
+    };
+
     template<typename T> bool compare(const T& v1, const T& v2) { return v1 == v2; }
 
     template<typename T> bool compare(const shared_ptr<T>& v1, const shared_ptr<T>& v2)
@@ -79,6 +90,27 @@ namespace DataStorm
         }
     };
 
+    template<> struct Decoder<Marker>
+    {
+        static Marker decode(const Ice::CommunicatorPtr&, const vector<std::byte>& data)
+        {
+            return Marker{data.empty() ? 0 : static_cast<int>(data[0])};
+        }
+    };
+
+    template<> struct Encoder<Marker>
+    {
+        static vector<std::byte> encode(const Ice::CommunicatorPtr&, const Marker& value)
+        {
+            // The default value encodes to zero bytes; any other value encodes to a single byte.
+            if (value.value == 0)
+            {
+                return {};
+            }
+            return {static_cast<std::byte>(value.value)};
+        }
+    };
+
 }
 
 void ::Reader::run(int argc, char* argv[])
@@ -116,6 +148,23 @@ void ::Reader::run(int argc, char* argv[])
         Topic<color, string>(node, "enumstring"),
         map<color, string>{{color::blue, "v1"}, {color::red, "v2"}},
         map<color, string>{{color::blue, "u1"}, {color::red, "u2"}});
+
+    {
+        Topic<Marker, string> topic(node, "emptyencodedkey");
+        topic.setReaderDefaultConfig(ReaderConfig(-1, nullopt, ClearHistoryPolicy::Never));
+
+        // The writer marshals the key inline, so the reader decodes it from the sample and matches it against its
+        // own subscription.
+        auto reader = makeSingleKeyReader(topic, Marker{0});
+        auto s = reader.getNextUnread();
+        test(s.getEvent() == SampleEvent::Add && s.getKey() == Marker{0} && s.getValue() == "v1");
+
+        // A reader that joins after the sample was written gets the same key in the writer's initialization
+        // samples.
+        auto lateReader = makeSingleKeyReader(topic, Marker{0});
+        auto ls = lateReader.getNextUnread();
+        test(ls.getEvent() == SampleEvent::Add && ls.getKey() == Marker{0} && ls.getValue() == "v1");
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/types/Writer.cpp
+++ b/cpp/test/DataStorm/types/Writer.cpp
@@ -24,6 +24,16 @@ namespace
         red,
     };
 
+    // A key type with a custom encoding whose default value (0) encodes to zero bytes. The default Ice encoding
+    // never produces an empty byte sequence, so only a custom Encoder can, and an any-key writer marshals such a
+    // key inline like any other key.
+    struct Marker
+    {
+        int value = 0;
+
+        bool operator<(const Marker& other) const { return value < other.value; }
+    };
+
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     template<typename T, typename A, typename U> void testWriter(T topic, A add, U update)
     {
@@ -67,6 +77,27 @@ namespace DataStorm
         static vector<std::byte> encode(const Ice::CommunicatorPtr&, const color& value)
         {
             return {static_cast<std::byte>(value)};
+        }
+    };
+
+    template<> struct Decoder<Marker>
+    {
+        static Marker decode(const Ice::CommunicatorPtr&, const vector<std::byte>& data)
+        {
+            return Marker{data.empty() ? 0 : static_cast<int>(data[0])};
+        }
+    };
+
+    template<> struct Encoder<Marker>
+    {
+        static vector<std::byte> encode(const Ice::CommunicatorPtr&, const Marker& value)
+        {
+            // The default value encodes to zero bytes; any other value encodes to a single byte.
+            if (value.value == 0)
+            {
+                return {};
+            }
+            return {static_cast<std::byte>(value.value)};
         }
     };
 
@@ -125,6 +156,19 @@ void ::Writer::run(int argc, char* argv[])
         Topic<color, string>(node, "enumstring"),
         map<color, string>{{color::blue, "v1"}, {color::red, "v2"}},
         map<color, string>{{color::blue, "u1"}, {color::red, "u2"}});
+    cout << "ok" << endl;
+
+    cout << "testing key that encodes to zero bytes... " << flush;
+    {
+        Topic<Marker, string> topic(node, "emptyencodedkey");
+        topic.setWriterDefaultConfig(WriterConfig(-1, nullopt, ClearHistoryPolicy::Never));
+
+        // An any-key writer marshals the key inline with each sample, rather than sending the key id.
+        auto writer = makeAnyKeyWriter(topic);
+        writer.waitForReaders();
+        writer.add(Marker{0}, "v1");
+        writer.waitForNoReaders();
+    }
     cout << "ok" << endl;
 }
 


### PR DESCRIPTION
Fixes #6128.

## The bug

`Listener::addOrGet` keys subscribers by `(topicId, elementId)` only, so a local element attached to the same
remote element under several keys shares one `Subscriber`, whose `id` was frozen at the first key it attached
with. `subscribeToKey` counts the subscription under the *correct* per-key id, but both teardown paths used the
frozen id for every key, and they fail in opposite directions:

- `SessionI::detachElements` calls `detachKey` once per key, each passing `subscriber->id` — so the first key's
  count is decremented once per key, and the other keys are never decremented.
- `DataElementI::disconnect` calls `disconnectFromKey` once per *element* rather than once per key — a plain
  under-decrement.

The result is corrupted per-key subscriber accounting: a count driven to `-1` in an entry that can never be
erased, plus leaked entries that retain a `shared_ptr<Key>` for the life of the session.

## The fix

The subscriber now tracks the remote key id per key (`Subscriber::keyIds`), and each key is detached with its
own id. `Subscriber::id` is gone — it had no other reader — and with it the now-unused `subscriberId` parameter
of `Listener::addOrGet` and `attachFilter`.

## Hardening in the same area

`TopicSubscriber::keys` had five `operator[]` accesses, all of which insert on miss, including one *read* in
`getLastIds` and one inside an `assert` — the latter mutating the map in debug builds only. An inserted entry
has a null `Key`, which is indistinguishable from a real subscription and defeats the unknown-key checks the
sample paths rely on; the absent-entry half of that was already a field crash once (#5825, fixed by #5870).

Everything except `subscribeToKey` now looks the entry up, through a new `TopicSubscriber::findKey` that
collapses "no entry" and "entry with a null key" into a single unresolvable result. `unsubscribeFromKey` asserts
the invariant it now relies on.

## A second, related fix

While auditing the above: `DataSample` documents `keyId == 0` as the discriminator for a key marshaled inline in
`keyValue`, but all four receive paths inferred it from `keyValue` being non-empty instead. Those disagree for a
key whose custom `Encoder` returns an empty byte sequence — the key-side twin of #6084. Such a sample was
discarded by `s()`, wedged initialization in `initSamples`, and was queued with `checkKey = false`, skipping the
reader's own key match. All four now test `keyId`.

That half is user-visible and has a changelog fragment; the accounting fix does not (internal bookkeeping, no
observable behaviour change).

## Testing

The empty-encoded key has a test. `types` gains a key type whose custom `Encoder` returns an empty byte
sequence, published by an any-key writer — which marshals the key inline — to a reader that is already
connected and to one that joins afterwards, covering the live path and initialization:

```
$ python3 allTests.py --debug --filter='DataStorm/types'    # with the discriminator reverted to keyValue.empty()
testing key that encodes to zero bytes...                  # hangs
```

Nothing comparable is possible for the accounting fix. The mis-targeted decrements only corrupt counts for an
element whose subscription is ending anyway, the resulting garbage is unreadable because every consumer gates on
`_elements` first, and it self-heals on the next `subscribeToKey`. The new invariant asserts in
`unsubscribeFromKey` are what make the existing tests decisive instead:

```
$ python3 allTests.py --debug --continue --filter='DataStorm/(partial|events)'     # before the fix
testing multi-key reader/multi-key writer... Assertion failed: (k != topicSubscriber.keys.end()),
    function unsubscribeFromKey, file SessionI.cpp, line 1226.
testing multi-key partial update... Assertion failed: (k != topicSubscriber.keys.end()),
    function unsubscribeFromKey, file SessionI.cpp, line 1226.
1 succeeded and 2 failed

$ python3 allTests.py --debug --continue --filter='DataStorm/'                     # after
Ran 11 tests in 34.95 seconds
11 succeeded
```

Both were built with `OPTIMIZE=no`; the `debug` rows of `ci.yml` (ubuntu, macOS, Windows) and the weekly
coverage job build the same way, so CI exercises these asserts.

The `partial` test's comments described the pre-fix mechanism rather than the behaviour, so they are reworded.

## Not in scope

The reconnect path still inflates these counts by one per reconnect — `SessionI::unsubscribe` deliberately
detaches without decrementing, and the reattach increments again — and `TopicSubscriber::reap` still does not
reap `keys`. That is #5781, retargeted to 3.9.0 with a design that removes the parallel refcount altogether.
