### PR TITLE
Correct the arg_info for IcePHP_defineClass

### DIFF
--- a/php/src/Init.cpp
+++ b/php/src/Init.cpp
@@ -28,11 +28,10 @@ ZEND_BEGIN_ARG_INFO_EX(Ice_declareClass_arginfo, 1, ZEND_RETURN_VALUE, static_ca
 ZEND_ARG_INFO(0, id)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(Ice_defineClass_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(6))
+ZEND_BEGIN_ARG_INFO_EX(Ice_defineClass_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(5))
 ZEND_ARG_INFO(0, id)
 ZEND_ARG_INFO(0, name)
 ZEND_ARG_INFO(0, compactId)
-ZEND_ARG_INFO(0, interface)
 ZEND_ARG_INFO(0, base)
 ZEND_ARG_INFO(0, members)
 ZEND_END_ARG_INFO()


### PR DESCRIPTION
`Ice_defineClass_arginfo` declares six parameters with `required_num_args` of six, but `IcePHP_defineClass` parses `"sslo!a!"` — five. Both call sites pass five: `php/lib/Ice/Value.php:27,44` and the code `slice2php` emits at `cpp/src/slice2php/Main.cpp:294`.

The extra `interface` argument is a leftover of the Ice 3.7 "interface by value" feature. Dropped it and set `required_num_args` to five, matching every other `arg_info` in the file — they all declare exactly as many arguments as their implementation parses.

PHP 8 exposes `arg_info` names through named arguments and Reflection, so the stale entry was visible as well as wrong.

Found while auditing the codebase for dead code.