### PR TITLE
Make ObjectAdapter.destroy retryable after an interrupt

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -329,46 +329,56 @@ public final class ObjectAdapter {
             _state = StateDestroying;
         }
 
-        if (_routerInfo != null) {
-            // Remove entry from the router manager.
-            _instance.routerManager().erase(_routerInfo.getRouter());
+        try {
+            if (_routerInfo != null) {
+                // Remove entry from the router manager.
+                _instance.routerManager().erase(_routerInfo.getRouter());
 
-            // Clear this object adapter with the router.
-            _routerInfo.setAdapter(null);
-        }
-
-        _instance.outgoingConnectionFactory().removeAdapter(this);
-
-        // Now it's also time to clean up our servants and servant locators.
-        _servantManager.destroy();
-
-        // Destroy the thread pool.
-        if (_threadPool != null) {
-            _threadPool.destroy();
-            try {
-                _threadPool.joinWithAllThreads();
-            } catch (InterruptedException e) {
-                throw new OperationInterruptedException(e);
+                // Clear this object adapter with the router.
+                _routerInfo.setAdapter(null);
             }
-        }
 
-        _objectAdapterFactory.removeObjectAdapter(this);
+            _instance.outgoingConnectionFactory().removeAdapter(this);
 
-        synchronized (this) {
-            _incomingConnectionFactories.clear();
+            // Now it's also time to clean up our servants and servant locators.
+            _servantManager.destroy();
 
-            // Remove object references (some of them cyclic).
-            _instance = null;
-            _threadPool = null;
-            _routerInfo = null;
-            _publishedEndpoints = new EndpointI[0];
-            _locatorInfo = null;
-            _reference = null;
-            _objectAdapterFactory = null;
+            // Destroy the thread pool.
+            if (_threadPool != null) {
+                _threadPool.destroy();
+                try {
+                    _threadPool.joinWithAllThreads();
+                } catch (InterruptedException e) {
+                    throw new OperationInterruptedException(e);
+                }
+            }
 
-            // Signal that destroying is complete.
-            _state = StateDestroyed;
-            notifyAll();
+            _objectAdapterFactory.removeObjectAdapter(this);
+
+            synchronized (this) {
+                _incomingConnectionFactories.clear();
+
+                // Remove object references (some of them cyclic).
+                _instance = null;
+                _threadPool = null;
+                _routerInfo = null;
+                _publishedEndpoints = new EndpointI[0];
+                _locatorInfo = null;
+                _reference = null;
+                _objectAdapterFactory = null;
+
+                // Signal that destroying is complete.
+                _state = StateDestroyed;
+                notifyAll();
+            }
+        } finally {
+            synchronized (this) {
+                if (_state == StateDestroying) {
+                    // The destruction was interrupted: restore a state that allows destroy to be called again.
+                    _state = StateDeactivated;
+                    notifyAll();
+                }
+            }
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -374,7 +374,7 @@ public final class ObjectAdapter {
         } finally {
             synchronized (this) {
                 if (_state == StateDestroying) {
-                    // The destruction was interrupted: restore a state that allows destroy to be called again.
+                    // Destroy did not complete: restore a state that allows destroy to be called again.
                     _state = StateDeactivated;
                     notifyAll();
                 }

--- a/java/test/src/main/java/test/Ice/interrupt/AllTests.java
+++ b/java/test/src/main/java/test/Ice/interrupt/AllTests.java
@@ -462,6 +462,35 @@ public class AllTests {
         }
         out.println("ok");
 
+        out.print("testing ObjectAdapter.destroy interrupt... ");
+        out.flush();
+        {
+            InitializationData initData = new InitializationData();
+            initData.properties = communicator.getProperties()._clone();
+            initData.properties.setProperty("DestroyAdapter.ThreadPool.Size", "1");
+            Communicator ic = helper.initialize(initData);
+            ObjectAdapter adapter = ic.createObjectAdapter("DestroyAdapter");
+            adapter.activate();
+
+            // Deactivate first so that destroy proceeds directly to joining with the adapter's thread pool.
+            adapter.deactivate();
+            adapter.waitForDeactivate();
+
+            Thread.currentThread().interrupt();
+            try {
+                adapter.destroy();
+                failIfNotInterrupted();
+            } catch (OperationInterruptedException ex) {
+                // Expected: destroy joins with the adapter's thread pool, and Thread.join throws
+                // InterruptedException immediately because the interrupted flag is set.
+            }
+
+            // destroy can be called again after an interrupt.
+            adapter.destroy();
+            ic.destroy();
+        }
+        out.println("ok");
+
         out.print("testing server interrupt... ");
         out.flush();
         {


### PR DESCRIPTION
When a thread was interrupted while `ObjectAdapter.destroy` joined with the adapter's thread pool, the resulting `OperationInterruptedException` left the adapter stuck in `StateDestroying` with no recovery path: every subsequent `destroy()` — including the one performed by `Communicator.destroy()` — blocked forever waiting for the state to advance.

This broke the retry-after-interrupt behavior the Java mapping implements for `Communicator.destroy()`: `Instance.destroy` restores a retryable state in a `finally` block precisely so that an interrupted `destroy` can be called again, but the interrupt propagating out of `ObjectAdapter.destroy` made that retry hang.

The fix mirrors `Instance.destroy`: the destroy body now runs in a `try`/`finally`, and the `finally` rolls the state back to `StateDeactivated` (and notifies waiters) when destruction did not complete. All the steps before the join are idempotent (`ThreadPool.destroy`, `ServantManager.destroy`, `OutgoingConnectionFactory.removeAdapter`, `RouterManager.erase`), so a retried `destroy` safely re-runs them and completes.

A new test in `Ice/interrupt` covers this: it deactivates an adapter with its own thread pool, sets the interrupt flag so the join throws deterministically, and verifies that a second `destroy()` completes. Without the fix, the second `destroy()` hangs forever.

On the issue's severity: it is overstated. Interrupt support is not documented at all in the current documentation; only the legacy 3.7/3.6 manual documented interruption points and the destroy-in-a-loop pattern, and it never mentioned `ObjectAdapter.destroy`. This fix aligns the adapter with the retry behavior the code itself implements for `Communicator.destroy()`. Given the narrow trigger, there is no CHANGELOG entry.

This is specific to the Java mapping: thread interrupt support does not exist in the other language mappings.

Fixes #6109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
