### PR TITLE
Prevent crash dump processing from hanging CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,10 +379,12 @@ jobs:
 
       - name: Process Linux crash dumps
         if: runner.os == 'Linux' && always()
+        timeout-minutes: 15
         run: |
           python3 scripts/process_linux_crash_dumps.py \
               --workspace $GITHUB_WORKSPACE \
-              --reports LinuxDumpReports
+              --reports LinuxDumpReports \
+              -v
         shell: bash
 
       - name: Upload Linux crash dump reports
@@ -403,6 +405,7 @@ jobs:
 
       - name: Process Windows crash dumps
         if: runner.os == 'Windows' && always()
+        timeout-minutes: 15
         shell: pwsh
         run: |
           $dumpDir   = Join-Path $env:GITHUB_WORKSPACE 'LocalDumps'
@@ -412,7 +415,8 @@ jobs:
               --dumps     $dumpDir `
               --workspace $env:GITHUB_WORKSPACE `
               --reports   $reportsDir `
-              --cdb "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe"
+              --cdb "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe" `
+              -v
 
       - name: Upload Windows crash dump reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/scripts/process_linux_crash_dumps.py
+++ b/scripts/process_linux_crash_dumps.py
@@ -43,6 +43,12 @@ from typing import Iterable, List
 
 LOGGER = logging.getLogger(__name__)
 
+# Timeouts (in seconds) for the external commands. Without them, a wedged gdb or coredumpctl
+# hangs the CI job until the job-level timeout.
+LIST_TIMEOUT = 60
+EXTRACT_TIMEOUT = 300
+GDB_TIMEOUT = 300
+
 # Matches lines from GDB's "info shared" output, e.g.:
 #   0x00007f... 0x00007f... Yes         /home/runner/work/ice/ice/cpp/lib/libIce.so.3.8
 #   0x00007f... 0x00007f... Yes (*)     /lib/x86_64-linux-gnu/libstdc++.so.6
@@ -51,11 +57,16 @@ SHARED_LIB_RE = re.compile(r"^\s*0x[0-9A-Fa-f]+\s+0x[0-9A-Fa-f]+\s+\S+(?:\s+\(\*
 
 def list_coredumps() -> list[dict]:
     """Return a list of core dump entries from ``coredumpctl``."""
-    result = subprocess.run(
-        ["coredumpctl", "list", "--json=short", "--no-pager"],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["coredumpctl", "list", "--json=short", "--no-pager"],
+            capture_output=True,
+            text=True,
+            timeout=LIST_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        LOGGER.error("coredumpctl list timed out after %d seconds", LIST_TIMEOUT)
+        return []
     if result.returncode != 0:
         LOGGER.info("coredumpctl list returned %d: %s", result.returncode, result.stderr.strip())
         return []
@@ -68,10 +79,15 @@ def list_coredumps() -> list[dict]:
 
 def extract_core(pid: int, dest: Path) -> bool:
     """Extract the core file for *pid* to *dest*. Returns True on success."""
-    result = subprocess.run(
-        ["coredumpctl", "dump", str(pid), "--output", str(dest), "--no-pager"],
-        capture_output=True,
-    )
+    try:
+        result = subprocess.run(
+            ["coredumpctl", "dump", str(pid), "--output", str(dest), "--no-pager"],
+            capture_output=True,
+            timeout=EXTRACT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        LOGGER.error("coredumpctl dump timed out after %d seconds for PID %d", EXTRACT_TIMEOUT, pid)
+        return False
     if result.returncode != 0:
         LOGGER.error("coredumpctl dump failed for PID %d: %s", pid, result.stderr.decode(errors="replace").strip())
         return False
@@ -85,6 +101,10 @@ def run_gdb(executable: Path, core: Path, output: Path) -> None:
         "-q",
         "-n",
         "-batch",
+        # Batch mode auto-answers "y" to every query, including the prompt that enables
+        # debuginfod; without this gdb can stall on network downloads for each library.
+        "-iex",
+        "set debuginfod enabled off",
         "-ex",
         "thread apply all bt full",
         "-ex",
@@ -95,7 +115,10 @@ def run_gdb(executable: Path, core: Path, output: Path) -> None:
     ]
     LOGGER.debug("Running: %s", " ".join(cmd))
     with open(output, "w", encoding="utf-8", errors="replace") as fp:
-        subprocess.run(cmd, stdout=fp, stderr=subprocess.STDOUT)
+        try:
+            subprocess.run(cmd, stdout=fp, stderr=subprocess.STDOUT, timeout=GDB_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            LOGGER.error("gdb timed out after %d seconds for %s", GDB_TIMEOUT, core)
 
 
 def parse_shared_libs(gdb_output: Path) -> Iterable[Path]:

--- a/scripts/process_windows_crash_dumps.py
+++ b/scripts/process_windows_crash_dumps.py
@@ -43,6 +43,10 @@ from typing import Iterable, List
 
 LOGGER = logging.getLogger(__name__)
 
+# Timeout (in seconds) for cdb, which downloads symbols from the Microsoft symbol server and can
+# otherwise hang the CI job until the job-level timeout.
+CDB_TIMEOUT = 300
+
 IMAGE_PATH_RE = re.compile(r"^\s*Image\s+path:\s+(.+)$", re.IGNORECASE)
 
 
@@ -59,7 +63,9 @@ def run_cdb(dump: Path, modules_txt: Path, cdb_exe: str) -> None:
         str(modules_txt),
     ]
     try:
-        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=CDB_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        LOGGER.error("cdb timed out after %d seconds for %s", CDB_TIMEOUT, dump)
     except FileNotFoundError as exc:
         LOGGER.error("Could not find cdb.exe - specify with --cdb or add it to PATH")
         raise SystemExit(1) from exc


### PR DESCRIPTION
The "Process Linux crash dumps" step can hang until the 6-hour job-level timeout: the processing scripts run external debuggers with no timeout, and a wedged `gdb` (or `cdb`) silently stalls the job. This happened on a recent CI run where the step sat for hours after a test failure left a core dump behind.

Changes:

- `process_linux_crash_dumps.py`: add timeouts to the `coredumpctl list` (60s), `coredumpctl dump` (300s), and `gdb` (300s) invocations. A timed-out `gdb` leaves a partial `backtrace.txt`, and processing continues with the remaining dumps. Also pass `set debuginfod enabled off` to `gdb`: batch mode auto-answers "y" to the debuginfod prompt on Ubuntu 24.04, which can stall on per-library network downloads.
- `process_windows_crash_dumps.py`: add a 300s timeout to the `cdb` invocation, which downloads symbols from the Microsoft symbol server.
- `ci.yml`: add `timeout-minutes: 15` to both crash dump processing steps as a backstop, and pass `-v` so the scripts report per-dump progress instead of running silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)