### PR TITLE
Fix race between concurrent ObjectAdapter destroy calls in Java

### DIFF
--- a/changelog.d/java/6271.md
+++ b/changelog.d/java/6271.md
@@ -1,0 +1,3 @@
+- Fixed a race condition in `ObjectAdapter`: when two threads called `destroy` (or `deactivate`) concurrently on the
+  same object adapter, the second call could mark a fully destroyed adapter as merely deactivated, and a subsequent
+  `destroy` call would then fail with a `NullPointerException`.

--- a/changelog.d/java/6271.md
+++ b/changelog.d/java/6271.md
@@ -1,3 +1,3 @@
-- Fixed a race condition in `ObjectAdapter`: when two threads called `destroy` (or `deactivate`) concurrently on the
-  same object adapter, the second call could mark a fully destroyed adapter as merely deactivated, and a subsequent
-  `destroy` call would then fail with a `NullPointerException`.
+- Fixed a race condition in `ObjectAdapter`: when `destroy` raced with another `destroy` or with `deactivate` on
+  the same object adapter, the destroyed adapter could be marked as merely deactivated, and a subsequent `destroy`
+  call would then fail with a `NullPointerException`.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -220,7 +220,7 @@ public final class ObjectAdapter {
         synchronized (this) {
             // Wait for activation or a previous deactivation to complete.
             // This is necessary to avoid out of order locator updates.
-            while (_state == StateActivating) {
+            while (_state == StateActivating || _state == StateDeactivating) {
                 try {
                     wait();
                 } catch (InterruptedException ex) {
@@ -251,6 +251,7 @@ public final class ObjectAdapter {
         }
 
         synchronized (this) {
+            assert (_state == StateDeactivating);
             _state = StateDeactivated;
             notifyAll();
         }


### PR DESCRIPTION
`ObjectAdapter.deactivate()` only waited out `StateActivating`, so a second concurrent `deactivate()` entered the deactivation body while the first was still blocked in `updateLocatorRegistry`, and later unconditionally wrote `StateDeactivated` — overwriting `StateDestroyed` if the first thread's `destroy()` had already completed. The second `destroy()` then failed with a `NullPointerException` on the fields the completed destroy had cleared, and its cleanup path restored `StateDeactivated`, leaving the destroyed adapter destroyable again.

The wait loop now also covers `StateDeactivating`, matching the C++ and C# implementations, so only one thread ever runs the deactivation body; a concurrent caller wakes once the state has advanced past `StateDeactivating` and returns through the existing guard. Also added the same assertion before the final state write that C++ and C# have.

Fixes #6271

🤖 Generated with [Claude Code](https://claude.com/claude-code)