### PR TITLE
Fix Java registry config loading and TCP fd leaks

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
@@ -283,6 +283,7 @@ public final class Network {
             socket.setTcpNoDelay(true);
             socket.setKeepAlive(true);
         } catch (IOException ex) {
+            closeSocketNoThrow(fd);
             throw new SocketException(ex);
         }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -456,17 +456,20 @@ public final class Properties {
             && (file.startsWith("HKCU\\") || file.startsWith("HKLM\\"))) {
             try {
                 java.lang.Process process = Runtime.getRuntime().exec(new String[]{"reg", "query", file});
-                process.waitFor();
-                if (process.exitValue() != 0) {
-                    throw new InitializationException("Could not read Windows registry key '" + file + "'");
-                }
 
+                // Drain stdout before waiting for the process: reg blocks when its output fills the pipe buffer.
                 java.io.InputStream is = process.getInputStream();
                 StringWriter sw = new StringWriter();
                 int c;
                 while ((c = is.read()) != -1) {
                     sw.write(c);
                 }
+
+                process.waitFor();
+                if (process.exitValue() != 0) {
+                    throw new InitializationException("Could not read Windows registry key '" + file + "'");
+                }
+
                 String[] result = sw.toString().split("\n");
 
                 for (String line : result) {
@@ -482,27 +485,25 @@ public final class Properties {
                     if (pos != -1) {
                         String name = line.substring(0, pos).trim();
                         line = line.substring(pos + 13, line.length()).trim();
-                        while (true) {
-                            int start = line.indexOf('%', 0);
-                            int end = line.indexOf('%', start + 1);
 
-                            // If there isn't more %var% break the loop
+                        // Expand each %var% in a single pass; an expanded value is not re-scanned, so a variable
+                        // whose value contains %var% references cannot loop the expansion.
+                        StringBuilder expanded = new StringBuilder();
+                        int index = 0;
+                        while (true) {
+                            int start = line.indexOf('%', index);
+                            int end = start == -1 ? -1 : line.indexOf('%', start + 1);
                             if (start == -1 || end == -1) {
+                                expanded.append(line, index, line.length());
                                 break;
                             }
 
-                            String envKey = line.substring(start + 1, end);
-                            String envValue = System.getenv(envKey);
-                            if (envValue == null) {
-                                envValue = "";
-                            }
-
-                            envKey = "%" + envKey + "%";
-                            do {
-                                line = line.replace(envKey, envValue);
-                            } while (line.indexOf(envKey) != -1);
+                            String envValue = System.getenv(line.substring(start + 1, end));
+                            expanded.append(line, index, start);
+                            expanded.append(envValue == null ? "" : envValue);
+                            index = end + 1;
                         }
-                        setProperty(name, line);
+                        setProperty(name, expanded.toString());
                         continue;
                     }
                 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -6,7 +6,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PushbackInputStream;
-import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -455,22 +455,28 @@ public final class Properties {
         if (System.getProperty("os.name").startsWith("Windows")
             && (file.startsWith("HKCU\\") || file.startsWith("HKLM\\"))) {
             try {
-                java.lang.Process process = Runtime.getRuntime().exec(new String[]{"reg", "query", file});
+                java.lang.Process process =
+                    new ProcessBuilder("reg", "query", file)
+                        .redirectError(ProcessBuilder.Redirect.DISCARD)
+                        .start();
 
-                // Drain stdout before waiting for the process: reg blocks when its output fills the pipe buffer.
-                java.io.InputStream is = process.getInputStream();
-                StringWriter sw = new StringWriter();
-                int c;
-                while ((c = is.read()) != -1) {
-                    sw.write(c);
+                String output;
+                try {
+                    // Drain stdout before waiting for the process: reg blocks when its output fills the pipe
+                    // buffer. reg writes in the platform's native encoding, not the JVM default charset.
+                    try (java.io.InputStream is = process.getInputStream()) {
+                        output = new String(is.readAllBytes(), Charset.forName(System.getProperty("native.encoding")));
+                    }
+                    process.waitFor();
+                } finally {
+                    process.destroy();
                 }
 
-                process.waitFor();
                 if (process.exitValue() != 0) {
                     throw new InitializationException("Could not read Windows registry key '" + file + "'");
                 }
 
-                String[] result = sw.toString().split("\n");
+                String[] result = output.split("\n");
 
                 for (String line : result) {
                     int pos = line.indexOf("REG_SZ");

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
@@ -29,7 +29,7 @@ class TcpAcceptor implements Acceptor {
         try {
             _addr = Network.doBind(_fd, _addr, _backlog);
         } catch (LocalException ex) {
-            _fd = null;
+            close();
             throw ex;
         }
         _endpoint = _endpoint.endpoint(this);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
@@ -79,7 +79,10 @@ class TcpAcceptor implements Acceptor {
 
             _addr = Network.getAddressForServer(host, port, instance.protocolSupport(), instance.preferIPv6());
         } catch (RuntimeException ex) {
-            _fd = null;
+            if (_fd != null) {
+                Network.closeSocketNoThrow(_fd);
+                _fd = null;
+            }
             throw ex;
         }
     }


### PR DESCRIPTION
Addresses items 1 and 2 of #6117. Item 3 is fixed by #6235.

## Item 1 — `Properties.load` with a Windows registry key

- The `reg query` output is now drained before `Process.waitFor`. The previous order deadlocked startup when the
  key held more configuration than the OS pipe buffer: `reg` blocked writing while `load` waited for it to exit.
  stderr is discarded at the OS level (`ProcessBuilder.Redirect.DISCARD`), so it cannot fill a pipe either. The
  rework also destroys the `reg` process when reading its output fails, and decodes that output using the
  platform's native encoding instead of byte-by-byte Latin-1.
- `%var%` references in a `REG_EXPAND_SZ` value are now expanded in a single pass: an expanded value is not
  rescanned. This fixes two bugs of the old rescan-from-the-start approach. First, a variable whose value
  contains `%var%` references (self- or mutual) looped the expansion forever. Second, a variable whose value
  contains a literal `%` silently corrupted the rest of the string: the introduced `%` paired with the next
  `%var%` reference, which was then swallowed as an empty-named variable — with `PCT=50%` and `A=alpha`, the
  input `%PCT%%A%` expanded to `50A%`; it now expands to `50%alpha`. `ExpandEnvironmentStringsW`, which the C++
  runtime uses for the same registry values, does not rescan either. An unknown variable still expands to the
  empty string, as before (this is pre-existing behavior that differs from `ExpandEnvironmentStringsW`, which
  leaves the reference in place).

## Item 2 — TCP file descriptor leaks on failure paths

- `Network.doAccept` now closes the accepted channel when setting its socket options fails. The existing catch
  translates the failure into a `SocketException` for the caller, but it left the accepted fd behind. Reachable
  when the peer resets the connection right after the handshake — what TCP health probes and port scanners
  produce — with the option call then failing on BSD-derived stacks; a listening server leaked one fd per
  occurrence.
- The `TcpAcceptor` constructor closes the server socket before discarding it when a later step throws — in
  practice `getAddressForServer` on a host that fails to resolve, or `setTcpBufSize` on a malformed
  `Ice.TCP.RcvSize` value, whose `PropertyException` is thrown before reaching the option helper that would
  have closed the socket. The `Network` option helpers close the socket themselves before throwing, and their
  close is idempotent, so the constructor's close is safe on every path.

The audit's third leak candidate, `Network.createTcpSocket`, is left unchanged: the socket is not connected yet
when its options are set, so no peer can invalidate it and the failure is not reachable in practice.

No changelog entry: the registry config path is a niche feature and the fixes are hardening; the fd leaks only
occur on failure paths. No tests: the registry path is Windows-only subprocess plumbing, and the fd leaks would
require injecting socket-option failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

