### PR TITLE
Fix two DEBUG macro checks that never fired

### DIFF
--- a/cpp/src/Ice/ResourceConfig.h
+++ b/cpp/src/Ice/ResourceConfig.h
@@ -18,7 +18,7 @@
 #    define ICE_LIBNAME(NAME) NAME ICE_SO_VERSION ""
 #endif
 
-#ifndef DEBUG
+#ifndef _DEBUG
 #    define VER_DEBUG 0
 #else
 #    define VER_DEBUG VS_FF_DEBUG

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -376,7 +376,7 @@ IcePHP::TypedInvocation::prepareRequest(
     }
 
     // The operation's configuration (zend_function) forces out parameters to be passed by reference.
-#ifdef DEBUG
+#ifndef NDEBUG
     for (int i = static_cast<int>(_op->inParams.size()); i < _op->numParams; ++i)
     {
         assert(Z_ISREF(args[i]));


### PR DESCRIPTION
Neither build system defines a bare `DEBUG`. Make adds `-DNDEBUG` for optimized builds and only `-g` otherwise, and MSBuild defines `_DEBUG` for Debug and `NDEBUG` for Release. These were the only two bare-`DEBUG` checks in the tree, and both were dead on every platform and configuration.

- `php/src/Operation.cpp`: the out-parameter `Z_ISREF` checks in `prepareRequest` were gated on `DEBUG`, so they had never run. Switched to `NDEBUG`, which is what governs `assert()` and what `Operation.cpp:778`, `Types.cpp`, `DefaultSliceLoader.cpp` and `Config.h` already use.
- `cpp/src/Ice/ResourceConfig.h`: `VER_DEBUG` was gated on `DEBUG`, so it was always `0` and the 31 `.rc` files using `FILEFLAGS VER_DEBUG` never set `VS_FF_DEBUG` — Windows debug binaries were not marked as debug builds. Switched to `_DEBUG`, matching `ICE_LIBNAME` six lines above and what MSBuild passes to `rc.exe`.

Found while auditing the codebase for dead code.