### PR TITLE
Prevent a non-Ice exception from stranding a retry task and hanging Communicator.destroy

### DIFF
--- a/cpp/include/Ice/OutgoingAsync.h
+++ b/cpp/include/Ice/OutgoingAsync.h
@@ -155,7 +155,11 @@ namespace IceInternal
         bool exception(std::exception_ptr) override;
 
         void retryException();
+
+        // Retries the invocation; when the retry attempt fails, completes the invocation with the exception. This
+        // function never throws.
         void retry();
+
         void abort(std::exception_ptr);
 
         std::shared_ptr<ProxyOutgoingAsyncBase> shared_from_this()

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -481,7 +481,7 @@ ProxyOutgoingAsyncBase::invokeImpl(bool userThread)
             }
         }
     }
-    catch (const Exception&)
+    catch (...)
     {
         // If called from the user thread we re-throw, the exception will be caught by the caller and handled using
         // abort.

--- a/csharp/src/Ice/Internal/RetryQueue.cs
+++ b/csharp/src/Ice/Internal/RetryQueue.cs
@@ -15,15 +15,20 @@ public class RetryTask : TimerTask, CancellationHandler
 
     public void runTimerTask()
     {
-        _outAsync.retry();
-
-        //
-        // NOTE: this must be called last, destroy() blocks until all task
-        // are removed to prevent the client thread pool to be destroyed
-        // (we still need the client thread pool at this point to call
-        // exception callbacks with CommunicatorDestroyedException).
-        //
-        _retryQueue.remove(this);
+        try
+        {
+            _outAsync.retry();
+        }
+        finally
+        {
+            //
+            // NOTE: this must be called last, destroy() blocks until all task
+            // are removed to prevent the client thread pool to be destroyed
+            // (we still need the client thread pool at this point to call
+            // exception callbacks with CommunicatorDestroyedException).
+            //
+            _retryQueue.remove(this);
+        }
     }
 
     public void asyncRequestCanceled(OutgoingAsyncBase outAsync, Ice.LocalException ex)

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RetryTask.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RetryTask.java
@@ -14,13 +14,18 @@ class RetryTask implements Runnable, CancellationHandler {
     @Override
     public void run() {
         if (cancel()) {
-            _outAsync.retry();
-
-            // NOTE: this must be called last, destroy() blocks until all task
-            // are removed to prevent the client thread pool to be destroyed
-            // (we still need the client thread pool at this point to call
-            // exception callbacks with CommunicatorDestroyedException).
-            _queue.remove(this);
+            try {
+                _outAsync.retry();
+            } catch (Throwable ex) {
+                // The scheduled executor silently swallows exceptions thrown by its tasks.
+                _instance.initializationData().logger.error("unexpected exception from retry task:\n" + Ex.toString(ex));
+            } finally {
+                // NOTE: this must be called last, destroy() blocks until all task
+                // are removed to prevent the client thread pool to be destroyed
+                // (we still need the client thread pool at this point to call
+                // exception callbacks with CommunicatorDestroyedException).
+                _queue.remove(this);
+            }
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RetryTask.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RetryTask.java
@@ -18,7 +18,8 @@ class RetryTask implements Runnable, CancellationHandler {
                 _outAsync.retry();
             } catch (Throwable ex) {
                 // The scheduled executor silently swallows exceptions thrown by its tasks.
-                _instance.initializationData().logger.error("unexpected exception from retry task:\n" + Ex.toString(ex));
+                String msg = "unexpected exception from retry task:\n" + Ex.toString(ex);
+                _instance.initializationData().logger.error(msg);
             } finally {
                 // NOTE: this must be called last, destroy() blocks until all task
                 // are removed to prevent the client thread pool to be destroyed


### PR DESCRIPTION
A non-Ice exception escaping `ProxyOutgoingAsyncBase.retry()` left the retry task in the retry queue forever: `Communicator.destroy()` waits for the queue to empty and hung permanently, and in Java the exception wasn't even logged (the scheduled executor swallows task exceptions into an unread `Future`).

This is defense-in-depth, not support for new behavior. Every sanctioned flow on the retry path — connection failures, `NoEndpointException`, retry exhaustion — raises an Ice exception, which was already caught and completed the invocation; the new code is unreachable for those flows. What can actually reach it:

- an instrumentation observer callback (`InvocationObserver.retried()`, `failed()`, `getRemoteObserver()`) that throws a non-Ice exception — forbidden since #6292, but nothing enforces the contract until the `noexcept` work planned with #6192;
- an allocation failure (`std::bad_alloc` / `OutOfMemoryException` / `OutOfMemoryError`) in the retry machinery — rare but not misuse;
- a latent runtime bug under `sendAsyncRequest`.

For all three, a silent permanent hang of `destroy()` is the worst possible outcome.

## The fix

- **C++**: `invokeImpl` now catches any exception on the retry path (`catch (...)` instead of `catch (const Exception&)`) and completes the invocation with it — the C++ completion machinery is `exception_ptr`-based end to end, so the caller's future receives the original exception. As a result `retry()` never throws, which is now documented on its declaration. (`noexcept` was deliberately not added in 3.8.x to keep the exported function's contract unchanged; it can come with the #6192 `noexcept` work in 3.9.)
- **C# and Java**: the completion machinery only accepts Ice exceptions, and wrapping a locally-thrown exception in `UnknownException` would misuse its meaning ("the server replied with the UnknownException reply status"), so these runtimes get containment instead: the retry task removes itself from the queue in a `finally` block, preserving the requirement that removal happens only after the retry attempt finishes. In C#, the timer's existing catch-all logs the escaped exception; in Java, the task logs it (`catch (Throwable)`, as in #6254) since the executor would swallow it silently. The invocation's `Task`/`CompletableFuture` still doesn't complete in this case — generalizing the C#/Java exception plumbing so it can, mirroring the C++ model, is #6294 (3.9).

One residual in C++: an observer that throws from `failed()` *during* the exceptional completion — a second contract violation — can still escape; that's inherent until observers are `noexcept` (3.9, #6192).

No changelog entry: defense-in-depth for contract-violating callbacks and allocation failure. No tests: exercising the path requires a deliberately-throwing observer, and a regression would manifest as a suite timeout rather than a clean failure.

Verified with the `Ice/retry` and `Ice/ami` suites in C++, C#, and Java. JavaScript is unaffected: its runtime has no instrumentation observers on the retry path.

Fixes #6111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)