### PR TITLE
Generate JavaScript UUIDs with the Web Crypto API

### DIFF
--- a/js/packages/ice/src/Ice/UUID.js
+++ b/js/packages/ice/src/Ice/UUID.js
@@ -1,11 +1,17 @@
 // Copyright (c) ZeroC, Inc.
 
+/**
+ * Generates a version 4 (random) UUID.
+ * @returns The UUID, in the canonical 8-4-4-4-12 lowercase hexadecimal form.
+ */
 export function generateUUID() {
-    let d = new Date().getTime();
-    const uuid = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, c => {
-        const r = ((d + Math.random() * 16) % 16) | 0;
-        d = Math.floor(d / 16);
-        return (c == "x" ? r : (r & 0x3) | 0x8).toString(16);
-    });
-    return uuid;
+    // crypto.getRandomValues is the only member of the Crypto interface that is not restricted to secure contexts,
+    // so this works in browsers served over plain HTTP as well.
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    // Set the version (4) and variant (10xx) bits.
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, "0")).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }


### PR DESCRIPTION
Fixes #6260.

`generateUUID` built UUIDs from `Date.getTime()` and `Math.random()`. Every other mapping uses a CSPRNG, so this
switches the JavaScript mapping to the Web Crypto API.

### Why `getRandomValues` and not `randomUUID`

#2576 proposed this in 2024 and was closed `NOT_PLANNED` because `crypto.randomUUID()` is secure-context-only. That
is true of `randomUUID`, but `[SecureContext]` is applied to individual `Crypto` members rather than to the
interface — `getRandomValues()` carries no such restriction. Verified in Chrome on a non-localhost plain-HTTP origin,
where `127.0.0.1` would give a false pass because it is a *potentially trustworthy* origin:

```
origin:                        http://192.168.1.62:8080
isSecureContext:               false
typeof crypto.randomUUID:      undefined
typeof crypto.subtle:          undefined
typeof crypto.getRandomValues: function
```

So this deliberately has no `randomUUID` fast path. Branching on it would pick a different code path depending on
whether the page happens to be on HTTPS — the failure mode that sank #2576.

Note that no test can catch a regression here: the browser harness serves over `127.0.0.1` (`scripts/Util.py`), which
is a secure context, and CI never runs the tests in a browser at all.

### Verification

Old implementation, two Node processes with the same V8 `--random_seed`:

| | old | new |
|---|---|---|
| run A | `2cf8533a-f51e-4f4e-9619-6e97f7800a05` | `dfe6528e-9b94-4913-8dee-e1eaa0b771f9` |
| run B | `def8533a-f51e-4f4e-9619-6e97f7800a05` | `b27f7247-4b65-4496-8648-6532d893c135` |

The old one reproduces 30 of 32 hex digits — `d` is divided by 16 each iteration, so the timestamp is exhausted after
about ten characters and everything after it comes from `Math.random()` alone.

- 100k UUIDs per version on Node 22.22, 23.11, 24.14 and 25.6: all match the RFC 9562 v4 form, all unique, version
  nibble always `4`, variant nibble always one of `8/9/a/b`.
- `Ice/facets`, `Ice/ami` and `Ice/inheritance` pass in Chrome via `allTests.py --browser Manual` against a C++
  server over `ws`, including `testing add facet with uuid`. Every browser test reaches `generateUUID` regardless,
  since the test controller registers each process with `addWithUUID`.
- Exercised through the real rollup bundle in the browser: 20,000 `addWithUUID` identities, all unique and well
  formed, on the insecure origin above.

No changelog entry: the JavaScript mapping is mostly used client side, where the identities minted by `addWithUUID`
are only reachable by the peer that was already given them, so this is consistency with the other mappings rather
than a user-visible fix.

The one remaining `Math.random()` in the mapping (`Reference.js`) shuffles endpoints for
`EndpointSelectionType.Random` and is left alone.
