### PR TITLE
Honour the deb_build_options workflow input

### DIFF
--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -18,6 +18,7 @@ on:
       deb_build_options:
         type: string
         required: false
+        default: "nocheck parallel=4"
 
 jobs:
   build:
@@ -58,7 +59,7 @@ jobs:
           - distribution: sid
             arch: arm64
     env:
-      DEB_BUILD_OPTIONS: "nocheck parallel=4"
+      DEB_BUILD_OPTIONS: ${{ inputs.deb_build_options }}
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
`deb_build_options` is declared on both `workflow_dispatch` and `workflow_call`, but nothing reads it — the job hardcodes `DEB_BUILD_OPTIONS: "nocheck parallel=4"` and passes that to the container at line 96. Dispatching the workflow with a custom value silently discards it.

Gave the `workflow_call` input the same default the dispatch trigger already declared, and consumed the input in `env`. Using the input directly rather than a fallback expression means an explicitly empty value is honoured as "no options" instead of being overridden.

`build-release.yml` is the only caller and passes just `ice_version`, so it picks up the default and behaviour there is unchanged.

Found while auditing the codebase for dead code.