### PR TITLE
Fix wrong-category eviction in the Java Logger admin facet

### DIFF
--- a/changelog.d/java/6108.md
+++ b/changelog.d/java/6108.md
@@ -1,0 +1,4 @@
+- Fixed the eviction of old log messages by the Logger admin facet. Once the facet had accumulated
+  `Ice.Admin.Logger.KeepLogs` log messages and `Ice.Admin.Logger.KeepTraces` trace messages, the arrival of a new
+  message could evict a message of the wrong category — for example, a new trace message could evict a warning
+  message. As a result, `getLog` and attached remote loggers could receive fewer or older messages than expected.

--- a/cpp/test/Ice/admin/AllTests.cpp
+++ b/cpp/test/Ice/admin/AllTests.cpp
@@ -533,6 +533,33 @@ allTests(Test::TestHelper* helper)
 
         com->destroy();
     }
+    {
+        // With KeepLogs=1 and KeepTraces=1, a new message evicts the previous message of the same category,
+        // regardless of the messages of the other category in between.
+        PropertyDict props;
+        props["Ice.Admin.Endpoints"] = "tcp -h " + defaultHost;
+        props["Ice.Admin.InstanceName"] = "Test";
+        props["NullLogger"] = "1";
+        props["Ice.Admin.Logger.KeepLogs"] = "1";
+        props["Ice.Admin.Logger.KeepTraces"] = "1";
+        optional<RemoteCommunicatorPrx> com = factory->createCommunicator(props);
+
+        com->print("print1");
+        com->trace("testCat", "trace1");
+        com->print("print2");
+        com->trace("testCat", "trace2");
+
+        auto logger = com->getAdmin()->ice_facet<LoggerAdminPrx>("Logger");
+        string prefix;
+
+        LogMessageSeq logMessages = logger->getLog(LogMessageTypeSeq(), StringSeq(), -1, prefix);
+        test(logMessages.size() == 2);
+        auto p = logMessages.begin();
+        test(p++->message == "print2");
+        test(p->message == "trace2");
+
+        com->destroy();
+    }
     cout << "ok" << endl;
 
     cout << "testing custom facet... " << flush;

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -416,6 +416,34 @@ public class AllTests : global::Test.AllTests
 
             com.destroy();
         }
+        {
+            // With KeepLogs=1 and KeepTraces=1, a new message evicts the previous message of the same category,
+            // regardless of the messages of the other category in between.
+            var props = new Dictionary<string, string>
+            {
+                { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                { "Ice.Admin.InstanceName", "Test" },
+                { "NullLogger", "1" },
+                { "Ice.Admin.Logger.KeepLogs", "1" },
+                { "Ice.Admin.Logger.KeepTraces", "1" }
+            };
+            Test.RemoteCommunicatorPrx com = factory.createCommunicator(props);
+
+            com.print("print1");
+            com.trace("testCat", "trace1");
+            com.print("print2");
+            com.trace("testCat", "trace2");
+
+            var logger = Ice.LoggerAdminPrxHelper.checkedCast(com.getAdmin(), "Logger");
+            test(logger != null);
+
+            Ice.LogMessage[] logMessages = logger.getLog(null, null, -1, out string prefix);
+            test(logMessages.Length == 2);
+            test(logMessages[0].message == "print2");
+            test(logMessages[1].message == "trace2");
+
+            com.destroy();
+        }
         output.WriteLine("ok");
 
         output.Write("testing custom facet... ");

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
@@ -175,39 +176,18 @@ final class LoggerAdminI implements LoggerAdmin {
             if (logMessage.type != LogMessageType.TraceMessage) {
                 assert (_maxLogCount > 0);
                 if (_logCount == _maxLogCount) {
-                    // Need to remove the oldest log from the queue
-                    assert (_oldestLog != -1);
-                    _queue.remove(_oldestLog);
-                    int qs = _queue.size();
-
-                    while (_oldestLog < qs && _queue.get(_oldestLog).type == LogMessageType.TraceMessage) {
-                        _oldestLog++;
-                    }
-                    assert (_oldestLog < qs); // remember: we just added a log message at end
+                    removeOldestLog();
                 } else {
                     assert (_logCount < _maxLogCount);
                     _logCount++;
-                    if (_oldestLog == -1) {
-                        _oldestLog = _queue.size() - 1;
-                    }
                 }
             } else {
                 assert (_maxTraceCount > 0);
                 if (_traceCount == _maxTraceCount) {
-                    // Need to remove the oldest trace from the queue
-                    assert (_oldestTrace != -1);
-                    _queue.remove(_oldestTrace);
-                    int qs = _queue.size();
-                    while (_oldestTrace < qs && _queue.get(_oldestTrace).type != LogMessageType.TraceMessage) {
-                        _oldestTrace++;
-                    }
-                    assert (_oldestTrace < qs); // remember: we just added a trace message at end
+                    removeOldestTrace();
                 } else {
                     assert (_traceCount < _maxTraceCount);
                     _traceCount++;
-                    if (_oldestTrace == -1) {
-                        _oldestTrace = _queue.size() - 1;
-                    }
                 }
             }
 
@@ -332,15 +312,36 @@ final class LoggerAdminI implements LoggerAdmin {
         return new Communicator(initData);
     }
 
+    // Removes the oldest log (non-trace) message from _queue.
+    private void removeOldestLog() {
+        Iterator<LogMessage> p = _queue.iterator();
+        while (p.hasNext()) {
+            if (p.next().type != LogMessageType.TraceMessage) {
+                p.remove();
+                return;
+            }
+        }
+        assert false; // the queue contains at least the log message we just added
+    }
+
+    // Removes the oldest trace message from _queue.
+    private void removeOldestTrace() {
+        Iterator<LogMessage> p = _queue.iterator();
+        while (p.hasNext()) {
+            if (p.next().type == LogMessageType.TraceMessage) {
+                p.remove();
+                return;
+            }
+        }
+        assert false; // the queue contains at least the trace message we just added
+    }
+
     private final List<LogMessage> _queue = new LinkedList<>();
     private int _logCount; // non-trace messages
     private final int _maxLogCount;
     private int _traceCount;
     private final int _maxTraceCount;
     private final int _traceLevel;
-
-    private int _oldestTrace = -1;
-    private int _oldestLog = -1;
 
     private static class Filters {
         Filters(LogMessageType[] m, String[] c) {

--- a/java/test/src/main/java/test/Ice/admin/AllTests.java
+++ b/java/test/src/main/java/test/Ice/admin/AllTests.java
@@ -437,6 +437,32 @@ public class AllTests {
 
             rcom.destroy();
         }
+        {
+            // With KeepLogs=1 and KeepTraces=1, a new message evicts the previous message of the
+            // same category, regardless of the messages of the other category in between.
+            Map<String, String> props = new HashMap<>();
+            props.put("Ice.Admin.Endpoints", "tcp -h 127.0.0.1");
+            props.put("Ice.Admin.InstanceName", "Test");
+            props.put("NullLogger", "1");
+            props.put("Ice.Admin.Logger.KeepLogs", "1");
+            props.put("Ice.Admin.Logger.KeepTraces", "1");
+            RemoteCommunicatorPrx rcom = factory.createCommunicator(props);
+
+            rcom.print("print1");
+            rcom.trace("testCat", "trace1");
+            rcom.print("print2");
+            rcom.trace("testCat", "trace2");
+
+            LoggerAdminPrx logger = LoggerAdminPrx.checkedCast(rcom.getAdmin(), "Logger");
+            test(logger != null);
+
+            LoggerAdmin.GetLogResult r = logger.getLog(null, null, -1);
+            test(r.returnValue.length == 2);
+            test("print2".equals(r.returnValue[0].message));
+            test("trace2".equals(r.returnValue[1].message));
+
+            rcom.destroy();
+        }
         out.println("ok");
 
         out.print("testing custom facet... ");


### PR DESCRIPTION
## Summary

The Java `LoggerAdminI` tracked the oldest log and the oldest trace message by absolute position (`_oldestLog`, `_oldestTrace`) in the single queue shared by both categories. Removing a message shifts the positions of all later messages, so the other category's stale index could evict the wrong message. With the caps set to 1, the sequence print, trace, print, trace left the queue with two trace messages and no log message at all. The C++ and C# implementations use stable `list` iterators / `LinkedListNode` references and don't have this bug; the Java port mistranslated them into indexes.

The fix removes the cached positions entirely: when a category is at its cap, the queue is scanned from the head and the first message of that category is removed. With no cross-category state, wrong-category eviction is impossible by construction, and the scan is bounded by the queue's configured capacity.

The new eviction test runs in all three mappings; it fails against the previous Java code and passes against the (already correct) C++ and C# implementations.

Fixes #6108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)