### PR TITLE
Discard batch auto-flush failures instead of dropping the promise

### DIFF
--- a/changelog.d/js/6107.md
+++ b/changelog.d/js/6107.md
@@ -1,0 +1,2 @@
+- Fixed a bug where a batch auto-flush that could not be delivered terminated the process in Node.js with an
+  unhandled promise rejection. The auto-flush failure is now discarded, as in the other language mappings.

--- a/js/packages/ice/src/Ice/BatchRequestQueue.js
+++ b/js/packages/ice/src/Ice/BatchRequestQueue.js
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+import { LocalException } from "./LocalException.js";
 import { Protocol } from "./Protocol.js";
 import { OutputStream } from "./OutputStream.js";
 
@@ -29,10 +30,14 @@ export class BatchRequestQueue {
 
         try {
             if (this._maxSize > 0 && this._batchStream.size >= this._maxSize) {
-                // Auto flush. We don't wait for the flush to complete, and we discard any failure, like the other
-                // language mappings. The no-op rejection handler is required because an unhandled promise rejection
-                // terminates the process in Node.js.
-                proxy.ice_flushBatchRequests().catch(() => {});
+                // Auto flush. We don't wait for the flush to complete, and we discard local exceptions. Any other
+                // error is a bug, and we rethrow it: the resulting unhandled promise rejection terminates the
+                // process in Node.js.
+                proxy.ice_flushBatchRequests().catch(ex => {
+                    if (!(ex instanceof LocalException)) {
+                        throw ex;
+                    }
+                });
             }
 
             console.assert(this._batchMarker < this._batchStream.size);

--- a/js/packages/ice/src/Ice/BatchRequestQueue.js
+++ b/js/packages/ice/src/Ice/BatchRequestQueue.js
@@ -29,7 +29,10 @@ export class BatchRequestQueue {
 
         try {
             if (this._maxSize > 0 && this._batchStream.size >= this._maxSize) {
-                proxy.ice_flushBatchRequests(); // Auto flush
+                // Auto flush. We don't wait for the flush to complete, and we discard any failure, like the other
+                // language mappings. The no-op rejection handler is required because an unhandled promise rejection
+                // terminates the process in Node.js.
+                proxy.ice_flushBatchRequests().catch(() => {});
             }
 
             console.assert(this._batchMarker < this._batchStream.size);

--- a/js/packages/test/Ice/operations/BatchOneways.ts
+++ b/js/packages/test/Ice/operations/BatchOneways.ts
@@ -69,12 +69,14 @@ export async function batchOneways(prx: Test.MyInterfacePrx, helper: TestHelper)
     await batch.ice_flushBatchRequests();
     await batch.ice_ping();
 
-    // An auto-flush that cannot be delivered fails silently: the batched requests are lost, like any other oneway,
-    // and the failure is not reported to the caller that happened to fill the batch. Nothing listens on this
-    // endpoint, so the flush triggered by Ice.BatchAutoFlushSize cannot connect.
+    // Nothing listens on this endpoint.
     const unreachable = Test.MyInterfacePrx.uncheckedCast(
         new Test.MyInterfacePrx(prx.ice_getCommunicator(), `test:${helper.getTestEndpoint(1)}`).ice_batchOneway(),
     );
+
+    // Filling the batch past Ice.BatchAutoFlushSize triggers an auto-flush that cannot connect. It fails silently:
+    // the batched requests are lost, like any other oneway, and the failure is not reported to the caller that
+    // happened to fill the batch.
     for (let i = 0; i < 11; ++i) {
         await unreachable.opByteSOneway(bs1);
     }

--- a/js/packages/test/Ice/operations/BatchOneways.ts
+++ b/js/packages/test/Ice/operations/BatchOneways.ts
@@ -2,9 +2,9 @@
 
 import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
-import { test } from "../../Common/TestHelper.js";
+import { TestHelper, test } from "../../Common/TestHelper.js";
 
-export async function batchOneways(prx: Test.MyInterfacePrx) {
+export async function batchOneways(prx: Test.MyInterfacePrx, helper: TestHelper) {
     const bs1 = new Uint8Array(10 * 1024);
     for (let i = 0; i < bs1.length; ++i) {
         bs1[i] = 0;
@@ -68,4 +68,22 @@ export async function batchOneways(prx: Test.MyInterfacePrx) {
     batch.ice_ping();
     await batch.ice_flushBatchRequests();
     await batch.ice_ping();
+
+    // An auto-flush that cannot be delivered fails silently: the batched requests are lost, like any other oneway,
+    // and the failure is not reported to the caller that happened to fill the batch. Nothing listens on this
+    // endpoint, so the flush triggered by Ice.BatchAutoFlushSize cannot connect.
+    const unreachable = Test.MyInterfacePrx.uncheckedCast(
+        new Test.MyInterfacePrx(prx.ice_getCommunicator(), `test:${helper.getTestEndpoint(1)}`).ice_batchOneway(),
+    );
+    for (let i = 0; i < 11; ++i) {
+        await unreachable.opByteSOneway(bs1);
+    }
+    try {
+        // Both flushes are queued on the same request handler, which completes them in order, so once this one
+        // fails the auto-flush above has already settled.
+        await unreachable.ice_flushBatchRequests();
+        test(false);
+    } catch (ex) {
+        test(ex instanceof Ice.LocalException, ex as Error);
+    }
 }

--- a/js/packages/test/Ice/operations/BatchOneways.ts
+++ b/js/packages/test/Ice/operations/BatchOneways.ts
@@ -81,8 +81,7 @@ export async function batchOneways(prx: Test.MyInterfacePrx, helper: TestHelper)
         await unreachable.opByteSOneway(bs1);
     }
     try {
-        // Both flushes are queued on the same request handler, which completes them in order, so once this one
-        // fails the auto-flush above has already settled.
+        // This flush fails the same way; by the time it does, the auto-flush above has settled too.
         await unreachable.ice_flushBatchRequests();
         test(false);
     } catch (ex) {

--- a/js/packages/test/Ice/operations/Client.ts
+++ b/js/packages/test/Ice/operations/Client.ts
@@ -25,7 +25,7 @@ export class Client extends TestHelper {
         out.writeLine("ok");
 
         out.write("testing batch oneway operations... ");
-        await batchOneways(cl);
+        await batchOneways(cl, this);
         out.writeLine("ok");
 
         await cl.shutdown();


### PR DESCRIPTION
`BatchRequestQueue.finishBatchRequest` auto-flushes by calling `ice_flushBatchRequests()` and
dropping the returned promise. The surrounding `try`/`finally` only catches synchronous throws, so a
flush that fails *asynchronously* — typically because the connection cannot be established — left an
unobserved rejection behind. Node.js terminates the process on an unhandled rejection, so a batching
application could be killed by a network failure.

Reproduced against the unmodified runtime: queueing batched requests past `Ice.BatchAutoFlushSize`
against an endpoint with no listener exits the process with
`Unhandled Rejection ... Ice.ConnectionRefusedException`. With the fix the same script runs to
completion.

The fix attaches a rejection handler that discards `LocalException`, the delivery failure the other
mappings also discard — C++ passes a null exception callback (`cpp/src/Ice/BatchRequestQueue.cpp:97`),
C# discards the `Task` and Java discards the `CompletableFuture`. Anything else means a bug in the
runtime, so it is rethrown and the resulting unhandled rejection still terminates the process; this
mirrors `OutgoingConnectionFactory.flushAsyncBatchRequests`. Logging instead would be new
JavaScript-only behaviour, and if it is wanted it should be decided across mappings rather than in a
patch release. Application calls to `ice_flushBatchRequests()` are untouched and still reject
normally.

### Test

Added to the existing `Ice/operations` batch-oneway test, which already configures
`Ice.BatchAutoFlushSize=100` and relies on auto-flush firing. It queues 11 requests of 10 KiB at an
endpoint with no listener, which triggers exactly one auto-flush, then awaits an explicit flush.
Both flushes are queued on the same request handler and a connection failure completes them in
order, so once the explicit flush rejects the auto-flush has necessarily settled — no sleep needed.

Under Node this is red before the fix and green after, because the test harness turns an unhandled
rejection into `process.exit(1)` (`js/packages/test/Common/run.js:19-23`). Forcing the flush to
reject with a `TypeError` instead makes it red again, which is the intended behaviour for a bug. A
browser run is inert either way, since nothing there promotes an unhandled rejection to a failure;
that is acceptable for a Node-specific defect.

Fixes #6107
