### PR TITLE
Catch Throwable from connection close callbacks in Java

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -301,7 +301,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         public void run() {
                             try {
                                 callback.closed(ConnectionI.this);
-                            } catch (LocalException ex) {
+                            } catch (Throwable ex) {
                                 _logger.error("connection callback exception:\n" + ex + '\n' + _desc);
                             }
                         }
@@ -898,7 +898,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         if (_closeCallback != null) {
             try {
                 _closeCallback.closed(this);
-            } catch (LocalException ex) {
+            } catch (Throwable ex) {
                 _logger.error("connection callback exception:\n" + ex + '\n' + _desc);
             }
             _closeCallback = null;

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -955,6 +955,19 @@ public class AllTests {
                 cb.check();
             }
             {
+                // Setting a close callback on an already-closed connection invokes the callback
+                // immediately; an Error thrown by the callback is logged, not propagated.
+                p.ice_ping(); // Establishes a new working connection: the previous one is closed.
+                Connection con = p.ice_getConnection();
+                con.close();
+                Callback cb = new Callback();
+                con.setCloseCallback(c -> {
+                    cb.called();
+                    throw new AssertionError("close callback");
+                });
+                cb.check();
+            }
+            {
                 //
                 // Remote case.
                 //

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -941,6 +941,20 @@ public class AllTests {
                 cb.check();
             }
             {
+                // A close callback that throws: the exception is logged and the connection still
+                // finishes (a stranded connection would hang Communicator.destroy at the end of the
+                // test).
+                p.ice_ping(); // Establishes a new working connection: the previous one is closed.
+                Connection con = p.ice_getConnection();
+                Callback cb = new Callback();
+                con.setCloseCallback(c -> {
+                    cb.called();
+                    throw new RuntimeException("close callback");
+                });
+                con.close();
+                cb.check();
+            }
+            {
                 //
                 // Remote case.
                 //


### PR DESCRIPTION
In the Java mapping, the connection close callback was invoked under `catch (LocalException)`, so a `RuntimeException` (or `Error`) thrown by a user-supplied `CloseCallback` escaped `ConnectionI.finish` before `StateFinished` was set and before the connection was removed from its factory. The connection then never finished, and `Communicator.destroy()` hung forever in `waitUntilFinished`. I reproduced this hang with a standalone program: the exception propagates from the callback through `ConnectionI.finish` into the thread pool, which logs it and carries on, leaving the connection stranded.

The fix widens the guard to `catch (Throwable)` at both call sites — `finish()` and the immediate dispatch in `setCloseCallback` when the connection is already closed — matching the convention used elsewhere in the Java runtime for user callbacks, and the behavior of the other mappings (C++ catches `...`, C# catches `System.Exception`, JS catches everything).

A new case in the `Ice/ami` test sets a throwing close callback on an active connection and closes it. Without the fix, the test suite hangs at communicator destruction; with the fix, the exception is logged and the connection finishes normally. Note the `ice_ping` in the test is load-bearing: after the previous case closes the connection, `ice_getConnection` returns the same closed connection, and a callback set on it takes the immediate-dispatch path instead of the `finish()` path.

Close callbacks are not supposed to throw, so this is a robustness/consistency fix rather than the High-severity issue reported; there is no CHANGELOG entry.

Fixes #6101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
