### PR TITLE
Remove the unused formatFields helper from slice2py

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -480,30 +480,6 @@ Slice::Python::CodeVisitor::operationReturnTypeHint(const OperationPtr& operatio
     return " -> " + returnTypeHint(operation, methodKind);
 }
 
-string
-Slice::Python::formatFields(const DataMemberList& members)
-{
-    if (members.empty())
-    {
-        return "";
-    }
-
-    ostringstream os;
-    bool first = true;
-    os << "{format_fields(";
-    for (const auto& dataMember : members)
-    {
-        if (!first)
-        {
-            os << ", ";
-        }
-        first = false;
-        os << dataMember->mappedName() << "=self." << dataMember->mappedName();
-    }
-    os << ")}";
-    return os.str();
-}
-
 Python::CodeFragment
 Slice::Python::createCodeFragmentForPythonModule(const ContainedPtr& contained, const string& code)
 {

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -176,9 +176,6 @@ namespace Slice::Python
     /// @return The name of the meta-type for the given Slice definition.
     std::string getMetaType(const SyntaxTreeBasePtr& p);
 
-    /// Helper method to emit the generated code that format the fields of a type in __repr__ implementation.
-    std::string formatFields(const DataMemberList& members);
-
     CodeFragment createCodeFragmentForPythonModule(const ContainedPtr& contained, const std::string& code);
 
     // Get a list of all definitions exported for the Python module corresponding to the given Slice definition.


### PR DESCRIPTION
Removes `Slice::Python::formatFields`, which is dead code in `slice2py`.

The helper builds a `{format_fields(...)}` f-string fragment and looks like a leftover from an earlier approach to generating `__repr__`. Nothing in the tree references it: a repo-wide grep for `formatFields` and `format_fields` now comes up empty. This deletes the definition in `PythonUtil.cpp` along with its declaration and doc comment in `PythonUtil.h`; `make -C cpp slice2py` still builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)