### PR TITLE
Type hint the rest of the Python sources

### DIFF
--- a/config/makeprops.py
+++ b/config/makeprops.py
@@ -9,9 +9,10 @@ import shutil
 import signal
 import sys
 from enum import StrEnum, auto
-from typing import override
+from typing import TextIO, override
 from xml.sax import make_parser
 from xml.sax.handler import ContentHandler, feature_namespaces
+from xml.sax.xmlreader import AttributesImpl
 
 
 class Language(StrEnum):
@@ -37,49 +38,49 @@ class PropertyArray:
         self.prefixOnly = prefixOnly
         self.isOptIn = isOptIn
         self.isClass = isClass
-        self.properties = []
+        self.properties: list[str] = []
 
-    def addProperty(self, property):
+    def addProperty(self, property: str) -> None:
         self.properties.append(property)
 
 
 class PropertyHandler(ContentHandler):
-    def __init__(self, language):
+    def __init__(self, language: Language):
         # The language we are generating properties for
         self.language = language
         # The section we are currently parsing
-        self.parentNodeName = None
+        self.parentNodeName: str | None = None
         # Dictionary of section names to attr dicts
         self.propertyArrayDict: dict[str, PropertyArray] = dict()
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         # Needs to be overridden in derived class
         pass
 
-    def openFiles(self):
+    def openFiles(self) -> None:
         # Needs to be overridden in derived class
         pass
 
-    def closeFiles(self):
+    def closeFiles(self) -> None:
         # Needs to be overridden in derived class
         pass
 
     def createProperty(
         self,
-        propertyName,
-        usesRegex,
-        defaultValue,
-        deprecated,
-        propertyArrayName,
-    ):
+        propertyName: str,
+        usesRegex: bool,
+        defaultValue: str,
+        deprecated: bool,
+        propertyArrayName: str | None,
+    ) -> str:
+        # Needs to be overridden in derived class
+        raise NotImplementedError()
+
+    def writePropertyArray(self, propertyArray: PropertyArray) -> None:
         # Needs to be overridden in derived class
         pass
 
-    def writePropertyArray(self, propertyArray: PropertyArray):
-        # Needs to be overridden in derived class
-        pass
-
-    def writeProperties(self):
+    def writeProperties(self) -> None:
         self.openFiles()
 
         for propertyArray in self.propertyArrayDict.values():
@@ -87,19 +88,21 @@ class PropertyHandler(ContentHandler):
 
         self.closeFiles()
 
-    def moveFiles(self, location):
+    def moveFiles(self, location: str) -> None:
         # Needs to be overridden in derived class
         pass
 
     # The list of property arrays to get generated
-    def generatedPropertyArrays(self):
+    def generatedPropertyArrays(self) -> list[str]:
         return [name for name, propertyArray in self.propertyArrayDict.items() if not propertyArray.isClass]
 
-    def reservedPropertyPrefixes(self):
+    def reservedPropertyPrefixes(self) -> list[str]:
         return [name for name, array in self.propertyArrayDict.items() if not array.isClass]
 
-    def parseProperty(self, attrs):
+    def parseProperty(self, attrs: AttributesImpl) -> str:
         name = attrs.get("name")
+        # validateKnownAttributes only warns about a missing name, and every path below needs one.
+        assert name is not None, "property element is missing its name attribute"
         usesRegex = "[any]" in name
         deprecated = attrs.get("deprecated", "false").lower() == "true"
         defaultValue = attrs.get("default", None)
@@ -125,7 +128,7 @@ class PropertyHandler(ContentHandler):
             propertyArrayName,
         )
 
-    def validateKnownAttributes(self, validAttrs, attrs):
+    def validateKnownAttributes(self, validAttrs: list[str], attrs: AttributesImpl) -> None:
         if "name" not in attrs:
             print(sys.stderr, "missing name attribute")
 
@@ -133,7 +136,7 @@ class PropertyHandler(ContentHandler):
             if a not in validAttrs:
                 print(sys.stderr, "invalid attribute '%s'" % a)
 
-    def validateLanguages(self, attrs):
+    def validateLanguages(self, attrs: AttributesImpl) -> bool:
         languageAttr = attrs.get("languages", None)
         # If no language attribute is specified issue a warning and skip code generation for this element
         if languageAttr is None:
@@ -165,7 +168,7 @@ class PropertyHandler(ContentHandler):
         return Language.ALL in languages or self.language in languages
 
     @override
-    def startElement(self, name, attrs):
+    def startElement(self, name: str, attrs: AttributesImpl) -> None:
         match name:
             case "properties":
                 pass
@@ -183,12 +186,16 @@ class PropertyHandler(ContentHandler):
                 )
             case "section":
                 isOptIn = attrs.get("opt-in", "false").lower() == "true"
-                name = attrs.get("name")
+                # Not "name": that is this method's parameter, and the class branch above already
+                # rebinds it to a str.
+                sectionName = attrs.get("name")
 
                 self.validateKnownAttributes(["name", "opt-in"], attrs)
-                self.parentNodeName = name
+                # As in parseProperty: the warning above does not stop us, but the dict is keyed by name.
+                assert sectionName is not None, "section element is missing its name attribute"
+                self.parentNodeName = sectionName
                 self.propertyArrayDict[self.parentNodeName] = PropertyArray(
-                    name=name,
+                    name=sectionName,
                     prefixOnly=False,
                     isClass=False,
                     isOptIn=isOptIn,
@@ -202,12 +209,14 @@ class PropertyHandler(ContentHandler):
 
                 property = self.parseProperty(attrs)
 
+                # A property element only appears inside a section or class, both of which set this.
+                assert self.parentNodeName is not None, "property element outside a section or class"
                 self.propertyArrayDict[self.parentNodeName].addProperty(property)
             case _:
                 raise ValueError(f"Unknown element: {name}")
 
     @override
-    def endElement(self, name):
+    def endElement(self, name: str) -> None:
         if name == "section" or name == "class":
             self.parentNodeName = None
 
@@ -215,11 +224,11 @@ class PropertyHandler(ContentHandler):
 class CppPropertyHandler(PropertyHandler):
     def __init__(self):
         super().__init__(Language.CPP)
-        self.hFile = None
-        self.cppFile = None
+        self.hFile: TextIO | None = None
+        self.cppFile: TextIO | None = None
 
     @override
-    def cleanup(self):
+    def cleanup(self) -> None:
         if self.hFile is not None:
             self.hFile.close()
             if os.path.exists("PropertyNames.h"):
@@ -230,7 +239,7 @@ class CppPropertyHandler(PropertyHandler):
                 os.remove("PropertyNames.cpp")
 
     @override
-    def openFiles(self):
+    def openFiles(self) -> None:
         self.hFile = open("PropertyNames.h", "w")
         self.cppFile = open("PropertyNames.cpp", "w")
         self.hFile.write(f"""\
@@ -275,7 +284,9 @@ using namespace IceInternal;
 """)
 
     @override
-    def closeFiles(self):
+    def closeFiles(self) -> None:
+        # writeProperties calls openFiles before anything reaches here.
+        assert self.hFile is not None and self.cppFile is not None
         self.hFile.write(f"""
         /// Property arrays defined using sections in PropertyNames.xml.
         static const std::array<PropertyArray, {len(self.generatedPropertyArrays())}> validProps;
@@ -295,11 +306,12 @@ const std::array<PropertyArray, {len(self.generatedPropertyArrays())}> PropertyN
         self.hFile.close()
         self.cppFile.close()
 
-    def fix(self, propertyName):
+    def fix(self, propertyName: str) -> str:
         return propertyName.replace("[any]", "*")
 
     @override
-    def writePropertyArray(self, propertyArray):
+    def writePropertyArray(self, propertyArray: PropertyArray) -> None:
+        assert self.hFile is not None and self.cppFile is not None
         name = propertyArray.name
         arrayName = f"{name}PropsData"
         prefixOnly = "true" if propertyArray.prefixOnly else "false"
@@ -330,19 +342,26 @@ const PropertyArray PropertyNames::{name}Props
 """)
 
     @override
-    def createProperty(self, propertyName, usesRegex, defaultValue, deprecated, propertyArray):
+    def createProperty(
+        self,
+        propertyName: str,
+        usesRegex: bool,
+        defaultValue: str,
+        deprecated: bool,
+        propertyArrayName: str | None,
+    ) -> str:
         propertyLine = 'Property{{"{pattern}", {defaultValue}, {usesRegex}, {deprecated}, {propertyArray}}}'.format(
             pattern=self.fix(propertyName) if usesRegex else propertyName,
             defaultValue=f'"{defaultValue}"',
             usesRegex="true" if usesRegex else "false",
             deprecated="true" if deprecated else "false",
-            propertyArray=f"&PropertyNames::{propertyArray}Props" if propertyArray else "nullptr",
+            propertyArray=f"&PropertyNames::{propertyArrayName}Props" if propertyArrayName else "nullptr",
         )
 
         return propertyLine
 
     @override
-    def moveFiles(self, location):
+    def moveFiles(self, location: str) -> None:
         dest = os.path.join(location, "cpp", "src", "Ice")
         if os.path.exists(os.path.join(dest, "PropertyNames.h")):
             os.remove(os.path.join(dest, "PropertyNames.h"))
@@ -355,17 +374,17 @@ const PropertyArray PropertyNames::{name}Props
 class JavaPropertyHandler(PropertyHandler):
     def __init__(self):
         super().__init__(Language.JAVA)
-        self.srcFile = None
+        self.srcFile: TextIO | None = None
 
     @override
-    def cleanup(self):
+    def cleanup(self) -> None:
         if self.srcFile is not None:
             self.srcFile.close()
             if os.path.exists("PropertyNames.java"):
                 os.remove("PropertyNames.java")
 
     @override
-    def openFiles(self):
+    def openFiles(self) -> None:
         self.srcFile = open("PropertyNames.java", "w")
         self.srcFile.write(f"""\
 {commonPreamble}
@@ -375,7 +394,9 @@ final class PropertyNames {{
 """)
 
     @override
-    def closeFiles(self):
+    def closeFiles(self) -> None:
+        # writeProperties calls openFiles before anything reaches here.
+        assert self.srcFile is not None
         self.srcFile.write(f"""\
     public static final PropertyArray validProps[] =
     {{
@@ -385,14 +406,15 @@ final class PropertyNames {{
 """)
         self.srcFile.close()
 
-    def fix(self, propertyName):
+    def fix(self, propertyName: str) -> str:
         #
         # The Java property strings are actually regexp's that will be passed to Java's regexp facility.
         #
         return propertyName.replace(".", r"\\.").replace("[any]", r"[^\\s]+")
 
     @override
-    def writePropertyArray(self, propertyArray):
+    def writePropertyArray(self, propertyArray: PropertyArray) -> None:
+        assert self.srcFile is not None
         name = propertyArray.name
         prefixOnly = "true" if propertyArray.prefixOnly else "false"
         isOptIn = "true" if propertyArray.isOptIn else "false"
@@ -414,24 +436,24 @@ final class PropertyNames {{
     @override
     def createProperty(
         self,
-        propertyName,
-        usesRegex,
-        defaultValue,
-        deprecated,
-        propertyArray,
-    ):
+        propertyName: str,
+        usesRegex: bool,
+        defaultValue: str,
+        deprecated: bool,
+        propertyArrayName: str | None,
+    ) -> str:
         line = 'new Property("{pattern}", {usesRegex}, {defaultValue}, {deprecated}, {propertyArray})'.format(
             pattern=self.fix(propertyName) if usesRegex else propertyName,
             usesRegex="true" if usesRegex else "false",
             defaultValue=f'"{defaultValue}"',
             deprecated="true" if deprecated else "false",
-            propertyArray=f"PropertyNames.{propertyArray}Props" if propertyArray else "null",
+            propertyArray=f"PropertyNames.{propertyArrayName}Props" if propertyArrayName else "null",
         )
 
         return line
 
     @override
-    def moveFiles(self, location):
+    def moveFiles(self, location: str) -> None:
         dest = os.path.join(
             location,
             "java",
@@ -452,17 +474,17 @@ final class PropertyNames {{
 class CSPropertyHandler(PropertyHandler):
     def __init__(self):
         super().__init__(Language.CSHARP)
-        self.srcFile = None
+        self.srcFile: TextIO | None = None
 
     @override
-    def cleanup(self):
+    def cleanup(self) -> None:
         if self.srcFile is not None:
             self.srcFile.close()
             if os.path.exists("PropertyNames.cs"):
                 os.remove("PropertyNames.cs")
 
     @override
-    def openFiles(self):
+    def openFiles(self) -> None:
         self.srcFile = open("PropertyNames.cs", "w")
         self.srcFile.write(f"""\
 {commonPreamble}
@@ -473,7 +495,9 @@ internal sealed class PropertyNames
 """)
 
     @override
-    def closeFiles(self):
+    def closeFiles(self) -> None:
+        # writeProperties calls openFiles before anything reaches here.
+        assert self.srcFile is not None
         self.srcFile.write(f"""\
     internal static PropertyArray[] validProps =
     [
@@ -483,11 +507,12 @@ internal sealed class PropertyNames
 """)
         self.srcFile.close()
 
-    def fix(self, propertyName):
+    def fix(self, propertyName: str) -> str:
         return propertyName.replace(".", r"\.").replace("[any]", r"[^\s]+")
 
     @override
-    def writePropertyArray(self, propertyArray):
+    def writePropertyArray(self, propertyArray: PropertyArray) -> None:
+        assert self.srcFile is not None
         name = propertyArray.name
         prefixOnly = "true" if propertyArray.prefixOnly else "false"
         isOptIn = "true" if propertyArray.isOptIn else "false"
@@ -509,23 +534,23 @@ internal sealed class PropertyNames
     @override
     def createProperty(
         self,
-        propertyName,
-        usesRegex,
-        defaultValue,
-        deprecated,
-        propertyArray,
-    ):
+        propertyName: str,
+        usesRegex: bool,
+        defaultValue: str,
+        deprecated: bool,
+        propertyArrayName: str | None,
+    ) -> str:
         line = 'new(pattern: @"{pattern}", usesRegex: {usesRegex}, defaultValue: {defaultValue}, deprecated: {deprecated}, propertyArray: {propertyArray})'.format(
             pattern=f"^{self.fix(propertyName)}$" if usesRegex else propertyName,
             usesRegex="true" if usesRegex else "false",
             defaultValue=f'"{defaultValue}"',
             deprecated="true" if deprecated else "false",
-            propertyArray=f"{propertyArray}Props" if propertyArray else "null",
+            propertyArray=f"{propertyArrayName}Props" if propertyArrayName else "null",
         )
         return line
 
     @override
-    def moveFiles(self, location):
+    def moveFiles(self, location: str) -> None:
         dest = os.path.join(location, "csharp", "src", "Ice", "Internal")
         if os.path.exists(os.path.join(dest, "PropertyNames.cs")):
             os.remove(os.path.join(dest, "PropertyNames.cs"))
@@ -535,17 +560,17 @@ internal sealed class PropertyNames
 class JSPropertyHandler(PropertyHandler):
     def __init__(self):
         super().__init__(Language.JS)
-        self.srcFile = None
+        self.srcFile: TextIO | None = None
 
     @override
-    def cleanup(self):
+    def cleanup(self) -> None:
         if self.srcFile is not None:
             self.srcFile.close()
             if os.path.exists("PropertyNames.js"):
                 os.remove("PropertyNames.js")
 
     @override
-    def openFiles(self):
+    def openFiles(self) -> None:
         self.srcFile = open("PropertyNames.js", "w")
         self.srcFile.write(f"""
 {commonPreamble}
@@ -555,7 +580,9 @@ export const PropertyNames = {{}};
 """)
 
     @override
-    def closeFiles(self):
+    def closeFiles(self) -> None:
+        # writeProperties calls openFiles before anything reaches here.
+        assert self.srcFile is not None
         self.srcFile.write(f"""\
 PropertyNames.validProps = [
 {",\n".join([f"    PropertyNames.{name}Props" for name in self.generatedPropertyArrays()])},
@@ -563,11 +590,12 @@ PropertyNames.validProps = [
 """)
         self.srcFile.close()
 
-    def fix(self, propertyName):
+    def fix(self, propertyName: str) -> str:
         return propertyName.replace(".", "\\.").replace("[any]", ".")
 
     @override
-    def writePropertyArray(self, propertyArray):
+    def writePropertyArray(self, propertyArray: PropertyArray) -> None:
+        assert self.srcFile is not None
         name = propertyArray.name
         prefixOnly = "true" if propertyArray.prefixOnly else "false"
         isOptIn = "true" if propertyArray.isOptIn else "false"
@@ -584,23 +612,23 @@ PropertyNames.{name}Props.properties = [{properties}
     @override
     def createProperty(
         self,
-        propertyName,
-        usesRegex,
-        defaultValue,
-        deprecated,
-        propertyArray,
-    ):
+        propertyName: str,
+        usesRegex: bool,
+        defaultValue: str,
+        deprecated: bool,
+        propertyArrayName: str | None,
+    ) -> str:
         line = "new Property({pattern}, {usesRegex}, {defaultValue}, {deprecated}, {propertyArray})".format(
             pattern=f"/^{self.fix(propertyName)}/" if usesRegex else f'"{propertyName}"',
             usesRegex="true" if usesRegex else "false",
             defaultValue=f'"{defaultValue}"',
             deprecated="true" if deprecated else "false",
-            propertyArray=f"PropertyNames.{propertyArray}Props" if propertyArray else "null",
+            propertyArray=f"PropertyNames.{propertyArrayName}Props" if propertyArrayName else "null",
         )
         return line
 
     @override
-    def moveFiles(self, location):
+    def moveFiles(self, location: str) -> None:
         dest = os.path.join(location, "js", "src", "Ice")
         if os.path.exists(os.path.join(dest, "PropertyNames.js")):
             os.remove(os.path.join(dest, "PropertyNames.js"))
@@ -608,29 +636,29 @@ PropertyNames.{name}Props.properties = [{properties}
 
 
 class MultiHandler(ContentHandler):
-    def __init__(self, handlers):
+    def __init__(self, handlers: list[PropertyHandler]):
         self.handlers = handlers
         super().__init__()
 
     @override
-    def startElement(self, name, attrs):
+    def startElement(self, name: str, attrs: AttributesImpl) -> None:
         for f in self.handlers:
             f.startElement(name, attrs)
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         for f in self.handlers:
             f.cleanup()
 
-    def moveFiles(self, location):
+    def moveFiles(self, location: str) -> None:
         for f in self.handlers:
             f.moveFiles(location)
 
-    def writeProperties(self):
+    def writeProperties(self) -> None:
         for f in self.handlers:
             f.writeProperties()
 
 
-def main():
+def main() -> None:
     if len(sys.argv) != 1 and len(sys.argv) != 3:
         print(sys.stderr, "makeprops.py does not take any arguments")
         sys.exit(1)

--- a/config/makeprops.py
+++ b/config/makeprops.py
@@ -110,14 +110,14 @@ class PropertyHandler(ContentHandler):
 
         if propertyArrayName and defaultValue:
             print(
-                sys.stderr,
                 f"Property '{name}' cannot have both a class and a default value",
+                file=sys.stderr,
             )
 
         if propertyArrayName and usesRegex:
             print(
-                sys.stderr,
                 f"Property '{name}' cannot have both a class and use a regex",
+                file=sys.stderr,
             )
 
         return self.createProperty(
@@ -130,19 +130,19 @@ class PropertyHandler(ContentHandler):
 
     def validateKnownAttributes(self, validAttrs: list[str], attrs: AttributesImpl) -> None:
         if "name" not in attrs:
-            print(sys.stderr, "missing name attribute")
+            print("missing name attribute", file=sys.stderr)
 
         for a in attrs.keys():
             if a not in validAttrs:
-                print(sys.stderr, "invalid attribute '%s'" % a)
+                print("invalid attribute '%s'" % a, file=sys.stderr)
 
     def validateLanguages(self, attrs: AttributesImpl) -> bool:
         languageAttr = attrs.get("languages", None)
         # If no language attribute is specified issue a warning and skip code generation for this element
         if languageAttr is None:
             print(
-                sys.stderr,
                 "missing languages attribute in property element %s" % attrs.get("name"),
+                file=sys.stderr,
             )
             return False
 
@@ -151,17 +151,17 @@ class PropertyHandler(ContentHandler):
         for lang in languages:
             if lang not in [lang.value for lang in Language]:
                 print(
-                    sys.stderr,
                     "invalid language '%s' in property element %s" % (lang, attrs.get("name")),
+                    file=sys.stderr,
                 )
                 return False
 
         # All should be by itself. Issue a warning but continue generation for this element.
         if Language.ALL in languages and len(languages) > 1:
             print(
-                sys.stderr,
                 "Invalid languages attribute in property element: %s. 'all' must be specified alone."
                 % attrs.get("name"),
+                file=sys.stderr,
             )
 
         # True if the current language is in the list of languages or if the list contains 'all'
@@ -660,7 +660,7 @@ class MultiHandler(ContentHandler):
 
 def main() -> None:
     if len(sys.argv) != 1 and len(sys.argv) != 3:
-        print(sys.stderr, "makeprops.py does not take any arguments")
+        print("makeprops.py does not take any arguments", file=sys.stderr)
         sys.exit(1)
 
     # Find the top-level directory of the Ice repository
@@ -669,8 +669,8 @@ def main() -> None:
 
     if not os.path.exists(propsFile):
         print(
-            sys.stderr,
             "Cannot find top-level directory. Please run this script from the Ice repository.",
+            file=sys.stderr,
         )
         sys.exit(1)
 
@@ -696,7 +696,7 @@ def main() -> None:
         contentHandler.writeProperties()
         contentHandler.moveFiles(topLevel)
     except Exception as ex:
-        print(sys.stderr, str(ex))
+        print(str(ex), file=sys.stderr)
         contentHandler.cleanup()
         sys.exit(1)
 

--- a/config/makeprops.py
+++ b/config/makeprops.py
@@ -101,7 +101,6 @@ class PropertyHandler(ContentHandler):
 
     def parseProperty(self, attrs: AttributesImpl) -> str:
         name = attrs.get("name")
-        # validateKnownAttributes only warns about a missing name, and every path below needs one.
         assert name is not None, "property element is missing its name attribute"
         usesRegex = "[any]" in name
         deprecated = attrs.get("deprecated", "false").lower() == "true"
@@ -186,12 +185,9 @@ class PropertyHandler(ContentHandler):
                 )
             case "section":
                 isOptIn = attrs.get("opt-in", "false").lower() == "true"
-                # Not "name": that is this method's parameter, and the class branch above already
-                # rebinds it to a str.
                 sectionName = attrs.get("name")
 
                 self.validateKnownAttributes(["name", "opt-in"], attrs)
-                # As in parseProperty: the warning above does not stop us, but the dict is keyed by name.
                 assert sectionName is not None, "section element is missing its name attribute"
                 self.parentNodeName = sectionName
                 self.propertyArrayDict[self.parentNodeName] = PropertyArray(
@@ -209,7 +205,6 @@ class PropertyHandler(ContentHandler):
 
                 property = self.parseProperty(attrs)
 
-                # A property element only appears inside a section or class, both of which set this.
                 assert self.parentNodeName is not None, "property element outside a section or class"
                 self.propertyArrayDict[self.parentNodeName].addProperty(property)
             case _:
@@ -285,7 +280,6 @@ using namespace IceInternal;
 
     @override
     def closeFiles(self) -> None:
-        # writeProperties calls openFiles before anything reaches here.
         assert self.hFile is not None and self.cppFile is not None
         self.hFile.write(f"""
         /// Property arrays defined using sections in PropertyNames.xml.
@@ -395,7 +389,6 @@ final class PropertyNames {{
 
     @override
     def closeFiles(self) -> None:
-        # writeProperties calls openFiles before anything reaches here.
         assert self.srcFile is not None
         self.srcFile.write(f"""\
     public static final PropertyArray validProps[] =
@@ -496,7 +489,6 @@ internal sealed class PropertyNames
 
     @override
     def closeFiles(self) -> None:
-        # writeProperties calls openFiles before anything reaches here.
         assert self.srcFile is not None
         self.srcFile.write(f"""\
     internal static PropertyArray[] validProps =
@@ -581,7 +573,6 @@ export const PropertyNames = {{}};
 
     @override
     def closeFiles(self) -> None:
-        # writeProperties calls openFiles before anything reaches here.
         assert self.srcFile is not None
         self.srcFile.write(f"""\
 PropertyNames.validProps = [

--- a/cpp/test/DataStorm/fanInRelay/test.py
+++ b/cpp/test/DataStorm/fanInRelay/test.py
@@ -13,6 +13,8 @@
 #   subB --app--> /
 #
 
+from __future__ import annotations
+
 from typing import Any
 
 from DataStormUtil import Node, Reader, Writer

--- a/cpp/test/DataStorm/fanInRelay/test.py
+++ b/cpp/test/DataStorm/fanInRelay/test.py
@@ -13,8 +13,10 @@
 #   subB --app--> /
 #
 
+from typing import Any
+
 from DataStormUtil import Node, Reader, Writer
-from Util import ClientServerTestCase, TestSuite
+from Util import ClientServerTestCase, Driver, Process, Props, TestSuite
 
 # Properties shared by every node in the test.
 commonProps = {
@@ -22,7 +24,7 @@ commonProps = {
 }
 
 
-def relay(name):
+def relay(name: str) -> Props:
     return dict(
         commonProps,
         **{
@@ -35,7 +37,7 @@ def relay(name):
     )
 
 
-def app(name):
+def app(name: str) -> Props:
     return dict(
         commonProps,
         **{
@@ -47,7 +49,7 @@ def app(name):
 
 
 class FanInTestCase(ClientServerTestCase):
-    def __init__(self, relayNode, publisher, subA, subB, **kwargs):
+    def __init__(self, relayNode: Process, publisher: Process, subA: Process, subB: Process, **kwargs: Any):
         ClientServerTestCase.__init__(self, **kwargs)
         self.relayNode = relayNode
         self.publisher = publisher
@@ -61,7 +63,7 @@ class FanInTestCase(ClientServerTestCase):
     def getServerType(self):
         return None
 
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         self.relayNode.start(current)
         self.publisher.start(current)
         self.subA.start(current)
@@ -82,7 +84,7 @@ class FanInTestCase(ClientServerTestCase):
         self.subA.stop(current, waitSuccess=True)
         self.subB.stop(current, waitSuccess=True)
 
-    def teardownClientSide(self, current, success):
+    def teardownClientSide(self, current: Driver.Current, success: bool) -> None:
         for process in [self.subA, self.subB, self.publisher, self.relayNode]:
             if process.isStarted(current):
                 process.stop(current)

--- a/cpp/test/DataStorm/relayReconnect/test.py
+++ b/cpp/test/DataStorm/relayReconnect/test.py
@@ -24,9 +24,11 @@
 #
 
 import os
+from collections.abc import Sequence
+from typing import Any
 
 from DataStormUtil import Node, Reader, Writer, waitForLogMessage
-from Util import ClientServerTestCase, TestSuite
+from Util import ClientServerTestCase, Driver, Process, Props, TestSuite
 
 # Constant, fast retry so the relays reconnect promptly once the middle relay starts. Session trace level 2+ makes the
 # relays log the "topic ... announced" markers; each relay's trace goes to its own Ice.LogFile (set in runClientSide)
@@ -39,7 +41,7 @@ nodeProps = {
 }
 
 
-def relay(endpoint, connectTo, name):
+def relay(endpoint: int, connectTo: int | None, name: str) -> Props:
     return dict(
         nodeProps,
         **{
@@ -50,7 +52,7 @@ def relay(endpoint, connectTo, name):
     )
 
 
-def app(connectTo, name):
+def app(connectTo: int, name: str) -> Props:
     return {
         "DataStorm.Node.Multicast.Enabled": 0,
         "DataStorm.Node.Server.Enabled": 0,
@@ -64,9 +66,18 @@ class RelayReconnectTestCase(ClientServerTestCase):
     # middleRelay: the relay that joins the two halves, started last.
     # writerRelay/readerRelay: the relays whose logs confirm the writer/reader announcement arrived before the middle
     # relay starts.
-    def __init__(self, nodes, middleRelay, writerRelay, readerRelay, reader, writer, **kwargs):
+    def __init__(
+        self,
+        nodes: Sequence[Node],
+        middleRelay: Process,
+        writerRelay: Process,
+        readerRelay: Process,
+        reader: Process,
+        writer: Process,
+        **kwargs: Any,
+    ):
         ClientServerTestCase.__init__(self, **kwargs)
-        self.nodes = nodes
+        self.nodes = list(nodes)
         self.middleRelay = middleRelay
         self.writerRelay = writerRelay
         self.readerRelay = readerRelay
@@ -81,7 +92,7 @@ class RelayReconnectTestCase(ClientServerTestCase):
     def getServerType(self):
         return None
 
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         # Send each relay's trace to its own log file (removing any stale copy) so the test can synchronize on the
         # announcement markers without polluting the test console.
         self.logs = {}
@@ -89,7 +100,10 @@ class RelayReconnectTestCase(ClientServerTestCase):
             log = os.path.join(current.testsuite.getPath(), f"{node.desc}.log")
             if os.path.exists(log):
                 os.remove(log)
-            node.props["Ice.LogFile"] = log
+            # props is only a callable when a process computes them; these relays pass a dict.
+            nodeProps = node.props
+            assert not callable(nodeProps)
+            nodeProps["Ice.LogFile"] = log
             self.logs[node] = log
 
         # Bring up every relay except the middle one, then both applications. Each application announces its topic to
@@ -116,7 +130,7 @@ class RelayReconnectTestCase(ClientServerTestCase):
         self.writer.stop(current, waitSuccess=True)
         self.reader.stop(current, waitSuccess=True)
 
-    def teardownClientSide(self, current, success):
+    def teardownClientSide(self, current: Driver.Current, success: bool) -> None:
         for process in [self.writer, self.reader] + list(reversed(self.nodes)):
             if process.isStarted(current):
                 process.stop(current)

--- a/cpp/test/DataStorm/relayReconnect/test.py
+++ b/cpp/test/DataStorm/relayReconnect/test.py
@@ -23,6 +23,8 @@
 #                              (interior) (last) (interior)
 #
 
+from __future__ import annotations
+
 import os
 from collections.abc import Sequence
 from typing import Any

--- a/cpp/test/DataStorm/relayReconnect/test.py
+++ b/cpp/test/DataStorm/relayReconnect/test.py
@@ -102,7 +102,6 @@ class RelayReconnectTestCase(ClientServerTestCase):
             log = os.path.join(current.testsuite.getPath(), f"{node.desc}.log")
             if os.path.exists(log):
                 os.remove(log)
-            # props is only a callable when a process computes them; these relays pass a dict.
             nodeProps = node.props
             assert not callable(nodeProps)
             nodeProps["Ice.LogFile"] = log

--- a/cpp/test/Glacier2/dynamicFiltering/test.py
+++ b/cpp/test/Glacier2/dynamicFiltering/test.py
@@ -4,6 +4,8 @@
 # Note: we limit the send buffer size with Ice.TCP.SndSize, the
 # test relies on send() blocking
 #
+from __future__ import annotations
+
 from Glacier2Util import Glacier2Router, Glacier2TestSuite
 from Util import ClientServerTestCase, Driver, Process, Props, Server
 

--- a/cpp/test/Glacier2/dynamicFiltering/test.py
+++ b/cpp/test/Glacier2/dynamicFiltering/test.py
@@ -5,10 +5,10 @@
 # test relies on send() blocking
 #
 from Glacier2Util import Glacier2Router, Glacier2TestSuite
-from Util import ClientServerTestCase, Server
+from Util import ClientServerTestCase, Driver, Process, Props, Server
 
 
-def routerProps(process, current):
+def routerProps(process: Process, current: Driver.Current) -> Props:
     return {
         "Glacier2.SessionManager": "SessionManager:{0}".format(current.getTestEndpoint(0)),
         "Glacier2.PermissionsVerifier": "Glacier2/NullPermissionsVerifier",

--- a/cpp/test/Glacier2/hashpassword/test.py
+++ b/cpp/test/Glacier2/hashpassword/test.py
@@ -3,22 +3,23 @@
 import os
 import sys
 
-from Util import ClientTestCase, TestSuite, run, toplevel
+from Util import ClientTestCase, Driver, TestSuite, run, toplevel
 
 
 class Glacier2HashPasswordTestCase(ClientTestCase):
-    def runClientSide(self, current):
-        import passlib.hash
+    def runClientSide(self, current: Driver.Current) -> None:
+        # As scripts/icehashpassword.py: passlib is installed by whoever runs the Glacier2 tests.
+        import passlib.hash  # pyright: ignore[reportMissingImports]
 
         hashpassword = os.path.join(toplevel, "scripts", "icehashpassword.py")
         usePBKDF2 = sys.platform == "win32" or sys.platform == "darwin"
         useCryptExt = sys.platform.startswith("linux")
 
-        def test(b):
+        def test(b: object) -> None:
             if not b:
                 raise RuntimeError("test assertion failed")
 
-        def hashPasswords(password, args=""):
+        def hashPasswords(password: str, args: str = "") -> str:
             return run(
                 '"%s" "%s" %s' % (sys.executable, hashpassword, args),
                 stdin=(password + "\r\n").encode("UTF-8"),

--- a/cpp/test/Glacier2/hashpassword/test.py
+++ b/cpp/test/Glacier2/hashpassword/test.py
@@ -1,5 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 import os
 import sys
 

--- a/cpp/test/Glacier2/sessionControl/test.py
+++ b/cpp/test/Glacier2/sessionControl/test.py
@@ -4,6 +4,8 @@
 # Note: we limit the send buffer size with Ice.TCP.SndSize, the
 # test relies on send() blocking
 #
+from __future__ import annotations
+
 from Glacier2Util import Glacier2Router, Glacier2TestSuite
 from Util import ClientServerTestCase, Driver, Process, Props, Server
 

--- a/cpp/test/Glacier2/sessionControl/test.py
+++ b/cpp/test/Glacier2/sessionControl/test.py
@@ -5,10 +5,10 @@
 # test relies on send() blocking
 #
 from Glacier2Util import Glacier2Router, Glacier2TestSuite
-from Util import ClientServerTestCase, Server
+from Util import ClientServerTestCase, Driver, Process, Props, Server
 
 
-def routerProps(process, current):
+def routerProps(process: Process, current: Driver.Current) -> Props:
     return {
         "Glacier2.SessionManager": "SessionManager:{0}".format(current.getTestEndpoint(0)),
         "Glacier2.PermissionsVerifier": "Glacier2/NullPermissionsVerifier",

--- a/cpp/test/Glacier2/ssl/test.py
+++ b/cpp/test/Glacier2/ssl/test.py
@@ -1,10 +1,10 @@
 # Copyright (c) ZeroC, Inc.
 
 from Glacier2Util import Glacier2Router, Glacier2TestSuite
-from Util import Client, ClientServerTestCase, Server
+from Util import Client, ClientServerTestCase, Driver, Process, Props, Server
 
 
-def routerProps(process, current):
+def routerProps(process: Process, current: Driver.Current) -> Props:
     return {
         "Ice.Warn.Dispatch": "0",
         "Glacier2.AddConnectionContext": "1",
@@ -26,8 +26,8 @@ def routerProps(process, current):
 #
 
 
-def sslProps(process, current):
-    return current.testcase.getMapping().getSSLProps(process, current)
+def sslProps(process: Process, current: Driver.Current) -> Props:
+    return current.getTestCase().getMapping().getSSLProps(process, current)
 
 
 Glacier2TestSuite(

--- a/cpp/test/Glacier2/ssl/test.py
+++ b/cpp/test/Glacier2/ssl/test.py
@@ -1,5 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 from Glacier2Util import Glacier2Router, Glacier2TestSuite
 from Util import Client, ClientServerTestCase, Driver, Process, Props, Server
 

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import platform
 
 from Glacier2Util import Glacier2Router, Glacier2TestSuite
 from Util import Client, ClientServerTestCase, Driver, Server

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -1,5 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 import os
 import platform
 

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -4,11 +4,11 @@ import os
 import platform
 
 from Glacier2Util import Glacier2Router, Glacier2TestSuite
-from Util import Client, ClientServerTestCase, Server
+from Util import Client, ClientServerTestCase, Driver, Server
 
 
 class Glacier2StaticFilteringTestCase(ClientServerTestCase):
-    def __init__(self, testcase, hostname):
+    def __init__(self, testcase: tuple[str, tuple[str, ...], list[tuple[bool, str]], list[str]], hostname: str):
         self.hostname = hostname
         description, self.tcArgs, self.attacks, self.xtraConfig = testcase
 
@@ -32,10 +32,10 @@ class Glacier2StaticFilteringTestCase(ClientServerTestCase):
             client=Client(props=clientProps),
         )
 
-    def setupClientSide(self, current):
+    def setupClientSide(self, current: Driver.Current) -> None:
         current.write("testing {0}... ".format(self))
 
-    def setupServerSide(self, current):
+    def setupServerSide(self, current: Driver.Current) -> None:
         (
             acceptFilter,
             rejectFilter,
@@ -92,13 +92,13 @@ class Glacier2StaticFilteringTestCase(ClientServerTestCase):
             if not len(adapterFilter) == 0:
                 routerConfig.write("Glacier2.Filter.AdapterId.Accept=%s\n" % adapterFilter)
 
-    def teardownServerSide(self, current, success):
+    def teardownServerSide(self, current: Driver.Current, success: bool) -> None:
         for c in ["client.cfg", "router.cfg", "server.cfg"]:
             os.remove(os.path.join(self.getTestSuite().getPath(), c))
 
 
 class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
-    def setup(self, current):
+    def setup(self, current: Driver.Current) -> None:
         Glacier2TestSuite.setup(self, current)
 
         import socket
@@ -653,7 +653,7 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
             current.writeln("WARNING: The network configuration for this host does not permit all ")
             current.writeln("         tests to run correctly, some tests have been disabled.")
 
-        self.testcases = {}
+        self.testcases.clear()
         for testcase in testcases:
             self.addTestCase(Glacier2StaticFilteringTestCase(testcase, hostname))
 

--- a/cpp/test/Ice/echo/test.py
+++ b/cpp/test/Ice/echo/test.py
@@ -1,6 +1,8 @@
 # Copyright (c) ZeroC, Inc.
 
 
+from __future__ import annotations
+
 from Util import ClientServerTestCase, Driver, Server, TestSuite
 
 

--- a/cpp/test/Ice/echo/test.py
+++ b/cpp/test/Ice/echo/test.py
@@ -1,14 +1,14 @@
 # Copyright (c) ZeroC, Inc.
 
 
-from Util import ClientServerTestCase, Server, TestSuite
+from Util import ClientServerTestCase, Driver, Server, TestSuite
 
 
 class EchoServerTestCase(ClientServerTestCase):
     def __init__(self):
         ClientServerTestCase.__init__(self, "server", server=Server(quiet=True, waitForShutdown=False))
 
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         pass
 
 

--- a/cpp/test/Ice/logger/test.py
+++ b/cpp/test/Ice/logger/test.py
@@ -5,10 +5,10 @@ import os
 import subprocess
 import sys
 
-from Util import Client, ClientTestCase, TestSuite, Windows, platform
+from Util import Client, ClientTestCase, Driver, Mapping, Process, TestSuite, Windows, platform
 
 
-def test(process, current, match, enc, mapping):
+def test(process: Process, current: Driver.Current, match: bytes, enc: str, mapping: Mapping) -> None:
     cmd = process.getCommandLine(current)
     p = subprocess.Popen(
         cmd,
@@ -16,7 +16,7 @@ def test(process, current, match, enc, mapping):
         stderr=subprocess.STDOUT,
         env=mapping.getEnv(process, current),
     )
-    out, err = p.communicate()
+    out, _ = p.communicate()
     ret = p.poll()
     if ret != 0:
         raise RuntimeError("%s failed! status %s " % (cmd, ret))
@@ -25,7 +25,7 @@ def test(process, current, match, enc, mapping):
 
 
 class IceLoggerTestCase(ClientTestCase):
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         client1 = Client(exe="client1")
         client2 = Client(exe="client2")
         client3 = Client(exe="client3")
@@ -133,7 +133,7 @@ class IceLoggerTestCase(ClientTestCase):
 
         print("ok")
 
-    def teardownClientSide(self, current, success):
+    def teardownClientSide(self, current: Driver.Current, success: bool) -> None:
         self.clean()
 
     def clean(self):

--- a/cpp/test/Ice/logger/test.py
+++ b/cpp/test/Ice/logger/test.py
@@ -1,5 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 import glob
 import os
 import subprocess

--- a/cpp/test/IceGrid/admin/test.py
+++ b/cpp/test/IceGrid/admin/test.py
@@ -18,7 +18,6 @@ class IceGridAdminTestCase(IceGridTestCase):
 
     def runClientSide(self, current: Driver.Current) -> None:
         def expect(admin: Process, msg: str | list[str]) -> None:
-            # Spelled out rather than concatenated: a list[str] is not a list[ExpectPattern].
             patterns: list[ExpectPattern] = ["error:", msg] if isinstance(msg, str) else ["error:", *msg]
             if (
                 admin.expect(

--- a/cpp/test/IceGrid/admin/test.py
+++ b/cpp/test/IceGrid/admin/test.py
@@ -3,9 +3,10 @@
 
 import os
 
+from Expect import ExpectPattern
 from Glacier2Util import Glacier2Router
 from IceGridUtil import IceGridAdmin, IceGridTestCase
-from Util import TestSuite, Windows, platform
+from Util import Driver, Process, Props, TestSuite, Windows, platform
 
 
 class IceGridAdminTestCase(IceGridTestCase):
@@ -13,12 +14,14 @@ class IceGridAdminTestCase(IceGridTestCase):
         self.glacier2router = Glacier2Router(props=routerProps, waitForShutdown=False)
         IceGridTestCase.__init__(self, application=None, server=self.glacier2router)
 
-    def runClientSide(self, current):
-        def expect(admin, msg):
+    def runClientSide(self, current: Driver.Current) -> None:
+        def expect(admin: Process, msg: str | list[str]) -> None:
+            # Spelled out rather than concatenated: a list[str] is not a list[ExpectPattern].
+            patterns: list[ExpectPattern] = ["error:", msg] if isinstance(msg, str) else ["error:", *msg]
             if (
                 admin.expect(
                     current,
-                    ["error:", msg] if isinstance(msg, str) else ["error:"] + msg,
+                    patterns,
                 )
                 == 0
             ):
@@ -157,7 +160,9 @@ class IceGridAdminTestCase(IceGridTestCase):
             raise RuntimeError("failed!\n" + str(e))
 
 
-def routerProps(process, current):
+def routerProps(process: Process, current: Driver.Current) -> Props:
+    testcase = current.getTestCase()
+    assert isinstance(testcase, IceGridTestCase)
     return {
         "Glacier2.SessionManager": "TestIceGrid/AdminSessionManager",
         "Glacier2.PermissionsVerifier": "Glacier2/NullPermissionsVerifier",
@@ -165,7 +170,7 @@ def routerProps(process, current):
         # we disable the inactivity timeout for outgoing connections when we use an IceGrid session manager
         "Ice.Connection.Client.InactivityTimeout": "0",
         "Glacier2.SSLPermissionsVerifier": "Glacier2/NullSSLPermissionsVerifier",
-        "Ice.Default.Locator": current.testcase.getLocator(current),
+        "Ice.Default.Locator": testcase.getLocator(current),
         "IceSSL.VerifyPeer": 1,
     }
 

--- a/cpp/test/IceGrid/admin/test.py
+++ b/cpp/test/IceGrid/admin/test.py
@@ -1,6 +1,8 @@
 # Copyright (c) ZeroC, Inc.
 
 
+from __future__ import annotations
+
 import os
 
 from Expect import ExpectPattern

--- a/cpp/test/IceGrid/deployer/test.py
+++ b/cpp/test/IceGrid/deployer/test.py
@@ -1,6 +1,8 @@
 # Copyright (c) ZeroC, Inc.
 
 
+from __future__ import annotations
+
 import os
 
 from IceGridUtil import IceGridClient, IceGridNode, IceGridTestCase

--- a/cpp/test/IceGrid/deployer/test.py
+++ b/cpp/test/IceGrid/deployer/test.py
@@ -4,10 +4,10 @@
 import os
 
 from IceGridUtil import IceGridClient, IceGridNode, IceGridTestCase
-from Util import TestSuite, Windows, platform
+from Util import Driver, Process, Props, TestSuite, Windows, platform
 
 
-def clientProps(process, current):
+def clientProps(process: Process, current: Driver.Current) -> Props:
     return {"TestDir": current.getBuildDir("server")}
 
 

--- a/cpp/test/IceGrid/fileLock/test.py
+++ b/cpp/test/IceGrid/fileLock/test.py
@@ -4,11 +4,11 @@
 import sys
 
 from IceGridUtil import IceGridRegistryMaster, IceGridTestCase
-from Util import TestSuite
+from Util import Driver, TestSuite
 
 
 class IceGridAdminTestCase(IceGridTestCase):
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         sys.stdout.write("testing IceGrid file lock... ")
         registry = IceGridRegistryMaster(portnum=25, ready="", quiet=True)
         registry.start(current)

--- a/cpp/test/IceGrid/fileLock/test.py
+++ b/cpp/test/IceGrid/fileLock/test.py
@@ -1,6 +1,8 @@
 # Copyright (c) ZeroC, Inc.
 
 
+from __future__ import annotations
+
 import sys
 
 from IceGridUtil import IceGridRegistryMaster, IceGridTestCase

--- a/cpp/test/IceGrid/icegriddb/test.py
+++ b/cpp/test/IceGrid/icegriddb/test.py
@@ -1,5 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 import filecmp
 import os
 import shutil

--- a/cpp/test/IceGrid/icegriddb/test.py
+++ b/cpp/test/IceGrid/icegriddb/test.py
@@ -3,13 +3,14 @@
 import filecmp
 import os
 import shutil
+from typing import Any
 
 from IceGridUtil import IceGridRegistryMaster, IceGridTestCase
-from Util import Mapping, ProcessFromBinDir, SimpleClient, TestSuite, Windows, platform
+from Util import Driver, Mapping, ProcessFromBinDir, SimpleClient, TestSuite, Windows, platform
 
 
 class IceGridDb(ProcessFromBinDir, SimpleClient):
-    def __init__(self, quiet=True, *args, **kargs):
+    def __init__(self, quiet: bool = True, *args: Any, **kargs: Any):
         SimpleClient.__init__(
             self,
             exe="icegriddb",
@@ -28,7 +29,7 @@ class IceGridDbExportImportTestCase(IceGridTestCase):
             icegridregistry=[IceGridRegistryMaster()],
         )
 
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         testdir = current.testsuite.getPath()
 
         # Shut down the node and registry to release the LMDB lock.
@@ -69,8 +70,9 @@ class IceGridDbExportImportTestCase(IceGridTestCase):
             os.rename(importDir, dbPath)
             importDir = None  # Moved, no longer needs cleanup
 
-            # Bypass setup() to preserve the imported database files.
-            self.icegridregistry[0].setup = lambda c: None
+            # Keep setup() from wiping the imported database files. start() does not call setup()
+            # today, so this only matters if the restart is ever routed through the test case.
+            self.icegridregistry[0].createDb = False
             self.icegridregistry[0].start(current)
 
             output = self.runadmin(current, "application list", quiet=True)
@@ -87,7 +89,7 @@ class IceGridDbExportImportTestCase(IceGridTestCase):
             if importDir and os.path.exists(importDir):
                 shutil.rmtree(importDir)
 
-    def teardownClientSide(self, current, success):
+    def teardownClientSide(self, current: Driver.Current, success: bool) -> None:
         # Registry and node are already shut down in runClientSide.
         pass
 

--- a/cpp/test/IceGrid/noRestartUpdate/test.py
+++ b/cpp/test/IceGrid/noRestartUpdate/test.py
@@ -5,17 +5,17 @@ import os
 
 from IceBoxUtil import IceBox
 from IceGridUtil import IceGridClient, IceGridTestCase
-from Util import TestSuite, Windows, platform
+from Util import Driver, Process, Props, TestSuite, Windows, platform
 
 
 class IceGridNoRestartUpdateTestCase(IceGridTestCase):
-    def setupClientSide(self, current):
+    def setupClientSide(self, current: Driver.Current) -> None:
         IceGridTestCase.setupClientSide(self, current)
         current.mkdirs("db/node1")
         current.mkdirs("db/node2")
 
 
-def clientProps(process, current):
+def clientProps(process: Process, current: Driver.Current) -> Props:
     return {
         "IceBoxExe": IceBox().getCommandLine(current),
         "ServerDir": current.getBuildDir("server"),

--- a/cpp/test/IceGrid/noRestartUpdate/test.py
+++ b/cpp/test/IceGrid/noRestartUpdate/test.py
@@ -1,6 +1,8 @@
 # Copyright (c) ZeroC, Inc.
 
 
+from __future__ import annotations
+
 import os
 
 from IceBoxUtil import IceBox

--- a/cpp/test/IceGrid/replication/test.py
+++ b/cpp/test/IceGrid/replication/test.py
@@ -1,6 +1,8 @@
 # Copyright (c) ZeroC, Inc.
 
 
+from __future__ import annotations
+
 import os
 
 from IceGridUtil import IceGridClient, IceGridTestCase

--- a/cpp/test/IceGrid/replication/test.py
+++ b/cpp/test/IceGrid/replication/test.py
@@ -4,10 +4,10 @@
 import os
 
 from IceGridUtil import IceGridClient, IceGridTestCase
-from Util import TestSuite, Windows, platform
+from Util import Driver, Process, Props, TestSuite, Windows, platform
 
 
-def clientProps(process, current):
+def clientProps(process: Process, current: Driver.Current) -> Props:
     return {"ServerDir": current.getBuildDir("server")}
 
 

--- a/cpp/test/IceGrid/session/test.py
+++ b/cpp/test/IceGrid/session/test.py
@@ -30,7 +30,6 @@ class IceGridSessionTestCase(IceGridTestCase):
         current.writeln("ok")
 
     def teardownServerSide(self, current: Driver.Current, success: bool) -> None:
-        # setupServerSide always runs first, so the verifier is started by the time we get here.
         assert self.verifier is not None
         self.verifier.stop(current, success)
         self.verifier = None

--- a/cpp/test/IceGrid/session/test.py
+++ b/cpp/test/IceGrid/session/test.py
@@ -1,6 +1,8 @@
 # Copyright (c) ZeroC, Inc.
 
 
+from __future__ import annotations
+
 import os
 
 from IceGridUtil import (

--- a/cpp/test/IceGrid/session/test.py
+++ b/cpp/test/IceGrid/session/test.py
@@ -9,15 +9,15 @@ from IceGridUtil import (
     IceGridRegistryMaster,
     IceGridTestCase,
 )
-from Util import Server, TestSuite, Windows, platform
+from Util import Driver, Process, Props, Server, TestSuite, Windows, platform
 
 
 class IceGridSessionTestCase(IceGridTestCase):
-    def setupClientSide(self, current):
+    def setupClientSide(self, current: Driver.Current) -> None:
         IceGridTestCase.setupClientSide(self, current)
         current.mkdirs("db/node-1")
 
-    def setupServerSide(self, current):
+    def setupServerSide(self, current: Driver.Current) -> None:
         self.verifier = Server(
             exe="verifier",
             waitForShutdown=False,
@@ -27,7 +27,9 @@ class IceGridSessionTestCase(IceGridTestCase):
         self.verifier.start(current)
         current.writeln("ok")
 
-    def teardownServerSide(self, current, success):
+    def teardownServerSide(self, current: Driver.Current, success: bool) -> None:
+        # setupServerSide always runs first, so the verifier is started by the time we get here.
+        assert self.verifier is not None
         self.verifier.stop(current, success)
         self.verifier = None
 
@@ -44,7 +46,7 @@ registryProps = {
 }
 
 
-def clientProps(process, current):
+def clientProps(process: Process, current: Driver.Current) -> Props:
     return {
         "IceGridNodeExe": IceGridNode().getCommandLine(current),
         "ServerDir": current.getBuildDir("server"),
@@ -52,7 +54,7 @@ def clientProps(process, current):
     }
 
 
-def clientProps10(process, current):
+def clientProps10(process: Process, current: Driver.Current) -> Props:
     return {
         "IceGridNodeExe": IceGridNode().getCommandLine(current),
         "ServerDir": current.getBuildDir("server"),

--- a/cpp/test/IceGrid/update/test.py
+++ b/cpp/test/IceGrid/update/test.py
@@ -5,19 +5,21 @@ import os
 
 from IceBoxUtil import IceBox
 from IceGridUtil import IceGridClient, IceGridNode, IceGridTestCase
-from Util import TestSuite, Windows, platform
+from Util import Driver, Process, Props, TestSuite, Windows, platform
 
 
 class IceGridUpdateTestCase(IceGridTestCase):
-    def setupClientSide(self, current):
+    def setupClientSide(self, current: Driver.Current) -> None:
         IceGridTestCase.setupClientSide(self, current)
         current.mkdirs("db/node-1")
         current.mkdirs("db/node-2")
 
 
-def clientProps(process, current):
+def clientProps(process: Process, current: Driver.Current) -> Props:
+    testcase = current.getTestCase()
+    assert isinstance(testcase, IceGridTestCase)
     return {
-        "NodePropertiesOverride": current.testcase.icegridnode[0].getPropertiesOverride(current),
+        "NodePropertiesOverride": testcase.icegridnode[0].getPropertiesOverride(current),
         "IceBoxExe": IceBox().getCommandLine(current),
         "IceGridNodeExe": IceGridNode().getCommandLine(current),
         "ServerDir": current.getBuildDir("server"),

--- a/cpp/test/IceGrid/update/test.py
+++ b/cpp/test/IceGrid/update/test.py
@@ -1,6 +1,8 @@
 # Copyright (c) ZeroC, Inc.
 
 
+from __future__ import annotations
+
 import os
 
 from IceBoxUtil import IceBox

--- a/cpp/test/IceStorm/createOrRetrieve/test.py
+++ b/cpp/test/IceStorm/createOrRetrieve/test.py
@@ -1,7 +1,9 @@
 # Copyright (c) ZeroC, Inc.
 
+from typing import Any, override
+
 from IceStormUtil import IceStorm, IceStormProcess, IceStormTestCase
-from Util import Client, ClientTestCase, TestSuite
+from Util import Client, ClientTestCase, Driver, Props, TestSuite
 
 props = {}
 persistent = IceStorm(props=props)
@@ -10,18 +12,22 @@ replicated = [IceStorm(replica=i, nreplicas=3, props=props) for i in range(0, 3)
 
 
 class CreateOrRetrieveTestCase(IceStormTestCase):
-    def teardownClientSide(self, current, success):
+    def teardownClientSide(self, current: Driver.Current, success: bool) -> None:
         self.shutdown(current)
 
 
 class IceStormClient(IceStormProcess, Client):
     processType = "client"
 
-    def __init__(self, instanceName=None, instance=None, *args, **kargs):
+    def __init__(self, instanceName: str | None = None, instance: IceStorm | None = None, *args: Any, **kargs: Any):
         Client.__init__(self, *args, **kargs)
         IceStormProcess.__init__(self, instanceName, instance)
 
-    getParentProps = Client.getProps  # Used by IceStormProcess to get the client properties
+    @override
+    def getParentProps(self, current: Driver.Current) -> Props:
+        # IceStormProcess.getProps calls this to reach the Client props rather than its own entry
+        # in the MRO.
+        return Client.getProps(self, current)
 
 
 TestSuite(

--- a/cpp/test/IceStorm/createOrRetrieve/test.py
+++ b/cpp/test/IceStorm/createOrRetrieve/test.py
@@ -1,6 +1,8 @@
 # Copyright (c) ZeroC, Inc.
 
-from typing import Any, override
+from __future__ import annotations
+
+from typing import Any
 
 from IceStormUtil import IceStorm, IceStormProcess, IceStormTestCase
 from Util import Client, ClientTestCase, Driver, Props, TestSuite
@@ -23,7 +25,6 @@ class IceStormClient(IceStormProcess, Client):
         Client.__init__(self, *args, **kargs)
         IceStormProcess.__init__(self, instanceName, instance)
 
-    @override
     def getParentProps(self, current: Driver.Current) -> Props:
         # IceStormProcess.getProps calls this to reach the Client props rather than its own entry
         # in the MRO.

--- a/cpp/test/IceStorm/federation/test.py
+++ b/cpp/test/IceStorm/federation/test.py
@@ -1,6 +1,8 @@
 # Copyright (c) ZeroC, Inc.
 
 
+from __future__ import annotations
+
 from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
 from Util import ClientServerTestCase, Driver, TestSuite
 

--- a/cpp/test/IceStorm/federation/test.py
+++ b/cpp/test/IceStorm/federation/test.py
@@ -2,14 +2,14 @@
 
 
 from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
-from Util import ClientServerTestCase, TestSuite
+from Util import ClientServerTestCase, Driver, TestSuite
 
 
 class IceStormFederationTestCase(IceStormTestCase):
-    def setupClientSide(self, current):
+    def setupClientSide(self, current: Driver.Current) -> None:
         self.runadmin(current, "create fed1 fed2 fed3; link fed1 fed2 10; link fed2 fed3 5")
 
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         current.write("testing oneway subscribers...")
         ClientServerTestCase(client=Publisher(), server=Subscriber()).run(current)
         current.writeln("ok")
@@ -18,7 +18,7 @@ class IceStormFederationTestCase(IceStormTestCase):
         ClientServerTestCase(client=Publisher(), server=Subscriber(args=["-b"])).run(current)
         current.writeln("ok")
 
-    def teardownClientSide(self, current, success):
+    def teardownClientSide(self, current: Driver.Current, success: bool) -> None:
         self.runadmin(current, "destroy fed1 fed2 fed3")
         self.shutdown(current)
 

--- a/cpp/test/IceStorm/federation2/test.py
+++ b/cpp/test/IceStorm/federation2/test.py
@@ -9,7 +9,7 @@ import time
 
 import Expect
 from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
-from Util import ClientServerTestCase, TestSuite
+from Util import ClientServerTestCase, Driver, TestSuite
 
 pub1Sub2Oneway = ClientServerTestCase(client=Publisher("TestIceStorm1"), server=Subscriber("TestIceStorm2"))
 pub1Sub2Batch = ClientServerTestCase(client=Publisher("TestIceStorm1"), server=Subscriber("TestIceStorm2", args=["-b"]))
@@ -18,7 +18,7 @@ pub1Sub1Oneway = ClientServerTestCase(client=Publisher("TestIceStorm1"), server=
 
 
 class IceStormFederation2TestCase(IceStormTestCase):
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         current.write("setting up the topics... ")
         self.runadmin(
             current,

--- a/cpp/test/IceStorm/federation2/test.py
+++ b/cpp/test/IceStorm/federation2/test.py
@@ -4,6 +4,8 @@
 # Publisher/subscriber test cases, publisher publishes on TestIceStorm1 instance(s) and
 # the subscriber subscribes to the TestIceStorm2 instance(s)
 #
+from __future__ import annotations
+
 import re
 import time
 

--- a/cpp/test/IceStorm/icestormdb/test.py
+++ b/cpp/test/IceStorm/icestormdb/test.py
@@ -3,13 +3,14 @@
 import filecmp
 import os
 import shutil
+from typing import Any
 
 from IceStormUtil import IceStorm, IceStormTestCase
-from Util import Mapping, ProcessFromBinDir, SimpleClient, TestSuite
+from Util import Driver, Mapping, ProcessFromBinDir, SimpleClient, TestSuite
 
 
 class IceStormDb(ProcessFromBinDir, SimpleClient):
-    def __init__(self, quiet=True, *args, **kargs):
+    def __init__(self, quiet: bool = True, *args: Any, **kargs: Any):
         SimpleClient.__init__(
             self,
             exe="icestormdb",
@@ -31,7 +32,7 @@ class IceStormDbExportImportTestCase(IceStormTestCase):
             icestorm=icestorm,
         )
 
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         testdir = current.testsuite.getPath()
 
         # Topic names of different lengths: the marshaled key byte-order (which sorts by the
@@ -79,8 +80,9 @@ class IceStormDbExportImportTestCase(IceStormTestCase):
             os.rename(importDir, dbPath)
             importDir = None  # Moved, no longer needs cleanup
 
-            # Bypass setup() to preserve the imported database files.
-            self.icestorm[0].setup = lambda c: None
+            # Keep setup() from wiping the imported database files. start() does not call setup()
+            # today, so this only matters if the restart is ever routed through the test case.
+            self.icestorm[0].createDb = False
             self.icestorm[0].start(current)
 
             output = self.runadmin(current, "topics", quiet=True)
@@ -114,7 +116,7 @@ class IceStormDbExportImportTestCase(IceStormTestCase):
             if importDir and os.path.exists(importDir):
                 shutil.rmtree(importDir)
 
-    def teardownClientSide(self, current, success):
+    def teardownClientSide(self, current: Driver.Current, success: bool) -> None:
         # IceStorm is already shut down in runClientSide.
         pass
 

--- a/cpp/test/IceStorm/icestormdb/test.py
+++ b/cpp/test/IceStorm/icestormdb/test.py
@@ -1,5 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 import filecmp
 import os
 import shutil

--- a/cpp/test/IceStorm/persistent/test.py
+++ b/cpp/test/IceStorm/persistent/test.py
@@ -1,30 +1,32 @@
 # Copyright (c) ZeroC, Inc.
 
+from typing import Any, override
+
 from IceStormUtil import IceStorm, IceStormAdmin, IceStormProcess
-from Util import Client, ClientTestCase, TestCase, TestSuite
+from Util import Client, ClientTestCase, Driver, Mapping, Props, TestCase, TestSuite
 
 icestorm1 = IceStorm(createDb=True, cleanDb=False)
 icestorm2 = IceStorm(createDb=False, cleanDb=True)
 
 
-def test(value):
+def test(value: object) -> None:
     if not value:
         raise RuntimeError("test failed")
 
 
 class IceStormPersistentTestCase(TestCase):
-    def __init__(self, name, icestorm, *args, **kargs):
+    def __init__(self, name: str, icestorm: IceStorm, *args: Any, **kargs: Any):
         TestCase.__init__(self, name, *args, **kargs)
         self.icestorm = icestorm
 
-    def init(self, mapping, testsuite):
+    def init(self, mapping: Mapping, testsuite: TestSuite) -> None:
         TestCase.init(self, mapping, testsuite)
         self.servers = [self.icestorm]
 
-    def runWithDriver(self, current):
+    def runWithDriver(self, current: Driver.Current) -> None:
         current.driver.runClientServerTestCase(current)
 
-    def teardownClientSide(self, current, success):
+    def teardownClientSide(self, current: Driver.Current, success: bool) -> None:
         admin = IceStormAdmin(
             instance=self.icestorm,
             quiet=True,
@@ -58,11 +60,15 @@ class IceStormPersistentTestCase(TestCase):
 class PersistentClient(IceStormProcess, Client):
     processType = "client"
 
-    def __init__(self, instanceName=None, instance=None, *args, **kargs):
+    def __init__(self, instanceName: str | None = None, instance: IceStorm | None = None, *args: Any, **kargs: Any):
         Client.__init__(self, *args, **kargs)
         IceStormProcess.__init__(self, instanceName, instance)
 
-    getParentProps = Client.getProps  # Used by IceStormProcess to get the client properties
+    @override
+    def getParentProps(self, current: Driver.Current) -> Props:
+        # IceStormProcess.getProps calls this to reach the Client props rather than its own entry
+        # in the MRO.
+        return Client.getProps(self, current)
 
 
 TestSuite(

--- a/cpp/test/IceStorm/persistent/test.py
+++ b/cpp/test/IceStorm/persistent/test.py
@@ -1,6 +1,8 @@
 # Copyright (c) ZeroC, Inc.
 
-from typing import Any, override
+from __future__ import annotations
+
+from typing import Any
 
 from IceStormUtil import IceStorm, IceStormAdmin, IceStormProcess
 from Util import Client, ClientTestCase, Driver, Mapping, Props, TestCase, TestSuite
@@ -64,7 +66,6 @@ class PersistentClient(IceStormProcess, Client):
         Client.__init__(self, *args, **kargs)
         IceStormProcess.__init__(self, instanceName, instance)
 
-    @override
     def getParentProps(self, current: Driver.Current) -> Props:
         # IceStormProcess.getProps calls this to reach the Client props rather than its own entry
         # in the MRO.

--- a/cpp/test/IceStorm/rep1/test.py
+++ b/cpp/test/IceStorm/rep1/test.py
@@ -8,6 +8,8 @@
 # truncated). See also bug #6070.
 #
 
+from __future__ import annotations
+
 import sys
 
 from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber

--- a/cpp/test/IceStorm/rep1/test.py
+++ b/cpp/test/IceStorm/rep1/test.py
@@ -11,7 +11,7 @@
 import sys
 
 from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
-from Util import ClientServerTestCase, TestSuite
+from Util import ClientServerTestCase, Driver, TestSuite
 
 props = {
     "IceStorm.Election.MasterTimeout": 2,
@@ -23,21 +23,20 @@ icestorm = [IceStorm(replica=i, nreplicas=3, props=props) for i in range(0, 3)]
 
 
 class IceStormRep1TestCase(IceStormTestCase):
-    def runClientSide(self, current):
-        def checkExpect(output, expect):
+    def runClientSide(self, current: Driver.Current) -> None:
+        def checkExpect(output: str, expect: str | list[str] | None) -> None:
             if not expect:
                 return
 
-            if isinstance(expect, str):
-                expect = [expect]
+            expected = [expect] if isinstance(expect, str) else expect
 
-            for e in expect:
+            for e in expected:
                 if output.find(e) >= 0:
                     break
             else:
                 raise RuntimeError("unexpected output `{0}' (expected `{1}')".format(output, expect))
 
-        def adminForReplica(replica, cmd, expect):
+        def adminForReplica(replica: int, cmd: str, expect: str | list[str] | None) -> None:
             checkExpect(
                 self.runadmin(
                     current,
@@ -49,20 +48,20 @@ class IceStormRep1TestCase(IceStormTestCase):
                 expect,
             )
 
-        def stopReplica(num):
+        def stopReplica(num: int) -> None:
             self.icestorm[num].shutdown(current)
             self.icestorm[num].stop(current, True)
 
-        def startReplica(num):
+        def startReplica(num: int) -> None:
             self.icestorm[num].start(current)
 
-        def runtest(s="", p=""):
+        def runtest(s: str = "", p: str = "") -> None:
             ClientServerTestCase(
                 client=Publisher(args=p.split(" ")),
                 server=Subscriber(args=s.split(" ")),
             ).run(current)
 
-        def runsub2(replica=None, expect=None):
+        def runsub2(replica: int | None = None, expect: str | list[str] | None = None) -> None:
             subscriber = Subscriber(
                 exe="sub",
                 instance=None if replica is None else self.icestorm[replica],
@@ -73,7 +72,7 @@ class IceStormRep1TestCase(IceStormTestCase):
             subscriber.run(current, exitstatus=1 if expect else 0)
             checkExpect(subscriber.getOutput(current), expect)
 
-        def rununsub2(replica=None, expect=None):
+        def rununsub2(replica: int | None = None, expect: str | list[str] | None = None) -> None:
             sub = Subscriber(
                 exe="sub",
                 instance=None if replica is None else self.icestorm[replica],

--- a/cpp/test/IceStorm/repstress/test.py
+++ b/cpp/test/IceStorm/repstress/test.py
@@ -25,7 +25,6 @@ icestorm = [IceStorm(replica=i, nreplicas=3, props=props) for i in range(0, 3)]
 
 
 def matchGroup(process: Process, current: Driver.Current) -> str:
-    # Only called right after expect() matched, so there is always a match to read.
     match = process.getMatch(current)
     assert match is not None
     return match.group(1)

--- a/cpp/test/IceStorm/repstress/test.py
+++ b/cpp/test/IceStorm/repstress/test.py
@@ -10,7 +10,7 @@
 import time
 
 from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
-from Util import Client, TestSuite
+from Util import Client, Driver, Process, TestSuite
 
 props = {
     "IceStorm.Election.MasterTimeout": 2,
@@ -22,13 +22,20 @@ props = {
 icestorm = [IceStorm(replica=i, nreplicas=3, props=props) for i in range(0, 3)]
 
 
+def matchGroup(process: Process, current: Driver.Current) -> str:
+    # Only called right after expect() matched, so there is always a match to read.
+    match = process.getMatch(current)
+    assert match is not None
+    return match.group(1)
+
+
 class IceStormRepStressTestCase(IceStormTestCase):
-    def runClientSide(self, current):
-        def stopReplica(num):
+    def runClientSide(self, current: Driver.Current) -> None:
+        def stopReplica(num: int) -> None:
             self.icestorm[num].shutdown(current)
             self.icestorm[num].stop(current, True)
 
-        def startReplica(num):
+        def startReplica(num: int) -> None:
             self.icestorm[num].start(current)
 
         current.write("creating topic... ")
@@ -39,19 +46,19 @@ class IceStormRepStressTestCase(IceStormTestCase):
         subscriber = Subscriber(quiet=True)
         subscriber.start(current)
         subscriber.expect(current, "([^\n]+)\n")
-        subControl = subscriber.getMatch(current).group(1)
+        subControl = matchGroup(subscriber, current)
         current.writeln("ok")
 
         current.write("running publisher... ")
         publisher = Publisher(quiet=True)
         publisher.start(current)
         publisher.expect(current, "([^\n]+)\n")
-        pubControl = publisher.getMatch(current).group(1)
+        pubControl = matchGroup(publisher, current)
         current.writeln("ok")
 
         time.sleep(2)
 
-        for i in range(0, 3):
+        for _ in range(0, 3):
             # 0, 1
             current.write("stopping replica 2 (0, 1 running)... ")
             stopReplica(2)
@@ -86,7 +93,7 @@ class IceStormRepStressTestCase(IceStormTestCase):
         current.write("stopping publisher... ")
         Client(exe="control", args=[pubControl]).run(current)
         publisher.expect(current, "([^\n]+)\n")
-        publisherCount = publisher.getMatch(current).group(1)
+        publisherCount = matchGroup(publisher, current)
         publisher.stop(current, True)
         current.writeln("ok")
 
@@ -97,7 +104,7 @@ class IceStormRepStressTestCase(IceStormTestCase):
         current.write("stopping subscriber... ")
         Client(exe="control", args=[subControl]).run(current)
         subscriber.expect(current, "([^\n]+)\n")
-        subscriberCount = subscriber.getMatch(current).group(1)
+        subscriberCount = matchGroup(subscriber, current)
         subscriber.stop(current, True)
         current.writeln("ok")
 

--- a/cpp/test/IceStorm/repstress/test.py
+++ b/cpp/test/IceStorm/repstress/test.py
@@ -7,6 +7,8 @@
 # send buffer size (causing the received messages to be
 # truncated). See also bug #6070.
 #
+from __future__ import annotations
+
 import time
 
 from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber

--- a/cpp/test/IceStorm/single/test.py
+++ b/cpp/test/IceStorm/single/test.py
@@ -7,6 +7,8 @@
 # send buffer size (causing the received messages to be truncated). See
 # bug #6070 and #7558.
 #
+from __future__ import annotations
+
 from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
 from Util import ClientServerTestCase, Driver, TestSuite
 

--- a/cpp/test/IceStorm/single/test.py
+++ b/cpp/test/IceStorm/single/test.py
@@ -8,7 +8,7 @@
 # bug #6070 and #7558.
 #
 from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
-from Util import ClientServerTestCase, TestSuite
+from Util import ClientServerTestCase, Driver, TestSuite
 
 props = {"Ice.UDP.SndSize": 512 * 1024, "Ice.Warn.Dispatch": 0}
 persistent = IceStorm(props=props)
@@ -24,10 +24,10 @@ pub = Publisher(args=["{testcase.parent.name}"])
 
 
 class IceStormSingleTestCase(IceStormTestCase):
-    def setupClientSide(self, current):
+    def setupClientSide(self, current: Driver.Current) -> None:
         self.runadmin(current, "create single")
 
-    def teardownClientSide(self, current, success):
+    def teardownClientSide(self, current: Driver.Current, success: bool) -> None:
         self.runadmin(current, "destroy single")
         self.shutdown(current)
 

--- a/cpp/test/IceStorm/stress/test.py
+++ b/cpp/test/IceStorm/stress/test.py
@@ -4,6 +4,8 @@
 # Publisher/subscriber test cases, publisher publishes on TestIceStorm1 instance(s) and
 # the subscriber subscribes to the TestIceStorm2 instance(s)
 #
+from __future__ import annotations
+
 from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
 from Util import ClientServerTestCase, Driver, TestSuite
 

--- a/cpp/test/IceStorm/stress/test.py
+++ b/cpp/test/IceStorm/stress/test.py
@@ -5,15 +5,11 @@
 # the subscriber subscribes to the TestIceStorm2 instance(s)
 #
 from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
-from Util import ClientServerTestCase, TestSuite
-
-
-def pubSub(si, pi, s={}, p={}):
-    ClientServerTestCase(client=Publisher(args=s), server=Subscriber(args=p))
+from Util import ClientServerTestCase, Driver, TestSuite
 
 
 class IceStormStressTestCase(IceStormTestCase):
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         icestorm1 = [icestorm for icestorm in self.icestorm if icestorm.getInstanceName() == "TestIceStorm1"]
         # TODO: This variable is unused. Are we missing a test case?
         # icestorm2 = [
@@ -22,7 +18,7 @@ class IceStormStressTestCase(IceStormTestCase):
         #     if icestorm.getInstanceName() == "TestIceStorm2"
         # ]
 
-        def doTest(subOpts, pubOpts):
+        def doTest(subOpts: tuple[str, str] | list[tuple[str, str]], pubOpts: str) -> None:
             # Create the subscribers
             subscribers = []
             for instanceName, opts in subOpts if isinstance(subOpts, list) else [subOpts]:

--- a/cpp/test/Slice/errorDetection/test.py
+++ b/cpp/test/Slice/errorDetection/test.py
@@ -1,5 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 import glob
 import os
 import re

--- a/cpp/test/Slice/errorDetection/test.py
+++ b/cpp/test/Slice/errorDetection/test.py
@@ -5,11 +5,11 @@ import os
 import re
 import shutil
 
-from Util import ClientTestCase, SliceTranslator, TestSuite
+from Util import ClientTestCase, Driver, SliceTranslator, TestSuite
 
 
 class SliceErrorDetectionTestCase(ClientTestCase):
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         testdir = current.testsuite.getPath()
         slice2cpp = SliceTranslator("slice2cpp", quiet=True)
 

--- a/cpp/test/Slice/headers/test.py
+++ b/cpp/test/Slice/headers/test.py
@@ -1,5 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 import os
 import re
 import shutil

--- a/cpp/test/Slice/headers/test.py
+++ b/cpp/test/Slice/headers/test.py
@@ -22,7 +22,6 @@ class SliceHeadersTestCase(ClientTestCase):
         self.clean()
 
         slice2cpp = SliceTranslator("slice2cpp")
-        # init() has run by now, so the test case knows its suite and mapping.
         assert self.testsuite is not None and self.mapping is not None
 
         os.symlink("slices", "linktoslices")

--- a/cpp/test/Slice/headers/test.py
+++ b/cpp/test/Slice/headers/test.py
@@ -6,6 +6,7 @@ import shutil
 
 from Util import (
     ClientTestCase,
+    Driver,
     SliceTranslator,
     TestSuite,
     Windows,
@@ -15,10 +16,12 @@ from Util import (
 
 
 class SliceHeadersTestCase(ClientTestCase):
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         self.clean()
 
         slice2cpp = SliceTranslator("slice2cpp")
+        # init() has run by now, so the test case knows its suite and mapping.
+        assert self.testsuite is not None and self.mapping is not None
 
         os.symlink("slices", "linktoslices")
         os.symlink("dir1", os.path.join("slices", "linktodir1"))
@@ -29,7 +32,7 @@ class SliceHeadersTestCase(ClientTestCase):
         slicedir = component.getSliceDir(self.mapping, current)
         os.symlink(slicedir, "iceslices")
 
-        def runTest(args):
+        def runTest(args: str) -> None:
             slice2cpp.run(current, args=args.split(" "))
             f = open("b.h")
             if not re.search(
@@ -58,7 +61,7 @@ class SliceHeadersTestCase(ClientTestCase):
             runTest("-IICESLICES -ISLICES SLICES/DIR2/B.ice")
             runTest("-IICESLICES -ILINKTOSLICES LINKTOSLICES/LINKTODIR2/B.ice")
 
-        slice2cpp = slice2cpp.getCommandLine(current)
+        slice2cppCommand = slice2cpp.getCommandLine(current)
 
         #
         # Slice files are symlinks, include dir is a regular directory
@@ -74,7 +77,7 @@ class SliceHeadersTestCase(ClientTestCase):
         f.write("#include <services/settings/slices/A.ice>")
         f.close()
 
-        os.system("cd project1 && %s -Isrc src/services/settings/slices/B.ice" % slice2cpp)
+        os.system("cd project1 && %s -Isrc src/services/settings/slices/B.ice" % slice2cppCommand)
         f = open("project1/B.h")
         if not re.search(re.escape("#include <services/settings/slices/A.h>"), f.read()):
             raise RuntimeError("failed!")
@@ -92,7 +95,7 @@ class SliceHeadersTestCase(ClientTestCase):
         f = open("project1/A.ice", "w")
         f.write("#include <Ice/Identity.ice>")
         f.close()
-        os.system("cd project1 && %s -Ishare/slice A.ice" % slice2cpp)
+        os.system("cd project1 && %s -Ishare/slice A.ice" % slice2cppCommand)
         f = open("project1/A.h")
         if not re.search(re.escape("#include <Ice/Identity.h>"), f.read()):
             raise RuntimeError("failed!")
@@ -111,7 +114,7 @@ class SliceHeadersTestCase(ClientTestCase):
         f = open("project1/A.ice", "w")
         f.write("#include <Ice/Identity.ice>")
         f.close()
-        os.system("cd project1 && %s -I%s/tmp/Ice-x.y/slice A.ice" % (slice2cpp, basedir))
+        os.system("cd project1 && %s -I%s/tmp/Ice-x.y/slice A.ice" % (slice2cppCommand, basedir))
         f = open("project1/A.h")
         if not re.search(re.escape("#include <Ice/Identity.h>"), f.read()):
             raise RuntimeError("failed!")
@@ -131,7 +134,7 @@ class SliceHeadersTestCase(ClientTestCase):
         f = open("project1/A.ice", "w")
         f.write("#include <Ice/Identity.ice>")
         f.close()
-        os.system("cd project1 && %s -I%s/tmp/Ice/slice A.ice" % (slice2cpp, basedir))
+        os.system("cd project1 && %s -I%s/tmp/Ice/slice A.ice" % (slice2cppCommand, basedir))
         f = open("project1/A.h")
         if not re.search(re.escape("#include <Ice/Identity.h>"), f.read()):
             raise RuntimeError("failed!")
@@ -139,10 +142,10 @@ class SliceHeadersTestCase(ClientTestCase):
 
         current.writeln("ok")
 
-    def teardownClientSide(self, current, success):
+    def teardownClientSide(self, current: Driver.Current, success: bool) -> None:
         self.clean()
 
-    def clean(self):
+    def clean(self) -> None:
         for f in [
             "iceslices",
             "linktoslices",

--- a/cpp/test/Slice/unicodePaths/test.py
+++ b/cpp/test/Slice/unicodePaths/test.py
@@ -4,11 +4,11 @@ import locale
 import os
 import shutil
 
-from Util import ClientTestCase, Linux, SliceTranslator, TestSuite, platform
+from Util import ClientTestCase, Driver, Linux, SliceTranslator, TestSuite, platform
 
 
 class SliceUnicodePathsTestCase(ClientTestCase):
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         if isinstance(platform, Linux):
             encoding = locale.getdefaultlocale()[1]
             if encoding != "UTF-8":

--- a/cpp/test/Slice/unicodePaths/test.py
+++ b/cpp/test/Slice/unicodePaths/test.py
@@ -1,5 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 import locale
 import os
 import shutil

--- a/cpp/test/Slice/utf8BOM/test.py
+++ b/cpp/test/Slice/utf8BOM/test.py
@@ -3,11 +3,11 @@
 import os
 import shutil
 
-from Util import ClientTestCase, Linux, SliceTranslator, TestSuite, platform
+from Util import ClientTestCase, Driver, Linux, SliceTranslator, TestSuite, platform
 
 
 class SliceUtf8BomTestCase(ClientTestCase):
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         test_file_name = "Test.ice"
         slice2cpp = SliceTranslator("slice2cpp", quiet=True)
 

--- a/cpp/test/Slice/utf8BOM/test.py
+++ b/cpp/test/Slice/utf8BOM/test.py
@@ -1,5 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 import os
 import shutil
 

--- a/php/test/Ice/ini/test.py
+++ b/php/test/Ice/ini/test.py
@@ -1,15 +1,17 @@
 # Copyright (c) ZeroC, Inc.
 
-from Util import Client, ClientTestCase, TestSuite
+from typing import Any
+
+from Util import Client, ClientTestCase, Driver, TestSuite
 
 
 class IniClient(Client):
-    def __init__(self, iceOptions, iceProfile=None, *args, **kargs):
+    def __init__(self, iceOptions: str, iceProfile: str | None = None, *args: Any, **kargs: Any):
         Client.__init__(self, *args, **kargs)
         self.iceOptions = iceOptions
         self.iceProfile = iceProfile
 
-    def setup(self, current):
+    def setup(self, current: Driver.Current) -> None:
         if self.iceProfile:
             current.createFile(
                 "ice.profiles",
@@ -21,11 +23,11 @@ class IniClient(Client):
             )
         current.write("testing... ")
 
-    def teardown(self, current, success):
+    def teardown(self, current: Driver.Current, success: bool) -> None:
         if success:
             current.writeln("ok")
 
-    def getPhpArgs(self, current):
+    def getPhpArgs(self, current: Driver.Current) -> list[str]:
         if self.iceProfile:
             return ["-d", 'ice.profiles="ice.profiles"']
         else:

--- a/php/test/Ice/ini/test.py
+++ b/php/test/Ice/ini/test.py
@@ -1,5 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 from typing import Any
 
 from Util import Client, ClientTestCase, Driver, TestSuite

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,7 +1,24 @@
 {
-    "include": ["python", "scripts"],
-    "exclude": ["python/dist", "python/.venv"],
-    "extraPaths": ["python/python"],
+    "include": [
+        "allTests.py",
+        "config",
+        "cpp",
+        "csharp",
+        "java",
+        "js",
+        "matlab",
+        "packaging",
+        "php",
+        "python",
+        "ruby",
+        "scripts",
+        "swift"
+    ],
+    "exclude": ["python/dist", "python/.venv", "**/node_modules"],
+    // scripts is on the search path for every tree, not just its own execution environment: the
+    // test.py files under cpp/test and friends import the framework by name, the way loadTestSuites
+    // runs them.
+    "extraPaths": ["python/python", "scripts"],
     // The test framework modules under scripts import each other by name; "root" is what puts scripts
     // itself on the search path for the files it contains.
     "executionEnvironments": [

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,19 +1,9 @@
 {
-    // Neither "include" nor "exclude": everything under the repository is checked, so a new Python
-    // file is covered wherever it lands, and pyright's own excludes still keep out node_modules,
-    // __pycache__ and anything hidden, which is what holds the virtual environments back.
-    // scripts is on the search path for every tree, not just its own execution environment: the
-    // test.py files under cpp/test and friends import the framework by name, the way loadTestSuites
-    // runs them.
     "extraPaths": ["python/python", "scripts"],
-    // The test framework modules under scripts import each other by name; "root" is what puts scripts
-    // itself on the search path for the files it contains.
     "executionEnvironments": [
         {
             "root": "scripts",
-            // "." is for the scripts.tests.* package imports; loadTestSuites puts the repository root
-            // on sys.path at run time. "python/python" is repeated from the top-level extraPaths
-            // because an execution environment replaces those rather than adding to them.
+            // Repeats python/python because these replace the paths above rather than adding to them.
             "extraPaths": [".", "python/python"]
         }
     ],

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,20 +1,8 @@
 {
-    "include": [
-        "allTests.py",
-        "config",
-        "cpp",
-        "csharp",
-        "java",
-        "js",
-        "matlab",
-        "packaging",
-        "php",
-        "python",
-        "ruby",
-        "scripts",
-        "swift"
-    ],
-    "exclude": ["python/dist", "python/.venv", "**/node_modules"],
+    // No "include": everything under the repository is checked, so a new Python file is covered
+    // wherever it lands. Naming "exclude" replaces pyright's own defaults rather than adding to
+    // them, so they are repeated here -- "**/.*" is what keeps the virtual environments out.
+    "exclude": ["**/node_modules", "**/__pycache__", "**/.*", "python/dist"],
     // scripts is on the search path for every tree, not just its own execution environment: the
     // test.py files under cpp/test and friends import the framework by name, the way loadTestSuites
     // runs them.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,8 +1,7 @@
 {
-    // No "include": everything under the repository is checked, so a new Python file is covered
-    // wherever it lands. Naming "exclude" replaces pyright's own defaults rather than adding to
-    // them, so they are repeated here -- "**/.*" is what keeps the virtual environments out.
-    "exclude": ["**/node_modules", "**/__pycache__", "**/.*", "python/dist"],
+    // Neither "include" nor "exclude": everything under the repository is checked, so a new Python
+    // file is covered wherever it lands, and pyright's own excludes still keep out node_modules,
+    // __pycache__ and anything hidden, which is what holds the virtual environments back.
     // scripts is on the search path for every tree, not just its own execution environment: the
     // test.py files under cpp/test and friends import the framework by name, the way loadTestSuites
     // runs them.

--- a/python/dist/lib/slice2py.py
+++ b/python/dist/lib/slice2py.py
@@ -7,7 +7,7 @@ import Ice
 import IcePy
 
 
-def main():
+def main() -> int:
     sliceDir = Ice.getSliceDir()
     # Automatically add the slice dir.
     if sliceDir is not None:

--- a/scripts/Glacier2Util.py
+++ b/scripts/Glacier2Util.py
@@ -32,7 +32,7 @@ class Glacier2Router(ProcessFromBinDir, ProcessIsReleaseOnly, Server):
     def __init__(
         self,
         portnum: int = 50,
-        passwords: dict[str, str] = {"userid": "abc123"},
+        passwords: dict[str, str] | None = {"userid": "abc123"},
         *args: Any,
         **kargs: Any,
     ):

--- a/scripts/IceGridUtil.py
+++ b/scripts/IceGridUtil.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shutil
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from Glacier2Util import Glacier2Router
@@ -183,7 +184,15 @@ class IceGridNode(ProcessFromBinDir, Server):
 
 
 class IceGridRegistry(ProcessFromBinDir, Server):
-    def __init__(self, name: str, portnum: int = 20, ready: str = "AdminSessionManager", *args: Any, **kargs: Any):
+    def __init__(
+        self,
+        name: str,
+        portnum: int = 20,
+        ready: str = "AdminSessionManager",
+        createDb: bool = True,
+        *args: Any,
+        **kargs: Any,
+    ):
         Server.__init__(
             self,
             "icegridregistry",
@@ -196,6 +205,9 @@ class IceGridRegistry(ProcessFromBinDir, Server):
         self.portnum = portnum
         self.readyCount = -1
         self.name = name
+        # As IceStorm's flag of the same name: clear it to keep setup from wiping a database the
+        # test put in place itself.
+        self.createDb = createDb
 
     def getExe(self, current: Driver.Current) -> str:
         assert self.exe is not None
@@ -204,9 +216,10 @@ class IceGridRegistry(ProcessFromBinDir, Server):
     def setup(self, current: Driver.Current) -> None:
         # Create the database directory
         self.dbdir = os.path.join(current.testsuite.getPath(), "registry-{0}".format(self.name))
-        if os.path.exists(self.dbdir):
-            shutil.rmtree(self.dbdir)
-        os.mkdir(self.dbdir)
+        if self.createDb:
+            if os.path.exists(self.dbdir):
+                shutil.rmtree(self.dbdir)
+            os.mkdir(self.dbdir)
 
     def teardown(self, current: Driver.Current, success: bool) -> None:
         Server.teardown(self, current, success)
@@ -285,8 +298,8 @@ class IceGridTestCase(TestCase):
     def __init__(
         self,
         name: str = "IceGrid",
-        icegridregistry: IceGridRegistry | list[IceGridRegistry] | None = None,
-        icegridnode: IceGridNode | list[IceGridNode] | None = None,
+        icegridregistry: IceGridRegistry | Sequence[IceGridRegistry] | None = None,
+        icegridnode: IceGridNode | Sequence[IceGridNode] | None = None,
         application: str | None = "application.xml",
         variables: dict[str, Any] = {},
         targets: list[str] = [],
@@ -296,12 +309,14 @@ class IceGridTestCase(TestCase):
     ):
         TestCase.__init__(self, name, *args, **kargs)
         if icegridnode:
-            self.icegridnode = icegridnode if isinstance(icegridnode, list) else [icegridnode]
+            self.icegridnode = [icegridnode] if isinstance(icegridnode, IceGridNode) else list(icegridnode)
         else:
             self.icegridnode = [IceGridNode()]
 
         if icegridregistry:
-            self.icegridregistry = icegridregistry if isinstance(icegridregistry, list) else [icegridregistry]
+            self.icegridregistry = (
+                [icegridregistry] if isinstance(icegridregistry, IceGridRegistry) else list(icegridregistry)
+            )
         else:
             self.icegridregistry = [IceGridRegistryMaster(), IceGridRegistrySlave(1)]
 


### PR DESCRIPTION
Follows #6176. Pyright's `include` now covers the whole repository rather than just `python` and `scripts`, and everything outside `python/` type checks clean — 249 errors across 32 files.

- Put `scripts` on the top-level search path: the `test.py` files under `cpp/test` and friends import the framework by name, the way `loadTestSuites` runs them.
- Type hint `config/makeprops.py`, the densest file left at 74 errors. Its generated file handles are `None` until `openFiles` runs, so every write and close went unchecked; `createProperty`'s overrides named their last parameter differently from the base, which makes the override incompatible by keyword; and a section's name reached a dict key as `str | None`. Regenerating `PropertyNames` for C++, Java and C# gives output identical to what is checked in.
- Type hint the 30 `test.py` files under `cpp/test` and `php/test`.
- `IceGridTestCase` and `RelayReconnectTestCase` took `list`s their callers could not satisfy, since `list` is invariant and both are given a list of a subclass. They take a `Sequence`, as elsewhere in the framework.
- `IceGridRegistry` gains the `createDb` flag `IceStorm` already has, so `icegriddb` can keep `setup` from wiping the database it imported instead of replacing the method with a lambda. `icestormdb` does the same through the existing flag.
- `Glacier2Router`'s `passwords` is optional; `dynamicFiltering` passes `None` and both readers test it for truthiness.
- Write `makeprops.py`'s diagnostics to stderr. All ten were `print(sys.stderr, "...")`, which passes the stream as a value to print rather than as its destination, so each message went to stdout with the stream's repr in front of it.
- Fix things the annotations exposed: `Slice/headers` rebound `slice2cpp` from the translator to its command line, leaving a nested call to `.run()` on a `str`; `staticFiltering` reset the suite's `OrderedDict` by rebinding it to a plain dict; `repstress` read `.group(1)` straight off a match that can be `None`; and `stress` carried a dead `pubSub()` that built a test case it discarded and passed dicts where a process wants arguments.

