### PR TITLE
Fail a run whose suite list matches nothing

### DIFF
--- a/scripts/LocalDriver.py
+++ b/scripts/LocalDriver.py
@@ -548,6 +548,14 @@ class LocalDriver(Driver):
                                 for i in range(max(4, len(lines) - 8), len(lines)):
                                     print("  " + lines[i])
                     return 1
+                elif not results and (testSuiteIds or self.filters or self.rfilters):
+                    # Asking for specific suites and matching none is a failure, not a pass. A job
+                    # that names its suites explicitly -- the Bluetooth ones in ci.yml, say -- would
+                    # otherwise stay green through a rename or a typo while running nothing at all.
+                    # Only an explicit request is held to this: an unfiltered run that finds no
+                    # suites is a legitimate no-op on a mapping this platform does not support.
+                    print("no test suite matched {0}".format(", ".join(testSuiteIds) or "the given filters"))
+                    return 1
                 else:
                     print("{0} succeeded".format(len(results)))
                     if not self.loop:


### PR DESCRIPTION
`allTests.py` reported `0 succeeded` and exited 0 when the requested suites matched none, so a job that names its suites explicitly stays green through a rename or a typo while running nothing. Both Bluetooth jobs in `ci.yml` pass explicit lists.

- Exit non-zero when an explicit request — suite ids, `--filter` or `--rfilter` — selects no suites.
- Unfiltered runs are exempt: finding no suites is a legitimate no-op on a mapping the platform does not support.

Fixes #6236