### PR TITLE
Restore a dropped $ in IceRuby's extra_sources

### DIFF
--- a/ruby/src/IceRuby/Makefile.mk
+++ b/ruby/src/IceRuby/Makefile.mk
@@ -12,7 +12,7 @@ IceRuby_dependencies     := IceDiscovery IceLocatorDiscovery Ice
 IceRuby_libs            := mcpp
 IceRuby_extra_sources   := $(wildcard $(top_srcdir)/cpp/src/Slice/*.cpp) \
                            $(top_srcdir)/cpp/src/slice2rb/RubyUtil.cpp   \
-                           (top_srcdir)/cpp/src/slice2rb/Ruby.cpp        \
+                           $(top_srcdir)/cpp/src/slice2rb/Ruby.cpp       \
 
 #
 # On the default platform, always write the module in the ruby directory.


### PR DESCRIPTION
The `Ruby.cpp` entry in `IceRuby_extra_sources` lost its leading `$` in #1702, so it expands to a literal `(top_srcdir)/cpp/src/slice2rb/Ruby.cpp` rather than a real path.

### Why this never broke the build

`source-to-object` (`config/Make.project.rules:1112`) applies `$(notdir ...)`, so the broken entry and a correct one reduce to the same object name — `Ruby.o`. The bogus directory is discarded before the object list is built, so `Ruby.o` was always in the link.

`make-objects` is then invoked once per unique source *directory* (`config/Make.project.rules:489`), which leaves make holding two competing pattern rules for the same objdir:

```
src/IceRuby/build/macosx/obj/%.o: ../cpp/src/slice2rb/%.cpp            # from RubyUtil.cpp, line 14
src/IceRuby/build/macosx/obj/%.o: (top_srcdir)/cpp/src/slice2rb/%.cpp  # from line 15
```

Implicit-rule search picks the rule whose prerequisite actually exists, and the bogus path does not, so the real source wins. Confirmed by resolving the target directly: both before and after this change, make compiles `../cpp/src/slice2rb/Ruby.cpp`. The only observable difference is that the fix collapses the two rules to one.

### Why fix it anyway

The entry has been load-bearing in name only — `Ruby.cpp` compiled the whole time, carried by its neighbour. The failure mode is narrow and delayed: if `RubyUtil.cpp` is ever moved, renamed, or absorbed elsewhere, `cpp/src/slice2rb` stops being registered as a source directory. `Ruby.o` then either fails with "No rule to make target" or drops `Slice::Ruby::compile` from the extension, which `ruby/src/IceRuby/Slice.cpp:175` calls.

Found while auditing the codebase for dead code.
