### PR TITLE
Generate random bytes with the OS CSPRNG instead of std::random_device

### DIFF
--- a/changelog.d/cpp/6206.md
+++ b/changelog.d/cpp/6206.md
@@ -1,4 +1,3 @@
-- Fixed `Ice::generateUUID` occasionally returning duplicate, all-zero UUIDs on x86-64 systems with defective
-  hardware entropy, such as AMD Zen 5 CPUs without fixed firmware (CVE-2025-62626). Ice now generates random
-  bytes — including those behind `Ice::generateUUID` and `addWithUUID` — with the operating system's CSPRNG
-  instead of `std::random_device`.
+- Fixed `Ice::generateUUID` returning duplicate, all-zero UUIDs on systems with defective hardware entropy.
+  Ice now generates random bytes — including those behind `Ice::generateUUID` and `addWithUUID` — with the
+  operating system's CSPRNG instead of `std::random_device`.

--- a/changelog.d/cpp/6206.md
+++ b/changelog.d/cpp/6206.md
@@ -1,0 +1,4 @@
+- Fixed `Ice::generateUUID` occasionally returning duplicate, all-zero UUIDs on x86-64 systems with defective
+  hardware entropy, such as AMD Zen 5 CPUs without fixed firmware (CVE-2025-62626). Ice now generates random
+  bytes — including those behind `Ice::generateUUID` and `addWithUUID` — with the operating system's CSPRNG
+  instead of `std::random_device`.

--- a/changelog.d/cpp/6206.md
+++ b/changelog.d/cpp/6206.md
@@ -1,3 +1,2 @@
-- Fixed `Ice::generateUUID` returning duplicate UUIDs on systems with defective hardware entropy.
-  Ice now generates random bytes — including those behind `Ice::generateUUID` and `addWithUUID` — with the
+- Ice now generates random bytes — including those behind `Ice::generateUUID` and `addWithUUID` — with the
   operating system's CSPRNG instead of `std::random_device`.

--- a/changelog.d/cpp/6206.md
+++ b/changelog.d/cpp/6206.md
@@ -1,3 +1,3 @@
-- Fixed `Ice::generateUUID` returning duplicate, all-zero UUIDs on systems with defective hardware entropy.
+- Fixed `Ice::generateUUID` returning duplicate UUIDs on systems with defective hardware entropy.
   Ice now generates random bytes — including those behind `Ice::generateUUID` and `addWithUUID` — with the
   operating system's CSPRNG instead of `std::random_device`.

--- a/cpp/include/Ice/UUID.h
+++ b/cpp/include/Ice/UUID.h
@@ -10,6 +10,7 @@ namespace Ice
 {
     /// Generates a universally unique identifier (UUID).
     /// @return The UUID.
+    /// @throws std::system_error If the operating system's random number generator fails.
     ICE_API std::string generateUUID();
 }
 

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -38,7 +38,6 @@ Glacier2::RouterI::RouterI(
     {
         Identity ident = {"dummy", ""};
 
-        // We use ASCII 33-126 (from ! to ~, w/o space); bytes >= 188 are rejected to avoid modulo bias.
         ident.category.reserve(20);
         while (ident.category.size() < 20)
         {
@@ -47,8 +46,10 @@ Glacier2::RouterI::RouterI(
             for (char c : buf)
             {
                 auto b = static_cast<unsigned char>(c);
+                // Reject bytes >= 188 (= 2 * 94) to avoid modulo bias.
                 if (b < 188)
                 {
+                    // Map the byte to ASCII 33-126 (from ! to ~, w/o space).
                     ident.category.push_back(static_cast<char>(33 + b % 94));
                     if (ident.category.size() == 20)
                     {

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 #include "RouterI.h"
+#include "../Ice/Random.h"
 #include "FilterManager.h"
 #include "ForwardObserver.h"
 #include "Glacier2/Session.h"
@@ -39,8 +40,7 @@ Glacier2::RouterI::RouterI(
     {
         Identity ident = {"dummy", ""};
 
-        random_device rd;
-        mt19937 gen(rd());
+        mt19937 gen = IceInternal::createMT19937();
         uniform_int_distribution<> dist(33, 126); // We use ASCII 33-126 (from ! to ~, w/o space).
         for (unsigned int i = 0; i < 20; ++i)
         {

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -7,8 +7,6 @@
 #include "Glacier2/Session.h"
 #include "RoutingTable.h"
 
-#include <random>
-
 using namespace std;
 using namespace Ice;
 using namespace Glacier2;
@@ -40,11 +38,24 @@ Glacier2::RouterI::RouterI(
     {
         Identity ident = {"dummy", ""};
 
-        mt19937 gen = IceInternal::createMT19937();
-        uniform_int_distribution<> dist(33, 126); // We use ASCII 33-126 (from ! to ~, w/o space).
-        for (unsigned int i = 0; i < 20; ++i)
+        // We use ASCII 33-126 (from ! to ~, w/o space); bytes >= 188 are rejected to avoid modulo bias.
+        ident.category.reserve(20);
+        while (ident.category.size() < 20)
         {
-            ident.category.push_back(static_cast<char>(dist(gen)));
+            char buf[32];
+            IceInternal::generateRandom(buf, sizeof(buf));
+            for (char c : buf)
+            {
+                auto b = static_cast<unsigned char>(c);
+                if (b < 188)
+                {
+                    ident.category.push_back(static_cast<char>(33 + b % 94));
+                    if (ident.category.size() == 20)
+                    {
+                        break;
+                    }
+                }
+            }
         }
 
         const_cast<optional<ObjectPrx>&>(_serverProxy) = _instance->serverObjectAdapter()->createProxy(ident);

--- a/cpp/src/Ice/Random.cpp
+++ b/cpp/src/Ice/Random.cpp
@@ -11,7 +11,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <stdexcept>
 #include <system_error>
 
 #if defined(__linux__)
@@ -51,7 +50,8 @@ IceInternal::generateRandom(char* buffer, size_t size)
     arc4random_buf(buffer, size);
 #elif defined(__linux__)
     // getrandom with flags == 0 deliberately blocks until the kernel's entropy pool is initialized; don't
-    // "fix" this with GRND_NONBLOCK.
+    // "fix" this with GRND_NONBLOCK. There is also deliberately no /dev/urandom fallback here: getrandom is
+    // available in every supported glibc (2.25+), so a failure is a real error, not a missing feature.
     size_t index = 0;
     while (index < size)
     {
@@ -64,7 +64,7 @@ IceInternal::generateRandom(char* buffer, size_t size)
             }
             if (n == 0)
             {
-                throw runtime_error("getrandom returned no data");
+                throw system_error(EIO, generic_category(), "getrandom returned no data");
             }
             throw system_error(errno, generic_category(), "getrandom failed");
         }
@@ -94,7 +94,7 @@ IceInternal::generateRandom(char* buffer, size_t size)
             close(fd);
             if (n == 0)
             {
-                throw runtime_error("unexpected EOF reading /dev/urandom");
+                throw system_error(EIO, generic_category(), "unexpected EOF reading /dev/urandom");
             }
             throw system_error(err, generic_category(), "cannot read /dev/urandom");
         }

--- a/cpp/src/Ice/Random.cpp
+++ b/cpp/src/Ice/Random.cpp
@@ -1,29 +1,110 @@
 // Copyright (c) ZeroC, Inc.
 
+#ifdef _WIN32
+#    define _CRT_RAND_S
+#endif
+
 #include "Random.h"
 
+#include <array>
 #include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <system_error>
+
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#    include <cstdlib>
+#elif defined(__linux__)
+#    include <cerrno>
+#    include <sys/random.h>
+#elif !defined(_WIN32)
+#    include <cerrno>
+#    include <fcntl.h>
+#    include <unistd.h>
+#endif
 
 using namespace std;
 
+// The random bytes must come from the operating system's CSPRNG, not from std::random_device. On x86-64,
+// libstdc++ implements std::random_device with the raw RDSEED CPU instruction, and on AMD Zen 5 CPUs without
+// fixed firmware, RDSEED frequently returns 0 while reporting success (CVE-2025-62626); this produced
+// duplicate all-zero UUIDs. The OS conditions hardware entropy sources instead of trusting their output.
 void
 IceInternal::generateRandom(char* buffer, size_t size)
 {
-    // We use the random_device directly here to get cryptographic random numbers when possible.
-    thread_local static std::random_device rd;
-    uniform_int_distribution<unsigned int> distribution(0, 255);
-    for (size_t i = 0; i < size; ++i, ++buffer)
+#if defined(_WIN32)
+    // rand_s is backed by the same system CSPRNG as BCryptGenRandom and requires no additional link
+    // dependency.
+    size_t index = 0;
+    while (index < size)
     {
-        *buffer = static_cast<char>(distribution(rd));
+        unsigned int r = 0;
+        errno_t err = rand_s(&r);
+        if (err != 0)
+        {
+            throw system_error(err, generic_category(), "rand_s failed");
+        }
+        size_t n = min(sizeof(r), size - index);
+        memcpy(buffer + index, &r, n);
+        index += n;
     }
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+    arc4random_buf(buffer, size);
+#elif defined(__linux__)
+    size_t index = 0;
+    while (index < size)
+    {
+        ssize_t n = getrandom(buffer + index, size - index, 0);
+        if (n < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            throw system_error(errno, generic_category(), "getrandom failed");
+        }
+        index += static_cast<size_t>(n);
+    }
+#else
+    int fd = open("/dev/urandom", O_RDONLY);
+    if (fd == -1)
+    {
+        throw system_error(errno, generic_category(), "cannot open /dev/urandom");
+    }
+    size_t index = 0;
+    while (index < size)
+    {
+        ssize_t n = read(fd, buffer + index, size - index);
+        if (n <= 0)
+        {
+            if (n < 0 && errno == EINTR)
+            {
+                continue;
+            }
+            int err = errno;
+            close(fd);
+            throw system_error(err, generic_category(), "cannot read /dev/urandom");
+        }
+        index += static_cast<size_t>(n);
+    }
+    close(fd);
+#endif
 }
 
 unsigned int
 IceInternal::random(unsigned int limit)
 {
     assert(limit > 0);
-    thread_local static std::random_device rd;
-    thread_local static std::mt19937 rng(rd());
+    thread_local static mt19937 rng = createMT19937();
     uniform_int_distribution<unsigned int> distribution(0, limit - 1);
     return distribution(rng);
+}
+
+mt19937
+IceInternal::createMT19937()
+{
+    array<uint32_t, 8> seedData;
+    generateRandom(reinterpret_cast<char*>(seedData.data()), sizeof(seedData));
+    seed_seq seq(seedData.begin(), seedData.end());
+    return mt19937(seq);
 }

--- a/cpp/src/Ice/Random.cpp
+++ b/cpp/src/Ice/Random.cpp
@@ -25,10 +25,9 @@
 
 using namespace std;
 
-// The random bytes must come from the operating system's CSPRNG, not from std::random_device. On x86-64,
-// libstdc++ implements std::random_device with the raw RDSEED CPU instruction, and on AMD Zen 5 CPUs without
-// fixed firmware, RDSEED frequently returns 0 while reporting success (CVE-2025-62626); this produced
-// duplicate all-zero UUIDs. The OS conditions hardware entropy sources instead of trusting their output.
+// Generate the random bytes with the operating system's CSPRNG, never with std::random_device: the C++
+// standard gives std::random_device no cryptographic guarantee, and some implementations draw from raw CPU
+// entropy instructions whose output defective hardware can make predictable.
 void
 IceInternal::generateRandom(char* buffer, size_t size)
 {

--- a/cpp/src/Ice/Random.cpp
+++ b/cpp/src/Ice/Random.cpp
@@ -9,15 +9,15 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
+#include <stdexcept>
 #include <system_error>
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
-#    include <cstdlib>
-#elif defined(__linux__)
+#if defined(__linux__)
 #    include <cerrno>
 #    include <sys/random.h>
-#elif !defined(_WIN32)
+#elif !defined(_WIN32) && !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
 #    include <cerrno>
 #    include <fcntl.h>
 #    include <unistd.h>
@@ -51,22 +51,32 @@ IceInternal::generateRandom(char* buffer, size_t size)
 #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
     arc4random_buf(buffer, size);
 #elif defined(__linux__)
+    // getrandom with flags == 0 deliberately blocks until the kernel's entropy pool is initialized; don't
+    // "fix" this with GRND_NONBLOCK.
     size_t index = 0;
     while (index < size)
     {
         ssize_t n = getrandom(buffer + index, size - index, 0);
-        if (n < 0)
+        if (n <= 0)
         {
-            if (errno == EINTR)
+            if (n < 0 && errno == EINTR)
             {
                 continue;
+            }
+            if (n == 0)
+            {
+                throw runtime_error("getrandom returned no data");
             }
             throw system_error(errno, generic_category(), "getrandom failed");
         }
         index += static_cast<size_t>(n);
     }
 #else
-    int fd = open("/dev/urandom", O_RDONLY);
+    int fd;
+    do
+    {
+        fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+    } while (fd == -1 && errno == EINTR);
     if (fd == -1)
     {
         throw system_error(errno, generic_category(), "cannot open /dev/urandom");
@@ -83,6 +93,10 @@ IceInternal::generateRandom(char* buffer, size_t size)
             }
             int err = errno;
             close(fd);
+            if (n == 0)
+            {
+                throw runtime_error("unexpected EOF reading /dev/urandom");
+            }
             throw system_error(err, generic_category(), "cannot read /dev/urandom");
         }
         index += static_cast<size_t>(n);

--- a/cpp/src/Ice/Random.cpp
+++ b/cpp/src/Ice/Random.cpp
@@ -16,10 +16,6 @@
 #if defined(__linux__)
 #    include <cerrno>
 #    include <sys/random.h>
-#elif !defined(_WIN32) && !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
-#    include <cerrno>
-#    include <fcntl.h>
-#    include <unistd.h>
 #endif
 
 using namespace std;
@@ -71,36 +67,7 @@ IceInternal::generateRandom(char* buffer, size_t size)
         index += static_cast<size_t>(n);
     }
 #else
-    int fd;
-    do
-    {
-        fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
-    } while (fd == -1 && errno == EINTR);
-    if (fd == -1)
-    {
-        throw system_error(errno, generic_category(), "cannot open /dev/urandom");
-    }
-    size_t index = 0;
-    while (index < size)
-    {
-        ssize_t n = read(fd, buffer + index, size - index);
-        if (n <= 0)
-        {
-            if (n < 0 && errno == EINTR)
-            {
-                continue;
-            }
-            int err = errno;
-            close(fd);
-            if (n == 0)
-            {
-                throw system_error(EIO, generic_category(), "unexpected EOF reading /dev/urandom");
-            }
-            throw system_error(err, generic_category(), "cannot read /dev/urandom");
-        }
-        index += static_cast<size_t>(n);
-    }
-    close(fd);
+#    error "unsupported platform: no OS CSPRNG binding"
 #endif
 }
 

--- a/cpp/src/Ice/Random.h
+++ b/cpp/src/Ice/Random.h
@@ -9,13 +9,18 @@
 
 namespace IceInternal
 {
+    // Fills the buffer with cryptographically strong random bytes from the operating system's CSPRNG.
+    // See Random.cpp for why this must not draw from std::random_device.
     ICE_API void generateRandom(char*, size_t);
+
     ICE_API unsigned int random(unsigned int = 0);
+
+    // Creates a std::mt19937 engine seeded from the operating system's CSPRNG.
+    ICE_API std::mt19937 createMT19937();
 
     template<class T> void shuffle(T first, T last)
     {
-        thread_local static std::random_device rd;
-        thread_local static std::mt19937 rng(rd());
+        thread_local static std::mt19937 rng = createMT19937();
         std::shuffle(first, last, rng);
     }
 }

--- a/cpp/src/Ice/Random.h
+++ b/cpp/src/Ice/Random.h
@@ -10,7 +10,6 @@
 namespace IceInternal
 {
     // Fills the buffer with cryptographically strong random bytes from the operating system's CSPRNG.
-    // See Random.cpp for why this must not draw from std::random_device.
     ICE_API void generateRandom(char*, size_t);
 
     ICE_API unsigned int random(unsigned int = 0);

--- a/cpp/src/Ice/UUID.cpp
+++ b/cpp/src/Ice/UUID.cpp
@@ -2,8 +2,7 @@
 
 #include "Ice/UUID.h"
 
-// We use the operating system's CSPRNG (see Random.h) to generate
-// "version 4" UUIDs, as described in
+// We use the operating system's CSPRNG (see Random.h) to generate "version 4" UUIDs, as described in
 // http://www.ietf.org/internet-drafts/draft-mealling-uuid-urn-00.txt
 #include "Random.h"
 

--- a/cpp/src/Ice/UUID.cpp
+++ b/cpp/src/Ice/UUID.cpp
@@ -2,8 +2,8 @@
 
 #include "Ice/UUID.h"
 
-// We use a high quality random number generator
-// (std::random_device) to generate "version 4" UUIDs, as described in
+// We use the operating system's CSPRNG (see Random.h) to generate
+// "version 4" UUIDs, as described in
 // http://www.ietf.org/internet-drafts/draft-mealling-uuid-urn-00.txt
 #include "Random.h"
 


### PR DESCRIPTION
The IceUtil/uuid test has been failing intermittently on CI since mid-June with a duplicate `00000000-0000-4000-8000-000000000000` UUID (#6206). The root cause is not in Ice or the test: some GitHub `ubuntu-24.04` jobs now land on Azure `Standard_D4ads_v7` runners (AMD EPYC 9V45, Zen 5), where 32-bit RDSEED frequently returns 0 while reporting success (CVE-2025-62626). libstdc++ implements `std::random_device` with raw RDSEED on x86-64, so `IceInternal::generateRandom` could fill entire buffers with zeros — on an affected runner, [this probe](https://github.com/externl/ice/actions/runs/30375189802/job/90328941105) measured 4.1M zero-with-success draws out of 15M, and 66% of 16-byte fills came back all zero. Reading the OS CSPRNG avoids trusting the CPU instruction directly, on any hardware or firmware.

- `IceInternal::generateRandom` now uses `getrandom()` on Linux, `arc4random_buf()` on macOS/BSD, and `rand_s` on Windows; other platforms fail the build with `#error`
- `IceInternal::random` and `shuffle` seed their `mt19937` from the new `createMT19937()` helper instead of `std::random_device`
- Glacier2's per-session callback category is drawn directly from `generateRandom`, with modulo-bias rejection
- Documented that `Ice::generateUUID` can throw `std::system_error`, and added a changelog fragment

Fixes #6206