### PR TITLE
Fix four low-severity issues in the Ruby extension

### DIFF
--- a/changelog.d/ruby/6116.md
+++ b/changelog.d/ruby/6116.md
@@ -1,0 +1,4 @@
+- Added a `hash` method to `Connection`, consistent with `eql?`. Previously, two `Connection` objects representing
+  the same connection could compare equal but hash differently, so connections could not be used reliably as `Hash`
+  keys or `Set` elements.
+- `ConnectionInfo#connectionId` now returns the ID of the connection. Previously, it was always `nil`.

--- a/changelog.d/ruby/6116.md
+++ b/changelog.d/ruby/6116.md
@@ -1,3 +1,5 @@
+- Fixed a hang at program exit when a communicator is created with a custom `sliceLoader` and destroyed through the
+  block form of `Ice::initialize`, or not destroyed at all.
 - Added a `hash` method to `Connection`, consistent with `eql?`. Previously, two `Connection` objects representing
   the same connection could compare equal but hash differently, so connections could not be used reliably as `Hash`
   keys or `Set` elements.

--- a/ruby/src/IceRuby/Communicator.cpp
+++ b/ruby/src/IceRuby/Communicator.cpp
@@ -28,7 +28,12 @@ namespace
 extern "C" void
 IceRuby_Communicator_free(void* p)
 {
-    delete static_cast<Ice::CommunicatorPtr*>(p);
+    // The wrapper is collected only once no other object (such as a proxy) marks it. Erase the map
+    // entries so that the native communicator and slice loader can be released.
+    auto communicator = static_cast<Ice::CommunicatorPtr*>(p);
+    _communicatorMap.erase(*communicator);
+    _sliceLoaderMap.erase(*communicator);
+    delete communicator;
 }
 
 static const rb_data_type_t IceRuby_CommunicatorType = {
@@ -158,11 +163,6 @@ IceRuby_initialize(int argc, VALUE* argv, VALUE /*self*/)
             &IceRuby_CommunicatorType,
             new Ice::CommunicatorPtr(communicator));
 
-        CommunicatorMap::iterator p = _communicatorMap.find(communicator);
-        if (p != _communicatorMap.end())
-        {
-            _communicatorMap.erase(p);
-        }
         _communicatorMap.insert(CommunicatorMap::value_type(communicator, reinterpret_cast<const VALUE&>(result)));
 
         _sliceLoaderMap[communicator] = sliceLoader;

--- a/ruby/src/IceRuby/Connection.cpp
+++ b/ruby/src/IceRuby/Connection.cpp
@@ -188,13 +188,10 @@ IceRuby_Connection_equals(VALUE self, VALUE other)
 {
     ICE_RUBY_TRY
     {
-        if (NIL_P(other))
+        // eql? returns false for a non-Connection argument: Ruby calls it with arbitrary keys on a Hash collision.
+        if (NIL_P(other) || callRuby(rb_obj_is_kind_of, other, _connectionClass) != Qtrue)
         {
             return Qfalse;
-        }
-        if (callRuby(rb_obj_is_kind_of, other, _connectionClass) != Qtrue)
-        {
-            throw RubyException(rb_eTypeError, "argument must be a connection");
         }
         Ice::ConnectionPtr* p1 = reinterpret_cast<Ice::ConnectionPtr*>(DATA_PTR(self));
         Ice::ConnectionPtr* p2 = reinterpret_cast<Ice::ConnectionPtr*>(DATA_PTR(other));

--- a/ruby/src/IceRuby/Connection.cpp
+++ b/ruby/src/IceRuby/Connection.cpp
@@ -204,6 +204,19 @@ IceRuby_Connection_equals(VALUE self, VALUE other)
     return Qnil;
 }
 
+extern "C" VALUE
+IceRuby_Connection_hash(VALUE self)
+{
+    ICE_RUBY_TRY
+    {
+        Ice::ConnectionPtr* p = reinterpret_cast<Ice::ConnectionPtr*>(DATA_PTR(self));
+        // Hash the native pointer, which is exactly what eql? compares.
+        return INT2FIX(std::hash<Ice::ConnectionPtr>{}(*p));
+    }
+    ICE_RUBY_CATCH
+    return Qnil;
+}
+
 // ConnectionInfo
 
 extern "C" void
@@ -300,6 +313,7 @@ IceRuby::createConnectionInfo(const Ice::ConnectionInfoPtr& p)
     rb_ivar_set(info, rb_intern("@underlying"), createConnectionInfo(p->underlying));
     rb_ivar_set(info, rb_intern("@incoming"), p->incoming ? Qtrue : Qfalse);
     rb_ivar_set(info, rb_intern("@adapterName"), createString(p->adapterName));
+    rb_ivar_set(info, rb_intern("@connectionId"), createString(p->connectionId));
     return info;
 }
 
@@ -333,6 +347,7 @@ IceRuby::initConnection(VALUE iceModule)
     rb_define_method(_connectionClass, "inspect", CAST_METHOD(IceRuby_Connection_toString), 0);
     rb_define_method(_connectionClass, "==", CAST_METHOD(IceRuby_Connection_equals), 1);
     rb_define_method(_connectionClass, "eql?", CAST_METHOD(IceRuby_Connection_equals), 1);
+    rb_define_method(_connectionClass, "hash", CAST_METHOD(IceRuby_Connection_hash), 0);
 
     //
     // ConnectionInfo.

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -553,7 +553,7 @@ IceRuby::PrimitiveInfo::marshal(VALUE p, Ice::OutputStream* os, ValueMap*, bool)
             }
             assert(TYPE(val) == T_FLOAT);
             double d = static_cast<double>(RFLOAT_VALUE(val));
-            if (isfinite(d) && (d > numeric_limits<float>::max() || d < -numeric_limits<float>::max()))
+            if (isfinite(d) && (d > numeric_limits<float>::max() || d < numeric_limits<float>::lowest()))
             {
                 throw RubyException(rb_eTypeError, "value is out of range for a float");
             }
@@ -1421,7 +1421,12 @@ IceRuby::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, VALU
                     throw RubyException(rb_eTypeError, "unable to convert array element %ld to a float", i);
                 }
                 assert(TYPE(v) == T_FLOAT);
-                seq[static_cast<size_t>(i)] = static_cast<float>(RFLOAT_VALUE(v));
+                double d = static_cast<double>(RFLOAT_VALUE(v));
+                if (isfinite(d) && (d > numeric_limits<float>::max() || d < numeric_limits<float>::lowest()))
+                {
+                    throw RubyException(rb_eTypeError, "array element %ld is out of range for a float", i);
+                }
+                seq[static_cast<size_t>(i)] = static_cast<float>(d);
             }
             os->write(seq);
             break;

--- a/ruby/test/Ice/info/AllTests.rb
+++ b/ruby/test/Ice/info/AllTests.rb
@@ -105,6 +105,15 @@ def allTests(helper, communicator)
 
     test(!info.incoming)
     test(info.adapterName.length == 0)
+    test(info.connectionId == "")
+    test(testIntf.ice_connectionId("ID").ice_getConnection().getInfo().connectionId == "ID")
+
+    # Two wrappers for the same connection are eql? and hash to the same value, so they can be
+    # used interchangeably as Hash keys.
+    otherConnection = testIntf.ice_getConnection()
+    test(connection.eql?(otherConnection))
+    test(connection.hash == otherConnection.hash)
+    test({ connection => 1 }.key?(otherConnection))
     test(tcpinfo.remotePort == port)
     if defaultHost == "127.0.0.1"
         test(tcpinfo.remoteAddress == defaultHost)

--- a/ruby/test/Ice/info/AllTests.rb
+++ b/ruby/test/Ice/info/AllTests.rb
@@ -108,12 +108,6 @@ def allTests(helper, communicator)
     test(info.connectionId == "")
     test(testIntf.ice_connectionId("ID").ice_getConnection().getInfo().connectionId == "ID")
 
-    # Two wrappers for the same connection are eql? and hash to the same value, so they can be
-    # used interchangeably as Hash keys.
-    otherConnection = testIntf.ice_getConnection()
-    test(connection.eql?(otherConnection))
-    test(connection.hash == otherConnection.hash)
-    test({ connection => 1 }.key?(otherConnection))
     test(tcpinfo.remotePort == port)
     if defaultHost == "127.0.0.1"
         test(tcpinfo.remoteAddress == defaultHost)
@@ -121,6 +115,14 @@ def allTests(helper, communicator)
     end
     test(tcpinfo.rcvSize >= 1024)
     test(tcpinfo.sndSize >= 2048)
+
+    # Two wrappers for the same connection are eql? and hash to the same value, so they can be
+    # used interchangeably as Hash keys.
+    otherConnection = testIntf.ice_getConnection()
+    test(connection.eql?(otherConnection))
+    test(connection.hash == otherConnection.hash)
+    test({ connection => 1 }.key?(otherConnection))
+    test(!connection.eql?("not a connection"))
 
     ctx = testIntf.getConnectionInfoAsContext()
     test(ctx["incoming"] == "true")

--- a/ruby/test/Ice/objects/Client.rb
+++ b/ruby/test/Ice/objects/Client.rb
@@ -15,5 +15,14 @@ class Client < ::TestHelper
             initial = allTests(self, communicator)
             initial.shutdown()
         end
+
+        # The block form of Ice::initialize destroys the communicator through the C++ API when the block returns,
+        # without going through the Ruby-level destroy. The process must still exit cleanly when a custom slice
+        # loader is set.
+        initData = Ice::InitializationData.new
+        initData.properties = self.createTestProperties(args:args)
+        initData.sliceLoader = CustomSliceLoader.new
+        Ice::initialize(initData) do |communicator|
+        end
     end
 end

--- a/ruby/test/Ice/operations/Twoways.rb
+++ b/ruby/test/Ice/operations/Twoways.rb
@@ -244,6 +244,12 @@ def twoways(helper, communicator, p)
     rescue TypeError
     end
 
+    begin
+        p.opFloatDoubleS([-3.402823466E38*2], [])
+        test(false)
+    rescue TypeError
+    end
+
     #
     # opString
     #

--- a/ruby/test/Ice/operations/Twoways.rb
+++ b/ruby/test/Ice/operations/Twoways.rb
@@ -238,6 +238,12 @@ def twoways(helper, communicator, p)
     rescue TypeError
     end
 
+    begin
+        p.opFloatDoubleS([3.402823466E38*2], [])
+        test(false)
+    rescue TypeError
+    end
+
     #
     # opString
     #


### PR DESCRIPTION
One fix per item of #6116:

**1. Communicator / slice-loader map leak — and a hang at exit.** The `_communicatorMap`/`_sliceLoaderMap` entries now get erased in the communicator wrapper's GC free function. They cannot be erased in `destroy()`: `IceRuby_ObjectPrx_mark` looks up (and asserts) the communicator wrapper in the map for every live proxy, so the entry must survive as long as any proxy does. The free function is the correct point — it only runs once nothing marks the wrapper, which implies no proxy for that communicator is alive. This releases the native communicator and slice loader that were previously pinned for the process lifetime, and it fixes a deterministic hang at exit: with a custom `sliceLoader`, the pinned entry was released only during the C++ runtime's static destruction, which runs after the Ruby VM is gone — `~RubySliceLoader` then calls `rb_gc_unregister_address` on a dead VM, segfaults, and Ruby's fatal-signal handler wedges. Any program that doesn't call the Ruby-level `destroy()` was affected, including programs using the documented block form of `Ice::initialize`: the block form destroys the communicator through the C++ API and so never ran the Ruby-level erase. Our test suite always destroys communicators explicitly through `TestHelper`, which is why CI never saw the hang. Also removed the dead lookup before the map insert: a live entry's key (a `shared_ptr`) keeps the C++ communicator alive, so `Ice::initialize` can never return a pointer that is still a key.

**2. `Connection#hash`.** Added, hashing the native pointer — exactly what `eql?` compares — restoring Ruby's `eql?` ⇒ `hash` contract so connections work as `Hash` keys and `Set` elements. Proxy and Endpoint already had `hash`; Connection was the only mismatch. `eql?` also now returns `false` for a non-Connection argument instead of raising `TypeError`: Ruby calls `eql?` with arbitrary keys on a `Hash` collision, so a well-behaved `Hash` key must accept them.

**3. `ConnectionInfo#connectionId`.** Now assigned from the C++ `ConnectionInfo`; it was declared but never set, so it was always `nil`. Assigning (rather than removing the attr, as the issue suggested) is backward compatible and matches C++, C#, and Java, which all expose `connectionId`; Python's missing exposure is tracked in #6301.

**4. `sequence<float>` range check.** The optimized sequence marshaling path now applies the same check as a plain `float` parameter: a finite value outside the `float` range raises `TypeError` instead of silently marshaling as `Infinity` (the finite-out-of-range `double` → `float` conversion is also undefined behavior in C++). Infinity and NaN still pass through, as for plain floats. Both checks now spell the lower bound with `numeric_limits<float>::lowest()`. The same gap exists in IcePy and is tracked in #6301.

Tests: `Ice/objects` now exercises the block form of `Ice::initialize` with a custom slice loader and exits normally — against the unfixed extension, the client hangs at exit. `Ice/info` covers `connectionId` (default and with `ice_connectionId`), `eql?`/`hash`/Hash-membership for two wrappers of the same connection, and `eql?` with a non-Connection argument; `Ice/operations` covers out-of-range `sequence<float>` elements of both signs. All three suites fail against the unfixed extension and pass with the fixes.

The changelog fragment covers items 1–3; item 4 only changes how an out-of-range input fails.

Fixes #6116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
