### PR TITLE
Detach the encaps node popped from the cache in initEncaps

### DIFF
--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2991,6 +2991,8 @@ public sealed class InputStream
             if (_encapsStack != null)
             {
                 _encapsCache = _encapsCache!.next;
+                // Detach the reused node from the cache: as the outermost encapsulation it has no next.
+                _encapsStack.next = null;
             }
             else
             {

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -2270,6 +2270,8 @@ public sealed class OutputStream
             if (_encapsStack != null)
             {
                 _encapsCache = _encapsCache!.next;
+                // Detach the reused node from the cache: as the outermost encapsulation it has no next.
+                _encapsStack.next = null;
             }
             else
             {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -2257,6 +2257,8 @@ public final class InputStream {
             _encapsStack = _encapsCache;
             if (_encapsStack != null) {
                 _encapsCache = _encapsCache.next;
+                // Detach the reused node from the cache: as the outermost encapsulation it has no next.
+                _encapsStack.next = null;
             } else {
                 _encapsStack = new Encaps();
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
@@ -1887,6 +1887,8 @@ public final class OutputStream {
             _encapsStack = _encapsCache;
             if (_encapsStack != null) {
                 _encapsCache = _encapsCache.next;
+                // Detach the reused node from the cache: as the outermost encapsulation it has no next.
+                _encapsStack.next = null;
             } else {
                 _encapsStack = new Encaps();
             }


### PR DESCRIPTION
This PR fixes the C# and Java `initEncaps` implementations (`OutputStream` and `InputStream` in both mappings) to detach the encapsulation node they pop off the `_encapsCache` free list, mirroring the JavaScript fix from #6212. Without the detach, the node installed as `_encapsStack` keeps a stale `next` link into the remaining cache, and the `_encapsStack.next == null` assertion in `clear()` can fire spuriously.

Note that this is a latent bug: the assertion is debug-only (`Debug.Assert` in C#, `-ea` in Java), and the trigger sequence cannot occur inside the Ice runtime itself. Reaching it takes three steps on one stream:

1. Ending a nested encapsulation, so the cache holds two chained nodes. The only nested encapsulation in the Slice encoding is an endpoint encapsulation inside a parameter/return/exception encapsulation, so this means marshaling or unmarshaling a proxy with at least one endpoint. Sequential top-level encapsulations (e.g. batch requests) never chain nodes, since `startEncapsulation` pops the node right back.
2. Taking the lazy `initEncaps` path — calling `writeValue`/`writeException`/`readValue`/`throwException` with no open encapsulation. The runtime always opens an explicit encapsulation first; only application code using the streaming API directly can take this path.
3. Calling `clear()`/`reset()` on that stream. The only in-tree caller is `ConnectionI`'s stream reuse, and those streams never take step 2.

So only an application driving the streaming API through this exact sequence, in a debug build, can see the assertion failure. There is no data or control-flow consequence either way — hence no CHANGELOG entry.

The C++ and Swift streams are not affected: C++ uses an embedded pre-allocated encaps with no free list, and Swift supports a single encapsulation per stream.

The generality that makes this bug possible is tracked separately for 3.9 in #6251.

Fixes #6216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
