### PR TITLE
Replace Glacier2's duplicate-category assert with a runtime check

### DIFF
--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -1129,21 +1129,29 @@ SessionRouterI::finishCreateSession(const ConnectionPtr& connection, const share
 
     if (_destroy)
     {
-        router->destroy([self = shared_from_this()](exception_ptr e) { self->sessionDestroyException(e); });
+        router->destroy(defaultSessionDestroyExceptionHandler());
 
         throw CannotCreateSessionException("router is shutting down");
     }
 
-    _routersByConnectionHint = _routersByConnection.insert(_routersByConnectionHint, {connection, router});
-
     if (_instance->serverObjectAdapter())
     {
+        // The category is randomly generated, so a collision with an existing session's category should never
+        // occur. Check anyway, and register the category before the connection so that a failure leaves nothing
+        // to undo.
         string category = router->serverProxy()->ice_getIdentity().category;
         assert(!category.empty());
-        auto rc = _routersByCategory.insert({category, router});
-        assert(rc.second);
-        _routersByCategoryHint = rc.first;
+        auto [pos, inserted] = _routersByCategory.insert({category, router});
+        if (!inserted)
+        {
+            router->destroy(defaultSessionDestroyExceptionHandler());
+
+            throw CannotCreateSessionException("duplicate server proxy category");
+        }
+        _routersByCategoryHint = pos;
     }
+
+    _routersByConnectionHint = _routersByConnection.insert(_routersByConnectionHint, {connection, router});
 
     connection->setCloseCallback(
         [self = shared_from_this()](const ConnectionPtr& c)

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -1146,7 +1146,9 @@ SessionRouterI::finishCreateSession(const ConnectionPtr& connection, const share
         {
             router->destroy(defaultSessionDestroyExceptionHandler());
 
-            throw CannotCreateSessionException("duplicate server proxy category");
+            // Not a CannotCreateSessionException: this is an internal error, and the default LoggerMiddleware
+            // logs UnknownException replies.
+            throw UnknownException{__FILE__, __LINE__, "duplicate client category"};
         }
         _routersByCategoryHint = pos;
     }

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -1146,8 +1146,8 @@ SessionRouterI::finishCreateSession(const ConnectionPtr& connection, const share
         {
             router->destroy(defaultSessionDestroyExceptionHandler());
 
-            // Not a CannotCreateSessionException: this is an internal error, and the default LoggerMiddleware
-            // logs UnknownException replies.
+            // Internal error: the only way to get here is a collision of the randomly generated categories.
+            // UnknownException replies are logged by the default LoggerMiddleware.
             throw UnknownException{__FILE__, __LINE__, "duplicate client category"};
         }
         _routersByCategoryHint = pos;


### PR DESCRIPTION
Follow-up to [pepone's review of #6233](https://github.com/zeroc-ice/ice/pull/6233#pullrequestreview-4810201595). Glacier2 guards the uniqueness of each session's randomly generated server proxy category with only an `assert`, which optimized builds compile out: a duplicate silently corrupts `_routersByCategory`, callbacks for the two colliding sessions misroute, and destroying either session erases the shared entry.

With #6233 a duplicate is essentially unreachable, so this is defense in depth: a duplicate now fails cleanly at session creation.

- Move the category registration ahead of the connection registration and check the insert result: a duplicate destroys the router (as the `_destroy` branch does) and throws, leaving no half-registered state.
- Throw `UnknownException` rather than `CannotCreateSessionException`: a duplicate is an internal error, not a refusal, and the default `LoggerMiddleware` logs Unknown replies so the operator sees it.
- Reuse `defaultSessionDestroyExceptionHandler()` in the `_destroy` branch in place of an identical inline lambda.

Fixes zeroc-ice/ice-audit#127.
