### PR TITLE
Make ice_getCachedConnection return null instead of throwing during a failed connection establishment

### DIFF
--- a/changelog.d/general/6278.md
+++ b/changelog.d/general/6278.md
@@ -1,0 +1,2 @@
+- Fixed a race during failed connection establishments: `ice_getCachedConnection`, called concurrently on a proxy
+  using this connection, could throw the connection-establishment exception instead of returning null.

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -211,7 +211,7 @@ CollocatedRequestHandler::dispatchException(int32_t requestId, exception_ptr ex)
 }
 
 ConnectionIPtr
-CollocatedRequestHandler::getConnection()
+CollocatedRequestHandler::getConnection() noexcept
 {
     return nullptr;
 }

--- a/cpp/src/Ice/CollocatedRequestHandler.h
+++ b/cpp/src/Ice/CollocatedRequestHandler.h
@@ -34,7 +34,7 @@ namespace IceInternal
 
         void asyncRequestCanceled(const OutgoingAsyncBasePtr&, std::exception_ptr) final;
 
-        Ice::ConnectionIPtr getConnection() final;
+        Ice::ConnectionIPtr getConnection() noexcept final;
 
         AsyncStatus invokeAsyncRequest(OutgoingAsyncBase*, int, bool);
 

--- a/cpp/src/Ice/ConnectRequestHandler.cpp
+++ b/cpp/src/Ice/ConnectRequestHandler.cpp
@@ -62,20 +62,10 @@ Ice::ConnectionIPtr
 ConnectRequestHandler::getConnection()
 {
     lock_guard lock(_mutex);
-    //
-    // First check for the connection, it's important otherwise the user could first get a connection
-    // and then the exception if he tries to obtain the proxy cached connection multiple times (the
-    // exception can be set after the connection is set if the flush of pending requests fails).
-    //
-    if (_connection)
-    {
-        return _connection;
-    }
-    else if (_exception)
-    {
-        rethrow_exception(_exception);
-    }
-    return nullptr;
+    // Return the connection in whatever state it is; when the connection establishment failed, return null. Like all
+    // getConnection implementations, this function never throws: a null return is how the absence of a connection is
+    // reported.
+    return _connection;
 }
 
 void

--- a/cpp/src/Ice/ConnectRequestHandler.cpp
+++ b/cpp/src/Ice/ConnectRequestHandler.cpp
@@ -59,10 +59,10 @@ ConnectRequestHandler::asyncRequestCanceled(const OutgoingAsyncBasePtr& outAsync
 }
 
 Ice::ConnectionIPtr
-ConnectRequestHandler::getConnection()
+ConnectRequestHandler::getConnection() noexcept
 {
     lock_guard lock(_mutex);
-    // Return the connection in whatever state it is; when the connection establishment failed, return null. Like all
+    // Return the connection in whatever state it is; if the connection establishment failed, return null. Like all
     // getConnection implementations, this function never throws: a null return is how the absence of a connection is
     // reported.
     return _connection;

--- a/cpp/src/Ice/ConnectRequestHandler.h
+++ b/cpp/src/Ice/ConnectRequestHandler.h
@@ -25,7 +25,7 @@ namespace IceInternal
 
         void asyncRequestCanceled(const OutgoingAsyncBasePtr&, std::exception_ptr) final;
 
-        Ice::ConnectionIPtr getConnection() final;
+        Ice::ConnectionIPtr getConnection() noexcept final;
 
         // setConnection and setException are the response and exception for RoutableReference::getConnectionAsync.
         void setConnection(Ice::ConnectionIPtr, bool);

--- a/cpp/src/Ice/FixedRequestHandler.cpp
+++ b/cpp/src/Ice/FixedRequestHandler.cpp
@@ -28,7 +28,7 @@ FixedRequestHandler::asyncRequestCanceled(const OutgoingAsyncBasePtr& outAsync, 
 }
 
 Ice::ConnectionIPtr
-FixedRequestHandler::getConnection()
+FixedRequestHandler::getConnection() noexcept
 {
     return _connection;
 }

--- a/cpp/src/Ice/FixedRequestHandler.h
+++ b/cpp/src/Ice/FixedRequestHandler.h
@@ -18,7 +18,7 @@ namespace IceInternal
 
         void asyncRequestCanceled(const OutgoingAsyncBasePtr&, std::exception_ptr) final;
 
-        Ice::ConnectionIPtr getConnection() final;
+        Ice::ConnectionIPtr getConnection() noexcept final;
 
     private:
         Ice::ConnectionIPtr _connection;

--- a/cpp/src/Ice/RequestHandler.h
+++ b/cpp/src/Ice/RequestHandler.h
@@ -44,7 +44,7 @@ namespace IceInternal
 
         // Returns this request handler's connection, or null if no connection is available. This function never
         // throws.
-        virtual Ice::ConnectionIPtr getConnection() = 0;
+        virtual Ice::ConnectionIPtr getConnection() noexcept = 0;
 
     protected:
         const ReferencePtr _reference;

--- a/cpp/src/Ice/RequestHandler.h
+++ b/cpp/src/Ice/RequestHandler.h
@@ -42,6 +42,8 @@ namespace IceInternal
 
         virtual AsyncStatus sendAsyncRequest(const ProxyOutgoingAsyncBasePtr&) = 0;
 
+        // Returns this request handler's connection, or null if no connection is available. This function never
+        // throws.
         virtual Ice::ConnectionIPtr getConnection() = 0;
 
     protected:

--- a/cpp/src/Ice/RequestHandlerCache.cpp
+++ b/cpp/src/Ice/RequestHandlerCache.cpp
@@ -45,7 +45,7 @@ RequestHandlerCache::getRequestHandler()
 }
 
 ConnectionPtr
-RequestHandlerCache::getCachedConnection()
+RequestHandlerCache::getCachedConnection() noexcept
 {
     if (_cacheConnection)
     {

--- a/cpp/src/Ice/RequestHandlerCache.h
+++ b/cpp/src/Ice/RequestHandlerCache.h
@@ -18,7 +18,7 @@ namespace IceInternal
 
         RequestHandlerPtr getRequestHandler();
 
-        Ice::ConnectionPtr getCachedConnection();
+        Ice::ConnectionPtr getCachedConnection() noexcept;
 
         void clearCachedRequestHandler(const RequestHandlerPtr& handler);
 

--- a/csharp/src/Ice/Internal/ConnectRequestHandler.cs
+++ b/csharp/src/Ice/Internal/ConnectRequestHandler.cs
@@ -65,7 +65,7 @@ internal class ConnectRequestHandler : RequestHandler, Reference.GetConnectionCa
     {
         lock (_mutex)
         {
-            // Return the connection in whatever state it is; when the connection establishment failed, return null.
+            // Return the connection in whatever state it is; if the connection establishment failed, return null.
             // Like all getConnection implementations, this method never throws: a null return is how the absence of a
             // connection is reported.
             return _connection;

--- a/csharp/src/Ice/Internal/ConnectRequestHandler.cs
+++ b/csharp/src/Ice/Internal/ConnectRequestHandler.cs
@@ -65,20 +65,10 @@ internal class ConnectRequestHandler : RequestHandler, Reference.GetConnectionCa
     {
         lock (_mutex)
         {
-            //
-            // First check for the connection, it's important otherwise the user could first get a connection
-            // and then the exception if he tries to obtain the proxy cached connection multiple times (the
-            // exception can be set after the connection is set if the flush of pending requests fails).
-            //
-            if (_connection != null)
-            {
-                return _connection;
-            }
-            else if (_exception != null)
-            {
-                throw _exception;
-            }
-            return null;
+            // Return the connection in whatever state it is; when the connection establishment failed, return null.
+            // Like all getConnection implementations, this method never throws: a null return is how the absence of a
+            // connection is reported.
+            return _connection;
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectRequestHandler.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectRequestHandler.java
@@ -51,9 +51,9 @@ final class ConnectRequestHandler
 
     @Override
     public synchronized ConnectionI getConnection() {
-        // Return the connection in whatever state it is; when the connection establishment failed,
-        // return null. Like all getConnection implementations, this method never throws: a null
-        // return is how the absence of a connection is reported.
+        // Return the connection in whatever state it is; if the connection establishment failed, return null.
+        // Like all getConnection implementations, this method never throws: a null return is how the absence of a
+        // connection is reported.
         return _connection;
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectRequestHandler.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectRequestHandler.java
@@ -51,16 +51,10 @@ final class ConnectRequestHandler
 
     @Override
     public synchronized ConnectionI getConnection() {
-        // First check for the connection, it's important otherwise the user could first get a
-        // connection and then the exception if he tries to obtain the proxy cached connection
-        // multiple times (the exception can be set after the connection is set if the flush of
-        // pending requests fails).
-        if (_connection != null) {
-            return _connection;
-        } else if (_exception != null) {
-            throw (LocalException) _exception.fillInStackTrace();
-        }
-        return null;
+        // Return the connection in whatever state it is; when the connection establishment failed,
+        // return null. Like all getConnection implementations, this method never throws: a null
+        // return is how the absence of a connection is reported.
+        return _connection;
     }
 
     //


### PR DESCRIPTION
`ice_getCachedConnection` is documented to return the cached connection if there is one and null otherwise, and in C++ it is also declared `noexcept`. It could nevertheless throw: while a connection establishment is failing, `ConnectRequestHandler.setException` publishes the exception before the queued requests evict the handler from the proxy's request-handler cache, so a concurrent `ice_getCachedConnection` call in that window reached the rethrow branch in `ConnectRequestHandler.getConnection`. In C++, the exception escaped through the `noexcept` frame and terminated the application; in C# and Java, the call threw the connection-establishment exception where the documentation promises null.

The window is not always brief. When no request is queued on the handler at `setException` time — the establishment fails between `getRequestHandler()` and `sendAsyncRequest()`, including a synchronous failure inside `getRequestHandler()` — nothing evicts the handler: it stays in the cache, and `ice_getCachedConnection` kept throwing, until the pending `sendAsyncRequest` throws and clears it.

## The fix

`ConnectRequestHandler.getConnection` now returns the connection in whatever state it is — null when the establishment failed — instead of rethrowing the stored exception (C++, C#, Java). A comment on `RequestHandler.getConnection` records the contract: implementations never throw; a null return is how the absence of a connection is reported. In C++, the contract is also compiler-enforced: `RequestHandler::getConnection`, its three implementations, and `RequestHandlerCache::getCachedConnection` are now `noexcept`.

## Why the ripple effect is contained

The throwing branch had no legitimate consumer — the entire call chain is a straight line, verified in each mapping:

- `RequestHandlerCache.getCachedConnection` is the **only** caller of `RequestHandler.getConnection`. The other implementations of that method (`FixedRequestHandler` / `ConnectionRequestHandler`, and `CollocatedRequestHandler`) already never throw; `ConnectRequestHandler`'s was the only throwing one.
- The proxy method `ice_getCachedConnection` is in turn the **only** caller of `RequestHandlerCache.getCachedConnection`.

So the change's entire observable surface is the return value of `ice_getCachedConnection` during the failed-establishment window: it now returns null — the same value it returns once the failed handler is evicted from the cache.

JavaScript has the same code shape but is not affected: `setException` and the cache eviction run synchronously in the same event-loop turn, so user code cannot observe the window. The JS code is left unchanged.

No tests: hitting the window requires a thread to call `ice_getCachedConnection` while the runtime is between publishing the connection-establishment failure and completing the queued requests, and there is no deterministic way to hold the runtime in that state from the test harness.

Fixes #6278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
