### PR TITLE
Account for every request in a batch in the connection dispatch count

### DIFF
--- a/changelog.d/js/6106.md
+++ b/changelog.d/js/6106.md
@@ -1,0 +1,2 @@
+- Fixed a bug where a connection no longer enforced the inactivity timeout after receiving a batch of more than one
+  request.

--- a/js/packages/ice/src/Ice/ConnectionI.js
+++ b/js/packages/ice/src/Ice/ConnectionI.js
@@ -1301,9 +1301,7 @@ export class ConnectionI {
                         // A batched request occupies at least 12 bytes on the wire (a 2-byte identity, a 1-byte
                         // facet path, a 1-byte operation name, a 1-byte operation mode, a 1-byte context, and a
                         // 6-byte parameters encapsulation). Reject a count larger than the remaining message
-                        // data could possibly hold. The message size is already capped at Ice.MessageSizeMax, so
-                        // this also keeps requestCount well within range when it is accumulated into the dispatch
-                        // counters below.
+                        // data could possibly hold.
                         const minBatchRequestSize = 12;
                         if (requestCount > (info.stream.size - info.stream.pos) / minBatchRequestSize) {
                             throw new MarshalException(

--- a/js/packages/ice/src/Ice/ConnectionI.js
+++ b/js/packages/ice/src/Ice/ConnectionI.js
@@ -764,7 +764,7 @@ export class ConnectionI {
         this.setState(StateClosed, ex);
 
         if (requestCount > 0) {
-            console.assert(this._upcallCount > requestCount);
+            console.assert(this._upcallCount >= requestCount);
             this._upcallCount -= requestCount;
             console.assert(this._upcallCount >= 0);
             if (this._upcallCount === 0) {
@@ -1301,7 +1301,9 @@ export class ConnectionI {
                         // A batched request occupies at least 12 bytes on the wire (a 2-byte identity, a 1-byte
                         // facet path, a 1-byte operation name, a 1-byte operation mode, a 1-byte context, and a
                         // 6-byte parameters encapsulation). Reject a count larger than the remaining message
-                        // data could possibly hold.
+                        // data could possibly hold. The message size is already capped at Ice.MessageSizeMax, so
+                        // this also keeps requestCount well within range when it is accumulated into the dispatch
+                        // counters below.
                         const minBatchRequestSize = 12;
                         if (requestCount > (info.stream.size - info.stream.pos) / minBatchRequestSize) {
                             throw new MarshalException(
@@ -1314,7 +1316,7 @@ export class ConnectionI {
                         this._upcallCount += info.requestCount;
 
                         this.cancelInactivityTimer();
-                        ++this._dispatchCount;
+                        this._dispatchCount += info.requestCount;
                     }
                     break;
                 }


### PR DESCRIPTION
When a batch request message is parsed, `_upcallCount` is increased by the number of requests in the
batch but `_dispatchCount` was incremented only once, while each dispatched request decrements it
through `sendResponse`. A completed batch of N requests therefore left `_dispatchCount` at `1 - N`,
and it never returned to zero.

`_dispatchCount` has a single consumer in this mapping — the inactivity scheduler, which only arms
the timer when the count is zero — so once a connection received a batch of more than one request,
`Ice.Connection.*.InactivityTimeout` stopped applying to it for good. The old code also let the
count reach zero transiently after the first response of a batch, arming the timer while the
remaining requests were still being dispatched.

Accumulate the request count instead, matching `cpp/src/Ice/ConnectionI.cpp:3274`,
`csharp/src/Ice/ConnectionI.cs:2354` and `ConnectionI.java:1778`. This also handles a zero-count
batch correctly, where `++` previously had no matching decrement.

One small related change in the same file: `dispatchException` asserted
`_upcallCount > requestCount`; C++ and C# both assert `>=`, and equality is valid when the failed
requests are the only outstanding upcalls. Diagnostic only — `console.assert` does not throw.

No test: the only observable consequence of the counter is inactivity closure, so an honest probe
has to wait out a multi-second `InactivityTimeout`, and the C++ echo servant this would run against
asserts on strict `startBatch` → oneways → `flushBatch` ordering, which makes a test that passes
against unfixed code easy to write by accident.

Fixes #6106
