### PR TITLE
Fix Ruby getImplicitContext crash under the default configuration

### DIFF
--- a/changelog.d/ruby/6104.md
+++ b/changelog.d/ruby/6104.md
@@ -1,0 +1,3 @@
+- Fixed a crash in `Communicator#getImplicitContext`: with the default `Ice.ImplicitContext=None` configuration, this
+  method returned a broken `ImplicitContext` object whose methods crashed the Ruby interpreter. It now returns `nil`
+  when the communicator has no implicit context.

--- a/ruby/src/IceRuby/Communicator.cpp
+++ b/ruby/src/IceRuby/Communicator.cpp
@@ -390,7 +390,7 @@ IceRuby_Communicator_getImplicitContext(VALUE self)
     {
         Ice::CommunicatorPtr p = getCommunicator(self);
         Ice::ImplicitContextPtr implicitContext = p->getImplicitContext();
-        return createImplicitContext(implicitContext);
+        return implicitContext ? createImplicitContext(implicitContext) : Qnil;
     }
     ICE_RUBY_CATCH
     return Qnil;

--- a/ruby/test/Ice/operations/Twoways.rb
+++ b/ruby/test/Ice/operations/Twoways.rb
@@ -1227,6 +1227,14 @@ def twoways(helper, communicator, p)
     #
     # Test implicit context propagation
     #
+
+    # Under the default Ice.ImplicitContext=None, there is no implicit context.
+    initData = Ice::InitializationData.new
+    initData.properties = communicator.getProperties().clone()
+    ic = Ice::initialize(initData)
+    test(ic.getImplicitContext().nil?)
+    ic.destroy()
+
     impls = [ 'Shared', 'PerThread' ]
     for i in impls
         initData = Ice::InitializationData.new


### PR DESCRIPTION
With the default `Ice.ImplicitContext=None`, the C++ `getImplicitContext()` returns a null `shared_ptr`. The Ruby wrapper stored the null pointer unconditionally, and every method on the returned `ImplicitContext` object (`getContext`, `setContext`, `get`, `put`, `containsKey`, `remove`) dereferenced it, crashing the Ruby interpreter. This is the Ruby sibling of the MATLAB crash fixed by #5975.

`Communicator#getImplicitContext` now returns `nil` when the communicator has no implicit context, matching the existing Python guard.

Following the precedent of #5975, the implicit-context section of the `Ice/operations` test now includes a default-configuration case asserting that `getImplicitContext` returns `nil`. The test fails against the unfixed extension.

Fixes #6104

🤖 Generated with [Claude Code](https://claude.com/claude-code)