### PR TITLE
Hold the writer's adapter to keep the DataStorm partialReconnect gap open

### DIFF
--- a/cpp/test/DataStorm/partialReconnect/Writer.cpp
+++ b/cpp/test/DataStorm/partialReconnect/Writer.cpp
@@ -33,15 +33,25 @@ void ::Writer::run(int argc, char* argv[])
         writer.waitForReaders();
         writer.add("base");
 
-        // Wait until the reader has consumed the base value, then close the session connection and publish while it is
-        // down. The reader cannot learn of the closure before close completes, and reconnecting takes a full session
-        // handshake, so both samples land in the gap.
+        // Wait until the reader has consumed the base value, then hold this node's adapter before closing the session
+        // connection. A held adapter stops reading requests, so the reader cannot re-establish the session until the
+        // adapter is activated again. Without it the gap is not observable: the session reconnect is attempted
+        // immediately, and the reader resumes before the two samples below are published.
         auto sample = makeSingleKeyReader(barrier, "ready").getNextUnread();
+        auto adapter = node.getCommunicator()->getDefaultObjectAdapter();
+        adapter->hold();
+        adapter->waitForHold();
+
         auto connection = node.getSessionConnection(sample.getSession());
         test(connection);
         connection->close().get();
+
+        // Publish once the session is gone, so both samples land in the gap.
+        writer.waitForNoReaders();
         writer.update("second");
         writer.partialUpdate<string>("append")("-tail");
+
+        adapter->activate();
 
         // Wait until the reader has consumed the value it resumed with, so this partial update is delivered live
         // rather than folded into the initialization batch.

--- a/cpp/test/DataStorm/partialReconnect/test.py
+++ b/cpp/test/DataStorm/partialReconnect/test.py
@@ -8,11 +8,16 @@
 # current per-key base instead, delivered as a single full update carrying the resolved value. The scenarios in
 # DataStorm/partial cover the same re-seeding for readers that join fresh, with a last sample id of 0.
 #
-# The writer opens the gap by closing the session connection and publishing immediately afterwards, which is only
-# reliable while the two nodes share a single connection. This test therefore pins the topology: multicast is disabled
-# and the writer runs as a client with no server endpoint, so the reader can never connect back to it. Given more than
-# one connection between the nodes - multicast, or a relay chain - DataStorm can route the writer's publisher session
-# and the barrier's subscriber session over different connections, and closing one would leave the other delivering.
+# The writer opens the gap by holding its node adapter and closing the session connection, then publishes and
+# activates the adapter again. A held adapter stops reading requests, so the reader cannot re-establish the session
+# while the samples are published. This requires the writer to be the node that listens, because only the node whose
+# adapter is held can decide when the gap ends: the barrier that would otherwise carry that decision runs over the
+# session being interrupted.
+#
+# The topology is pinned for the same reason the gap is: multicast is disabled and the reader has no server endpoint,
+# so a single connection carries every session between the two nodes. Given more than one connection - multicast, or a
+# relay chain - DataStorm can route the writer's publisher session and the barrier's subscriber session over different
+# connections, and closing one would leave the other delivering.
 #
 
 from DataStormUtil import Reader, Writer
@@ -24,15 +29,15 @@ traceProps = {
     "DataStorm.Trace.Data": 2,
 }
 
-# The reader listens and never connects out; the writer only connects in. One connection carries every session between
+# The writer listens and never connects out; the reader only connects in. One connection carries every session between
 # them, so closing it interrupts the writer's data session.
-readerProps = {
+writerProps = {
     "DataStorm.Node.Multicast.Enabled": 0,
     "DataStorm.Node.Server.Endpoints": "tcp -p {port1}",
     "DataStorm.Node.ConnectTo": "",
 }
 
-writerProps = {
+readerProps = {
     "DataStorm.Node.Multicast.Enabled": 0,
     "DataStorm.Node.Server.Enabled": 0,
     "DataStorm.Node.ConnectTo": "tcp -p {port1}",
@@ -43,8 +48,8 @@ TestSuite(
     [
         ClientServerTestCase(
             name="partial update after reconnect across a history gap",
-            client=Writer(props=writerProps),
-            server=Reader(props=readerProps),
+            client=Reader(props=readerProps),
+            server=Writer(props=writerProps),
             traceProps=traceProps,
         )
     ],


### PR DESCRIPTION
Fixes #6211.

`DataStorm/partialReconnect` asserts that a reader resuming across a gap in the writer's history is re-seeded from the writer's per-key base as a single resolved update. Reaching that state required the writer to publish both gap samples before the session re-established itself, and nothing enforced that ordering: `SessionI::retry` always uses a zero delay for the first attempt (`SessionI.cpp:867`), and Ice fulfills the close future before invoking DataStorm's close callback (`ConnectionI.cpp:1752`, `:1804`). On Windows the reattach regularly won the race, both samples were delivered live, and the reader asserted on `Reader.cpp:44`.

The writer now holds its node adapter before closing the session connection and activates it again once both samples are published. A held adapter stops reading requests, so the reader cannot re-establish the session while the gap is being created.

This requires the writer to be the listening node, so the topology is flipped. Only the node whose adapter is held can decide when the gap ends — the barrier that would otherwise carry that decision runs over the very session being interrupted. `DataStorm/reliability` already exercises the reader-as-client / writer-as-listener arrangement, including passing a `Writer` as the test-framework server.

No product code changes: every interleaving already produced a correct resolved value, only the number of application-visible samples differed. No changelog entry, as this is test-only.

## Testing

Verified that the fix is what makes the outcome deterministic, rather than the platform being faster. Injecting a one-second stall between `close().get()` and the two publications simulates the Windows scheduling delay:

| Writer body | Injected stall | Result on macOS |
| --- | --- | --- |
| before this change | 1s | 3/3 fail — `Reader.cpp:44: assertion 'sample.getValue() == "second-tail"' failed`, the exact CI signature |
| with the adapter gate | 1s | 3/3 pass |

Also confirmed from the traces that the test still exercises the path it is written for, rather than passing by skipping it — the writer's second initialization batch carries the re-seeded base and samples 2 and 3 are never delivered live:

```
writer  p/1: initializing elements '[e1->e1:sz1]@0' on topic '0:partialUpdateGap'
reader  s/1: queuing sample '1[k2]' …    <- base, live
reader  s/1: initializing samples from 'e1' …   <- resolved "second-tail"
reader  s/1: queuing sample '4[k2]' …    <- the later "-live" partial, live
```

- `make -C cpp -j10 srcs tests`
- `python3 allTests.py --filter=DataStorm/partialReconnect` — 8/8 runs passed
- `python3 allTests.py --filter=DataStorm` — 11/11 passed
