### PR TITLE
Deliver messages to remote loggers when Logger admin retention is 0

### DIFF
--- a/changelog.d/cpp/6259.md
+++ b/changelog.d/cpp/6259.md
@@ -1,0 +1,5 @@
+- Fixed the delivery of log messages to remote loggers attached to the Logger admin facet when
+  `Ice.Admin.Logger.KeepLogs` or `Ice.Admin.Logger.KeepTraces` is set to `0` (their default value is `100`). These
+  properties control only how many messages the facet retains for `getLog` and `RemoteLogger::init`; previously,
+  setting one of them to `0` also prevented the live delivery of messages of the corresponding category to attached
+  remote loggers.

--- a/changelog.d/java/6259.md
+++ b/changelog.d/java/6259.md
@@ -1,0 +1,5 @@
+- Fixed the delivery of log messages to remote loggers attached to the Logger admin facet when
+  `Ice.Admin.Logger.KeepLogs` or `Ice.Admin.Logger.KeepTraces` is set to `0` (their default value is `100`). These
+  properties control only how many messages the facet retains for `getLog` and `RemoteLogger.init`; previously,
+  setting one of them to `0` also prevented the live delivery of messages of the corresponding category to attached
+  remote loggers.

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -510,21 +510,21 @@ namespace
                     }
                 }
             }
+        }
 
-            //
-            // Queue updated, now find which remote loggers want this message
-            //
-            for (const auto& q : _remoteLoggerMap)
+        //
+        // Queue updated, now find which remote loggers want this message
+        //
+        for (const auto& q : _remoteLoggerMap)
+        {
+            const Filters& filters = q.second;
+
+            if (filters.messageTypes.empty() || filters.messageTypes.count(logMessage.type) != 0)
             {
-                const Filters& filters = q.second;
-
-                if (filters.messageTypes.empty() || filters.messageTypes.count(logMessage.type) != 0)
+                if (logMessage.type != LogMessageType::TraceMessage || filters.traceCategories.empty() ||
+                    filters.traceCategories.count(logMessage.traceCategory) != 0)
                 {
-                    if (logMessage.type != LogMessageType::TraceMessage || filters.traceCategories.empty() ||
-                        filters.traceCategories.count(logMessage.traceCategory) != 0)
-                    {
-                        remoteLoggers.push_back(q.first);
-                    }
+                    remoteLoggers.push_back(q.first);
                 }
             }
         }

--- a/cpp/test/Ice/admin/AllTests.cpp
+++ b/cpp/test/Ice/admin/AllTests.cpp
@@ -560,6 +560,44 @@ allTests(Test::TestHelper* helper)
 
         com->destroy();
     }
+    {
+        // With KeepLogs=0 and KeepTraces=0, no message is retained, but messages are still delivered to
+        // attached remote loggers.
+        PropertyDict props;
+        props["Ice.Admin.Endpoints"] = "tcp -h " + defaultHost;
+        props["Ice.Admin.InstanceName"] = "Test";
+        props["NullLogger"] = "1";
+        props["Ice.Admin.Logger.KeepLogs"] = "0";
+        props["Ice.Admin.Logger.KeepTraces"] = "0";
+        optional<RemoteCommunicatorPrx> com = factory->createCommunicator(props);
+
+        com->print("print1");
+        com->trace("testCat", "trace1");
+
+        auto logger = com->getAdmin()->ice_facet<LoggerAdminPrx>("Logger");
+        string prefix;
+
+        LogMessageSeq logMessages = logger->getLog(LogMessageTypeSeq(), StringSeq(), -1, prefix);
+        test(logMessages.empty());
+
+        ObjectAdapterPtr adapter =
+            communicator->createObjectAdapterWithEndpoints("RemoteLoggerAdapter2", "tcp -h localhost");
+        RemoteLoggerIPtr remoteLogger = std::make_shared<RemoteLoggerI>();
+        auto myProxy = adapter->addWithUUID<RemoteLoggerPrx>(remoteLogger);
+        adapter->activate();
+
+        logger->attachRemoteLogger(myProxy, LogMessageTypeSeq(), StringSeq(), -1);
+        test(remoteLogger->wait(1));
+
+        com->print("print2");
+        com->trace("testCat", "trace2");
+        test(remoteLogger->wait(2));
+
+        remoteLogger->checkNextLog(LogMessageType::PrintMessage, "print2");
+        remoteLogger->checkNextLog(LogMessageType::TraceMessage, "trace2", "testCat");
+
+        com->destroy();
+    }
     cout << "ok" << endl;
 
     cout << "testing custom facet... " << flush;

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -444,6 +444,47 @@ public class AllTests : global::Test.AllTests
 
             com.destroy();
         }
+        {
+            // With KeepLogs=0 and KeepTraces=0, no message is retained, but messages are still delivered to
+            // attached remote loggers.
+            var props = new Dictionary<string, string>
+            {
+                { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                { "Ice.Admin.InstanceName", "Test" },
+                { "NullLogger", "1" },
+                { "Ice.Admin.Logger.KeepLogs", "0" },
+                { "Ice.Admin.Logger.KeepTraces", "0" }
+            };
+            Test.RemoteCommunicatorPrx com = factory.createCommunicator(props);
+
+            com.print("print1");
+            com.trace("testCat", "trace1");
+
+            var logger = Ice.LoggerAdminPrxHelper.checkedCast(com.getAdmin(), "Logger");
+            test(logger != null);
+
+            Ice.LogMessage[] logMessages = logger.getLog(null, null, -1, out string prefix);
+            test(logMessages.Length == 0);
+
+            Ice.ObjectAdapter adapter =
+                communicator.createObjectAdapterWithEndpoints("RemoteLoggerAdapter2", "tcp -h localhost");
+            var remoteLogger = new RemoteLoggerI();
+            Ice.RemoteLoggerPrx myProxy =
+                Ice.RemoteLoggerPrxHelper.uncheckedCast(adapter.addWithUUID(remoteLogger));
+            adapter.activate();
+
+            logger.attachRemoteLogger(myProxy, null, null, -1);
+            remoteLogger.wait(1);
+
+            com.print("print2");
+            com.trace("testCat", "trace2");
+            remoteLogger.wait(2);
+
+            remoteLogger.checkNextLog(Ice.LogMessageType.PrintMessage, "print2", "");
+            remoteLogger.checkNextLog(Ice.LogMessageType.TraceMessage, "trace2", "testCat");
+
+            com.destroy();
+        }
         output.WriteLine("ok");
 
         output.Write("testing custom facet... ");

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -350,7 +350,7 @@ public class AllTests : global::Test.AllTests
             logMessages = logger.getLog(null, null, -1, out prefix);
 
             logger.attachRemoteLogger(myProxy, null, null, -1);
-            remoteLogger.wait(1);
+            test(remoteLogger.wait(1));
 
             foreach (LogMessage m in logMessages)
             {
@@ -362,7 +362,7 @@ public class AllTests : global::Test.AllTests
             com.error("rerror");
             com.print("rprint");
 
-            remoteLogger.wait(4);
+            test(remoteLogger.wait(4));
 
             remoteLogger.checkNextLog(Ice.LogMessageType.TraceMessage, "rtrace", "testCat");
             remoteLogger.checkNextLog(Ice.LogMessageType.WarningMessage, "rwarning", "");
@@ -379,7 +379,7 @@ public class AllTests : global::Test.AllTests
             test(logMessages.Length == 4);
 
             logger.attachRemoteLogger(myProxy, messageTypes, categories, 4);
-            remoteLogger.wait(1);
+            test(remoteLogger.wait(1));
 
             foreach (LogMessage m in logMessages)
             {
@@ -392,7 +392,7 @@ public class AllTests : global::Test.AllTests
             com.error("rerror2");
             com.print("rprint2");
 
-            remoteLogger.wait(2);
+            test(remoteLogger.wait(2));
 
             remoteLogger.checkNextLog(Ice.LogMessageType.TraceMessage, "rtrace2", "testCat");
             remoteLogger.checkNextLog(Ice.LogMessageType.ErrorMessage, "rerror2", "");
@@ -474,11 +474,11 @@ public class AllTests : global::Test.AllTests
             adapter.activate();
 
             logger.attachRemoteLogger(myProxy, null, null, -1);
-            remoteLogger.wait(1);
+            test(remoteLogger.wait(1));
 
             com.print("print2");
             com.trace("testCat", "trace2");
-            remoteLogger.wait(2);
+            test(remoteLogger.wait(2));
 
             remoteLogger.checkNextLog(Ice.LogMessageType.PrintMessage, "print2", "");
             remoteLogger.checkNextLog(Ice.LogMessageType.TraceMessage, "trace2", "testCat");
@@ -720,16 +720,24 @@ public class AllTests : global::Test.AllTests
             }
         }
 
-        internal void wait(int calls)
+        internal bool wait(int calls)
         {
             lock (_mutex)
             {
                 _receivedCalls -= calls;
 
+                var timer = System.Diagnostics.Stopwatch.StartNew();
                 while (_receivedCalls < 0)
                 {
-                    Monitor.Wait(_mutex);
+                    TimeSpan timeout = TimeSpan.FromSeconds(20) - timer.Elapsed;
+                    if (timeout <= TimeSpan.Zero)
+                    {
+                        Console.Error.WriteLine($"expected '{calls}' received: '{calls + _receivedCalls}'");
+                        return false; // Waited for more than 20s, something's wrong.
+                    }
+                    Monitor.Wait(_mutex, timeout);
                 }
+                return true;
             }
         }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
@@ -190,20 +190,20 @@ final class LoggerAdminI implements LoggerAdmin {
                     _traceCount++;
                 }
             }
+        }
 
-            // Queue updated, now find which remote loggers want this message
-            for (RemoteLoggerData p : _remoteLoggerMap.values()) {
-                Filters filters = p.filters;
+        // Queue updated, now find which remote loggers want this message
+        for (RemoteLoggerData p : _remoteLoggerMap.values()) {
+            Filters filters = p.filters;
 
-                if (filters.messageTypes.isEmpty() || filters.messageTypes.contains(logMessage.type)) {
-                    if (logMessage.type != LogMessageType.TraceMessage
-                        || filters.traceCategories.isEmpty()
-                        || filters.traceCategories.contains(logMessage.traceCategory)) {
-                        if (remoteLoggers == null) {
-                            remoteLoggers = new ArrayList<>();
-                        }
-                        remoteLoggers.add(p.remoteLogger);
+            if (filters.messageTypes.isEmpty() || filters.messageTypes.contains(logMessage.type)) {
+                if (logMessage.type != LogMessageType.TraceMessage
+                    || filters.traceCategories.isEmpty()
+                    || filters.traceCategories.contains(logMessage.traceCategory)) {
+                    if (remoteLoggers == null) {
+                        remoteLoggers = new ArrayList<>();
                     }
+                    remoteLoggers.add(p.remoteLogger);
                 }
             }
         }

--- a/java/test/src/main/java/test/Ice/admin/AllTests.java
+++ b/java/test/src/main/java/test/Ice/admin/AllTests.java
@@ -463,6 +463,51 @@ public class AllTests {
 
             rcom.destroy();
         }
+        {
+            // With KeepLogs=0 and KeepTraces=0, no message is retained, but messages are still
+            // delivered to attached remote loggers.
+            Map<String, String> props = new HashMap<>();
+            props.put("Ice.Admin.Endpoints", "tcp -h 127.0.0.1");
+            props.put("Ice.Admin.InstanceName", "Test");
+            props.put("NullLogger", "1");
+            props.put("Ice.Admin.Logger.KeepLogs", "0");
+            props.put("Ice.Admin.Logger.KeepTraces", "0");
+            RemoteCommunicatorPrx rcom = factory.createCommunicator(props);
+
+            rcom.print("print1");
+            rcom.trace("testCat", "trace1");
+
+            LoggerAdminPrx logger = LoggerAdminPrx.checkedCast(rcom.getAdmin(), "Logger");
+            test(logger != null);
+
+            LoggerAdmin.GetLogResult r = logger.getLog(null, null, -1);
+            test(r.returnValue.length == 0);
+
+            ObjectAdapter adapter =
+                helper.communicator()
+                    .createObjectAdapterWithEndpoints(
+                        "RemoteLoggerAdapter2", "tcp -h localhost");
+            RemoteLoggerI remoteLogger = new RemoteLoggerI();
+            RemoteLoggerPrx myProxy =
+                RemoteLoggerPrx.uncheckedCast(adapter.addWithUUID(remoteLogger));
+            adapter.activate();
+
+            try {
+                logger.attachRemoteLogger(myProxy, null, null, -1);
+            } catch (RemoteLoggerAlreadyAttachedException ex) {
+                test(false);
+            }
+            remoteLogger.wait(1);
+
+            rcom.print("print2");
+            rcom.trace("testCat", "trace2");
+            remoteLogger.wait(2);
+
+            remoteLogger.checkNextLog(LogMessageType.PrintMessage, "print2", "");
+            remoteLogger.checkNextLog(LogMessageType.TraceMessage, "trace2", "testCat");
+
+            rcom.destroy();
+        }
         out.println("ok");
 
         out.print("testing custom facet... ");

--- a/java/test/src/main/java/test/Ice/admin/AllTests.java
+++ b/java/test/src/main/java/test/Ice/admin/AllTests.java
@@ -375,7 +375,7 @@ public class AllTests {
             } catch (RemoteLoggerAlreadyAttachedException ex) {
                 test(false);
             }
-            remoteLogger.wait(1);
+            test(remoteLogger.wait(1));
 
             for (int i = 0; i < r.returnValue.length; i++) {
                 LogMessage m = r.returnValue[i];
@@ -387,7 +387,7 @@ public class AllTests {
             rcom.error("rerror");
             rcom.print("rprint");
 
-            remoteLogger.wait(4);
+            test(remoteLogger.wait(4));
 
             remoteLogger.checkNextLog(LogMessageType.TraceMessage, "rtrace", "testCat");
             remoteLogger.checkNextLog(LogMessageType.WarningMessage, "rwarning", "");
@@ -408,7 +408,7 @@ public class AllTests {
             } catch (RemoteLoggerAlreadyAttachedException ex) {
                 test(false);
             }
-            remoteLogger.wait(1);
+            test(remoteLogger.wait(1));
 
             for (int i = 0; i < r.returnValue.length; i++) {
                 LogMessage m = r.returnValue[i];
@@ -421,7 +421,7 @@ public class AllTests {
             rcom.error("rerror2");
             rcom.print("rprint2");
 
-            remoteLogger.wait(2);
+            test(remoteLogger.wait(2));
 
             remoteLogger.checkNextLog(LogMessageType.TraceMessage, "rtrace2", "testCat");
             remoteLogger.checkNextLog(LogMessageType.ErrorMessage, "rerror2", "");
@@ -497,11 +497,11 @@ public class AllTests {
             } catch (RemoteLoggerAlreadyAttachedException ex) {
                 test(false);
             }
-            remoteLogger.wait(1);
+            test(remoteLogger.wait(1));
 
             rcom.print("print2");
             rcom.trace("testCat", "trace2");
-            remoteLogger.wait(2);
+            test(remoteLogger.wait(2));
 
             remoteLogger.checkNextLog(LogMessageType.PrintMessage, "print2", "");
             remoteLogger.checkNextLog(LogMessageType.TraceMessage, "trace2", "testCat");

--- a/java/test/src/main/java/test/Ice/admin/RemoteLoggerI.java
+++ b/java/test/src/main/java/test/Ice/admin/RemoteLoggerI.java
@@ -49,16 +49,23 @@ class RemoteLoggerI implements RemoteLogger {
         test(logMessage.traceCategory.equals(category));
     }
 
-    synchronized void wait(int calls) {
+    synchronized boolean wait(int calls) {
         _receivedCalls -= calls;
 
+        final long start = System.currentTimeMillis();
         while (_receivedCalls < 0) {
+            long timeout = start + 20000 - System.currentTimeMillis();
+            if (timeout <= 0) {
+                System.err.println("expected '" + calls + "' received: '" + (calls + _receivedCalls) + "'");
+                return false; // Waited for more than 20s, something's wrong.
+            }
             try {
-                wait();
+                wait(timeout);
             } catch (InterruptedException ex) {
-                break;
+                return false;
             }
         }
+        return true;
     }
 
     private static void test(boolean b) {


### PR DESCRIPTION
In the C++ and Java `LoggerAdminI::log`, the loop that computes which attached remote loggers should receive a message was nested inside the `if` that guards the retention queue update. With `Ice.Admin.Logger.KeepLogs=0` or `Ice.Admin.Logger.KeepTraces=0`, messages of the corresponding category were therefore never delivered to attached remote loggers — silently. The retention properties are only supposed to bound what the facet keeps for `getLog` and `RemoteLogger::init`; C# already had the loop outside the guard and behaved correctly.

This PR moves the fan-out loop out of the retention guard in C++ and Java, matching the C# structure, and adds a retention=0 case to the admin test in all three mappings (C# included, to guard against future divergence): with both properties set to `0`, `getLog` returns nothing but an attached remote logger still receives print and trace messages live. I verified the new test fails against the unfixed C++ library.

Fixes #6259

🤖 Generated with [Claude Code](https://claude.com/claude-code)