### PR TITLE
Publish DataStorm partial updates with an empty custom encoding

### DIFF
--- a/changelog.d/datastorm/6306.md
+++ b/changelog.d/datastorm/6306.md
@@ -1,0 +1,4 @@
+- Fixed a bug where a partial update that a custom `Encoder` encodes to an empty byte sequence was published with
+  the encoding of the sample's full resolved value instead of the partial update's own payload, while the sample
+  event remained `PartialUpdate`. Readers then decoded the full value's bytes as a partial update value. The sample
+  now tracks whether its payload is encoded instead of treating an empty payload as not yet encoded.

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -320,7 +320,8 @@ namespace DataStormI
             Ice::ByteSeq value,
             std::int64_t timestamp)
             : Sample(std::move(session), std::move(origin), id, event, key, tag, std::move(value), timestamp),
-              _hasValue(false)
+              _hasValue(false),
+              _hasEncodedValue(true)
         {
         }
 
@@ -330,7 +331,8 @@ namespace DataStormI
 
         SampleT(Ice::ByteSeq value, const std::shared_ptr<Tag>& tag)
             : Sample(DataStorm::SampleEvent::PartialUpdate, tag),
-              _hasValue(false)
+              _hasValue(false),
+              _hasEncodedValue(true)
         {
             _encodedValue = std::move(value);
         }
@@ -378,9 +380,10 @@ namespace DataStormI
 
         [[nodiscard]] const Ice::ByteSeq& encode(const Ice::CommunicatorPtr& communicator) final
         {
-            if (_encodedValue.empty())
+            if (!_hasEncodedValue)
             {
                 _encodedValue = encodeValue(communicator);
+                _hasEncodedValue = true;
             }
             return _encodedValue;
         }
@@ -409,10 +412,16 @@ namespace DataStormI
             _value = DecoderT<Value>::decode(communicator, _encodedValue);
             _hasValue = true;
             _encodedValue.clear();
+            _hasEncodedValue = false;
         }
 
     private:
         bool _hasValue;
+        // True when _encodedValue holds the sample's encoded payload. The payload can be empty: a custom Encoder may
+        // legitimately encode a value or a partial update to zero bytes, so the emptiness of _encodedValue can't
+        // serve as the "not yet encoded" marker. Without this flag, encode() would replace a zero-byte partial update
+        // payload with the encoding of the full resolved value while the sample event remains PartialUpdate.
+        bool _hasEncodedValue = false;
         // Value-initialized because getValue() returns this member for a value-less sample, where it is documented to
         // return a default value; a scalar type would otherwise be indeterminate.
         Value _value{};

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -474,6 +474,30 @@ void ::Reader::run(int argc, char* argv[])
         test(sample.getValue().value == 5); // resolved against the empty-encoded base
     }
 
+    // A partial update whose custom encoding is empty is delivered as-is and resolved against the key's value: the
+    // writer must not replace the zero-byte payload with the encoding of the full resolved value.
+    Topic<string, Counter> emptyEncodedUpdateTopic(node, "emptyEncodedUpdateTopic");
+    emptyEncodedUpdateTopic.setReaderDefaultConfig(config);
+    emptyEncodedUpdateTopic.setUpdater<Counter>(
+        "add",
+        [](Counter& counter, Counter delta) { counter.value += delta.value; });
+    {
+        auto reader = makeSingleKeyReader(emptyEncodedUpdateTopic, "key");
+
+        auto sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Add);
+        test(sample.getValue().value == 5);
+
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::PartialUpdate);
+        test(sample.getUpdateTag() == "add");
+        test(sample.getValue().value == 5); // 5 + 0; the zero-byte payload was delivered, not the full value's bytes
+
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::PartialUpdate);
+        test(sample.getValue().value == 8); // 5 + 3
+    }
+
     // Two readers of the same key on one node hold different values for it, because only one of them applies the
     // priority discard policy. A partial update accepted by both is resolved against each reader's own value.
     Topic<string, StockPtr> perReaderTopic(node, "perReaderTopic");

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -413,6 +413,26 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // A partial update whose custom encoding is empty must be forwarded as-is: the emptiness of the encoded payload
+    // is not a "not yet encoded" marker. The writer used to replace a zero-byte payload with the encoding of the full
+    // resolved value while the sample event remained PartialUpdate, so the reader decoded full-value bytes as a
+    // partial update value.
+    Topic<string, Counter> emptyEncodedUpdateTopic(node, "emptyEncodedUpdateTopic");
+    emptyEncodedUpdateTopic.setWriterDefaultConfig(config);
+    emptyEncodedUpdateTopic.setUpdater<Counter>(
+        "add",
+        [](Counter& counter, Counter delta) { counter.value += delta.value; });
+    cout << "testing partial update with an empty encoding... " << flush;
+    {
+        auto writer = makeSingleKeyWriter(emptyEncodedUpdateTopic, "key");
+        writer.waitForReaders();
+        writer.add(Counter{5});
+        writer.partialUpdate<Counter>("add")(Counter{0}); // the update value 0 encodes to zero bytes
+        writer.partialUpdate<Counter>("add")(Counter{3});
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
     // Two readers of the same key on one node hold different values for it: the reader without a discard policy
     // accepts the low-priority writer's full value, the reader using the priority discard policy discards it and keeps
     // the high-priority writer's value. The partial update published next must be resolved against each reader's own


### PR DESCRIPTION
Fixes #6306.

A partial update whose custom `Encoder` produces an empty byte sequence was published with the encoding of the sample's full resolved value instead of its own payload, while the sample event remained `PartialUpdate`. Readers then decoded the full value's bytes as a partial update value, silently corrupting the update. Same bug class as #6084 (fixed by #6175), which established that zero-byte custom encodings are legitimate.

`SampleT::encode` used the emptiness of `_encodedValue` as its "not yet encoded" marker. The sample now tracks the encoded state with a dedicated `_hasEncodedValue` flag, so a legitimately empty payload is forwarded as-is. The flag is reset in `decode()`, preserving the existing re-encode behavior for decoded samples.

The `std::optional<Ice::ByteSeq>` refactoring suggested in the issue is left to #6231, which is scoped for 3.9.0; this fix uses a plain flag so it can be cherry-picked to 3.8.

Changes:
- `cpp/include/DataStorm/InternalT.h`: track encoded state explicitly instead of treating an empty payload as not yet encoded. Header-only change to a class instantiated only in application code; no library ABI impact.
- `cpp/test/DataStorm/partial`: new test section publishing a zero-byte-encoded partial update; it fails without the fix (the reader resolves 5 + 5 = 10 from the corrupted full-value payload instead of 5 + 0 = 5) and passes with it.
- `changelog.d/datastorm/6306.md`: changelog fragment.

The full DataStorm test suite (11 tests) passes on macOS.
