### PR TITLE
Hash the proxy request context in key order in Ice for JavaScript

### DIFF
--- a/js/packages/ice/src/Ice/Reference.js
+++ b/js/packages/ice/src/Ice/Reference.js
@@ -144,9 +144,11 @@ export class Reference {
         h = HashUtil.addNumber(h, this._mode);
         h = HashUtil.addHashable(h, this._identity);
         if (this._context !== null && this._context !== undefined) {
-            for (const [key, value] of this._context) {
+            // Fold the entries in key order. equals compares contexts without regard to order, so the hash code must
+            // not depend on the order in which the entries were inserted into the Map.
+            for (const key of [...this._context.keys()].sort()) {
                 h = HashUtil.addString(h, key);
-                h = HashUtil.addString(h, value);
+                h = HashUtil.addString(h, this._context.get(key));
             }
         }
         h = HashUtil.addString(h, this._facet);

--- a/js/packages/test/Ice/proxy/Client.ts
+++ b/js/packages/test/Ice/proxy/Client.ts
@@ -730,6 +730,19 @@ export class Client extends TestHelper {
         test(!compObj.ice_context(null!).equals(compObj.ice_context(ctx2)));
         test(!compObj.ice_context(ctx1).equals(compObj.ice_context(ctx2)));
 
+        // Two proxies with the same context entries are equal and hash the same, whatever the order in which the
+        // entries were added to the context.
+        const ctx3 = new Map([
+            ["ctx1", "v1"],
+            ["ctx2", "v2"],
+        ]);
+        const ctx4 = new Map([
+            ["ctx2", "v2"],
+            ["ctx1", "v1"],
+        ]);
+        test(compObj.ice_context(ctx3).equals(compObj.ice_context(ctx4)));
+        test(compObj.ice_context(ctx3).hashCode() === compObj.ice_context(ctx4).hashCode());
+
         let compObj1 = new Ice.ObjectPrx(communicator, "foo:" + defaultProtocol + " -h 127.0.0.1 -p 10000");
         let compObj2 = new Ice.ObjectPrx(communicator, "foo:" + defaultProtocol + " -h 127.0.0.1 -p 10001");
         test(!compObj1.equals(compObj2));


### PR DESCRIPTION
Fixes #6114

`Reference.hashCode` folded the context `Map` in iteration order — which for a JS `Map` is insertion
order — while `Reference.equals` compares contexts order-independently through `MapUtil.equals`.
`Ice.HashMap` short-circuits on the stored hash before consulting the comparator, so two equal
proxies whose context entries were added in different orders missed on `get`/`has`/`delete`, and
`set` inserted a duplicate entry instead of replacing the existing one.

Fold the entries in key order instead, which is what the C++ mapping gets for free by folding a
`std::map`.

JavaScript was the only mapping with this asymmetry: Java delegates to `Map.hashCode()`, and C#
hashes only the entry count.

Contexts that genuinely differ still hash differently — including ones differing only in the
key/value association, such as `{a: "1", b: "2"}` versus `{a: "2", b: "1"}`. The proxy's stored
context keeps its own iteration order, so nothing changes on the wire.

The added assertion in `Ice/proxy` fails without the fix.
