### PR TITLE
Cancel the invocation timeout timer on every completion path

### DIFF
--- a/changelog.d/js/6217.md
+++ b/changelog.d/js/6217.md
@@ -1,0 +1,2 @@
+- Fixed a bug where a successful invocation made with an invocation timeout kept its timer, and the request and
+  reply buffers it held, alive until the timeout elapsed.

--- a/changelog.d/js/6217.md
+++ b/changelog.d/js/6217.md
@@ -1,2 +1,2 @@
-- Fixed a bug where a successful invocation made with an invocation timeout kept its timer, and the request and
-  reply buffers it held, alive until the timeout elapsed.
+- Fixed a bug where an invocation made with an invocation timeout released its memory, including the marshaled
+  request and reply, only when the timeout elapsed instead of when the invocation completed.

--- a/js/packages/ice/src/Ice/OutgoingAsync.js
+++ b/js/packages/ice/src/Ice/OutgoingAsync.js
@@ -158,9 +158,8 @@ export class ProxyOutgoingAsyncBase extends OutgoingAsyncBase {
     }
 
     cancelTimeoutToken() {
-        // The timer hands out 0 as its first token, so the token must be compared against undefined rather than
-        // tested for truthiness. We clear the token before cancelling it, so that a completion path that runs
-        // again after timer() throws doesn't throw a second time and leave the invocation unresolved.
+        // 0 is a valid token. Clear it before calling timer() — which throws once the communicator is destroyed —
+        // so that a completion path running after that throw finds the token cleared and does nothing.
         if (this._timeoutToken !== undefined) {
             const token = this._timeoutToken;
             this._timeoutToken = undefined;

--- a/js/packages/ice/src/Ice/OutgoingAsync.js
+++ b/js/packages/ice/src/Ice/OutgoingAsync.js
@@ -69,6 +69,7 @@ export class ProxyOutgoingAsyncBase extends OutgoingAsyncBase {
         this._cnt = 0;
         this._sent = false;
         this._handler = null;
+        this._timeoutToken = undefined;
     }
 
     completedEx(ex) {
@@ -141,18 +142,30 @@ export class ProxyOutgoingAsyncBase extends OutgoingAsyncBase {
     markSent(done) {
         this._sent = true;
         if (done) {
-            if (this._timeoutToken) {
-                this._instance.timer().cancel(this._timeoutToken);
-            }
+            this.cancelTimeoutToken();
         }
         super.markSent.call(this, done);
     }
 
+    markFinished(ok, completed) {
+        this.cancelTimeoutToken();
+        super.markFinished.call(this, ok, completed);
+    }
+
     markFinishedEx(ex) {
-        if (this._timeoutToken) {
-            this._instance.timer().cancel(this._timeoutToken);
-        }
+        this.cancelTimeoutToken();
         super.markFinishedEx.call(this, ex);
+    }
+
+    cancelTimeoutToken() {
+        // The timer hands out 0 as its first token, so the token must be compared against undefined rather than
+        // tested for truthiness. We clear the token before cancelling it, so that a completion path that runs
+        // again after timer() throws doesn't throw a second time and leave the invocation unresolved.
+        if (this._timeoutToken !== undefined) {
+            const token = this._timeoutToken;
+            this._timeoutToken = undefined;
+            this._instance.timer().cancel(token);
+        }
     }
 
     handleRetryAfterException(ex) {


### PR DESCRIPTION
`ProxyOutgoingAsyncBase` schedules the invocation timeout timer in `invokeImpl`, but cancelled it in
only two of the three places an invocation can complete: `markSent(done)` when `done` is true, and
`markFinishedEx`. It never overrode `markFinished` — which is how a twoway invocation that *succeeds*
completes (`OutgoingAsync.js:475`), and also how `ProxyGetConnection` completes (`:553`). Those
invocations kept their timer armed, and with it the `OutgoingAsync` and its marshalled request and
reply buffers, until the invocation timeout elapsed.

The two existing cancel sites also tested the token for truthiness, and the timer hands out `0` as
its first token (`Timer.js:11,25`). `invokeImpl` schedules before a connection is established, so the
first timed invocation on a communicator always draws token 0 and was never cancelled. That bites
the paths completed by `markSent(true)` or `markFinishedEx` — oneway and datagram invocations, batch
flushes, and failures. A successful twoway calls `markSent(false)`, so it was unaffected by the token
value and only ever leaked through the missing `markFinished`.

`AsyncResult` sets the `Done` bit in exactly three methods, so routing all three through one helper
covers every completion path. C++ (`OutgoingAsync.cpp` `sentImpl`/`exceptionImpl`/`responseImpl`),
C# and Java all cancel on the same three, and Java nulls its `_timerFuture` the same way the helper
clears the token. JavaScript was the only mapping with two of three.

The helper clears the token *before* cancelling. `Instance.timer()` throws once the communicator is
destroyed, and with the other order a completion path that ran again after that throw would throw a
second time and leave the invocation neither resolved nor rejected.

### Measured

Against a real server, with `origin/main` versus this branch:

- successful `ice_getConnection` with an invocation timeout — `origin/main` leaves the token pending
  (`[0,1,4,5]` → `[0,1,4,5,6]`); with the fix the set is unchanged
- 2000 successful twoways — `origin/main` accumulates 2000 timer entries and 2000 live Node `Timeout`
  handles; with the fix, steady state
- first invocation on a fresh communicator, failing to connect — `origin/main` leaves token 0
  pending; with the fix it is released
- retry is unaffected: `invokeImpl(false)` never schedules a second timer, the token is never cleared
  mid-flight, and a 120 ms invocation timeout still fires across 4 retry attempts

### No test

The failure mode has no behavioural signature to assert on. The leaked callback runs
`cancelWithException` against an already-`Done` result whose `_cancellationHandler` was nulled, so it
does nothing observable; `Timer.destroy()` cancels outstanding tokens when the communicator is
destroyed, so end-of-test state is identical either way; and process exit is not a discriminator,
because the connection's own idle timers keep the loop alive regardless.

That leaves only white-box assertions on `_timeoutToken` or the timer's `_tokens` map. There is no
precedent for that in `js/packages/test` (no `as any`, no `as unknown as`, no `.instance`), and
asserting `_timeoutToken === undefined` would only prove the fix cleared its own field, not that the
timer was cancelled. Per the repo norm for an obviously-correct fix, I'd rather ship it without one.

Fixes #6217
