### PR TITLE
Deliver a sliced 1.0 exception that has no patch entry

### DIFF
--- a/changelog.d/js/6124.md
+++ b/changelog.d/js/6124.md
@@ -1,0 +1,3 @@
+- Fixed a bug where receiving a user exception with the 1.0 encoding could fail with a `TypeError` instead of
+  delivering the exception, when the reader sliced off a derived slice that held the only reference to a class
+  instance.

--- a/changelog.d/js/6124.md
+++ b/changelog.d/js/6124.md
@@ -1,3 +1,2 @@
-- Fixed a bug where receiving a user exception with the 1.0 encoding could fail with a `TypeError` instead of
-  delivering the exception, when the reader sliced off a derived slice that held the only reference to a class
-  instance.
+- Fixed a bug where receiving a user exception of an unknown type (but a known base type) could fail with a
+  `TypeError`. This only affects the 1.0 encoding.

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -382,10 +382,10 @@ class EncapsDecoder10 extends EncapsDecoder {
         // keep the biggest one.
         //
         this._classGraphDepth = 0;
-        const l = this._patchMap?.get(index);
-        if (l !== undefined) {
-            console.assert(l.length > 0);
-            for (const entry of l) {
+        const patchEntries = this._patchMap?.get(index);
+        if (patchEntries !== undefined) {
+            console.assert(patchEntries.length > 0);
+            for (const entry of patchEntries) {
                 if (entry.classGraphDepth > this._classGraphDepth) {
                     this._classGraphDepth = entry.classGraphDepth;
                 }

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -382,7 +382,7 @@ class EncapsDecoder10 extends EncapsDecoder {
         // keep the biggest one.
         //
         this._classGraphDepth = 0;
-        const l = this._patchMap === null ? null : this._patchMap.get(index);
+        const l = this._patchMap?.get(index);
         if (l !== undefined) {
             console.assert(l.length > 0);
             for (const entry of l) {

--- a/js/packages/test/Ice/stream/Client.ts
+++ b/js/packages/test/Ice/stream/Client.ts
@@ -516,6 +516,58 @@ export class Client extends TestHelper {
         }
 
         {
+            // With the 1.0 encoding, a reader slices off the derived part of an exception it doesn't know, and then
+            // still reads the class instances the sender queued after it. Here the sliced-off slice holds the only
+            // reference to such an instance, so the reader has nothing to patch it into: it must discard the
+            // instance and deliver the base exception it does know.
+            //
+            // This exception is deliberately never registered with the Slice loader, and it must carry a non-null
+            // value: with a null one the sender queues no instance and the reader never exercises this path.
+            class UnknownDerived extends Test.MyException {
+                value: Test.OptionalClass;
+
+                constructor(value: Test.OptionalClass) {
+                    super();
+                    this.value = value;
+                }
+
+                static get _parent() {
+                    return Test.MyException;
+                }
+
+                static get _ice_id() {
+                    return "::Test::UnknownDerived";
+                }
+
+                _mostDerivedType() {
+                    return UnknownDerived;
+                }
+
+                _writeMemberImpl(ostr: Ice.OutputStream) {
+                    ostr.writeValue(this.value);
+                }
+            }
+
+            const outS = new Ice.OutputStream(Ice.Encoding_1_0);
+            outS.writeException(new UnknownDerived(new Test.OptionalClass()));
+            const data = outS.finished();
+
+            const inS = new Ice.InputStream(communicator, Ice.Encoding_1_0, data);
+            try {
+                inS.throwException();
+                test(false);
+            } catch (ex1) {
+                if (ex1 instanceof Test.MyException) {
+                    // Not UnknownDerived: the most derived slice really was sliced off.
+                    test(ex1.ice_id() === "::Test::MyException");
+                    test(ex1.c === null);
+                } else {
+                    test(false, ex1 as Error);
+                }
+            }
+        }
+
+        {
             const dict = new Test.ByteBoolD();
             dict.set(4, true);
             dict.set(1, false);


### PR DESCRIPTION
`EncapsDecoder10.readInstance` looked up the class graph depth with

```js
const l = this._patchMap === null ? null : this._patchMap.get(index);
if (l !== undefined) {
    console.assert(l.length > 0);
```

`_patchMap` is lazily created, so it is still `null` when none of the slices the reader understands
referenced a class instance. The lookup then yielded `null`, which passes the `!== undefined` guard,
and evaluating `l.length` threw a raw `TypeError` out of the Ice runtime. (`console.assert` is not
the culprit — the throw happens while evaluating its argument, and the `for (const entry of l)` on
the next line would throw too. The optimized browser bundle strips `console.assert`, and still
fails.)

This is reachable over the 1.0 encoding: when the most derived slice of a user exception is unknown,
the reader slices it off without recording a patch entry, but the sender still queued the instance
that slice referenced, so `readPendingValues` reads it with nothing to patch it into. Because
`OutgoingAsync.throwUserException` only unwinds the encapsulation for a `UserException`, the
`TypeError` propagates verbatim: the application's `await proxy.op()` rejects with a `TypeError`
rather than the base exception it declared, and it isn't even an `Ice.LocalException`, so it slips
past the usual error handling.

The fix uses an optional lookup, so an absent patch map yields `undefined`. The orphan instance is
unmarshaled and discarded and the sliced exception is delivered — exactly what C++, C#, Java and
Swift already do (`csharp/src/Ice/InputStream.cs:2412` has the equivalent `_patchMap != null &&`
guard; C++ uses a non-optional `std::map`). The separate "index for class received, but no instance"
check in `readPendingValues` is unaffected.

This was the only one of the 13 `_patchMap` references that conflated "null map" with "no entry".

### Test

Added to `Ice/stream`, which already round-trips `MyException` through `OutputStream`/`InputStream`
and already uses `Ice.Encoding_1_0`. The test marshals a derived exception that is deliberately never
registered with the Slice loader, so any reader slices it off.

The scenario has two invisible preconditions, both verified by mutation to matter:

- the sliced-off slice must carry a **non-null** class reference — with a null one the sender queues
  no instance and the path is never reached (this is why the comment calls it out);
- the base slice's own class member must be nil, otherwise a patch entry is registered and the map
  is non-null — guarded by the `ex1.c === null` assertion.

`ex1.ice_id() === "::Test::MyException"` guards against the test quietly becoming a no-op if a
`::Test::UnknownDerived` is ever added to `stream/Test.ice` and thereby registered.

Verified red→green against a pristine `origin/main` runtime: unfixed it fails with
`TypeError: Cannot read properties of null (reading 'length')`; fixed it passes. A control
round-trip of a self-referential class graph confirms the populated-patch-map path is unchanged.

Fixes #6124
