### PR TITLE
Derive the WebSocket masking key and handshake nonce from a CSPRNG

### DIFF
--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -61,7 +61,7 @@ internal sealed class WSTransceiver : Transceiver
                     // encoded with Base64.
                     //
                     byte[] key = new byte[16];
-                    _rand.NextBytes(key);
+                    RandomNumberGenerator.Fill(key);
                     _key = System.Convert.ToBase64String(key);
                     @out.Append(_key + "\r\n\r\n"); // EOM
 
@@ -715,7 +715,6 @@ internal sealed class WSTransceiver : Transceiver
         _writeMask = new byte[4];
         _key = "";
         _pingPayload = [];
-        _rand = new Random();
     }
 
     private void handleRequest(Buffer responseBuffer)
@@ -1675,7 +1674,7 @@ internal sealed class WSTransceiver : Transceiver
             // and apply the mask.
             //
             _writeBuffer.b.put(1, (byte)(_writeBuffer.b.get(1) | FLAG_MASKED));
-            _rand.NextBytes(_writeMask);
+            RandomNumberGenerator.Fill(_writeMask);
             _writeBuffer.b.put(_writeMask);
         }
     }
@@ -1741,8 +1740,6 @@ internal sealed class WSTransceiver : Transceiver
     private bool _writePending;
 
     private byte[] _pingPayload;
-
-    private Random _rand;
 
     //
     // WebSocket opcodes

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
@@ -9,8 +9,8 @@ import java.nio.channels.SelectableChannel;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.HashSet;
-import java.util.Random;
 import java.util.Set;
 
 final class WSTransceiver implements Transceiver {
@@ -425,7 +425,6 @@ final class WSTransceiver implements Transceiver {
         _writeMask = new byte[4];
         _key = "";
         _pingPayload = new byte[0];
-        _rand = new Random();
     }
 
     private void handleRequest(Buffer responseBuffer) {
@@ -1242,7 +1241,7 @@ final class WSTransceiver implements Transceiver {
 
     private byte[] _pingPayload;
 
-    private Random _rand;
+    private final SecureRandom _rand = new SecureRandom();
 
     //
     // WebSocket opcodes


### PR DESCRIPTION
Fixes #6261.

RFC 6455 section 5.3 requires the client's per-frame masking key to be unpredictable and derived from a strong
source of entropy. The C# and Java WebSocket transports derived both the `Sec-WebSocket-Key` handshake nonce and
every masking key from a general-purpose PRNG (`System.Random` / `java.util.Random`), and from the *same* instance,
so observing one value leaked the others.

- **C#**: `RandomNumberGenerator.Fill`. It is static, so the `_rand` field and its initialization are gone.
- **Java**: `SecureRandom` in place of `java.util.Random`; `nextBytes` is a drop-in.

C++ already used `IceInternal::generateRandom` for both values, and JavaScript wraps the native WebSocket
implementation and never masks by hand, so no other mapping is affected.

### Verification

Both mappings build clean with no new warnings, `dotnet format --verify-no-changes` and the Java `checkstyleMain` /
`rewriteDryRun` tasks pass, and `Ice/operations` over `--protocol=ws` is green in C# and Java — that exercises the
handshake nonce and the per-frame masking path.

No test: whether the bytes come from a CSPRNG has no observable behavior to assert, and the WebSocket functional
path is already covered.

### Performance

`SecureRandom` is kept as a per-transceiver field, so incoming (server) transceivers construct one they never use,
and `nextBytes` now runs per outgoing frame. Measured locally: `new SecureRandom()` is 1.7 µs, once per connection
against a full HTTP upgrade round trip, and `nextBytes(4)` costs ~265 ns more than `Random.nextBytes(4)`. Both are
negligible, so the field structure is unchanged.