### PR TITLE
Normalize proxy timeouts so they round-trip through proxy properties

### DIFF
--- a/changelog.d/general/6235.md
+++ b/changelog.d/general/6235.md
@@ -1,0 +1,8 @@
+- The `ice_locatorCacheTimeout` and `ice_invocationTimeout` proxy methods now normalize their argument. Any
+  negative timeout means infinite and is normalized to -1; a positive timeout that is not a whole number of the
+  corresponding proxy property's unit (seconds for the locator cache timeout, milliseconds for the invocation
+  timeout) is rounded up to the next whole number; and a timeout greater than 2147483647 of this unit is rejected
+  with an exception. Previously, a fractional timeout set through a duration-typed overload was silently truncated
+  in C++ and Java, produced a proxy property value (such as `LocatorCacheTimeout=1.5`) that `propertyToProxy`
+  rejected in C#, and a positive C# invocation timeout smaller than one millisecond made the invocation time out
+  immediately.

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -169,12 +169,14 @@ namespace Ice
             {
                 return fromReference(asPrx()._invocationTimeout(std::chrono::milliseconds(-1)));
             }
-            auto roundedTimeout = std::chrono::ceil<std::chrono::milliseconds>(timeout);
-            if (roundedTimeout > std::chrono::milliseconds{std::numeric_limits<std::int32_t>::max()})
+            // Compare in a double-based representation that cannot overflow. The limit is a whole number of
+            // milliseconds, so a timeout that passes this check still fits after rounding up.
+            // The extra parentheses prevent the expansion of the max macro from Windows headers.
+            if (timeout > std::chrono::duration<double, std::milli>{(std::numeric_limits<std::int32_t>::max)()})
             {
                 throw std::invalid_argument("the invocation timeout cannot be greater than 2147483647 milliseconds");
             }
-            return fromReference(asPrx()._invocationTimeout(roundedTimeout));
+            return fromReference(asPrx()._invocationTimeout(std::chrono::ceil<std::chrono::milliseconds>(timeout)));
         }
 
         /// Creates a proxy that is identical to this proxy, except for the locator.
@@ -208,12 +210,14 @@ namespace Ice
             {
                 return fromReference(asPrx()._locatorCacheTimeout(std::chrono::seconds(-1)));
             }
-            auto roundedTimeout = std::chrono::ceil<std::chrono::seconds>(timeout);
-            if (roundedTimeout > std::chrono::seconds{std::numeric_limits<std::int32_t>::max()})
+            // Compare in a double-based representation that cannot overflow. The limit is a whole number of
+            // seconds, so a timeout that passes this check still fits after rounding up.
+            // The extra parentheses prevent the expansion of the max macro from Windows headers.
+            if (timeout > std::chrono::duration<double>{(std::numeric_limits<std::int32_t>::max)()})
             {
                 throw std::invalid_argument("the locator cache timeout cannot be greater than 2147483647 seconds");
             }
-            return fromReference(asPrx()._locatorCacheTimeout(roundedTimeout));
+            return fromReference(asPrx()._locatorCacheTimeout(std::chrono::ceil<std::chrono::seconds>(timeout)));
         }
 
         /// Creates a proxy that is identical to this proxy, but uses oneway invocations.

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -144,7 +144,8 @@ namespace Ice
         }
 
         /// Creates a proxy that is identical to this proxy, except for the invocation timeout.
-        /// @param timeout The new invocation timeout (in milliseconds).
+        /// @param timeout The new invocation timeout (in milliseconds). Any negative value means infinite and is
+        /// normalized to -1.
         /// @return A proxy with the new timeout.
         [[nodiscard]] Prx ice_invocationTimeout(int timeout) const
         {
@@ -152,13 +153,17 @@ namespace Ice
         }
 
         /// Creates a proxy that is identical to this proxy, except for the invocation timeout.
-        /// @param timeout The new invocation timeout.
+        /// @param timeout The new invocation timeout. Any negative duration means infinite and is normalized to
+        /// -1 millisecond; a duration that is not a whole number of milliseconds is rounded up to the next whole
+        /// number of milliseconds.
         /// @return A proxy with the new timeout.
         template<class Rep, class Period>
         [[nodiscard]] Prx ice_invocationTimeout(const std::chrono::duration<Rep, Period>& timeout) const
         {
-            return fromReference(
-                asPrx()._invocationTimeout(std::chrono::duration_cast<std::chrono::milliseconds>(timeout)));
+            return fromReference(asPrx()._invocationTimeout(
+                timeout < std::chrono::duration<Rep, Period>::zero()
+                    ? std::chrono::milliseconds(-1)
+                    : std::chrono::ceil<std::chrono::milliseconds>(timeout)));
         }
 
         /// Creates a proxy that is identical to this proxy, except for the locator.
@@ -170,7 +175,8 @@ namespace Ice
         }
 
         /// Creates a proxy that is identical to this proxy, except for the locator cache timeout.
-        /// @param timeout The new locator cache timeout (in seconds).
+        /// @param timeout The new locator cache timeout (in seconds). Any negative value means infinite and is
+        /// normalized to -1.
         /// @return A proxy with the new timeout.
         [[nodiscard]] Prx ice_locatorCacheTimeout(int timeout) const
         {
@@ -178,13 +184,17 @@ namespace Ice
         }
 
         /// Creates a proxy that is identical to this proxy, except for the locator cache timeout.
-        /// @param timeout The new locator cache timeout.
+        /// @param timeout The new locator cache timeout. Any negative duration means infinite and is normalized to
+        /// -1 second; a duration that is not a whole number of seconds is rounded up to the next whole number of
+        /// seconds.
         /// @return A proxy with the new timeout.
         template<class Rep, class Period>
         [[nodiscard]] Prx ice_locatorCacheTimeout(const std::chrono::duration<Rep, Period>& timeout) const
         {
-            return fromReference(
-                asPrx()._locatorCacheTimeout(std::chrono::duration_cast<std::chrono::milliseconds>(timeout)));
+            return fromReference(asPrx()._locatorCacheTimeout(
+                timeout < std::chrono::duration<Rep, Period>::zero()
+                    ? std::chrono::seconds(-1)
+                    : std::chrono::ceil<std::chrono::seconds>(timeout)));
         }
 
         /// Creates a proxy that is identical to this proxy, but uses oneway invocations.

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -14,10 +14,13 @@
 #include "RequestHandlerF.h"
 
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <future>
 #include <iosfwd>
+#include <limits>
 #include <optional>
+#include <stdexcept>
 #include <string_view>
 #include <type_traits>
 
@@ -157,13 +160,21 @@ namespace Ice
         /// -1 millisecond; a duration that is not a whole number of milliseconds is rounded up to the next whole
         /// number of milliseconds.
         /// @return A proxy with the new timeout.
+        /// @throws std::invalid_argument Thrown when @p timeout is greater than
+        /// `std::numeric_limits<std::int32_t>::max()` milliseconds.
         template<class Rep, class Period>
         [[nodiscard]] Prx ice_invocationTimeout(const std::chrono::duration<Rep, Period>& timeout) const
         {
-            return fromReference(asPrx()._invocationTimeout(
-                timeout < std::chrono::duration<Rep, Period>::zero()
-                    ? std::chrono::milliseconds(-1)
-                    : std::chrono::ceil<std::chrono::milliseconds>(timeout)));
+            if (timeout < std::chrono::duration<Rep, Period>::zero())
+            {
+                return fromReference(asPrx()._invocationTimeout(std::chrono::milliseconds(-1)));
+            }
+            auto roundedTimeout = std::chrono::ceil<std::chrono::milliseconds>(timeout);
+            if (roundedTimeout > std::chrono::milliseconds{std::numeric_limits<std::int32_t>::max()})
+            {
+                throw std::invalid_argument("the invocation timeout cannot be greater than 2147483647 milliseconds");
+            }
+            return fromReference(asPrx()._invocationTimeout(roundedTimeout));
         }
 
         /// Creates a proxy that is identical to this proxy, except for the locator.
@@ -188,13 +199,21 @@ namespace Ice
         /// -1 second; a duration that is not a whole number of seconds is rounded up to the next whole number of
         /// seconds.
         /// @return A proxy with the new timeout.
+        /// @throws std::invalid_argument Thrown when @p timeout is greater than
+        /// `std::numeric_limits<std::int32_t>::max()` seconds.
         template<class Rep, class Period>
         [[nodiscard]] Prx ice_locatorCacheTimeout(const std::chrono::duration<Rep, Period>& timeout) const
         {
-            return fromReference(asPrx()._locatorCacheTimeout(
-                timeout < std::chrono::duration<Rep, Period>::zero()
-                    ? std::chrono::seconds(-1)
-                    : std::chrono::ceil<std::chrono::seconds>(timeout)));
+            if (timeout < std::chrono::duration<Rep, Period>::zero())
+            {
+                return fromReference(asPrx()._locatorCacheTimeout(std::chrono::seconds(-1)));
+            }
+            auto roundedTimeout = std::chrono::ceil<std::chrono::seconds>(timeout);
+            if (roundedTimeout > std::chrono::seconds{std::numeric_limits<std::int32_t>::max()})
+            {
+                throw std::invalid_argument("the locator cache timeout cannot be greater than 2147483647 seconds");
+            }
+            return fromReference(asPrx()._locatorCacheTimeout(roundedTimeout));
         }
 
         /// Creates a proxy that is identical to this proxy, but uses oneway invocations.

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -1013,9 +1013,15 @@ IceInternal::RoutableReference::toProperty(string prefix) const
     properties[prefix + ".ConnectionCached"] = _cacheConnection ? "1" : "0";
     properties[prefix + ".EndpointSelection"] =
         _endpointSelection == EndpointSelectionType::Random ? "Random" : "Ordered";
+    // Any negative timeout means infinite; we emit it as -1, the documented value for infinite. A positive timeout
+    // that is not a whole number of the property's unit is rounded up, to the next whole number.
+    // TODO: remove this normalization in 3.9, once the timeouts are always normalized: in 3.8, code compiled
+    // against older headers can still set non-normalized values, and the values read from the per-proxy timeout
+    // properties are not normalized (or rejected) like the values set by the proxy methods.
     properties[prefix + ".LocatorCacheTimeout"] =
-        to_string(chrono::duration_cast<chrono::seconds>(_locatorCacheTimeout).count());
-    properties[prefix + ".InvocationTimeout"] = to_string(getInvocationTimeout().count());
+        _locatorCacheTimeout < 0ms ? "-1" : to_string(chrono::ceil<chrono::seconds>(_locatorCacheTimeout).count());
+    properties[prefix + ".InvocationTimeout"] =
+        getInvocationTimeout() < 0ms ? "-1" : to_string(getInvocationTimeout().count());
 
     if (_routerInfo)
     {

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -1015,9 +1015,9 @@ IceInternal::RoutableReference::toProperty(string prefix) const
         _endpointSelection == EndpointSelectionType::Random ? "Random" : "Ordered";
     // Any negative timeout means infinite; we emit it as -1, the documented value for infinite. A positive timeout
     // that is not a whole number of the property's unit is rounded up, to the next whole number.
-    // TODO: remove this normalization in 3.9, once the timeouts are always normalized: in 3.8, code compiled
-    // against older headers can still set non-normalized values, and the values read from the per-proxy timeout
-    // properties are not normalized (or rejected) like the values set by the proxy methods.
+    // TODO: remove this normalization in 3.9 (see #6112), once the timeouts are always normalized: in 3.8, code
+    // compiled against older headers can still set non-normalized values, and the values read from the per-proxy
+    // timeout properties are not normalized (or rejected) like the values set by the proxy methods.
     properties[prefix + ".LocatorCacheTimeout"] =
         _locatorCacheTimeout < 0ms ? "-1" : to_string(chrono::ceil<chrono::seconds>(_locatorCacheTimeout).count());
     properties[prefix + ".InvocationTimeout"] =

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -8,6 +8,8 @@
 #include "TestHelper.h"
 
 #include <array>
+#include <cstdint>
+#include <limits>
 #include <stdexcept>
 
 #ifdef _MSC_VER
@@ -697,6 +699,14 @@ allTests(TestHelper* helper)
     try
     {
         auto _ = base->ice_invocationTimeout(std::chrono::milliseconds{int64_t{numeric_limits<int32_t>::max()} + 1});
+        test(false);
+    }
+    catch (const std::invalid_argument&)
+    {
+    }
+    try
+    {
+        auto _ = base->ice_invocationTimeout(std::chrono::seconds::max());
         test(false);
     }
     catch (const std::invalid_argument&)

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -690,6 +690,27 @@ allTests(TestHelper* helper)
     test(base->ice_invocationTimeout(1500us)->ice_getInvocationTimeout() == 2ms);
     test(base->ice_invocationTimeout(-500us)->ice_getInvocationTimeout() == -1ms);
 
+    // A timeout greater than INT32_MAX of the property's unit is rejected.
+    test(
+        base->ice_invocationTimeout(std::chrono::milliseconds{numeric_limits<int32_t>::max()})
+            ->ice_getInvocationTimeout() == std::chrono::milliseconds{numeric_limits<int32_t>::max()});
+    try
+    {
+        auto _ = base->ice_invocationTimeout(std::chrono::milliseconds{int64_t{numeric_limits<int32_t>::max()} + 1});
+        test(false);
+    }
+    catch (const std::invalid_argument&)
+    {
+    }
+    try
+    {
+        auto _ = base->ice_locatorCacheTimeout(std::chrono::seconds{int64_t{numeric_limits<int32_t>::max()} + 1});
+        test(false);
+    }
+    catch (const std::invalid_argument&)
+    {
+    }
+
     cout << "ok" << endl;
 
     cout << "testing proxy comparison... " << flush;

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -623,6 +623,17 @@ allTests(TestHelper* helper)
     test(proxyProps["Test.Locator.Router.LocatorCacheTimeout"] == "200");
     test(proxyProps["Test.Locator.Router.InvocationTimeout"] == "1500");
 
+    // A negative timeout is emitted as -1, and a positive timeout is rounded up to the next whole number of the
+    // property's unit.
+    b1 = b1->ice_locatorCacheTimeout(1500ms)->ice_invocationTimeout(-2);
+    proxyProps = communicator->proxyToProperty(b1, "Test");
+    test(proxyProps["Test.LocatorCacheTimeout"] == "2");
+    test(proxyProps["Test.InvocationTimeout"] == "-1");
+
+    b1 = b1->ice_locatorCacheTimeout(-500ms);
+    proxyProps = communicator->proxyToProperty(b1, "Test");
+    test(proxyProps["Test.LocatorCacheTimeout"] == "-1");
+
     cout << "ok" << endl;
 
     cout << "testing ice_getCommunicator... " << flush;
@@ -655,8 +666,8 @@ allTests(TestHelper* helper)
     test(base->ice_invocationTimeout(-1)->ice_getInvocationTimeout() == -1ms);
     test(base->ice_invocationTimeout(-1ms)->ice_getInvocationTimeout() == -1ms);
 
-    test(base->ice_invocationTimeout(-2)->ice_getInvocationTimeout() == -2ms);
-    test(base->ice_invocationTimeout(-2ms)->ice_getInvocationTimeout() == -2ms);
+    test(base->ice_invocationTimeout(-2)->ice_getInvocationTimeout() == -1ms);
+    test(base->ice_invocationTimeout(-2ms)->ice_getInvocationTimeout() == -1ms);
 
     test(base->ice_locatorCacheTimeout(10)->ice_getLocatorCacheTimeout() == 10s);
 
@@ -666,12 +677,18 @@ allTests(TestHelper* helper)
     test(base->ice_locatorCacheTimeout(-1)->ice_getLocatorCacheTimeout() == -1s);
     test(base->ice_locatorCacheTimeout(-1s)->ice_getLocatorCacheTimeout() == -1s);
 
-    test(base->ice_locatorCacheTimeout(-2)->ice_getLocatorCacheTimeout() == -2s);
-    test(base->ice_locatorCacheTimeout(-2s)->ice_getLocatorCacheTimeout() == -2s);
+    test(base->ice_locatorCacheTimeout(-2)->ice_getLocatorCacheTimeout() == -1s);
+    test(base->ice_locatorCacheTimeout(-2s)->ice_getLocatorCacheTimeout() == -1s);
 
     test(base->ice_locatorCacheTimeout(2000ms)->ice_getLocatorCacheTimeout() == 2s);
-    test(base->ice_locatorCacheTimeout(1500ms)->ice_getLocatorCacheTimeout() == 1500ms);
-    test(base->ice_locatorCacheTimeout(-500ms)->ice_getLocatorCacheTimeout() == -500ms);
+
+    // A duration that is not a whole number of the timeout's unit is rounded up to the next whole number, and any
+    // negative duration is normalized to -1.
+    test(base->ice_locatorCacheTimeout(1500ms)->ice_getLocatorCacheTimeout() == 2s);
+    test(base->ice_locatorCacheTimeout(500us)->ice_getLocatorCacheTimeout() == 1s);
+    test(base->ice_locatorCacheTimeout(-500ms)->ice_getLocatorCacheTimeout() == -1s);
+    test(base->ice_invocationTimeout(1500us)->ice_getInvocationTimeout() == 2ms);
+    test(base->ice_invocationTimeout(-500us)->ice_getInvocationTimeout() == -1ms);
 
     cout << "ok" << endl;
 

--- a/csharp/src/Ice/Internal/Reference.cs
+++ b/csharp/src/Ice/Internal/Reference.cs
@@ -794,8 +794,8 @@ public class RoutableReference : Reference
                    _endpointSelection == Ice.EndpointSelectionType.Random ? "Random" : "Ordered",
             // Any negative timeout means infinite; we emit it as -1, the documented value for infinite. The
             // timeouts are otherwise always whole numbers of the property's unit.
-            // TODO: remove the -1 normalization in 3.9, once the values read from the per-proxy timeout properties
-            // are normalized (or rejected) like the values set by the proxy methods.
+            // TODO: remove the -1 normalization in 3.9 (see #6112), once the values read from the per-proxy timeout
+            // properties are normalized (or rejected) like the values set by the proxy methods.
             [prefix + ".LocatorCacheTimeout"] = _locatorCacheTimeout < TimeSpan.Zero ? "-1" :
                 ((long)_locatorCacheTimeout.TotalSeconds).ToString(CultureInfo.InvariantCulture),
             [prefix + ".InvocationTimeout"] = getInvocationTimeout() < TimeSpan.Zero ? "-1" :

--- a/csharp/src/Ice/Internal/Reference.cs
+++ b/csharp/src/Ice/Internal/Reference.cs
@@ -792,10 +792,14 @@ public class RoutableReference : Reference
             [prefix + ".ConnectionCached"] = _cacheConnection ? "1" : "0",
             [prefix + ".EndpointSelection"] =
                    _endpointSelection == Ice.EndpointSelectionType.Random ? "Random" : "Ordered",
-            [prefix + ".LocatorCacheTimeout"] =
-                _locatorCacheTimeout.TotalSeconds.ToString(CultureInfo.InvariantCulture),
-            [prefix + ".InvocationTimeout"] =
-                getInvocationTimeout().TotalMilliseconds.ToString(CultureInfo.InvariantCulture)
+            // Any negative timeout means infinite; we emit it as -1, the documented value for infinite. The
+            // timeouts are otherwise always whole numbers of the property's unit.
+            // TODO: remove the -1 normalization in 3.9, once the values read from the per-proxy timeout properties
+            // are normalized (or rejected) like the values set by the proxy methods.
+            [prefix + ".LocatorCacheTimeout"] = _locatorCacheTimeout < TimeSpan.Zero ? "-1" :
+                ((long)_locatorCacheTimeout.TotalSeconds).ToString(CultureInfo.InvariantCulture),
+            [prefix + ".InvocationTimeout"] = getInvocationTimeout() < TimeSpan.Zero ? "-1" :
+                ((long)getInvocationTimeout().TotalMilliseconds).ToString(CultureInfo.InvariantCulture)
         };
 
         if (_routerInfo != null)

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -217,26 +217,31 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the locator cache timeout.
     /// </summary>
-    /// <param name="newTimeout">The new locator cache timeout (in seconds).</param>
+    /// <param name="newTimeout">The new locator cache timeout (in seconds). Any negative value means infinite
+    /// and is normalized to -1.</param>
     ObjectPrx ice_locatorCacheTimeout(int newTimeout);
 
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the locator cache timeout.
     /// </summary>
-    /// <param name="newTimeout">The new locator cache timeout.</param>
+    /// <param name="newTimeout">The new locator cache timeout. Any negative timeout means infinite and is
+    /// normalized to -1 second; a timeout that is not a whole number of seconds is rounded up to the next whole
+    /// number of seconds.</param>
     ObjectPrx ice_locatorCacheTimeout(TimeSpan newTimeout);
 
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
     /// </summary>
-    /// <param name="newTimeout">The new invocation timeout (in milliseconds).</param>
+    /// <param name="newTimeout">The new invocation timeout (in milliseconds). Any negative value means infinite
+    /// and is normalized to -1.</param>
     ObjectPrx ice_invocationTimeout(int newTimeout);
 
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
     /// </summary>
-    /// <param name="newTimeout">The new invocation timeout. A positive timeout is rounded down to the nearest
-    /// millisecond.</param>
+    /// <param name="newTimeout">The new invocation timeout. Any negative timeout means infinite and is normalized
+    /// to -1 millisecond; a timeout that is not a whole number of milliseconds is rounded up to the next whole
+    /// number of milliseconds.</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newTimeout"/> is greater than
     /// <see cref="int.MaxValue"/> milliseconds.</exception>
     ObjectPrx ice_invocationTimeout(TimeSpan newTimeout);
@@ -1006,7 +1011,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the locator cache timeout.
     /// </summary>
-    /// <param name="newTimeout">The new locator cache timeout (in seconds).</param>
+    /// <param name="newTimeout">The new locator cache timeout (in seconds). Any negative value means infinite
+    /// and is normalized to -1.</param>
     /// <returns>The new proxy with the specified locator cache timeout.</returns>
     public ObjectPrx ice_locatorCacheTimeout(int newTimeout) =>
         ice_locatorCacheTimeout(TimeSpan.FromSeconds(newTimeout));
@@ -1014,10 +1020,14 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the locator cache timeout.
     /// </summary>
-    /// <param name="newTimeout">The new locator cache timeout.</param>
+    /// <param name="newTimeout">The new locator cache timeout. Any negative timeout means infinite and is
+    /// normalized to -1 second; a timeout that is not a whole number of seconds is rounded up to the next whole
+    /// number of seconds.</param>
     /// <returns>The new proxy with the specified locator cache timeout.</returns>
     public ObjectPrx ice_locatorCacheTimeout(TimeSpan newTimeout)
     {
+        newTimeout = newTimeout < TimeSpan.Zero ?
+            TimeSpan.FromSeconds(-1) : roundUp(newTimeout, TimeSpan.TicksPerSecond);
         if (newTimeout == _reference.getLocatorCacheTimeout())
         {
             return this;
@@ -1037,7 +1047,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
     /// </summary>
-    /// <param name="newTimeout">The new invocation timeout (in milliseconds).</param>
+    /// <param name="newTimeout">The new invocation timeout (in milliseconds). Any negative value means infinite
+    /// and is normalized to -1.</param>
     /// <returns>The new proxy with the specified invocation timeout.</returns>
     public ObjectPrx ice_invocationTimeout(int newTimeout) =>
         ice_invocationTimeout(TimeSpan.FromMilliseconds(newTimeout));
@@ -1045,8 +1056,9 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
     /// </summary>
-    /// <param name="newTimeout">The new invocation timeout. A positive timeout is rounded down to the nearest
-    /// millisecond.</param>
+    /// <param name="newTimeout">The new invocation timeout. Any negative timeout means infinite and is normalized
+    /// to -1 millisecond; a timeout that is not a whole number of milliseconds is rounded up to the next whole
+    /// number of milliseconds.</param>
     /// <returns>The new proxy with the specified invocation timeout.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newTimeout"/> is greater than
     /// <see cref="int.MaxValue"/> milliseconds.</exception>
@@ -1059,6 +1071,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
                 $"The invocation timeout cannot be greater than {int.MaxValue} milliseconds.");
         }
 
+        newTimeout = newTimeout < TimeSpan.Zero ?
+            TimeSpan.FromMilliseconds(-1) : roundUp(newTimeout, TimeSpan.TicksPerMillisecond);
         if (newTimeout == _reference.getInvocationTimeout())
         {
             return this;
@@ -1714,6 +1728,19 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <returns>The new proxy instance.</returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
     protected abstract ObjectPrxHelperBase iceNewInstance(Reference reference);
+
+    // Rounds a nonnegative timeout up to a whole number of the given unit; a timeout within one unit of
+    // TimeSpan.MaxValue is rounded down instead.
+    private static TimeSpan roundUp(TimeSpan timeout, long ticksPerUnit)
+    {
+        long remainder = timeout.Ticks % ticksPerUnit;
+        long ticks = timeout.Ticks - remainder;
+        if (remainder > 0 && ticks <= long.MaxValue - ticksPerUnit)
+        {
+            ticks += ticksPerUnit;
+        }
+        return TimeSpan.FromTicks(ticks);
+    }
 
     private readonly Reference _reference;
     private readonly RequestHandlerCache _requestHandlerCache;

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -1036,13 +1036,15 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
         }
         else
         {
-            newTimeout = roundUp(newTimeout, TimeSpan.TicksPerSecond);
+            // The limit is a whole number of seconds, so a timeout that passes this check still fits after
+            // rounding up.
             if (newTimeout > TimeSpan.FromSeconds(int.MaxValue))
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(newTimeout),
                     $"The locator cache timeout cannot be greater than {int.MaxValue} seconds.");
             }
+            newTimeout = roundUp(newTimeout, TimeSpan.TicksPerSecond);
         }
 
         if (newTimeout == _reference.getLocatorCacheTimeout())
@@ -1087,13 +1089,15 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
         }
         else
         {
-            newTimeout = roundUp(newTimeout, TimeSpan.TicksPerMillisecond);
+            // The limit is a whole number of milliseconds, so a timeout that passes this check still fits after
+            // rounding up.
             if (newTimeout > TimeSpan.FromMilliseconds(int.MaxValue))
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(newTimeout),
                     $"The invocation timeout cannot be greater than {int.MaxValue} milliseconds.");
             }
+            newTimeout = roundUp(newTimeout, TimeSpan.TicksPerMillisecond);
         }
 
         if (newTimeout == _reference.getInvocationTimeout())
@@ -1752,18 +1756,15 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     [EditorBrowsable(EditorBrowsableState.Never)]
     protected abstract ObjectPrxHelperBase iceNewInstance(Reference reference);
 
-    // Rounds a nonnegative timeout up to a whole number of the given unit; a timeout within one unit of
-    // TimeSpan.MaxValue is rounded down instead, so this method never overflows. The caller rejects such a large
-    // result with its range check.
+    // Rounds a nonnegative timeout of at most int.MaxValue units up to a whole number of the given unit.
     private static TimeSpan roundUp(TimeSpan timeout, long ticksPerUnit)
     {
         long remainder = timeout.Ticks % ticksPerUnit;
-        long ticks = timeout.Ticks - remainder;
-        if (remainder > 0 && ticks <= long.MaxValue - ticksPerUnit)
+        if (remainder == 0)
         {
-            ticks += ticksPerUnit;
+            return timeout;
         }
-        return TimeSpan.FromTicks(ticks);
+        return TimeSpan.FromTicks(timeout.Ticks - remainder + ticksPerUnit);
     }
 
     private readonly Reference _reference;

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -227,6 +227,8 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="newTimeout">The new locator cache timeout. Any negative timeout means infinite and is
     /// normalized to -1 second; a timeout that is not a whole number of seconds is rounded up to the next whole
     /// number of seconds.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newTimeout"/> is greater than
+    /// <see cref="int.MaxValue"/> seconds.</exception>
     ObjectPrx ice_locatorCacheTimeout(TimeSpan newTimeout);
 
     /// <summary>
@@ -1024,10 +1026,25 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// normalized to -1 second; a timeout that is not a whole number of seconds is rounded up to the next whole
     /// number of seconds.</param>
     /// <returns>The new proxy with the specified locator cache timeout.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newTimeout"/> is greater than
+    /// <see cref="int.MaxValue"/> seconds.</exception>
     public ObjectPrx ice_locatorCacheTimeout(TimeSpan newTimeout)
     {
-        newTimeout = newTimeout < TimeSpan.Zero ?
-            TimeSpan.FromSeconds(-1) : roundUp(newTimeout, TimeSpan.TicksPerSecond);
+        if (newTimeout < TimeSpan.Zero)
+        {
+            newTimeout = TimeSpan.FromSeconds(-1);
+        }
+        else
+        {
+            newTimeout = roundUp(newTimeout, TimeSpan.TicksPerSecond);
+            if (newTimeout > TimeSpan.FromSeconds(int.MaxValue))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(newTimeout),
+                    $"The locator cache timeout cannot be greater than {int.MaxValue} seconds.");
+            }
+        }
+
         if (newTimeout == _reference.getLocatorCacheTimeout())
         {
             return this;
@@ -1064,15 +1081,21 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <see cref="int.MaxValue"/> milliseconds.</exception>
     public ObjectPrx ice_invocationTimeout(TimeSpan newTimeout)
     {
-        if (newTimeout > TimeSpan.FromMilliseconds(int.MaxValue))
+        if (newTimeout < TimeSpan.Zero)
         {
-            throw new ArgumentOutOfRangeException(
-                nameof(newTimeout),
-                $"The invocation timeout cannot be greater than {int.MaxValue} milliseconds.");
+            newTimeout = TimeSpan.FromMilliseconds(-1);
+        }
+        else
+        {
+            newTimeout = roundUp(newTimeout, TimeSpan.TicksPerMillisecond);
+            if (newTimeout > TimeSpan.FromMilliseconds(int.MaxValue))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(newTimeout),
+                    $"The invocation timeout cannot be greater than {int.MaxValue} milliseconds.");
+            }
         }
 
-        newTimeout = newTimeout < TimeSpan.Zero ?
-            TimeSpan.FromMilliseconds(-1) : roundUp(newTimeout, TimeSpan.TicksPerMillisecond);
         if (newTimeout == _reference.getInvocationTimeout())
         {
             return this;
@@ -1730,7 +1753,8 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     protected abstract ObjectPrxHelperBase iceNewInstance(Reference reference);
 
     // Rounds a nonnegative timeout up to a whole number of the given unit; a timeout within one unit of
-    // TimeSpan.MaxValue is rounded down instead.
+    // TimeSpan.MaxValue is rounded down instead, so this method never overflows. The caller rejects such a large
+    // result with its range check.
     private static TimeSpan roundUp(TimeSpan timeout, long ticksPerUnit)
     {
         long remainder = timeout.Ticks % ticksPerUnit;

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -665,8 +665,23 @@ public class AllTests : global::Test.AllTests
         test(baseProxy.ice_invocationTimeout(TimeSpan.FromMilliseconds(-0.5)).ice_getInvocationTimeout() ==
             TimeSpan.FromMilliseconds(-1));
 
-        // TimeSpan.MaxValue cannot be rounded up; it must not overflow.
-        test(baseProxy.ice_locatorCacheTimeout(TimeSpan.MaxValue).ice_getLocatorCacheTimeout() > TimeSpan.Zero);
+        // A timeout greater than int.MaxValue of the property's unit is rejected.
+        try
+        {
+            baseProxy.ice_locatorCacheTimeout(TimeSpan.FromSeconds((double)int.MaxValue + 1));
+            test(false);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+        }
+        try
+        {
+            baseProxy.ice_locatorCacheTimeout(TimeSpan.MaxValue);
+            test(false);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+        }
 
         output.WriteLine("ok");
 

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -604,6 +604,17 @@ public class AllTests : global::Test.AllTests
         test(proxyProps["Test.Locator.Router.LocatorCacheTimeout"] == "200");
         test(proxyProps["Test.Locator.Router.InvocationTimeout"] == "1500");
 
+        // A negative timeout is emitted as -1, and a positive timeout is rounded up to the next whole number of the
+        // property's unit.
+        b1 = b1.ice_locatorCacheTimeout(TimeSpan.FromMilliseconds(1500)).ice_invocationTimeout(-2);
+        proxyProps = communicator.proxyToProperty(b1, "Test");
+        test(proxyProps["Test.LocatorCacheTimeout"] == "2");
+        test(proxyProps["Test.InvocationTimeout"] == "-1");
+
+        b1 = b1.ice_locatorCacheTimeout(TimeSpan.FromMilliseconds(-500));
+        proxyProps = communicator.proxyToProperty(b1, "Test");
+        test(proxyProps["Test.LocatorCacheTimeout"] == "-1");
+
         output.WriteLine("ok");
 
         output.Write("testing ice_getCommunicator... ");
@@ -627,7 +638,7 @@ public class AllTests : global::Test.AllTests
 
         test(baseProxy.ice_invocationTimeout(0).ice_getInvocationTimeout() == TimeSpan.Zero);
         test(baseProxy.ice_invocationTimeout(-1).ice_getInvocationTimeout() == TimeSpan.FromMilliseconds(-1));
-        test(baseProxy.ice_invocationTimeout(-2).ice_getInvocationTimeout() == TimeSpan.FromMilliseconds(-2));
+        test(baseProxy.ice_invocationTimeout(-2).ice_getInvocationTimeout() == TimeSpan.FromMilliseconds(-1));
         test(baseProxy.ice_invocationTimeout(int.MaxValue).ice_getInvocationTimeout() ==
             TimeSpan.FromMilliseconds(int.MaxValue));
         try
@@ -641,7 +652,21 @@ public class AllTests : global::Test.AllTests
 
         test(baseProxy.ice_locatorCacheTimeout(0).ice_getLocatorCacheTimeout() == TimeSpan.Zero);
         test(baseProxy.ice_locatorCacheTimeout(-1).ice_getLocatorCacheTimeout() == TimeSpan.FromSeconds(-1));
-        test(baseProxy.ice_locatorCacheTimeout(-2).ice_getLocatorCacheTimeout() == TimeSpan.FromSeconds(-2));
+        test(baseProxy.ice_locatorCacheTimeout(-2).ice_getLocatorCacheTimeout() == TimeSpan.FromSeconds(-1));
+
+        // A timeout that is not a whole number of the timeout's unit is rounded up to the next whole number, and
+        // any negative timeout is normalized to -1.
+        test(baseProxy.ice_locatorCacheTimeout(TimeSpan.FromMilliseconds(1500)).ice_getLocatorCacheTimeout() ==
+            TimeSpan.FromSeconds(2));
+        test(baseProxy.ice_locatorCacheTimeout(TimeSpan.FromMilliseconds(-0.5)).ice_getLocatorCacheTimeout() ==
+            TimeSpan.FromSeconds(-1));
+        test(baseProxy.ice_invocationTimeout(TimeSpan.FromMilliseconds(1.5)).ice_getInvocationTimeout() ==
+            TimeSpan.FromMilliseconds(2));
+        test(baseProxy.ice_invocationTimeout(TimeSpan.FromMilliseconds(-0.5)).ice_getInvocationTimeout() ==
+            TimeSpan.FromMilliseconds(-1));
+
+        // TimeSpan.MaxValue cannot be rounded up; it must not overflow.
+        test(baseProxy.ice_locatorCacheTimeout(TimeSpan.MaxValue).ice_getLocatorCacheTimeout() > TimeSpan.Zero);
 
         output.WriteLine("ok");
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -328,6 +328,8 @@ public interface ObjectPrx {
      *     normalized to -1 second, and a timeout that is not a whole number of seconds is rounded
      *     up to the next whole number of seconds
      * @return a proxy with the new timeout
+     * @throws IllegalArgumentException if {@code newTimeout} is greater than {@code
+     *     Integer.MAX_VALUE} seconds
      * @see Locator
      */
     ObjectPrx ice_locatorCacheTimeout(Duration newTimeout);
@@ -348,6 +350,8 @@ public interface ObjectPrx {
      *     normalized to -1 millisecond, and a timeout that is not a whole number of milliseconds
      *     is rounded up to the next whole number of milliseconds
      * @return a proxy with the new timeout
+     * @throws IllegalArgumentException if {@code newTimeout} is greater than {@code
+     *     Integer.MAX_VALUE} milliseconds
      */
     ObjectPrx ice_invocationTimeout(Duration newTimeout);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -314,7 +314,8 @@ public interface ObjectPrx {
     /**
      * Creates a proxy that is identical to this proxy, except for the locator cache timeout.
      *
-     * @param newTimeout the new locator cache timeout (in seconds)
+     * @param newTimeout the new locator cache timeout (in seconds); any negative value means
+     *     infinite and is normalized to -1
      * @return a proxy with the new timeout
      * @see Locator
      */
@@ -323,7 +324,9 @@ public interface ObjectPrx {
     /**
      * Creates a proxy that is identical to this proxy, except for the locator cache timeout.
      *
-     * @param newTimeout the new locator cache timeout
+     * @param newTimeout the new locator cache timeout; any negative timeout means infinite and is
+     *     normalized to -1 second, and a timeout that is not a whole number of seconds is rounded
+     *     up to the next whole number of seconds
      * @return a proxy with the new timeout
      * @see Locator
      */
@@ -332,7 +335,8 @@ public interface ObjectPrx {
     /**
      * Creates a proxy that is identical to this proxy, except for the invocation timeout.
      *
-     * @param newTimeout the new invocation timeout (in milliseconds)
+     * @param newTimeout the new invocation timeout (in milliseconds); any negative value means
+     *     infinite and is normalized to -1
      * @return a proxy with the new timeout
      */
     ObjectPrx ice_invocationTimeout(int newTimeout);
@@ -340,7 +344,9 @@ public interface ObjectPrx {
     /**
      * Creates a proxy that is identical to this proxy, except for the invocation timeout.
      *
-     * @param newTimeout the new invocation timeout
+     * @param newTimeout the new invocation timeout; any negative timeout means infinite and is
+     *     normalized to -1 millisecond, and a timeout that is not a whole number of milliseconds
+     *     is rounded up to the next whole number of milliseconds
      * @return a proxy with the new timeout
      */
     ObjectPrx ice_invocationTimeout(Duration newTimeout);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RoutableReference.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RoutableReference.java
@@ -263,16 +263,19 @@ class RoutableReference extends Reference {
             prefix + ".EndpointSelection",
             _endpointSelection == EndpointSelectionType.Random ? "Random" : "Ordered");
 
-        {
-            StringBuffer s = new StringBuffer();
-            s.append(getInvocationTimeout().toMillis());
-            properties.put(prefix + ".InvocationTimeout", s.toString());
-        }
-        {
-            StringBuffer s = new StringBuffer();
-            s.append(_locatorCacheTimeout.toSeconds());
-            properties.put(prefix + ".LocatorCacheTimeout", s.toString());
-        }
+        // Any negative timeout means infinite; we emit it as -1, the documented value for infinite. The
+        // timeouts are otherwise always whole numbers of the property's unit.
+        // TODO: remove the -1 normalization in 3.9, once the values read from the per-proxy timeout properties
+        // are normalized (or rejected) like the values set by the proxy methods.
+        Duration invocationTimeout = getInvocationTimeout();
+        properties.put(
+            prefix + ".InvocationTimeout",
+            invocationTimeout.isNegative() ? "-1" : Long.toString(invocationTimeout.toMillis()));
+        properties.put(
+            prefix + ".LocatorCacheTimeout",
+            _locatorCacheTimeout.isNegative()
+                ? "-1"
+                : Long.toString(_locatorCacheTimeout.toSeconds()));
 
         if (_routerInfo != null) {
             _ObjectPrxI h = (_ObjectPrxI) _routerInfo.getRouter();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RoutableReference.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RoutableReference.java
@@ -265,8 +265,8 @@ class RoutableReference extends Reference {
 
         // Any negative timeout means infinite; we emit it as -1, the documented value for infinite. The
         // timeouts are otherwise always whole numbers of the property's unit.
-        // TODO: remove the -1 normalization in 3.9, once the values read from the per-proxy timeout properties
-        // are normalized (or rejected) like the values set by the proxy methods.
+        // TODO: remove the -1 normalization in 3.9 (see #6112), once the values read from the per-proxy timeout
+        // properties are normalized (or rejected) like the values set by the proxy methods.
         Duration invocationTimeout = getInvocationTimeout();
         properties.put(
             prefix + ".InvocationTimeout",

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
@@ -379,8 +379,17 @@ class _ObjectPrxI implements ObjectPrx, Serializable {
 
     @Override
     public ObjectPrx ice_locatorCacheTimeout(Duration newTimeout) {
-        newTimeout =
-            newTimeout.isNegative() ? Duration.ofSeconds(-1) : roundUp(newTimeout, 1_000_000_000);
+        if (newTimeout.isNegative()) {
+            newTimeout = Duration.ofSeconds(-1);
+        } else {
+            newTimeout = roundUp(newTimeout, 1_000_000_000);
+            if (newTimeout.compareTo(Duration.ofSeconds(Integer.MAX_VALUE)) > 0) {
+                throw new IllegalArgumentException(
+                    "The locator cache timeout cannot be greater than "
+                        + Integer.MAX_VALUE
+                        + " seconds.");
+            }
+        }
         if (newTimeout.equals(_reference.getLocatorCacheTimeout())) {
             return this;
         } else {
@@ -395,8 +404,17 @@ class _ObjectPrxI implements ObjectPrx, Serializable {
 
     @Override
     public ObjectPrx ice_invocationTimeout(Duration newTimeout) {
-        newTimeout =
-            newTimeout.isNegative() ? Duration.ofMillis(-1) : roundUp(newTimeout, 1_000_000);
+        if (newTimeout.isNegative()) {
+            newTimeout = Duration.ofMillis(-1);
+        } else {
+            newTimeout = roundUp(newTimeout, 1_000_000);
+            if (newTimeout.compareTo(Duration.ofMillis(Integer.MAX_VALUE)) > 0) {
+                throw new IllegalArgumentException(
+                    "The invocation timeout cannot be greater than "
+                        + Integer.MAX_VALUE
+                        + " milliseconds.");
+            }
+        }
         if (newTimeout.equals(_reference.getInvocationTimeout())) {
             return this;
         } else {
@@ -405,7 +423,8 @@ class _ObjectPrxI implements ObjectPrx, Serializable {
     }
 
     // Rounds a nonnegative timeout up to a whole number of the given unit (a divisor of one second, in
-    // nanoseconds); a timeout within one unit of the maximum representable duration is rounded down instead.
+    // nanoseconds); a timeout within one unit of the maximum representable duration is rounded down instead, so
+    // this method never overflows. The caller rejects such a large result with its range check.
     private static Duration roundUp(Duration timeout, int unitNanos) {
         int remainder = timeout.getNano() % unitNanos;
         if (remainder == 0) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
@@ -379,6 +379,8 @@ class _ObjectPrxI implements ObjectPrx, Serializable {
 
     @Override
     public ObjectPrx ice_locatorCacheTimeout(Duration newTimeout) {
+        newTimeout =
+            newTimeout.isNegative() ? Duration.ofSeconds(-1) : roundUp(newTimeout, 1_000_000_000);
         if (newTimeout.equals(_reference.getLocatorCacheTimeout())) {
             return this;
         } else {
@@ -393,11 +395,27 @@ class _ObjectPrxI implements ObjectPrx, Serializable {
 
     @Override
     public ObjectPrx ice_invocationTimeout(Duration newTimeout) {
+        newTimeout =
+            newTimeout.isNegative() ? Duration.ofMillis(-1) : roundUp(newTimeout, 1_000_000);
         if (newTimeout.equals(_reference.getInvocationTimeout())) {
             return this;
         } else {
             return _newInstance(_reference.changeInvocationTimeout(newTimeout));
         }
+    }
+
+    // Rounds a nonnegative timeout up to a whole number of the given unit (a divisor of one second, in
+    // nanoseconds); a timeout within one unit of the maximum representable duration is rounded down instead.
+    private static Duration roundUp(Duration timeout, int unitNanos) {
+        int remainder = timeout.getNano() % unitNanos;
+        if (remainder == 0) {
+            return timeout;
+        }
+        int nanos = timeout.getNano() - remainder;
+        if (!(timeout.getSeconds() == Long.MAX_VALUE && nanos == 1_000_000_000 - unitNanos)) {
+            nanos += unitNanos;
+        }
+        return Duration.ofSeconds(timeout.getSeconds(), nanos);
     }
 
     @Override

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
@@ -382,13 +382,15 @@ class _ObjectPrxI implements ObjectPrx, Serializable {
         if (newTimeout.isNegative()) {
             newTimeout = Duration.ofSeconds(-1);
         } else {
-            newTimeout = roundUp(newTimeout, 1_000_000_000);
+            // The limit is a whole number of seconds, so a timeout that passes this check still fits after
+            // rounding up.
             if (newTimeout.compareTo(Duration.ofSeconds(Integer.MAX_VALUE)) > 0) {
                 throw new IllegalArgumentException(
                     "The locator cache timeout cannot be greater than "
                         + Integer.MAX_VALUE
                         + " seconds.");
             }
+            newTimeout = roundUp(newTimeout, 1_000_000_000);
         }
         if (newTimeout.equals(_reference.getLocatorCacheTimeout())) {
             return this;
@@ -407,13 +409,15 @@ class _ObjectPrxI implements ObjectPrx, Serializable {
         if (newTimeout.isNegative()) {
             newTimeout = Duration.ofMillis(-1);
         } else {
-            newTimeout = roundUp(newTimeout, 1_000_000);
+            // The limit is a whole number of milliseconds, so a timeout that passes this check still fits after
+            // rounding up.
             if (newTimeout.compareTo(Duration.ofMillis(Integer.MAX_VALUE)) > 0) {
                 throw new IllegalArgumentException(
                     "The invocation timeout cannot be greater than "
                         + Integer.MAX_VALUE
                         + " milliseconds.");
             }
+            newTimeout = roundUp(newTimeout, 1_000_000);
         }
         if (newTimeout.equals(_reference.getInvocationTimeout())) {
             return this;
@@ -422,19 +426,14 @@ class _ObjectPrxI implements ObjectPrx, Serializable {
         }
     }
 
-    // Rounds a nonnegative timeout up to a whole number of the given unit (a divisor of one second, in
-    // nanoseconds); a timeout within one unit of the maximum representable duration is rounded down instead, so
-    // this method never overflows. The caller rejects such a large result with its range check.
+    // Rounds a nonnegative timeout of at most Integer.MAX_VALUE units up to a whole number of the given unit
+    // (a divisor of one second, in nanoseconds).
     private static Duration roundUp(Duration timeout, int unitNanos) {
         int remainder = timeout.getNano() % unitNanos;
         if (remainder == 0) {
             return timeout;
         }
-        int nanos = timeout.getNano() - remainder;
-        if (!(timeout.getSeconds() == Long.MAX_VALUE && nanos == 1_000_000_000 - unitNanos)) {
-            nanos += unitNanos;
-        }
-        return Duration.ofSeconds(timeout.getSeconds(), nanos);
+        return Duration.ofSeconds(timeout.getSeconds(), timeout.getNano() - remainder + unitNanos);
     }
 
     @Override

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -34,6 +34,7 @@ import test.TestHelper;
 
 import java.io.PrintWriter;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -625,6 +626,17 @@ public class AllTests {
         test("200".equals(proxyProps.get("Test.Locator.Router.LocatorCacheTimeout")));
         test("1500".equals(proxyProps.get("Test.Locator.Router.InvocationTimeout")));
 
+        // A negative timeout is emitted as -1, and a positive timeout is rounded up to the next
+        // whole number of the property's unit.
+        b1 = b1.ice_locatorCacheTimeout(Duration.ofMillis(1500)).ice_invocationTimeout(-2);
+        proxyProps = communicator.proxyToProperty(b1, "Test");
+        test("2".equals(proxyProps.get("Test.LocatorCacheTimeout")));
+        test("-1".equals(proxyProps.get("Test.InvocationTimeout")));
+
+        b1 = b1.ice_locatorCacheTimeout(Duration.ofMillis(-500));
+        proxyProps = communicator.proxyToProperty(b1, "Test");
+        test("-1".equals(proxyProps.get("Test.LocatorCacheTimeout")));
+
         out.println("ok");
 
         out.print("testing ice_getCommunicator... ");
@@ -668,7 +680,7 @@ public class AllTests {
         test(
             base.ice_invocationTimeout(-2)
                 .ice_getInvocationTimeout()
-                .equals(Duration.ofMillis(-2)));
+                .equals(Duration.ofMillis(-1)));
 
         test(
             base.ice_locatorCacheTimeout(10)
@@ -682,7 +694,32 @@ public class AllTests {
         test(
             base.ice_locatorCacheTimeout(-2)
                 .ice_getLocatorCacheTimeout()
-                .equals(Duration.ofSeconds(-2)));
+                .equals(Duration.ofSeconds(-1)));
+
+        // A duration that is not a whole number of the timeout's unit is rounded up to the next
+        // whole number, and any negative duration is normalized to -1.
+        test(
+            base.ice_locatorCacheTimeout(Duration.ofMillis(1500))
+                .ice_getLocatorCacheTimeout()
+                .equals(Duration.ofSeconds(2)));
+        test(
+            base.ice_locatorCacheTimeout(Duration.ofNanos(-500_000))
+                .ice_getLocatorCacheTimeout()
+                .equals(Duration.ofSeconds(-1)));
+        test(
+            base.ice_invocationTimeout(Duration.ofNanos(1_500_000))
+                .ice_getInvocationTimeout()
+                .equals(Duration.ofMillis(2)));
+        test(
+            base.ice_invocationTimeout(Duration.ofNanos(-500_000))
+                .ice_getInvocationTimeout()
+                .equals(Duration.ofMillis(-1)));
+
+        // The maximum representable duration cannot be rounded up; it must not overflow.
+        test(
+            !base.ice_locatorCacheTimeout(ChronoUnit.FOREVER.getDuration())
+                .ice_getLocatorCacheTimeout()
+                .isNegative());
 
         // Ensure that the proxy methods can be called unambiguously with the correct return type.
         var diamondInterface = DiamondInterfacePrx.uncheckedCast(base);

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -731,6 +731,11 @@ public class AllTests {
             test(false);
         } catch (IllegalArgumentException ex) {
         }
+        try {
+            base.ice_invocationTimeout(ChronoUnit.FOREVER.getDuration());
+            test(false);
+        } catch (IllegalArgumentException ex) {
+        }
 
         // Ensure that the proxy methods can be called unambiguously with the correct return type.
         var diamondInterface = DiamondInterfacePrx.uncheckedCast(base);

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -715,11 +715,22 @@ public class AllTests {
                 .ice_getInvocationTimeout()
                 .equals(Duration.ofMillis(-1)));
 
-        // The maximum representable duration cannot be rounded up; it must not overflow.
-        test(
-            !base.ice_locatorCacheTimeout(ChronoUnit.FOREVER.getDuration())
-                .ice_getLocatorCacheTimeout()
-                .isNegative());
+        // A timeout greater than Integer.MAX_VALUE of the property's unit is rejected.
+        try {
+            base.ice_locatorCacheTimeout(Duration.ofSeconds(Integer.MAX_VALUE + 1L));
+            test(false);
+        } catch (IllegalArgumentException ex) {
+        }
+        try {
+            base.ice_locatorCacheTimeout(ChronoUnit.FOREVER.getDuration());
+            test(false);
+        } catch (IllegalArgumentException ex) {
+        }
+        try {
+            base.ice_invocationTimeout(Duration.ofMillis(Integer.MAX_VALUE + 1L));
+            test(false);
+        } catch (IllegalArgumentException ex) {
+        }
 
         // Ensure that the proxy methods can be called unambiguously with the correct return type.
         var diamondInterface = DiamondInterfacePrx.uncheckedCast(base);

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -74,7 +74,8 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject, Sendable {
 
     /// Creates a proxy that is identical to this proxy, except for the locator cache timeout.
     ///
-    /// - Parameter timeout: The new locator cache timeout (in seconds).
+    /// - Parameter timeout: The new locator cache timeout (in seconds). Any negative value means infinite and is
+    ///   normalized to -1.
     /// - Returns: A proxy with the new timeout.
     func ice_locatorCacheTimeout(_ timeout: Int32) -> Self
 
@@ -85,7 +86,8 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject, Sendable {
 
     /// Creates a proxy that is identical to this proxy, except for the invocation timeout.
     ///
-    /// - Parameter timeout: The new invocation timeout (in milliseconds).
+    /// - Parameter timeout: The new invocation timeout (in milliseconds). Any negative value means infinite and is
+    ///   normalized to -1.
     /// - Returns: A proxy with the new timeout.
     func ice_invocationTimeout(_ timeout: Int32) -> Self
 
@@ -613,7 +615,6 @@ open class ObjectPrxI: ObjectPrx, @unchecked Sendable {
 
     public func ice_locatorCacheTimeout(_ timeout: Int32) -> Self {
         precondition(!ice_isFixed(), "Cannot create a fixed proxy with a locatorCacheTimeout")
-        precondition(timeout >= -1, "Invalid locator cache timeout value")
         do {
             return try autoreleasepool {
                 try fromICEObjectPrx(handle.ice_locatorCacheTimeout(timeout)) as Self
@@ -628,7 +629,6 @@ open class ObjectPrxI: ObjectPrx, @unchecked Sendable {
     }
 
     public func ice_invocationTimeout(_ timeout: Int32) -> Self {
-        precondition(timeout >= 1 || timeout == -1 || timeout == -2, "Invalid invocation timeout value")
         do {
             return try autoreleasepool {
                 try fromICEObjectPrx(handle.ice_invocationTimeout(timeout)) as Self


### PR DESCRIPTION
## Summary

`ice_locatorCacheTimeout` and `ice_invocationTimeout` now normalize their argument at the API boundary, in C++, C# and Java:

- Any negative timeout means infinite and is normalized to -1 second (locator cache timeout) or -1 millisecond (invocation timeout).
- A positive timeout that is not a whole number of the corresponding property's unit (seconds for `LocatorCacheTimeout`, milliseconds for `InvocationTimeout`) is rounded up to the next whole number.
- A timeout greater than INT32_MAX of the property's unit — the maximum a proxy property can represent — is rejected with `std::invalid_argument` / `ArgumentOutOfRangeException` / `IllegalArgumentException`.

As a result, the timeouts stored in a proxy are always representable in the proxy property form, and `proxyToProperty` → `propertyToProxy` round-trips them exactly. Previously, a proxy with a 1500 ms locator cache timeout produced `LocatorCacheTimeout=1.5` in C# — which `propertyToProxy` then rejected with `PropertyException` — while C++ and Java silently emitted the truncated value `1`; a fractional-millisecond invocation timeout had the same defect in C#; and a huge timeout (e.g. `TimeSpan.MaxValue`) produced a property value outside the int32 range that `propertyToProxy` rejected in every mapping.

Swift's `Int32` timeout methods now inherit this normalization from the C++ core: the two preconditions that shadowed it are removed. `ice_locatorCacheTimeout(-2)` trapped instead of normalizing, `ice_invocationTimeout(0)` trapped even though the core accepts 0, and the `timeout == -2` allowance was a leftover of ICE-5666, dropped from the other mappings with `ice_timeout` in #2242. The other mappings with int32-only timeout APIs (Python, Ruby, PHP, MATLAB) inherit the normalization the same way.

`toProperty` also normalizes its output as a backstop: it emits `-1` for any negative stored timeout and rounds a positive locator cache timeout up to whole seconds. This remains necessary in 3.8 because the values read from the per-proxy `LocatorCacheTimeout`/`InvocationTimeout` properties bypass the proxy methods and are stored as-is (see the TODO comments); normalizing or validating these property values is left to #6112.

The doc-comments of all the timeout overloads now document this normalization.

### Caveat (C++)

The normalization of `ice_invocationTimeout` and `ice_locatorCacheTimeout` lives in inline template code in `Proxy.h`, so an existing application only picks it up when recompiled against the new headers. Code compiled against older 3.8 headers keeps the previous truncating behavior — one more reason `RoutableReference::toProperty` keeps its rounding/`-1` backstop until 3.9.

Fixes #6180.
Fixes #6189 — the C# immediate-`InvocationTimeoutException` trap for positive sub-millisecond invocation timeouts is resolved by rounding up to 1 ms rather than by rejecting the value, and the rule is applied uniformly to the three mappings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)