### PR TITLE
Stop encoding a value for DataStorm remove samples

### DIFF
--- a/changelog.d/datastorm/6232.md
+++ b/changelog.d/datastorm/6232.md
@@ -1,3 +1,2 @@
-- Fixed a bug where removing a data element encoded a default-constructed value and sent it to the readers, which
-  never read it. An application whose custom `Encoder` rejects a default-constructed value terminated, because
-  `remove` is `noexcept`. A remove sample no longer carries a value.
+- Removing a data element no longer calls the application's `Encoder` with a default-constructed value the
+  application never published.

--- a/changelog.d/datastorm/6232.md
+++ b/changelog.d/datastorm/6232.md
@@ -1,0 +1,3 @@
+- Fixed a bug where removing a data element encoded a default-constructed value and sent it to the readers, which
+  never read it. An application whose custom `Encoder` rejects a default-constructed value terminated, because
+  `remove` is `noexcept`. A remove sample no longer carries a value.

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -387,7 +387,13 @@ namespace DataStormI
 
         [[nodiscard]] Ice::ByteSeq encodeValue(const Ice::CommunicatorPtr& communicator) final
         {
-            assert(_hasValue || event == DataStorm::SampleEvent::Remove);
+            // A remove sample carries no value.
+            if (event == DataStorm::SampleEvent::Remove)
+            {
+                return {};
+            }
+
+            assert(_hasValue);
             return EncoderT<Value>::encode(communicator, _value);
         }
 
@@ -407,8 +413,8 @@ namespace DataStormI
 
     private:
         bool _hasValue;
-        // Value-initialized so a value-less sample (such as a remove) holds a determinate default value: scalar
-        // types would otherwise be indeterminate, and encodeValue encodes this member for remove samples.
+        // Value-initialized because getValue() returns this member for a value-less sample, where it is documented to
+        // return a default value; a scalar type would otherwise be indeterminate.
         Value _value{};
     };
 

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -27,6 +27,19 @@ namespace
     {
         int value = 0;
     };
+
+    // A user type whose Encoder records what it was asked to encode, so a test can check which values a writer
+    // encodes.
+    struct PublishedValue
+    {
+        int value = 0;
+    };
+
+    vector<int>& encodedValues()
+    {
+        static vector<int> values;
+        return values;
+    }
 }
 
 namespace DataStorm
@@ -39,6 +52,23 @@ namespace DataStorm
     template<> struct Decoder<CustomValue>
     {
         static CustomValue decode(const Ice::ByteSeq& data) { return CustomValue{static_cast<int>(data[0])}; }
+    };
+
+    template<> struct Encoder<PublishedValue>
+    {
+        static Ice::ByteSeq encode(const Ice::CommunicatorPtr&, const PublishedValue& value)
+        {
+            encodedValues().push_back(value.value);
+            return {static_cast<std::byte>(value.value)};
+        }
+    };
+
+    template<> struct Decoder<PublishedValue>
+    {
+        static PublishedValue decode(const Ice::CommunicatorPtr&, const Ice::ByteSeq& data)
+        {
+            return PublishedValue{static_cast<int>(data[0])};
+        }
     };
 }
 
@@ -354,6 +384,23 @@ void ::Writer::run(int argc, char* argv[])
 
         auto akws = make_shared<MultiKeyWriter<string, string>>(topic, vector<string>{});
         akws = make_shared<MultiKeyWriter<string, string>>(topic, vector<string>{}, "", WriterConfig());
+    }
+    cout << "ok" << endl;
+
+    cout << "testing remove... " << flush;
+    {
+        // A remove sample carries no value, so publishing one encodes nothing.
+        Topic<string, PublishedValue> topic(node, "removetopic");
+
+        auto skw = makeSingleKeyWriter(topic, "key");
+        skw.add(PublishedValue{5});
+        skw.remove();
+        test((encodedValues() == vector<int>{5}));
+
+        auto mkw = makeMultiKeyWriter(topic, {"key"});
+        mkw.add("key", PublishedValue{7});
+        mkw.remove("key");
+        test((encodedValues() == vector<int>{5, 7}));
     }
     cout << "ok" << endl;
 


### PR DESCRIPTION
Closes #6232

`toSample` encodes every sample it puts on the wire, and a remove sample has no value to encode, so `SampleT::encodeValue`
encoded the default-constructed `_value` instead — which is what the `assert(_hasValue || event == Remove)` was there to
permit. Nothing reads those bytes: `DataElementI::queue` doesn't call `decode()` for a remove, and `SampleT::decode`
returns early for one anyway.

The cost isn't only the bytes, because `EncoderT<Value>::encode` dispatches to the application's `Encoder<Value>`: every
`remove()` ran application codec code against a value the application never published. `publish` calls it synchronously
on the caller's thread, and `Writer::remove` is `noexcept`, so an `Encoder` that rejects a default-constructed value
terminated the process rather than throwing.

`encodeValue` now returns an empty `Ice::ByteSeq` for a remove, mirroring the carve-out `decode` already has.

The remove carve-outs were added to the reader side over time (#5882, #6083) and finally to `SampleT::decode` (#6175);
`encodeValue` never got the matching one. In the original import (8e3d0b07ec) nothing special-cased a remove: every
sample was encoded and every sample was decoded.

The comment on `_value` loses the `encodeValue` half of its rationale, but the member still has to be value-initialized:
`getValue()` returns it for a value-less sample, where it is documented to return a default value, and
`operator<<(std::ostream&, const Sample&)` calls `getValue()` unconditionally.

This changes what a remove carries on the wire, which is fine for 3.8.3: main already breaks the DataStorm wire contract
against 3.8.2 through #6138 and #6165 (`attachElements`/`attachElementsAck` gained a `peerTopicId` parameter,
`DataSamples` gained `peerId`, `DataSample.timestamp` went from milliseconds to microseconds, and `keyId` changed
meaning), so there is no mixed 3.8.2/3.8.3 deployment to consider.

## Tests

A `testing remove` section in `cpp/test/DataStorm/api/Writer.cpp`. `PublishedValue`'s `Encoder` records every value it is
asked to encode, and the test checks that list after a single-key and a multi-key add/remove pair, so only the published
values appear. Without the fix the list picks up the remove's default value and the assertion fails.
