### PR TITLE
Move minWireSize from the enum type to EnumHelper

### DIFF
--- a/js/packages/ice/src/Ice/EnumBase.js
+++ b/js/packages/ice/src/Ice/EnumBase.js
@@ -46,6 +46,12 @@ class EnumHelper {
     readOptional(is, tag) {
         return this._enumType._readOpt(is, tag);
     }
+
+    // SequenceHelper.read consults this to sanity-check a sequence's declared element count against the
+    // remaining buffer. An enum marshals as a size, which occupies at least one byte.
+    get minWireSize() {
+        return 1;
+    }
 }
 
 export function defineEnum(enumerators) {
@@ -67,8 +73,6 @@ export function defineEnum(enumerators) {
             maxValue = value;
         }
     }
-
-    Object.defineProperty(type, "minWireSize", { get: () => 1 });
 
     type._write = function (os, v) {
         os.writeEnum(v);


### PR DESCRIPTION
`minWireSize` was defined on the enum type rather than on `EnumHelper`. slice2js emits `<Type>._helper` in every helper position, so the stream helpers never saw it.

- `SequenceHelper.read` passes it to `readAndCheckSeqSize`, so for `sequence<SomeEnum>` the size check computed `sz * undefined === NaN` and never fired.
- The NaN then persisted: the reset condition is also false against NaN, so the guard stayed disabled for every later sequence on the same `InputStream`.
- Decoding was never affected. `minSize` feeds only the bounds check, not the element count read from the wire, so well-formed sequences read identically before and after; malformed ones now fail up front instead of on buffer underrun.
- Moved the property to `EnumHelper`, where the five readers in `StreamHelpers.js` actually look.
- Dictionaries and the fixed-length branches are unaffected; neither reaches an enum's `minWireSize`.
