### PR TITLE
Run one btbond worker per process

### DIFF
--- a/java/test/android/btbond/src/main/AndroidManifest.xml
+++ b/java/test/android/btbond/src/main/AndroidManifest.xml
@@ -10,8 +10,12 @@
     <uses-permission android:name="android.permission.BLUETOOTH_PRIVILEGED" />
 
     <application android:label="btbond">
+        <!-- Logic-only activity: handle every config change in place rather than being destroyed
+             and recreated. ApplicationInfo updates still relaunch it regardless; the onCreate guard
+             covers those. -->
         <activity
             android:name=".MainActivity"
+            android:configChanges="colorMode|density|fontScale|fontWeightAdjustment|grammaticalGender|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
+++ b/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
@@ -57,9 +57,11 @@ public class MainActivity extends Activity {
     private volatile BluetoothServerSocket serverSocket;
     private volatile BluetoothSocket socket;
 
-    // Process-wide, because the instances that race are in one process -- see onCreate. Only ever
-    // touched from the main thread.
-    private static Thread activeWorker;
+    // Process-wide, because the instances that race are in one process -- see onCreate. Set on the
+    // main thread, cleared by the worker's finally, so volatile. isAlive() is what keeps the guard
+    // correct either way; the clear just stops a finished thread staying reachable for the rest of
+    // the process.
+    private static volatile Thread activeWorker;
 
     // Best-effort auto-accept of incoming pairing requests. The app runs as a privileged system app
     // (BLUETOOTH_PRIVILEGED), so setPairingConfirmation should succeed; setPin is a fallback that logs
@@ -97,6 +99,13 @@ public class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle b) {
         super.onCreate(b);
+        // Registered before the guard below returns: a relaunch destroys the old instance first, so
+        // returning ahead of this would leave the process with no ACTION_PAIRING_REQUEST receiver
+        // for the rest of the surviving worker's run -- the one thing this app is installed to do.
+        registerReceiver(
+            pairingReceiver,
+            new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST),
+            Context.RECEIVER_EXPORTED);
         Intent it = getIntent();
         final String mode = it.getStringExtra("mode");
         final String peer = it.getStringExtra("peer");
@@ -105,24 +114,32 @@ public class MainActivity extends Activity {
         // reuses the original intent, so onCreate can run again with the same extras. Two RFCOMM
         // connects from one adapter to the same peer and UUID resolve the same DLCI: the second is
         // refused with PORT_ALREADY_OPENED and the stack tears down the first worker's port too, so
-        // both fail. One worker at a time. Report it, so a start refused here fails the caller with
-        // this reason rather than as an unexplained connect failure.
+        // both fail. One worker at a time.
         Thread running = activeWorker;
         if (running != null && running.isAlive()) {
-            result(mode, false, "a worker is already running in this process");
-            finish();
+            if (b == null) {
+                // A fresh start while a worker is still going -- a server left in accept() by an
+                // earlier attempt, say. Nothing else will speak for this one, so give the caller a
+                // verdict and a reason.
+                result(mode, false, "a worker is already running in this process");
+                finish();
+            } else {
+                // A relaunch: savedInstanceState is non-null because handleRelaunchActivityInner
+                // stops with saveState=true. The original worker owns this run, so emit no verdict
+                // -- bond() reads the last RESULT line, and a FAIL here would land while that
+                // worker is still in createBond/connect and condemn a healthy run. Stay resident
+                // until it finishes, so the process keeps an activity and this receiver.
+                Log.i(TAG, "relaunch while a worker is running; it owns this run's verdict");
+                finishWhenWorkerEnds();
+            }
             return;
         }
-        // ACTION_PAIRING_REQUEST is a system broadcast; register exported (and unregister in onDestroy).
-        registerReceiver(
-            pairingReceiver,
-            new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST),
-            Context.RECEIVER_EXPORTED);
         Log.i(TAG, "start mode=" + mode + " peer=" + peer);
         worker = new Thread(() -> {
             try {
                 run(mode, peer, uuid);
             } finally {
+                activeWorker = null;
                 // Finish so a subsequent `am start` re-runs onCreate with the new extras. A
                 // standard-launch-mode activity left resident is simply brought to front, and the
                 // caller would then match the previous run's result line out of logcat.
@@ -130,8 +147,8 @@ public class MainActivity extends Activity {
                 runOnUiThread(MainActivity.this::finish);
             }
         });
-        worker.start();
         activeWorker = worker;
+        worker.start();
         new Handler(Looper.getMainLooper()).postDelayed(
             () -> {
                 if (worker != null && worker.isAlive()) {
@@ -141,6 +158,26 @@ public class MainActivity extends Activity {
                 }
             },
             WATCHDOG_MS);
+    }
+
+    // Keeps a refused relaunch resident until the worker it deferred to is done. Finishing straight
+    // away would leave that worker in a process with no activity and no service, which Android is
+    // free to kill -- taking the server's listening socket with it.
+    private void finishWhenWorkerEnds() {
+        Handler handler = new Handler(Looper.getMainLooper());
+        handler.postDelayed(
+            new Runnable() {
+                @Override
+                public void run() {
+                    Thread running = activeWorker;
+                    if (running == null || !running.isAlive()) {
+                        finish();
+                    } else {
+                        handler.postDelayed(this, 1000);
+                    }
+                }
+            },
+            1000);
     }
 
     // Closing the sockets is what actually unblocks accept/connect/read; interrupt() does not.

--- a/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
+++ b/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
@@ -61,6 +61,10 @@ public class MainActivity extends Activity {
     // thread, cleared by the worker's finally, so volatile.
     private static volatile Thread activeWorker;
 
+    // Never cleared: a relaunch must not re-run the intent even after the worker it belongs to has
+    // finished -- activeWorker is null by then, but the run already has its verdict.
+    private static volatile boolean workerStarted;
+
     // Best-effort auto-accept of incoming pairing requests. The app runs as a privileged system app
     // (BLUETOOTH_PRIVILEGED), so setPairingConfirmation should succeed; setPin is a fallback that logs
     // any SecurityException.
@@ -109,21 +113,23 @@ public class MainActivity extends Activity {
         final String uuid = it.getStringExtra("uuid");
         // A relaunch (see onDestroy) re-runs onCreate with the same extras. Two RFCOMM connects to
         // the same peer and UUID resolve the same DLCI and the stack tears both down, taking the
-        // server's accepted connection with them -- so one worker at a time.
+        // server's accepted connection with them -- so one worker per process, ever.
+        //
+        // b is non-null when the instance is being recreated, not on a fresh `am start`. The
+        // worker -- live or already finished -- owns this run's verdict; a FAIL here would become
+        // the last RESULT line and condemn a healthy run. Stay resident so the process keeps an
+        // activity and this receiver.
+        if (b != null && workerStarted) {
+            Log.i(TAG, "relaunch after this process started a worker; it owns this run's verdict");
+            finishWhenWorkerEnds();
+            return;
+        }
         Thread running = activeWorker;
         if (running != null && running.isAlive()) {
-            if (b == null) {
-                // A fresh start while a worker is still going. Nothing else will speak for this
-                // attempt, so give the caller a verdict and a reason.
-                result(mode, false, "a worker is already running in this process");
-                finish();
-            } else {
-                // A relaunch -- savedInstanceState is non-null only then. The original worker owns
-                // this run's verdict; a FAIL here would become the last RESULT line and condemn a
-                // healthy run. Stay resident so the process keeps an activity and this receiver.
-                Log.i(TAG, "relaunch while a worker is running; it owns this run's verdict");
-                finishWhenWorkerEnds();
-            }
+            // A fresh start while a worker is still going. Nothing else will speak for this
+            // attempt, so give the caller a verdict and a reason.
+            result(mode, false, "a worker is already running in this process");
+            finish();
             return;
         }
         Log.i(TAG, "start mode=" + mode + " peer=" + peer);
@@ -140,6 +146,7 @@ public class MainActivity extends Activity {
             }
         });
         activeWorker = worker;
+        workerStarted = true;
         worker.start();
         new Handler(Looper.getMainLooper()).postDelayed(
             () -> {
@@ -155,13 +162,16 @@ public class MainActivity extends Activity {
     // Keeps a refused relaunch resident until the worker is done: a process with no activity is
     // fair game for the OS, worker and sockets included.
     private void finishWhenWorkerEnds() {
+        // Bounded: a worker wedged before its sockets are published never unblocks, and a resident
+        // activity would make every later `am start` a no-op for the rest of the boot.
+        long deadline = System.currentTimeMillis() + WATCHDOG_MS + 30_000;
         Handler handler = new Handler(Looper.getMainLooper());
         handler.postDelayed(
             new Runnable() {
                 @Override
                 public void run() {
                     Thread running = activeWorker;
-                    if (running == null || !running.isAlive()) {
+                    if (running == null || !running.isAlive() || System.currentTimeMillis() > deadline) {
                         finish();
                     } else {
                         handler.postDelayed(this, 1000);

--- a/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
+++ b/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
@@ -57,10 +57,9 @@ public class MainActivity extends Activity {
     private volatile BluetoothServerSocket serverSocket;
     private volatile BluetoothSocket socket;
 
-    // The worker of whichever instance is currently running one, or null. Process-wide, because the
-    // instances that race are in one process -- see onCreate. Only ever touched from the main
-    // thread; volatile so the worker's own writes are not needed for visibility.
-    private static volatile Thread activeWorker;
+    // Process-wide, because the instances that race are in one process -- see onCreate. Only ever
+    // touched from the main thread.
+    private static Thread activeWorker;
 
     // Best-effort auto-accept of incoming pairing requests. The app runs as a privileged system app
     // (BLUETOOTH_PRIVILEGED), so setPairingConfirmation should succeed; setPin is a fallback that logs
@@ -98,17 +97,19 @@ public class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle b) {
         super.onCreate(b);
-        // The system recreates this activity during a normal run (see onDestroy), and a relaunch
-        // reuses the original intent -- so onCreate can run again in this process with the same
-        // extras and start a second identical worker. That is survivable only while the two do not
-        // overlap in connect(): two RFCOMM connects from one adapter to the same peer and UUID
-        // resolve the same DLCI, the second is refused with PORT_ALREADY_OPENED, and the stack then
-        // tears down the *first* worker's port as well -- so both fail, and the server's
-        // already-accepted connection dies with them. One worker at a time. onCreate always runs on
-        // the main thread, so testing and assigning below needs no further synchronisation.
+        Intent it = getIntent();
+        final String mode = it.getStringExtra("mode");
+        final String peer = it.getStringExtra("peer");
+        final String uuid = it.getStringExtra("uuid");
+        // The system recreates this activity during a normal run (see onDestroy) and a relaunch
+        // reuses the original intent, so onCreate can run again with the same extras. Two RFCOMM
+        // connects from one adapter to the same peer and UUID resolve the same DLCI: the second is
+        // refused with PORT_ALREADY_OPENED and the stack tears down the first worker's port too, so
+        // both fail. One worker at a time. Report it, so a start refused here fails the caller with
+        // this reason rather than as an unexplained connect failure.
         Thread running = activeWorker;
         if (running != null && running.isAlive()) {
-            Log.i(TAG, "a worker is already running in this process; not starting another");
+            result(mode, false, "a worker is already running in this process");
             finish();
             return;
         }
@@ -117,10 +118,6 @@ public class MainActivity extends Activity {
             pairingReceiver,
             new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST),
             Context.RECEIVER_EXPORTED);
-        Intent it = getIntent();
-        final String mode = it.getStringExtra("mode");
-        final String peer = it.getStringExtra("peer");
-        final String uuid = it.getStringExtra("uuid");
         Log.i(TAG, "start mode=" + mode + " peer=" + peer);
         worker = new Thread(() -> {
             try {

--- a/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
+++ b/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
@@ -29,6 +29,7 @@ import android.content.IntentFilter;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.util.Log;
 
 import java.io.IOException;
@@ -113,7 +114,7 @@ public class MainActivity extends Activity {
         final String uuid = it.getStringExtra("uuid");
         // A relaunch (see onDestroy) re-runs onCreate with the same extras. Two RFCOMM connects to
         // the same peer and UUID resolve the same DLCI and the stack tears both down, taking the
-        // server's accepted connection with them -- so one worker per process, ever.
+        // server's accepted connection with them -- so at most one worker per `am start`.
         //
         // b is non-null when the instance is being recreated, not on a fresh `am start`. The
         // worker -- live or already finished -- owns this run's verdict; a FAIL here would become
@@ -163,15 +164,16 @@ public class MainActivity extends Activity {
     // fair game for the OS, worker and sockets included.
     private void finishWhenWorkerEnds() {
         // Bounded: a worker wedged before its sockets are published never unblocks, and a resident
-        // activity would make every later `am start` a no-op for the rest of the boot.
-        long deadline = System.currentTimeMillis() + WATCHDOG_MS + 30_000;
+        // activity would make every later `am start` a no-op for the rest of the boot. uptimeMillis,
+        // matching the postDelayed clock -- wall time can step and trip the cap early.
+        long deadline = SystemClock.uptimeMillis() + WATCHDOG_MS + 30_000;
         Handler handler = new Handler(Looper.getMainLooper());
         handler.postDelayed(
             new Runnable() {
                 @Override
                 public void run() {
                     Thread running = activeWorker;
-                    if (running == null || !running.isAlive() || System.currentTimeMillis() > deadline) {
+                    if (running == null || !running.isAlive() || SystemClock.uptimeMillis() > deadline) {
                         finish();
                     } else {
                         handler.postDelayed(this, 1000);

--- a/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
+++ b/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
@@ -57,10 +57,8 @@ public class MainActivity extends Activity {
     private volatile BluetoothServerSocket serverSocket;
     private volatile BluetoothSocket socket;
 
-    // Process-wide, because the instances that race are in one process -- see onCreate. Set on the
-    // main thread, cleared by the worker's finally, so volatile. isAlive() is what keeps the guard
-    // correct either way; the clear just stops a finished thread staying reachable for the rest of
-    // the process.
+    // Process-wide -- the instances that race share one process (see onCreate). Set on the main
+    // thread, cleared by the worker's finally, so volatile.
     private static volatile Thread activeWorker;
 
     // Best-effort auto-accept of incoming pairing requests. The app runs as a privileged system app
@@ -99,9 +97,8 @@ public class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle b) {
         super.onCreate(b);
-        // Registered before the guard below returns: a relaunch destroys the old instance first, so
-        // returning ahead of this would leave the process with no ACTION_PAIRING_REQUEST receiver
-        // for the rest of the surviving worker's run -- the one thing this app is installed to do.
+        // Before the guard below: a relaunch destroys the old instance (and its receiver) first,
+        // so returning earlier would leave the surviving worker with no pairing receiver.
         registerReceiver(
             pairingReceiver,
             new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST),
@@ -110,25 +107,20 @@ public class MainActivity extends Activity {
         final String mode = it.getStringExtra("mode");
         final String peer = it.getStringExtra("peer");
         final String uuid = it.getStringExtra("uuid");
-        // The system recreates this activity during a normal run (see onDestroy) and a relaunch
-        // reuses the original intent, so onCreate can run again with the same extras. Two RFCOMM
-        // connects from one adapter to the same peer and UUID resolve the same DLCI: the second is
-        // refused with PORT_ALREADY_OPENED and the stack tears down the first worker's port too, so
-        // both fail. One worker at a time.
+        // A relaunch (see onDestroy) re-runs onCreate with the same extras. Two RFCOMM connects to
+        // the same peer and UUID resolve the same DLCI and the stack tears both down, taking the
+        // server's accepted connection with them -- so one worker at a time.
         Thread running = activeWorker;
         if (running != null && running.isAlive()) {
             if (b == null) {
-                // A fresh start while a worker is still going -- a server left in accept() by an
-                // earlier attempt, say. Nothing else will speak for this one, so give the caller a
-                // verdict and a reason.
+                // A fresh start while a worker is still going. Nothing else will speak for this
+                // attempt, so give the caller a verdict and a reason.
                 result(mode, false, "a worker is already running in this process");
                 finish();
             } else {
-                // A relaunch: savedInstanceState is non-null because handleRelaunchActivityInner
-                // stops with saveState=true. The original worker owns this run, so emit no verdict
-                // -- bond() reads the last RESULT line, and a FAIL here would land while that
-                // worker is still in createBond/connect and condemn a healthy run. Stay resident
-                // until it finishes, so the process keeps an activity and this receiver.
+                // A relaunch -- savedInstanceState is non-null only then. The original worker owns
+                // this run's verdict; a FAIL here would become the last RESULT line and condemn a
+                // healthy run. Stay resident so the process keeps an activity and this receiver.
                 Log.i(TAG, "relaunch while a worker is running; it owns this run's verdict");
                 finishWhenWorkerEnds();
             }
@@ -160,9 +152,8 @@ public class MainActivity extends Activity {
             WATCHDOG_MS);
     }
 
-    // Keeps a refused relaunch resident until the worker it deferred to is done. Finishing straight
-    // away would leave that worker in a process with no activity and no service, which Android is
-    // free to kill -- taking the server's listening socket with it.
+    // Keeps a refused relaunch resident until the worker is done: a process with no activity is
+    // fair game for the OS, worker and sockets included.
     private void finishWhenWorkerEnds() {
         Handler handler = new Handler(Looper.getMainLooper());
         handler.postDelayed(

--- a/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
+++ b/java/test/android/btbond/src/main/java/com/zeroc/btbond/MainActivity.java
@@ -57,6 +57,11 @@ public class MainActivity extends Activity {
     private volatile BluetoothServerSocket serverSocket;
     private volatile BluetoothSocket socket;
 
+    // The worker of whichever instance is currently running one, or null. Process-wide, because the
+    // instances that race are in one process -- see onCreate. Only ever touched from the main
+    // thread; volatile so the worker's own writes are not needed for visibility.
+    private static volatile Thread activeWorker;
+
     // Best-effort auto-accept of incoming pairing requests. The app runs as a privileged system app
     // (BLUETOOTH_PRIVILEGED), so setPairingConfirmation should succeed; setPin is a fallback that logs
     // any SecurityException.
@@ -93,6 +98,20 @@ public class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle b) {
         super.onCreate(b);
+        // The system recreates this activity during a normal run (see onDestroy), and a relaunch
+        // reuses the original intent -- so onCreate can run again in this process with the same
+        // extras and start a second identical worker. That is survivable only while the two do not
+        // overlap in connect(): two RFCOMM connects from one adapter to the same peer and UUID
+        // resolve the same DLCI, the second is refused with PORT_ALREADY_OPENED, and the stack then
+        // tears down the *first* worker's port as well -- so both fail, and the server's
+        // already-accepted connection dies with them. One worker at a time. onCreate always runs on
+        // the main thread, so testing and assigning below needs no further synchronisation.
+        Thread running = activeWorker;
+        if (running != null && running.isAlive()) {
+            Log.i(TAG, "a worker is already running in this process; not starting another");
+            finish();
+            return;
+        }
         // ACTION_PAIRING_REQUEST is a system broadcast; register exported (and unregister in onDestroy).
         registerReceiver(
             pairingReceiver,
@@ -115,6 +134,7 @@ public class MainActivity extends Activity {
             }
         });
         worker.start();
+        activeWorker = worker;
         new Handler(Looper.getMainLooper()).postDelayed(
             () -> {
                 if (worker != null && worker.isAlive()) {

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3152,19 +3152,15 @@ class AndroidProcessController(RemoteProcessController):
         print("-- adb forwards --")
         print(self._adbTolerant("forward --list"))
         print("-- controller app logcat --")
-        # BTBOND, not just com.zeroc: btbond's own narrative -- "start mode=", "listening",
-        # "connecting...", "watchdog: run exceeded" -- carries no package name, so only its stack
-        # frames were surviving this filter. That left a bond failure showing where it threw but
-        # nothing about what either side had been doing.
+        # BTBOND, not just com.zeroc: btbond's own lines ("listening", "connecting...", "watchdog:")
+        # carry no package name, so only its stack frames were surviving this filter.
         keep = re.compile(
             "testcontroller|ControllerApp|ControllerActivity|AndroidRuntime|FATAL|IceInternal|com.zeroc|BTBOND"
         )
         lines = [ln for ln in self._adbTolerant("logcat -d").splitlines() if keep.search(ln)]
         print("\n".join(lines[-80:]))
-        # The events buffer, because activity relaunch is invisible in the main one: the "Relaunching"
-        # logs sit behind DEBUG_SWITCH/DEBUG_CONFIGURATION, both off in a release build, and a
-        # relaunch emits no new "START u0". wm_relaunch_activity/wm_create_activity are the durable
-        # record, and a second onCreate is what makes two workers race one RFCOMM channel.
+        # A relaunch emits no new "START u0" and its "Relaunching" logs are off in a release build,
+        # so wm_relaunch_activity is the only durable record that a second onCreate ran.
         print("-- activity lifecycle (events) --")
         events = re.compile("wm_(relaunch|create|destroy|finish)_activity|am_proc_(start|died)")
         lines = [ln for ln in self._adbTolerant("logcat -b events -d").splitlines() if events.search(ln)]

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3160,9 +3160,16 @@ class AndroidProcessController(RemoteProcessController):
         lines = [ln for ln in self._adbTolerant("logcat -d").splitlines() if keep.search(ln)]
         print("\n".join(lines[-80:]))
         # A relaunch emits no new "START u0" and its "Relaunching" logs are off in a release build,
-        # so wm_relaunch_activity is the only durable record that a second onCreate ran.
-        print("-- activity lifecycle (events) --")
-        events = re.compile("wm_(relaunch|create|destroy|finish)_activity|am_proc_(start|died)")
+        # so the events buffer is the only durable record that a second onCreate ran. wm_relaunch
+        # covers both the resumed (30019) and paused (30020) variants; wm_on_create_called and
+        # wm_on_destroy_called are logged from the app's own process, so they are direct evidence
+        # rather than a relaunch merely being requested. Every record carries the component or
+        # process name, so requiring btbond keeps unrelated churn from displacing these lines.
+        print("-- btbond lifecycle (events) --")
+        events = re.compile(
+            "(wm_relaunch|wm_on_(create|destroy)_called|wm_(create|destroy|finish)_activity"
+            "|am_proc_(start|died)).*btbond"
+        )
         lines = [ln for ln in self._adbTolerant("logcat -b events -d").splitlines() if events.search(ln)]
         print("\n".join(lines[-40:]) or "<none>")
 

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3159,12 +3159,9 @@ class AndroidProcessController(RemoteProcessController):
         )
         lines = [ln for ln in self._adbTolerant("logcat -d").splitlines() if keep.search(ln)]
         print("\n".join(lines[-80:]))
-        # A relaunch emits no new "START u0" and its "Relaunching" logs are off in a release build,
-        # so the events buffer is the only durable record that a second onCreate ran. wm_relaunch
-        # covers both the resumed (30019) and paused (30020) variants; wm_on_create_called and
-        # wm_on_destroy_called are logged from the app's own process, so they are direct evidence
-        # rather than a relaunch merely being requested. Every record carries the component or
-        # process name, so requiring btbond keeps unrelated churn from displacing these lines.
+        # A relaunch emits no new "START u0" and its main-buffer logs are compiled out, so the events
+        # buffer is the only durable record that a second onCreate ran. Scoped to btbond so
+        # unrelated churn cannot displace these lines.
         print("-- btbond lifecycle (events) --")
         events = re.compile(
             "(wm_relaunch|wm_on_(create|destroy)_called|wm_(create|destroy|finish)_activity"

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3057,6 +3057,10 @@ class AndroidProcessController(RemoteProcessController):
         # transient failure there must not kill the bond.
         run(f"{self.adb()} logcat -c")
         self._adbTolerantFor(peerAdb, "logcat -c")
+        # `logcat -c` clears only main,system,crash,kernel; the events buffer needs its own clear,
+        # or diagnostics cannot tell one attempt's lifecycle records from an earlier attempt's.
+        self._adbTolerant("logcat -b events -c")
+        self._adbTolerantFor(peerAdb, "logcat -b events -c")
         run(f"{peerAdb} shell am start -n {activity} --es mode server --es uuid {uuid}")
 
         def tail(log: str) -> str:
@@ -3160,12 +3164,12 @@ class AndroidProcessController(RemoteProcessController):
         lines = [ln for ln in self._adbTolerant("logcat -d").splitlines() if keep.search(ln)]
         print("\n".join(lines[-80:]))
         # A relaunch emits no new "START u0" and its main-buffer logs are compiled out, so the events
-        # buffer is the only durable record that a second onCreate ran. Scoped to btbond so
-        # unrelated churn cannot displace these lines.
+        # buffer is the only durable record that a second onCreate ran. bond() clears this buffer
+        # per attempt; scoping to btbond keeps the 40 display slots for the lines that matter.
         print("-- btbond lifecycle (events) --")
         events = re.compile(
             "(wm_relaunch|wm_on_(create|destroy)_called|wm_(create|destroy|finish)_activity"
-            "|am_proc_(start|died)).*btbond"
+            "|am_(proc_(start|died)|kill)).*btbond"
         )
         lines = [ln for ln in self._adbTolerant("logcat -b events -d").splitlines() if events.search(ln)]
         print("\n".join(lines[-40:]) or "<none>")

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3152,9 +3152,23 @@ class AndroidProcessController(RemoteProcessController):
         print("-- adb forwards --")
         print(self._adbTolerant("forward --list"))
         print("-- controller app logcat --")
-        keep = re.compile("testcontroller|ControllerApp|ControllerActivity|AndroidRuntime|FATAL|IceInternal|com.zeroc")
+        # BTBOND, not just com.zeroc: btbond's own narrative -- "start mode=", "listening",
+        # "connecting...", "watchdog: run exceeded" -- carries no package name, so only its stack
+        # frames were surviving this filter. That left a bond failure showing where it threw but
+        # nothing about what either side had been doing.
+        keep = re.compile(
+            "testcontroller|ControllerApp|ControllerActivity|AndroidRuntime|FATAL|IceInternal|com.zeroc|BTBOND"
+        )
         lines = [ln for ln in self._adbTolerant("logcat -d").splitlines() if keep.search(ln)]
-        print("\n".join(lines[-50:]))
+        print("\n".join(lines[-80:]))
+        # The events buffer, because activity relaunch is invisible in the main one: the "Relaunching"
+        # logs sit behind DEBUG_SWITCH/DEBUG_CONFIGURATION, both off in a release build, and a
+        # relaunch emits no new "START u0". wm_relaunch_activity/wm_create_activity are the durable
+        # record, and a second onCreate is what makes two workers race one RFCOMM channel.
+        print("-- activity lifecycle (events) --")
+        events = re.compile("wm_(relaunch|create|destroy|finish)_activity|am_proc_(start|died)")
+        lines = [ln for ln in self._adbTolerant("logcat -b events -d").splitlines() if events.search(ln)]
+        print("\n".join(lines[-40:]) or "<none>")
 
     # Emulator flags for the Bluetooth harness: -writable-system allows installing btbond as a
     # privileged system app, and -packet-streamer-endpoint attaches the emulator to the shared


### PR DESCRIPTION
An `android-bt` bond failure on `main` ([run 30546267419](https://github.com/zeroc-ice/ice/actions/runs/30546267419/job/90883086900)) had one `START`, one pid, and two btbond workers racing one RFCOMM channel. `onCreate` starts a worker unconditionally, and a relaunch — which `onDestroy` already notes happens during a normal run — reuses the original intent, so a second identical one starts. When the two overlap in `connect()` both die: the second is refused with `PORT_ALREADY_OPENED`, and the stack then tears down the first worker's port, dropping the server's accepted connection with it.

- Start a worker only if this process has none running; the refused instance reports `RESULT <mode> FAIL` and finishes, so a start refused here fails the caller with that reason rather than as an unexplained connect error.
- Keep btbond's own lines in the diagnostics — `listening`, `connecting...`, `watchdog:` carry no package name, so only stack frames were surviving the filter.
- Dump the events buffer: a relaunch emits no new `START`, so `wm_relaunch_activity` is the only durable record that a second `onCreate` ran.
