### PR TITLE
Wait for the reader's reconnect edge in the DataStorm reliability test

### DIFF
--- a/cpp/test/DataStorm/reliability/Writer.cpp
+++ b/cpp/test/DataStorm/reliability/Writer.cpp
@@ -145,8 +145,8 @@ void ::Writer::run(int argc, char* argv[])
         // published after the callback cannot overtake the batch.
         auto gate = make_shared<ReconnectGate>();
         writer.onConnectedReaders(
-            [](vector<string>) {},
-            [gate](CallbackReason reason, string)
+            [](const vector<string>&) {},
+            [gate](CallbackReason reason, const string&)
             {
                 lock_guard lock{gate->mutex};
                 if (reason == CallbackReason::Disconnect)

--- a/cpp/test/DataStorm/reliability/Writer.cpp
+++ b/cpp/test/DataStorm/reliability/Writer.cpp
@@ -3,8 +3,21 @@
 #include "DataStorm/DataStorm.h"
 #include "TestHelper.h"
 
+#include <condition_variable>
+#include <mutex>
+
 using namespace DataStorm;
 using namespace std;
+
+// Records that the writer's reader disconnected and then reconnected. The disconnect edge is latched, so a reconnect
+// that completes before the writer starts waiting is not missed.
+struct ReconnectGate
+{
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool disconnected{false};
+    bool reconnected{false};
+};
 
 class Writer : public Test::TestHelper
 {
@@ -122,12 +135,46 @@ void ::Writer::run(int argc, char* argv[])
         Topic<string, int> barrier(node, "partialUpdateReconnectBarrier");
         topic.setUpdater<string>("append", [](string& value, const string& suffix) { value += suffix; });
         auto writer = makeSingleKeyWriter(topic, "key", "", config);
+
+        // Latch the reader's disconnect and the reconnect that follows it. waitForReaders only inspects the current
+        // listener count, so on its own it can return on the pre-disconnect attachment while the reader's detach is
+        // still on its way; with a relay between the two nodes the reader's barrier signal can arrive first. A sample
+        // published then is not delivered live, and the reattach folds it into an initialization batch, where a
+        // leading partial update is resolved into a full one. The connect callback is queued by the attach that
+        // computes that batch while it holds the topic mutex, and publishing takes the same mutex, so a sample
+        // published after the callback cannot overtake the batch.
+        auto gate = make_shared<ReconnectGate>();
+        writer.onConnectedReaders(
+            [](vector<string>) {},
+            [gate](CallbackReason reason, string)
+            {
+                lock_guard lock{gate->mutex};
+                if (reason == CallbackReason::Disconnect)
+                {
+                    gate->disconnected = true;
+                }
+                else if (gate->disconnected)
+                {
+                    gate->reconnected = true;
+                    gate->condition.notify_all();
+                }
+            });
+
         writer.waitForReaders();
         writer.add("base");
 
         // Wait until the reader consumes the full value, closes the connection, and reconnects. The reconnect resumes
         // after the add, so this partial update must resolve against the reader's retained pre-disconnect base.
         [[maybe_unused]] auto ready = makeSingleKeyReader(barrier, "ready").getNextUnread();
+        {
+            // The bound only exists to fail with an assertion rather than block forever, so it has to sit outside the
+            // window in which DataStorm still recovers on its own: six retries backing off from 500ms, doubled again
+            // for a peer whose endpoints are unknown, is 64 seconds.
+            unique_lock lock{gate->mutex};
+            test(gate->condition.wait_for(lock, chrono::seconds(90), [&gate] { return gate->reconnected; }));
+        }
+
+        // The latch records that a reader reconnected, not that one is attached now, so keep the level check too.
         writer.waitForReaders();
         writer.partialUpdate<string>("append")("-after-reconnect");
         writer.update("done");

--- a/cpp/test/DataStorm/reliability/Writer.cpp
+++ b/cpp/test/DataStorm/reliability/Writer.cpp
@@ -169,7 +169,10 @@ void ::Writer::run(int argc, char* argv[])
         {
             // The bound only exists to fail with an assertion rather than block forever, so it has to sit outside the
             // window in which DataStorm still recovers on its own: six retries backing off from 500ms, doubled again
-            // for a peer whose endpoints are unknown, is 64 seconds.
+            // for a peer whose endpoints are unknown, is 64 seconds. That puts it above the 60 second no-output
+            // watchdog the test driver applies to local processes (scripts/Util.py), and this wait is silent, so a
+            // genuine failure is reported there as a hanging process before the assertion fires. In CI the driver
+            // waits 300 seconds and the assertion comes first.
             unique_lock lock{gate->mutex};
             test(gate->condition.wait_for(lock, chrono::seconds(90), [&gate] { return gate->reconnected; }));
         }


### PR DESCRIPTION
Fixes #6245.

The `testing partial update after reconnect` sub-test needs the writer to publish *after* the reader has resumed, so the partial update is delivered live. Its guard was `writer.waitForReaders()`, which only inspects the **current** listener count (`DataElementI.cpp:570-585`). While the reader's detach is still in flight the count is still one, so the guard returns on the pre-disconnect attachment and the writer publishes into a window where the reader cannot receive. The samples are then replayed through the reattach's initialization batch, where a leading partial update is deliberately resolved into a full `Update` (`DataElementI.cpp:1527-1532`) — so the reader sees `Update` where the test asserts `PartialUpdate`.

The writer now waits for the disconnect and the connect that follows it, via `onConnectedReaders`, and **keeps the listener-count check afterwards**. Three properties matter:

- The connect callback is queued by the attach that computes the reader's initialization batch, while that attach holds the topic mutex (`DataElementI.cpp:236-239`, `SessionI.cpp:464`), and publishing takes the same mutex (`DataElementI.cpp:1211`). A sample published after the callback therefore cannot overtake the batch. (The callback executor is global and can be flushed early by an unrelated dispatch, so the ordering rests on the topic mutex, not on the flush point.)
- A latched edge cannot miss a transient zero. `waitForNoReaders()` + `waitForReaders()` would not work here: `waitForNoReaders()` is `waitForReaders(-1)` (`DataStorm.h:1290-1292`) and equally level-triggered, so a detach and reattach that both complete before the call would leave it waiting forever.
- The latch is sticky — it records that a reader reconnected at some earlier instant, not that one is attached now — so `waitForReaders()` is retained after the edge wait rather than replaced by it.

The wait is bounded and asserted so a genuine failure to reconnect fails with a clear assertion instead of blocking. The bound is 90s, chosen to sit outside DataStorm's own recovery window: `Node.RetryCount=6` retries backing off from `Node.RetryDelay=500ms` reach 32s, doubled again for a peer whose endpoints are unknown (`SessionI.cpp:845-851`), i.e. 64s. A shorter bound could fail while recovery was still legitimately in progress.

Test-only change, no changelog entry.

## Testing

- `make -C cpp -j10 srcs tests`
- `python3 allTests.py --filter=DataStorm/reliability` — **15/15 runs passed** before the review corrections and **12/12 after**, each run covering all 16 configured topologies (so 432 executions of this sub-test in total)
- `python3 allTests.py --filter=DataStorm` — 11/11 passed

The repeated runs are also a check on the gate itself rather than just an absence of failures: the bounded wait is asserted, so if the edge were never observed — an inert or mis-latched gate — the sub-test would fail on the bounded wait's assertion in every topology. It did not fire once.

## On reproduction

I was **not** able to construct a deterministic local reproduction of the failing interleaving, and I would rather say so than present a weak one. Three attempts, all of which left the suite green (25/25 before this change, and 15/15 after):

1. **Writer stalls 200 ms after consuming `ready`.** Backwards — the stall gives the reconnect time to complete, which is the passing state, not the failing one.
2. **Reader signals `ready` before closing, plus a writer-side adapter `hold()`/`activate()` window** (the technique that worked for #6220). The held adapter does not stop the writer from processing the peer's close, so the detach lands during the hold and no stale-high count is created.
3. **Multicast two-connection topology**, so the barrier can travel a different connection than the one the reader closes. Did not lose the race in 5 runs.

The window in CI was ~10 ms wide and localized inside the relay node (`NodeSessionI::destroy` sends disconnect notifications asynchronously), which is not reachable from the test. The definitive evidence for the defect is the CI trace analysed in #6245: `ready` consumed at `.640`, the writer's detach at `.650`, and the reattach at `.679` carrying `initializing elements '[e1->e1:sz2]@4'`.

Reviewers should therefore weigh the mechanism argument and the cited ordering guarantees above rather than a red→green demonstration.

## Review

Cross-reviewed by OpenAI Codex (GPT-5.6) against the committed change, with the design restated as nine claims to refute. It confirmed that the race is closed in all topologies — including the relay cases, where `NodeForwarder::confirmCreateSessionAsync` records the writer's publisher session precisely so a target-reader disconnect is reported (`NodeSessionI.cpp:107`, `:220`) — and that the callback capture, bounded wait, and C++17 usage are sound.

It rejected the first version of this patch on two points, both fixed above:

1. **The sticky latch does not prove a reader is attached at publish time.** A later disconnect sets `disconnected` again but leaves `reconnected` true, while the listener count can legitimately fall to zero. `waitForReaders()` is now kept after the edge wait instead of being replaced by it.
2. **The original 20s bound was not derived from anything.** It sits inside DataStorm's 64s recovery envelope and could have failed while recovery was still in progress — converting one flake into another. Raised to 90s with the derivation recorded in the code.

It also noted my original justification was overstated: the callback executor is global, so an unrelated concurrent flush can deliver the callback early. The ordering guarantee comes from the shared topic mutex, and the description above now says so.

One residual, flagged as unverifiable from source: the gate has no epoch or connection identity, so any earlier recovery on this element would satisfy it. Making that categorical would need a pre-close barrier so the writer arms a fresh generation before the reader closes. In this test the sequence is controlled — registration precedes `add("base")`, and the reader closes only after consuming that base — so it is not reachable here, but it is worth knowing if this pattern gets copied.
