### PR TITLE
Remove the unused topicId and elementId from DataStorm's Subscriber

### DIFF
--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -41,8 +41,6 @@ namespace DataStormI
             {
             }
 
-            std::int64_t topicId;
-            std::int64_t elementId;
             std::set<std::shared_ptr<Key>> keys;
             // The remote key id each key in `keys` was attached with. A local element attached to the same remote
             // element under several keys shares a single Subscriber, so the ids are tracked per key: detaching one


### PR DESCRIPTION
`DataElementI::Subscriber` carries two fields that nothing uses:

```cpp
std::int64_t topicId;
std::int64_t elementId;
```

- **Never written.** The struct has one construction site — `make_shared<Subscriber>(filter, sampleFilter, name,
  priority)` in `Listener::addOrGet` — and that constructor's member-init list does not mention either field. Since
  the constructor is user-provided, both are default-initialized, which for `std::int64_t` means not initialized
  at all.
- **Never read.** `grep -rnE "(->|\.)(topicId|elementId)\b"` over `cpp/src`, `cpp/include` and `cpp/test` finds no
  member access.
- **Dead since the beginning.** `git log -L` on those two lines yields a single commit: 8e3d0b07ec, the DataStorm
  import.

They are also redundant: `Listener::subscribers` is keyed by `std::pair<topicId, elementId>`, so every lookup
already has both values, which is probably why nobody ever wired them up.

Nothing reads them, so there is no undefined behaviour today — but they are a trap. The next person to touch this
struct has every reason to assume they hold the subscriber's topic and element id, and they hold garbage. The
enabled clang-tidy checks (`clang-analyzer-*`, `cert-*`, `modernize-*`, `performance-*`) do not include
`cppcoreguidelines-pro-type-member-init` or the opt-in `clang-analyzer-optin.cplusplus.UninitializedObject`, so
CI would not have caught a first use either.

Internal only: `DataElementI.h` is not an installed header, no public header names `DataElementI` or `Subscriber`,
`Subscriber` is `protected` with every subclass declared in the same header, and `DataElementI` carries no
`DATASTORM_API`. No API or ABI impact, and no changelog entry.

Built with `OPTIMIZE=no` and ran the DataStorm suite — 11 tests, 11 succeeded.

> [!NOTE]
> Based on #6214, which reworks the same member block; separate branches would conflict in those four lines.
> Retarget to `main` once #6214 merges.
