### PR TITLE
Document that Logger and instrumentation observer implementations must not throw

### DIFF
--- a/cpp/include/Ice/Instrumentation.h
+++ b/cpp/include/Ice/Instrumentation.h
@@ -103,6 +103,9 @@ namespace Ice::Instrumentation
     };
 
     /// The base class for Ice observers.
+    /// @remark The Ice runtime calls observers from contexts where exceptions cannot be handled, such as `noexcept`
+    /// functions. Implementations of this interface and its derived interfaces must not throw exceptions: a thrown
+    /// exception can terminate the process.
     /// @headerfile Ice/Ice.h
     class Observer
     {
@@ -240,6 +243,9 @@ namespace Ice::Instrumentation
     /// objects. This interface should be implemented by add-ins that wish to observe Ice objects in order to collect
     /// statistics. An instance of this interface can be provided to the Ice runtime through the Ice communicator
     /// initialization data.
+    /// @remark The Ice runtime calls this interface from contexts where exceptions cannot be handled, such as
+    /// `noexcept` functions. An implementation of this interface must not throw exceptions: a thrown exception can
+    /// terminate the process.
     /// @headerfile Ice/Ice.h
     class CommunicatorObserver
     {

--- a/cpp/include/Ice/Instrumentation.h
+++ b/cpp/include/Ice/Instrumentation.h
@@ -103,9 +103,9 @@ namespace Ice::Instrumentation
     };
 
     /// The base class for Ice observers.
-    /// @remark The Ice runtime calls observers from contexts where exceptions cannot be handled, such as `noexcept`
-    /// functions. Implementations of this interface and its derived interfaces must not throw exceptions: a thrown
-    /// exception can terminate the process.
+    /// @remark The Ice runtime calls observers from contexts where exceptions cannot be handled, such as destructors
+    /// and `noexcept` functions. Implementations of this interface and its derived interfaces must not throw
+    /// exceptions: a thrown exception can terminate the process.
     /// @headerfile Ice/Ice.h
     class Observer
     {
@@ -244,8 +244,8 @@ namespace Ice::Instrumentation
     /// statistics. An instance of this interface can be provided to the Ice runtime through the Ice communicator
     /// initialization data.
     /// @remark The Ice runtime calls this interface from contexts where exceptions cannot be handled, such as
-    /// `noexcept` functions. An implementation of this interface must not throw exceptions: a thrown exception can
-    /// terminate the process.
+    /// destructors and `noexcept` functions. An implementation of this interface must not throw exceptions: a thrown
+    /// exception can terminate the process.
     /// @headerfile Ice/Ice.h
     class CommunicatorObserver
     {

--- a/cpp/include/Ice/Instrumentation.h
+++ b/cpp/include/Ice/Instrumentation.h
@@ -244,8 +244,8 @@ namespace Ice::Instrumentation
     /// statistics. An instance of this interface can be provided to the Ice runtime through the Ice communicator
     /// initialization data.
     /// @remark The Ice runtime calls this interface from contexts where exceptions cannot be handled, such as
-    /// destructors and `noexcept` functions. An implementation of this interface must not throw exceptions: a thrown
-    /// exception can terminate the process.
+    /// `noexcept` functions. An implementation of this interface must not throw exceptions: a thrown exception can
+    /// terminate the process.
     /// @headerfile Ice/Ice.h
     class CommunicatorObserver
     {

--- a/cpp/include/Ice/Logger.h
+++ b/cpp/include/Ice/Logger.h
@@ -17,9 +17,9 @@ namespace Ice
 
     /// Represents Ice's abstraction for logging and tracing. Applications can provide their own logger by
     /// implementing this abstraction and setting a logger on the communicator.
-    /// @remark The Ice runtime calls the logger from contexts where exceptions cannot be handled, such as destructors
-    /// and `noexcept` functions. An implementation of this interface must not throw exceptions: a thrown exception
-    /// can terminate the process.
+    /// @remark The Ice runtime calls #print, #trace, #warning and #error from contexts where exceptions cannot be
+    /// handled, such as destructors and `noexcept` functions. Implementations of these functions must not throw
+    /// exceptions: a thrown exception can terminate the process.
     /// @see InitializationData
     /// @headerfile Ice/Ice.h
     class ICE_API Logger

--- a/cpp/include/Ice/Logger.h
+++ b/cpp/include/Ice/Logger.h
@@ -17,6 +17,9 @@ namespace Ice
 
     /// Represents Ice's abstraction for logging and tracing. Applications can provide their own logger by
     /// implementing this abstraction and setting a logger on the communicator.
+    /// @remark The Ice runtime calls the logger from contexts where exceptions cannot be handled, such as destructors
+    /// and `noexcept` functions. An implementation of this interface must not throw exceptions: a thrown exception
+    /// can terminate the process.
     /// @see InitializationData
     /// @headerfile Ice/Ice.h
     class ICE_API Logger


### PR DESCRIPTION
Adds a `@remark` to the `Logger` class, the `Ice::Instrumentation::Observer` base class (covering all derived observer interfaces), and `CommunicatorObserver`, stating that the Ice runtime calls these interfaces from contexts where exceptions cannot be handled — such as destructors and `noexcept` functions — and that implementations must not throw: a thrown exception can terminate the process.

Neither interface previously said anything about exceptions, so an application had no way to know that a throwing logger or observer is fatal. The requirement itself is not new: for example, the `Trace`/`Warning`/`Error` helpers flush to the logger from their implicitly-`noexcept` destructors, so this has always been the de facto contract throughout the runtime.

This addresses the documentation part of #6192. Whether to additionally enforce the contract with a central exception barrier is deferred to 3.9.0 with that issue.

No changelog entry: documentation-only, and only applications whose own logger or observer implementations throw are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)