### PR TITLE
Discard DataStorm session creation replies from superseded attempts

### DIFF
--- a/changelog.d/datastorm/6282.md
+++ b/changelog.d/datastorm/6282.md
@@ -1,4 +1,4 @@
-- Fixed a session reconnect failure that could re-deliver a writer's retained samples. A late reply from a superseded
-  session creation attempt was charged against the attempt in progress, so a burst of them could exhaust the reconnect
-  retry budget in milliseconds and destroy a session that was reconnecting normally. The replacement session resumed
-  from the start of the writer's history, and the reader received samples it had already consumed.
+- Fixed a bug where a DataStorm reader could receive samples it had already consumed. When a session reconnected
+  to its peer — typically through a DataStorm node — stale replies from an earlier connection attempt could
+  exhaust the session's reconnect retries and destroy it; the replacement session then received the writer's
+  retained samples from the beginning.

--- a/changelog.d/datastorm/6282.md
+++ b/changelog.d/datastorm/6282.md
@@ -1,0 +1,4 @@
+- Fixed a session reconnect failure that could re-deliver a writer's retained samples. A late reply from a superseded
+  session creation attempt was charged against the attempt in progress, so a burst of them could exhaust the reconnect
+  retry budget in milliseconds and destroy a session that was reconnecting normally. The replacement session resumed
+  from the start of the writer's history, and the reader received samples it had already consumed.

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -194,6 +194,12 @@ NodeI::createSessionAsync(
     assert(instance);
 
     shared_ptr<PublisherSessionI> session;
+
+    // Identifies the attempt started here, so a reply that arrives after it has been superseded is discarded rather
+    // than charged against a later attempt's retry budget. It is read once, where the attempt starts, and never
+    // re-read for a failure that has already happened.
+    int64_t connectAttempt = 0;
+
     try
     {
         NodePrx s = *subscriber;
@@ -220,6 +226,11 @@ NodeI::createSessionAsync(
 
         unique_lock<mutex> lock(_mutex);
         session = createPublisherSessionServant(*subscriber);
+
+        // Identifies the attempt started here, so a reply that arrives after it has been superseded is discarded
+        // rather than charged against a later attempt's retry budget.
+        connectAttempt = session->connectAttempt();
+
         s->ice_getConnectionAsync(
             [=, self = shared_from_this()](const auto& connection) mutable
             {
@@ -271,8 +282,8 @@ NodeI::createSessionAsync(
                                 connection,
                                 instance->getTopicFactory()->getTopicWriters());
                         },
-                        [self, subscriber, session](auto ex)
-                        { self->retryPublisherSessionCreation(*subscriber, session, ex); });
+                        [self, subscriber, session, connectAttempt](auto ex)
+                        { self->retryPublisherSessionCreation(*subscriber, session, ex, connectAttempt); });
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
@@ -284,12 +295,12 @@ NodeI::createSessionAsync(
                 }
                 catch (const LocalException&)
                 {
-                    self->retryPublisherSessionCreation(*subscriber, session, current_exception());
+                    self->retryPublisherSessionCreation(*subscriber, session, current_exception(), connectAttempt);
                 }
             },
-            [self = shared_from_this(), session, subscriber, exception](exception_ptr ex)
+            [self = shared_from_this(), session, subscriber, exception, connectAttempt](exception_ptr ex)
             {
-                self->retryPublisherSessionCreation(*subscriber, session, ex);
+                self->retryPublisherSessionCreation(*subscriber, session, ex, connectAttempt);
                 exception(make_exception_ptr(SessionCreationException{SessionCreationError::Internal}));
             });
     }
@@ -307,7 +318,7 @@ NodeI::createSessionAsync(
     {
         assert(session);
         exception(make_exception_ptr(SessionCreationException{SessionCreationError::Internal}));
-        retryPublisherSessionCreation(*subscriber, session, current_exception());
+        retryPublisherSessionCreation(*subscriber, session, current_exception(), connectAttempt);
     }
 }
 
@@ -391,6 +402,10 @@ NodeI::createSubscriberSession(
     // The publisher session is null when we are creating a new session, in response to a topic reader announcement. It
     // is not null when we are attempting to reconnect an existing session.
 
+    // Identifies the attempt started here, so a reply that arrives after it has been superseded is discarded
+    // rather than charged against a later attempt's retry budget.
+    const int64_t connectAttempt = session ? session->connectAttempt() : 0;
+
     try
     {
         subscriber = getNodeWithExistingConnection(instance, subscriber, subscriberConnection);
@@ -398,11 +413,11 @@ NodeI::createSubscriberSession(
         subscriber->initiateCreateSessionAsync(
             _proxy,
             nullptr,
-            [self = shared_from_this(), session, subscriber](exception_ptr ex)
+            [self = shared_from_this(), session, subscriber, connectAttempt](exception_ptr ex)
             {
                 if (session)
                 {
-                    self->retryPublisherSessionCreation(subscriber, session, ex);
+                    self->retryPublisherSessionCreation(subscriber, session, ex, connectAttempt);
                 }
                 // Else node is shutting down, or the session was established by a concurrent call.
             });
@@ -419,7 +434,7 @@ NodeI::createSubscriberSession(
     {
         if (session)
         {
-            retryPublisherSessionCreation(subscriber, session, current_exception());
+            retryPublisherSessionCreation(subscriber, session, current_exception(), connectAttempt);
         }
         // Else node is shutting down, or the session was established by a concurrent call.
     }
@@ -437,6 +452,10 @@ NodeI::createPublisherSession(
 
     auto traceLevels = instance->getTraceLevels();
 
+    // Identifies the attempt started here, so a reply that arrives after it has been superseded is discarded
+    // rather than charged against a later attempt's retry budget.
+    int64_t connectAttempt = session ? session->connectAttempt() : 0;
+
     try
     {
         auto p = getNodeWithExistingConnection(instance, publisher, publisherConnection);
@@ -445,6 +464,7 @@ NodeI::createPublisherSession(
         if (!session)
         {
             session = createSubscriberSessionServant(publisher);
+            connectAttempt = session->connectAttempt();
             if (session->checkSession())
             {
                 // The session is already connected.
@@ -465,8 +485,8 @@ NodeI::createPublisherSession(
             uncheckedCast<SubscriberSessionPrx>(session->getProxy()),
             false,
             nullptr,
-            [self = shared_from_this(), publisher, session](exception_ptr ex)
-            { self->retrySubscriberSessionCreation(publisher, session, ex); });
+            [self = shared_from_this(), publisher, session, connectAttempt](exception_ptr ex)
+            { self->retrySubscriberSessionCreation(publisher, session, ex, connectAttempt); });
     }
     catch (const CommunicatorDestroyedException&)
     {
@@ -480,7 +500,7 @@ NodeI::createPublisherSession(
     }
     catch (const LocalException&)
     {
-        retrySubscriberSessionCreation(publisher, session, current_exception());
+        retrySubscriberSessionCreation(publisher, session, current_exception(), connectAttempt);
         throw SessionCreationException{SessionCreationError::Internal};
     }
 }
@@ -489,27 +509,13 @@ void
 NodeI::retrySubscriberSessionCreation(
     const NodePrx& node,
     const shared_ptr<SubscriberSessionI>& session,
-    exception_ptr ex)
+    exception_ptr ex,
+    std::int64_t connectAttempt)
 {
-    try
-    {
-        rethrow_exception(ex);
-    }
-    catch (const SessionCreationException& sessionCreationException)
-    {
-        if (sessionCreationException.error == SessionCreationError::AlreadyConnected && session->checkSession())
-        {
-            // A concurrent session attempt from the peer succeeded, no need to retry.
-            return;
-        }
-        // else let Session::retry handle the exception
-    }
-    catch (...)
-    {
-        // Let Session::retry handle the exception.
-    }
-
-    if (!session->retry(node, ex))
+    // SessionI::sessionCreationFailed classifies the failure and decides what to do with it in one step under the
+    // session mutex. Evaluating the session state here instead would not be race-free: checking it can itself
+    // disconnect the session, which changes the very state the decision depends on.
+    if (!session->sessionCreationFailed(node, ex, connectAttempt))
     {
         removeSubscriberSession(node, session, ex);
     }
@@ -536,27 +542,13 @@ void
 NodeI::retryPublisherSessionCreation(
     const NodePrx& node,
     const shared_ptr<PublisherSessionI>& session,
-    exception_ptr ex)
+    exception_ptr ex,
+    std::int64_t connectAttempt)
 {
-    try
-    {
-        rethrow_exception(ex);
-    }
-    catch (const SessionCreationException& sessionCreationException)
-    {
-        if (sessionCreationException.error == SessionCreationError::AlreadyConnected && session->checkSession())
-        {
-            // A concurrent session attempt from the peer succeeded, no need to retry.
-            return;
-        }
-        // else let Session::retry handle the exception
-    }
-    catch (...)
-    {
-        // Let Session::retry handle the exception.
-    }
-
-    if (!session->retry(node, ex))
+    // SessionI::sessionCreationFailed classifies the failure and decides what to do with it in one step under the
+    // session mutex. Evaluating the session state here instead would not be race-free: checking it can itself
+    // disconnect the session, which changes the very state the decision depends on.
+    if (!session->sessionCreationFailed(node, ex, connectAttempt))
     {
         removePublisherSession(node, session, ex);
     }

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -195,9 +195,6 @@ NodeI::createSessionAsync(
 
     shared_ptr<PublisherSessionI> session;
 
-    // Identifies the attempt started here, so a reply that arrives after it has been superseded is discarded rather
-    // than charged against a later attempt's retry budget. It is read once, where the attempt starts, and never
-    // re-read for a failure that has already happened.
     int64_t connectAttempt = 0;
 
     try
@@ -226,9 +223,6 @@ NodeI::createSessionAsync(
 
         unique_lock<mutex> lock(_mutex);
         session = createPublisherSessionServant(*subscriber);
-
-        // Identifies the attempt started here, so a reply that arrives after it has been superseded is discarded
-        // rather than charged against a later attempt's retry budget.
         connectAttempt = session->connectAttempt();
 
         s->ice_getConnectionAsync(
@@ -402,8 +396,6 @@ NodeI::createSubscriberSession(
     // The publisher session is null when we are creating a new session, in response to a topic reader announcement. It
     // is not null when we are attempting to reconnect an existing session.
 
-    // Identifies the attempt started here, so a reply that arrives after it has been superseded is discarded
-    // rather than charged against a later attempt's retry budget.
     const int64_t connectAttempt = session ? session->connectAttempt() : 0;
 
     try
@@ -452,8 +444,6 @@ NodeI::createPublisherSession(
 
     auto traceLevels = instance->getTraceLevels();
 
-    // Identifies the attempt started here, so a reply that arrives after it has been superseded is discarded
-    // rather than charged against a later attempt's retry budget.
     int64_t connectAttempt = session ? session->connectAttempt() : 0;
 
     try
@@ -512,9 +502,6 @@ NodeI::retrySubscriberSessionCreation(
     exception_ptr ex,
     std::int64_t connectAttempt)
 {
-    // SessionI::sessionCreationFailed classifies the failure and decides what to do with it in one step under the
-    // session mutex. Evaluating the session state here instead would not be race-free: checking it can itself
-    // disconnect the session, which changes the very state the decision depends on.
     if (!session->sessionCreationFailed(node, ex, connectAttempt))
     {
         removeSubscriberSession(node, session, ex);
@@ -545,9 +532,6 @@ NodeI::retryPublisherSessionCreation(
     exception_ptr ex,
     std::int64_t connectAttempt)
 {
-    // SessionI::sessionCreationFailed classifies the failure and decides what to do with it in one step under the
-    // session mutex. Evaluating the session state here instead would not be race-free: checking it can itself
-    // disconnect the session, which changes the very state the decision depends on.
     if (!session->sessionCreationFailed(node, ex, connectAttempt))
     {
         removePublisherSession(node, session, ex);

--- a/cpp/src/DataStorm/NodeI.h
+++ b/cpp/src/DataStorm/NodeI.h
@@ -57,15 +57,21 @@ namespace DataStormI
             const Ice::ConnectionPtr&,
             std::shared_ptr<SubscriberSessionI>);
 
+        /// Handles the failure of a session creation attempt. The last parameter is the value
+        /// SessionI::connectAttempt returned when the attempt was started; a reply from a superseded attempt is
+        /// discarded rather than charged against the current attempt's retry budget.
         void retrySubscriberSessionCreation(
             const DataStormContract::NodePrx&,
             const std::shared_ptr<SubscriberSessionI>&,
-            std::exception_ptr);
+            std::exception_ptr,
+            std::int64_t);
 
+        /// @copydoc retrySubscriberSessionCreation
         void retryPublisherSessionCreation(
             const DataStormContract::NodePrx&,
             const std::shared_ptr<PublisherSessionI>&,
-            std::exception_ptr);
+            std::exception_ptr,
+            std::int64_t);
 
         void removeSubscriberSession(
             const DataStormContract::NodePrx&,

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -697,13 +697,6 @@ SessionI::connected(SessionPrx session, const ConnectionPtr& newConnection, cons
 }
 
 bool
-SessionI::disconnected(const ConnectionPtr& connection, exception_ptr ex)
-{
-    lock_guard<mutex> lock(_mutex);
-    return disconnectedImpl(connection, ex);
-}
-
-bool
 SessionI::handleDisconnected(const ConnectionPtr& connection, exception_ptr ex)
 {
     lock_guard<mutex> lock(_mutex);
@@ -1095,9 +1088,9 @@ SessionI::checkSessionImpl()
         }
         catch (const LocalException&)
         {
-            // Ignore the result: either this call disconnected the session, or another thread already did. Both leave
-            // the session disconnected, which is what the caller needs to know.
-            [[maybe_unused]] bool disconnected = disconnectedImpl(_connection, current_exception());
+            // Either this call disconnected the session, or another thread already did. Both leave the session
+            // disconnected, which is what the caller needs to know.
+            disconnectedImpl(_connection, current_exception());
             return false;
         }
     }

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -669,6 +669,9 @@ SessionI::connected(SessionPrx session, const ConnectionPtr& newConnection, cons
 
     ++_sessionInstanceId;
 
+    // The session is connected: any attempt still in flight is superseded.
+    ++_connectAttempt;
+
     if (_traceLevels->session > 0)
     {
         Trace out(_traceLevels->logger, _traceLevels->sessionCat);
@@ -787,10 +790,57 @@ SessionI::disconnectedImpl(const ConnectionPtr& connection, exception_ptr ex)
 }
 
 bool
-SessionI::retry(NodePrx node, exception_ptr exception)
+SessionI::sessionCreationFailed(NodePrx node, exception_ptr exception, int64_t connectAttempt)
 {
     lock_guard<mutex> lock(_mutex);
+
+    if (connectAttempt != _connectAttempt)
+    {
+        // A reply from a superseded attempt: the session has connected since, or an earlier failure was already
+        // accounted for and a fresh attempt scheduled. Acting on it would consume the current attempt's retry budget
+        // for an outcome that no longer applies, and a burst of such replies exhausts the budget in milliseconds and
+        // destroys a session that is reconnecting normally.
+        if (_traceLevels->session > 1)
+        {
+            Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+            out << _id << ": ignoring a session creation failure from attempt " << connectAttempt
+                << ", the current attempt is " << _connectAttempt;
+        }
+        return true;
+    }
+
+    // AlreadyConnected reports that the peer already has a session with this node, so it is a failure only when this
+    // session is not connected. checkSessionImpl can disconnect the session when it finds the connection already
+    // closed, which is why the check runs here rather than in the caller: it must not be separated from the decision
+    // it feeds, and a disconnect discovered by it must still reach retryImpl below.
+    if (exception)
+    {
+        try
+        {
+            rethrow_exception(exception);
+        }
+        catch (const SessionCreationException& ex)
+        {
+            if (ex.error == SessionCreationError::AlreadyConnected && checkSessionImpl())
+            {
+                // A concurrent session creation from the peer succeeded, no need to retry.
+                return true;
+            }
+        }
+        catch (const std::exception&)
+        {
+            // Any other failure is handled by retryImpl below.
+        }
+    }
+
     return retryImpl(std::move(node), std::move(exception));
+}
+
+int64_t
+SessionI::connectAttempt() const
+{
+    lock_guard<mutex> lock(_mutex);
+    return _connectAttempt;
 }
 
 bool
@@ -804,6 +854,10 @@ SessionI::retryImpl(NodePrx node, exception_ptr exception)
     {
         return false;
     }
+
+    // This failure is about to be accounted for, either by scheduling a fresh attempt or by giving up. Either way
+    // the attempt it belongs to is finished, so later replies from it must not be counted again.
+    ++_connectAttempt;
 
     if (exception)
     {
@@ -1016,39 +1070,38 @@ SessionI::getConnection() const
 bool
 SessionI::checkSession()
 {
-    while (true)
+    lock_guard<mutex> lock(_mutex);
+    return checkSessionImpl();
+}
+
+bool
+SessionI::checkSessionImpl()
+{
+    // Called with the session mutex locked.
+    if (!_session)
     {
-        unique_lock<mutex> lock(_mutex);
-        if (_session)
+        return false;
+    }
+
+    if (_connection)
+    {
+        // Make sure the connection is still established. It's possible that the connection got closed and we were not
+        // notified yet by the connection manager. checkSession explicitly checks for the connection to make sure that
+        // if we get a session creation request from a peer (which might detect the connection closure before), it
+        // doesn't get ignored.
+        try
         {
-            if (_connection)
-            {
-                // Make sure the connection is still established. It's possible that the connection got closed and we
-                // were not notified yet by the connection manager. checkSession explicitly checks for the connection
-                // to make sure that if we get a session creation request from a peer (which might detect the connection
-                // closure before), it doesn't get ignored.
-                try
-                {
-                    _connection->throwException();
-                }
-                catch (const LocalException&)
-                {
-                    auto connection = _connection;
-                    lock.unlock();
-                    if (!disconnected(connection, current_exception()))
-                    {
-                        continue;
-                    }
-                    return false;
-                }
-            }
-            return true;
+            _connection->throwException();
         }
-        else
+        catch (const LocalException&)
         {
+            // Ignore the result: either this call disconnected the session, or another thread already did. Both leave
+            // the session disconnected, which is what the caller needs to know.
+            [[maybe_unused]] bool disconnected = disconnectedImpl(_connection, current_exception());
             return false;
         }
     }
+    return true;
 }
 
 optional<SessionPrx>

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -303,10 +303,10 @@ namespace DataStormI
         /// session.
         [[nodiscard]] bool handleDisconnected(const Ice::ConnectionPtr&, std::exception_ptr);
 
-        [[nodiscard]] bool retry(DataStormContract::NodePrx, std::exception_ptr);
         void destroyImpl(const std::exception_ptr&);
 
-        // The implementations of disconnected and retry; called with the session mutex locked.
+        // The implementations of checkSession, disconnected and retry; called with the session mutex locked.
+        [[nodiscard]] bool checkSessionImpl();
         [[nodiscard]] bool disconnectedImpl(const Ice::ConnectionPtr&, std::exception_ptr);
         [[nodiscard]] bool retryImpl(DataStormContract::NodePrx, std::exception_ptr);
 
@@ -320,6 +320,25 @@ namespace DataStormI
         [[nodiscard]] Ice::ConnectionPtr getConnection() const;
         [[nodiscard]] std::optional<DataStormContract::SessionPrx> getSession() const;
         [[nodiscard]] bool checkSession();
+
+        /// Returns the identifier of the session creation attempt in progress. Callers starting an attempt pass
+        /// the value they read here to #sessionCreationFailed.
+        [[nodiscard]] std::int64_t connectAttempt() const;
+
+        /// Handles the failure of a session creation attempt: classifies it and decides whether to ignore it, retry,
+        /// or give up, as a single step under the session mutex. It cannot be split into separate queries because
+        /// inspecting the session state can itself disconnect the session.
+        /// @param node The peer node to reconnect to.
+        /// @param exception The failure reported by the attempt.
+        /// @param connectAttempt The value #connectAttempt returned when the attempt was started. A reply from an
+        /// attempt that has since been superseded is ignored, so it cannot consume the current attempt's retry
+        /// budget; without this a burst of late replies destroys a session that is reconnecting normally.
+        /// @return `false` when the retry limit was reached or no retry is possible: the caller must remove the
+        /// session.
+        [[nodiscard]] bool sessionCreationFailed(
+            DataStormContract::NodePrx node,
+            std::exception_ptr exception,
+            std::int64_t connectAttempt);
 
         [[nodiscard]] DataStormContract::SessionPrx getProxy() const { return _proxy; }
 
@@ -463,6 +482,13 @@ namespace DataStormI
 
         // The number of attempts made to reconnect the session.
         int _retryCount{0};
+
+        // Identifies the current session creation attempt. It is incremented when the session connects and when a
+        // failure is accounted for, which are the two points that make an attempt still in flight irrelevant. It is
+        // deliberately NOT incremented on a bare disconnect: disconnecting does not by itself schedule a retry, so
+        // invalidating the in-flight attempt there would discard the failure that would have scheduled one, leaving
+        // the session with no attempt, no retry task, and no removal.
+        std::int64_t _connectAttempt{0};
 
         // A retry task, scheduled if an attempt to reconnect the session is underway; nullptr if no retry is scheduled.
         IceInternal::TimerTaskPtr _retryTask;

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -293,7 +293,6 @@ namespace DataStormI
 
         void
         connected(DataStormContract::SessionPrx, const Ice::ConnectionPtr&, const DataStormContract::TopicInfoSeq&);
-        [[nodiscard]] bool disconnected(const Ice::ConnectionPtr&, std::exception_ptr);
 
         /// Handles a disconnect notification (the peer's disconnected() request or the connection closure) and,
         /// when the session was connected, schedules the reconnection retry. Handling both under a single lock
@@ -307,7 +306,7 @@ namespace DataStormI
 
         // The implementations of checkSession, disconnected and retry; called with the session mutex locked.
         [[nodiscard]] bool checkSessionImpl();
-        [[nodiscard]] bool disconnectedImpl(const Ice::ConnectionPtr&, std::exception_ptr);
+        bool disconnectedImpl(const Ice::ConnectionPtr&, std::exception_ptr);
         [[nodiscard]] bool retryImpl(DataStormContract::NodePrx, std::exception_ptr);
 
         // Cancels and clears any pending retry task, breaking the _retryTask -> task -> lambda -> self reference


### PR DESCRIPTION
Fixes #6282.

A session creation attempt that fails is retried with a bounded budget (`DataStorm.Node.RetryCount`, backing off from `DataStorm.Node.RetryDelay`). Replies were not tied to the attempt that produced them, so a late reply from an attempt that had already been superseded was charged against the attempt in progress: it cancelled and rescheduled that attempt's retry task and consumed one of its retries.

A relay between two nodes makes such replies routine. `AlreadyConnected` means the peer already has a session with this node; `NodeI::retrySubscriberSessionCreation` treated it as success only while this session was connected, so after a later close it was reclassified as a failure of the current attempt. In the reported trace a burst of them exhausted the six-retry budget in **2 ms** — none of the nominal 15.5 s of backoff elapsed — and destroyed a session that was reconnecting normally:

```
15.071  s/1: retrying connecting to 'writer-app:…' in 500 (ms),  retry 2/6
15.072  s/1: retrying connecting to 'writer-app:…' in 1000 (ms), retry 3/6
15.072  s/1: retrying connecting to 'writer-app:…' in 2000 (ms), retry 4/6
15.073  s/1: retrying connecting to 'writer-app:…' in 4000 (ms), retry 5/6
15.073  s/1: retrying connecting to 'writer-app:…' in 8000 (ms), retry 6/6
15.073  s/1: connection to 'writer-app:…' failed and the retry limit has been reached
15.073  s/1: destroyed session
15.076  s/3: created session (peer = 'writer-app:…')
```

The replacement session had no record of what the reader had received, so `getLastIds` reported nothing, the writer's `lastId` was 0, and it resumed from the start of its retained history. The reader received samples it had already consumed. #6039 was the same event taking its other branch: there the destroyed session was never re-created, so the reader hung instead.

## The fix

Each attempt now carries an identifier. `SessionI::sessionCreationFailed` ignores a reply whose identifier no longer matches the attempt in progress, so late replies can no longer cancel a retry task, consume a retry, or remove the session.

Two details matter more than the token itself:

**The decision is atomic.** Classifying the failure and deciding what to do with it happen together under the session mutex. They cannot be split: inspecting the session state can itself disconnect the session (`checkSession` detects an already-closed connection and disconnects), which changes the very state the decision depends on. A caller that checked separately could have its *own* failure discarded and be left with no attempt in flight, no retry scheduled, and no removal — reintroducing #6039's hang. `checkSession` is therefore split into a locked `checkSessionImpl`, and a disconnect it discovers still falls through to `retryImpl` in the same critical section.

**The identifier advances only where something else takes responsibility for recovery** — when the session connects, and when a failure is accounted for. Deliberately *not* on a bare disconnect: disconnecting schedules nothing, so invalidating the in-flight attempt there would discard the failure that would have scheduled a retry.

`NodeI`'s two retry helpers reduce to a single call, and no longer evaluate session state themselves.

## Testing

- `make -C cpp -j10 srcs tests`
- `python3 allTests.py --filter=DataStorm` — 11/11, four runs after the final corrections (and four before them)

**No regression test.** The failing interleaving needs a late reply held across a disconnect, which survives only because it returns through a relay's own connections. Reproducing that deterministically would require either compiling DataStorm's internal `Contract.ice` into a test and implementing a controllable relay — the contract is unexported (`nm -gU libDataStorm.dylib | grep -c DataStormContract` → 0) and has churned recently, so it would rot — or adding a test-only seam to the product, for which there is no precedent in DataStorm. Neither seemed proportionate; I would rather say so than add a test that does not exercise the path. The new session trace line (`ignoring a session creation failure from attempt N, the current attempt is M`) makes the behaviour observable in a CI trace.

## Review

Cross-reviewed by OpenAI Codex (GPT-5.6) in two rounds, both initially rejecting the change.

The first round rejected composing the decision from separate `connectAttempt()` / `checkSession()` / `retry()` calls, for the stranded-session reason above — verified from source before reworking. The second round accepted the atomic rework (the lock-ordering change in `checkSession`, dropping its retry loop, and omitting the disconnect-time advance were all confirmed safe) but caught two mechanical defects, both fixed here:

- the attempt token was captured as `int` at three sites while the state was `std::int64_t`, so once the token exceeded `int` a current reply could never compare equal and would be discarded;
- one outer catch re-read the session's current token instead of the one belonging to the failed call, which could charge an older failure to a newer attempt — the original defect class.

It also noted the replaced code called `rethrow_exception(nullptr)` unconditionally, which is undefined when the exception is null; the new code guards it.

Its remaining suggestion — checked arithmetic for signed overflow of the token — is not adopted. The token is only compared for equality, and wrapping an `int64_t` is not reachable.

## Not addressed here

- `connected()` is still invoked from the confirmation callback without validating the attempt (`NodeI.cpp`). It cannot produce the stranded state this PR fixes, but it carries a stale-success risk that predates this change; worth its own issue.
- `NodeI::createPublisherSession` can be called with a null session and its `LocalException` catch already dereferences it. Unchanged and not made worse.
