### PR TITLE
Make Communicator.close non-interruptible in Java

### DIFF
--- a/changelog.d/java/6270.md
+++ b/changelog.d/java/6270.md
@@ -1,0 +1,3 @@
+- `Communicator.close` is no longer interruptible: it now always completes the destruction of the communicator and
+  preserves the calling thread's interrupt status. Previously, calling this method from an interrupted thread could
+  throw `OperationInterruptedException` and leave the communicator partially destroyed.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -90,8 +90,9 @@ public final class Communicator implements AutoCloseable {
 
     /**
      * Destroys this communicator. This method behaves like {@link #close}, except it can be interrupted: if the
-     * calling thread is interrupted, this method throws {@link OperationInterruptedException} and the destruction
-     * of the communicator is incomplete; call this method again to complete it.
+     * calling thread is interrupted while this method waits during the destruction, this method throws
+     * {@link OperationInterruptedException} and the destruction of the communicator is incomplete; call this
+     * method again to complete it.
      */
     public void destroy() {
         _instance.destroy(true);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -79,18 +79,22 @@ public final class Communicator implements AutoCloseable {
      * all object adapters, and closes all outgoing connections. This method waits for all outstanding dispatches
      * to complete before returning. This includes "bidirectional dispatches" that execute on outgoing connections.
      *
+     * <p>This method is not interruptible: if the calling thread is interrupted, the communicator is
+     * nevertheless fully destroyed, and the thread's interrupt status is restored before this method returns.
+     *
      * @see ObjectAdapter#destroy
      */
     public void close() {
-        // Don't allow destroy to be interrupted if called from try with statement.
         _instance.destroy(false);
     }
 
     /**
-     * Destroys this communicator. It's an alias for {@link #close}.
+     * Destroys this communicator. This method behaves like {@link #close}, except it can be interrupted: if the
+     * calling thread is interrupted, this method throws {@link OperationInterruptedException} and the destruction
+     * of the communicator is incomplete; call this method again to complete it.
      */
     public void destroy() {
-        _instance.destroy(true); // Destroy is interruptible when call explicitly.
+        _instance.destroy(true);
     }
 
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -89,10 +89,11 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Destroys this communicator. This method behaves like {@link #close}, except it can be interrupted: if the
-     * calling thread is interrupted while this method waits during the destruction, this method throws
-     * {@link OperationInterruptedException} and the destruction of the communicator is incomplete; call this
-     * method again to complete it.
+     * Destroys this communicator. This method behaves like {@link #close}, except it can be interrupted.
+     *
+     * @throws OperationInterruptedException if the calling thread is interrupted while this method waits during
+     *     the destruction. The destruction of the communicator is then incomplete; call this method again to
+     *     complete it.
      */
     public void destroy() {
         _instance.destroy(true);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
@@ -119,17 +119,16 @@ class EndpointHostResolver {
 
     void joinWithThread() throws InterruptedException {
         // Wait for the executor to terminate.
-        try {
-            while (!_executor.isTerminated()) {
-                // A very long time.
-                _executor.awaitTermination(100000, TimeUnit.SECONDS);
-            }
+        while (!_executor.isTerminated()) {
+            // A very long time.
+            _executor.awaitTermination(100000, TimeUnit.SECONDS);
+        }
 
-        } finally {
-            if (_observer != null) {
-                _observer.detach();
-                _observer = null;
-            }
+        // Don't detach the observer earlier (e.g. when the wait above is interrupted): an in-flight resolver task can
+        // use this observer until the executor has terminated.
+        if (_observer != null) {
+            _observer.detach();
+            _observer = null;
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
@@ -128,6 +128,7 @@ class EndpointHostResolver {
         } finally {
             if (_observer != null) {
                 _observer.detach();
+                _observer = null;
             }
         }
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -922,6 +922,10 @@ public final class Instance {
         }
     }
 
+    // Destroys this instance. This method does not throw any exception, with one exception: it throws
+    // OperationInterruptedException when the calling thread is interrupted during an interruptible wait. The
+    // destruction is then incomplete, and a new destroyImpl call can complete it. Note that the logger and the
+    // communicator observer, which this method calls during the destruction, are expected to not throw any exception.
     private void destroyImpl() {
         synchronized (this) {
             // If destroy is in progress, wait for it to be done.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -902,6 +902,27 @@ public final class Instance {
 
     // Only for use by com.zeroc.Ice.Communicator
     void destroy(boolean interruptible) {
+        if (interruptible) {
+            destroyImpl();
+        } else {
+            // Complete the destruction even if the calling thread is interrupted, and restore the
+            // interrupt status once the destruction is complete.
+            boolean interrupted = Thread.interrupted();
+            while (true) {
+                try {
+                    destroyImpl();
+                    break;
+                } catch (OperationInterruptedException ex) {
+                    interrupted = true;
+                }
+            }
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private void destroyImpl() {
         synchronized (this) {
             // If destroy is in progress, wait for it to be done.
             // This is necessary in case destroy() is called concurrently by multiple threads.
@@ -909,9 +930,7 @@ public final class Instance {
                 try {
                     wait();
                 } catch (InterruptedException ex) {
-                    if (interruptible) {
-                        throw new OperationInterruptedException(ex);
-                    }
+                    throw new OperationInterruptedException(ex);
                 }
             }
 
@@ -987,9 +1006,7 @@ public final class Instance {
                     }
                 }
             } catch (InterruptedException ex) {
-                if (interruptible) {
-                    throw new OperationInterruptedException(ex);
-                }
+                throw new OperationInterruptedException(ex);
             }
 
             // NOTE: at this point destroy() can't be interrupted
@@ -1052,7 +1069,7 @@ public final class Instance {
         } finally {
             synchronized (this) {
                 if (_state == StateDestroyInProgress) {
-                    assert interruptible;
+                    // Destroy did not complete: restore a state that allows destroy to be called again.
                     _state = StateActive;
                     notifyAll();
                 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
@@ -159,9 +159,11 @@ final class LoggerAdminI implements LoggerAdmin {
             }
         }
 
-        // Destroy outside lock to avoid deadlock when there are outstanding two-way log calls sent to remote loggers
+        // Destroy outside lock to avoid deadlock when there are outstanding two-way log calls sent to remote loggers.
+        // Use close, not destroy: this method is not re-runnable (_destroyed is already latched), so the destruction
+        // must not be interruptible.
         if (sendLogCommunicator != null) {
-            sendLogCommunicator.destroy();
+            sendLogCommunicator.close();
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -220,7 +220,7 @@ public final class ObjectAdapter {
         synchronized (this) {
             // Wait for activation or a previous deactivation to complete.
             // This is necessary to avoid out of order locator updates.
-            while (_state == StateActivating) {
+            while (_state == StateActivating || _state == StateDeactivating) {
                 try {
                     wait();
                 } catch (InterruptedException ex) {
@@ -240,6 +240,10 @@ public final class ObjectAdapter {
         if (hasPublishedEndpoints) {
             try {
                 updateLocatorRegistry(_locatorInfo, null);
+            } catch (OperationInterruptedException ex) {
+                // We can't throw exceptions in deactivate: re-set the interrupt flag so that the
+                // calling thread observes the interruption.
+                Thread.currentThread().interrupt();
             } catch (LocalException ex) {
                 // We can't throw exceptions in deactivate so we ignore
                 // failures to update the locator registry.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapterFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapterFactory.java
@@ -14,11 +14,6 @@ final class ObjectAdapterFactory {
     public void shutdown() {
         List<ObjectAdapter> adapters;
         synchronized (this) {
-            // Ignore shutdown requests if the object adapter factory has already been shut down.
-            if (_instance == null) {
-                return;
-            }
-
             _instance = null;
             _communicator = null;
             notifyAll();

--- a/java/test/src/main/java/test/Ice/interrupt/AllTests.java
+++ b/java/test/src/main/java/test/Ice/interrupt/AllTests.java
@@ -3,6 +3,7 @@
 package test.Ice.interrupt;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.CommunicatorDestroyedException;
 import com.zeroc.Ice.CompressBatch;
 import com.zeroc.Ice.Connection;
 import com.zeroc.Ice.InitializationData;
@@ -458,6 +459,31 @@ public class AllTests {
             executor.shutdown();
             while (!executor.isTerminated()) {
                 executor.awaitTermination(1000, TimeUnit.SECONDS);
+            }
+        }
+        out.println("ok");
+
+        out.print("testing Communicator.close interrupt... ");
+        out.flush();
+        if (p.ice_getConnection() != null) {
+            InitializationData initData = new InitializationData();
+            initData.properties = communicator.getProperties()._clone();
+            Communicator ic = helper.initialize(initData);
+            String proxyString = "test:" + helper.getTestEndpoint(0);
+            TestIntfPrx p2 = TestIntfPrx.createProxy(ic, proxyString);
+            p2.ice_ping();
+
+            // close() is not interruptible: it destroys the communicator even when the calling thread
+            // is interrupted, and restores the interrupt status.
+            Thread.currentThread().interrupt();
+            ic.close();
+            test(Thread.interrupted());
+
+            try {
+                TestIntfPrx.createProxy(ic, proxyString);
+                test(false);
+            } catch (CommunicatorDestroyedException ex) {
+                // Expected
             }
         }
         out.println("ok");


### PR DESCRIPTION
`Communicator.close` was intended to be non-interruptible (per the inline comment "Don't allow destroy to be interrupted if called from try with statement"), but `Instance.destroy(false)` only shielded its own wait/join calls. The `OperationInterruptedException` thrown from the interruptible waits reached through `ObjectAdapterFactory.destroy` and the other subsystem teardowns escaped `close()`, leaving the communicator partially destroyed and tripping `assert interruptible` under `-ea`.

This PR makes `close()` actually honor the contract. The destroy body is now always interruptible and restores a retryable state when interrupted — the design #6253 completed for object adapters — and the non-interruptible mode is a retry loop around it: it clears the calling thread's interrupt status, retries the destruction whenever an interrupt aborts it, and restores the interrupt status once the destruction is complete. This also fixes a secondary defect of the old shielding, where a swallowed interrupt skipped the remaining thread-pool joins. `Communicator.destroy()` keeps its documented interruptible behavior, and the doc-comments of both methods now state the contract (the old `destroy()` doc claimed it is an alias for `close`, which was inaccurate).

Making every teardown step re-runnable is a correctness requirement of this design, and the review found two steps that didn't meet it:

- `ObjectAdapterFactory.shutdown` early-returned once `_instance` was latched to null, so when the first destroy pass was interrupted inside an adapter's activation wait, the retried pass skipped the `deactivate` loop and `waitForShutdown` waited forever. The early return is removed: `ObjectAdapter.deactivate` is idempotent and `_adapters` is empty after destroy, so repeat calls are cheap.
- `EndpointHostResolver.joinWithThread` detached its observer without clearing it, so a retried pass detached the same observer twice (an `AssertionError` from `StopWatch` under `-ea`, corrupted thread metrics otherwise). The observer is now cleared after the detach.

A new comment on `destroyImpl` records its contract: it throws nothing but `OperationInterruptedException` (leaving the destruction incomplete but resumable), and the logger and communicator observer it calls during the destruction are expected to not throw. Consistent with that contract, the retry loop does not add defensive handling for exceptions that would only come from an implementation violating that expectation.

The new test is a red/green regression test for #6270: run unchanged against the previous `Instance.java`, it throws the #6270 `AssertionError` — the test guarantees a live outgoing connection, so the pre-set interrupt flag makes `ConnectionI.waitUntilFinished` throw immediately during `close()`. With this PR, `close()` destroys the communicator, does not throw, and preserves the interrupt status.

This is specific to the Java mapping: thread interrupt support does not exist in the other language mappings.

Fixes #6270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
