### PR TITLE
Remove some dead code in C++ 

### DIFF
--- a/cpp/include/Ice/StringUtil.h
+++ b/cpp/include/Ice/StringUtil.h
@@ -104,11 +104,6 @@ namespace IceInternal
     ICE_API std::string toUpper(std::string_view);
     ICE_API bool isAlpha(char);
     ICE_API bool isDigit(char);
-
-    //
-    // Remove all whitespace from a string
-    //
-    ICE_API std::string removeWhitespace(std::string_view);
 }
 
 #endif

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -1510,7 +1510,6 @@ IceInternal::IncomingConnectionFactory::startAcceptor()
         return;
     }
 
-    _acceptorStopped = false;
     createAcceptor();
 }
 
@@ -1523,7 +1522,6 @@ IceInternal::IncomingConnectionFactory::stopAcceptor()
         return;
     }
 
-    _acceptorStopped = true;
     _acceptorStarted = false;
     if (_adapter->getThreadPool()->finish(shared_from_this(), true))
     {

--- a/cpp/src/Ice/ConnectionFactory.h
+++ b/cpp/src/Ice/ConnectionFactory.h
@@ -241,9 +241,6 @@ namespace IceInternal
         EndpointIPtr _endpoint;
 
         bool _acceptorStarted{false};
-#if defined(__APPLE__) && TARGET_OS_IPHONE != 0
-        bool _acceptorStopped{false};
-#endif
 
         std::shared_ptr<Ice::ObjectAdapterI> _adapter;
         const bool _warn;

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -919,12 +919,6 @@ IceInternal::Instance::setLogger(const Ice::LoggerPtr& logger)
     _initData.logger = logger;
 }
 
-void
-IceInternal::Instance::setThreadHook(function<void()> threadStart, function<void()> threadStop)
-{
-    _initData.threadStart = std::move(threadStart);
-    _initData.threadStop = std::move(threadStop);
-}
 namespace
 {
     bool logStdErrConvert = true;

--- a/cpp/src/Ice/Instance.h
+++ b/cpp/src/Ice/Instance.h
@@ -40,9 +40,6 @@ namespace IceInternal
     class ThreadObserverTimer;
     using ThreadObserverTimerPtr = std::shared_ptr<ThreadObserverTimer>;
 
-    class MetricsAdminI;
-    using MetricsAdminIPtr = std::shared_ptr<MetricsAdminI>;
-
     /// Structure to track warnings for attempts to set socket buffer sizes.
     struct BufSizeWarnInfo
     {
@@ -112,7 +109,6 @@ namespace IceInternal
         void setDefaultRouter(const std::optional<Ice::RouterPrx>&);
 
         void setLogger(const Ice::LoggerPtr&);
-        void setThreadHook(std::function<void()>, std::function<void()>);
 
         [[nodiscard]] const Ice::StringConverterPtr& getStringConverter() const { return _stringConverter; }
         [[nodiscard]] const Ice::WstringConverterPtr& getWstringConverter() const { return _wstringConverter; }
@@ -178,7 +174,6 @@ namespace IceInternal
         ThreadObserverTimerPtr _timer;
         EndpointFactoryManagerPtr _endpointFactoryManager;
         Ice::PluginManagerPtr _pluginManager;
-        const Ice::ImplicitContextPtr _implicitContext;
         Ice::StringConverterPtr _stringConverter;
         Ice::WstringConverterPtr _wstringConverter;
         bool _adminEnabled{false};
@@ -186,7 +181,6 @@ namespace IceInternal
         Ice::FacetMap _adminFacets;
         Ice::Identity _adminIdentity;
         std::set<std::string, std::less<>> _adminFacetFilter;
-        IceInternal::MetricsAdminIPtr _metricsAdmin;
         std::map<std::int16_t, BufSizeWarnInfo> _setBufSizeWarn;
         std::mutex _setBufSizeWarnMutex;
         mutable std::recursive_mutex _mutex;

--- a/cpp/src/Ice/Network.h
+++ b/cpp/src/Ice/Network.h
@@ -43,7 +43,7 @@ typedef int ssize_t;
 #    error "Unsupported platform"
 #endif
 
-#if defined(_WIN32) || defined(__osf__)
+#if defined(_WIN32)
 typedef int socklen_t;
 #endif
 

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.h
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.h
@@ -62,7 +62,6 @@ namespace Ice::SSL::OpenSSL
         const bool _incoming;
         const IceInternal::TransceiverPtr _delegate;
         bool _connected;
-        std::string _cipher;
         X509* _peerCertificate;
         ::SSL* _ssl;
         SSL_CTX* _sslCtx;

--- a/cpp/src/Ice/StringUtil.cpp
+++ b/cpp/src/Ice/StringUtil.cpp
@@ -1126,17 +1126,3 @@ IceInternal::isDigit(char c)
 {
     return c >= '0' && c <= '9';
 }
-
-string
-IceInternal::removeWhitespace(string_view s)
-{
-    string result;
-    for (unsigned int i = 0; i < s.length(); ++i)
-    {
-        if (!isspace(static_cast<unsigned char>(s[i])))
-        {
-            result += s[i];
-        }
-    }
-    return result;
-}

--- a/cpp/src/Ice/TcpAcceptor.h
+++ b/cpp/src/Ice/TcpAcceptor.h
@@ -11,7 +11,6 @@
 
 namespace IceInternal
 {
-    class TcpEndpoint;
 
     class TcpAcceptor final : public Acceptor, public NativeInfo, public std::enable_shared_from_this<TcpAcceptor>
     {

--- a/cpp/src/Ice/UdpTransceiver.h
+++ b/cpp/src/Ice/UdpTransceiver.h
@@ -9,7 +9,6 @@
 
 namespace IceInternal
 {
-    class UdpEndpoint;
 
     class UdpTransceiver final : public Transceiver,
                                  public NativeInfo,

--- a/cpp/src/Ice/ios/iAPEndpointI.h
+++ b/cpp/src/Ice/ios/iAPEndpointI.h
@@ -13,7 +13,7 @@
 namespace IceObjC
 {
     class iAPEndpointI;
-    typedef std::shared_ptr<iAPEndpointI> iAPEndpointIPtr;
+    using iAPEndpointIPtr = std::shared_ptr<iAPEndpointI>;
 
     class iAPEndpointI final : public IceInternal::EndpointI, public std::enable_shared_from_this<iAPEndpointI>
     {


### PR DESCRIPTION
Dead code in the core C++ runtime.

- `IceInternal::removeWhitespace` — its only callers were `slice2freeze` and `slice2freezej`, deleted in `99c3941638f` when Freeze moved to its own repository.
- `Instance::setThreadHook`, orphaned by "Remove ThreadHookPlugin" (#3850).
- Four never-read fields: `Instance::_implicitContext` (the live path is `_implicitContextKind` plus `_sharedImplicitContext`) and `Instance::_metricsAdmin` with the forward declarations that existed only for it, `OpenSSLTransceiverI::_cipher`, and `IncomingConnectionFactory::_acceptorStopped`, write-only since #4499.
- `class TcpEndpoint;` and `class UdpEndpoint;` — forward declarations for classes that do not exist anywhere; the real ones are `TcpEndpointI` and `UdpEndpointI`.
- The `__osf__` disjunct in `Network.h`, for Tru64.
- `iAPEndpointIPtr` converted from `typedef` to `using`.