### PR TITLE
Complete DataStorm forwarded session requests when the node session is gone

### DIFF
--- a/changelog.d/datastorm/6307.md
+++ b/changelog.d/datastorm/6307.md
@@ -1,0 +1,4 @@
+- Fixed a bug where a session creation request forwarded through a relay node was never answered when the relay's
+  session for the target node was destroyed while the request was being forwarded. The requesting node's session
+  creation attempt then hung instead of failing and retrying: the forwarder now completes such requests with
+  `ObjectNotExistException`, the same failure the requester gets once the forwarder is unregistered.

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -54,6 +54,14 @@ namespace
                     exception(make_exception_ptr(SessionCreationException{SessionCreationError::NodeShutdown}));
                 }
             }
+            else
+            {
+                // The node session is destroyed: the target node is no longer reachable through this forwarder.
+                // Complete the dispatch with the same failure the caller gets once the forwarder is removed from the
+                // object adapter, so the caller accounts for the failure and can retry, instead of waiting forever
+                // for a response.
+                exception(make_exception_ptr(ObjectNotExistException{__FILE__, __LINE__}));
+            }
         }
 
         void createSessionAsync(
@@ -92,6 +100,11 @@ namespace
                     exception(make_exception_ptr(SessionCreationException{SessionCreationError::NodeShutdown}));
                 }
             }
+            else
+            {
+                // See initiateCreateSessionAsync.
+                exception(make_exception_ptr(ObjectNotExistException{__FILE__, __LINE__}));
+            }
         }
 
         void confirmCreateSessionAsync(
@@ -126,6 +139,11 @@ namespace
                 {
                     exception(make_exception_ptr(SessionCreationException{SessionCreationError::NodeShutdown}));
                 }
+            }
+            else
+            {
+                // See initiateCreateSessionAsync.
+                exception(make_exception_ptr(ObjectNotExistException{__FILE__, __LINE__}));
             }
         }
 


### PR DESCRIPTION
Fixes #6307.

The `NodeForwarder` AMD implementations (`initiateCreateSessionAsync`, `createSessionAsync`, `confirmCreateSessionAsync`) only completed the dispatch inside `if (auto nodeSession = _nodeSession.lock())`. When the node session was already destroyed, they returned without calling `response` or `exception`, so the peer's session creation dispatch never completed: with no invocation timeout configured (the default), the caller waited forever and its session creation retry accounting (`sessionCreationFailed`) never ran for that attempt.

Each operation now completes the dispatch with `Ice::ObjectNotExistException` when the node session is gone. This is the same failure the caller gets once `NodeSessionI::destroy` removes the forwarder from the object adapter — the destroyed node session means the target node is no longer reachable through this forwarder — and `SessionI::retryImpl` treats it as retryable, so the caller accounts for the failure and retries through the normal announcement path.

Changes:
- `cpp/src/DataStorm/NodeSessionI.cpp`: add the missing `else` branches.
- `changelog.d/datastorm/6307.md`: changelog fragment.

No new test: the window requires the node session to be destroyed between the dispatch of a forwarded session creation request and the `_nodeSession.lock()` call, which isn't deterministically reachable from the public API. The full DataStorm test suite (11 tests, including the relay tests that exercise the `NodeForwarder` paths) passes on macOS.
