### PR TITLE
Mark a DataStorm reader initialized only after its samples are decoded

### DIFF
--- a/changelog.d/datastorm/6308.md
+++ b/changelog.d/datastorm/6308.md
@@ -1,5 +1,0 @@
-- Fixed a bug where a reader permanently lost a writer's initialization samples when decoding one of their keys
-  threw. The reader was marked initialized, with its last received sample id advanced, before the samples were
-  decoded, so the writer treated them as already received and never offered them again, not even after a reconnect.
-  The reader now stays uninitialized in that case, so the writer can still offer these samples when the session
-  initializes the reader again.

--- a/changelog.d/datastorm/6308.md
+++ b/changelog.d/datastorm/6308.md
@@ -1,0 +1,5 @@
+- Fixed a bug where a reader permanently lost a writer's initialization samples when decoding one of their keys
+  threw. The reader was marked initialized, with its last received sample id advanced, before the samples were
+  decoded, so the writer treated them as already received and never offered them again, not even after a reconnect.
+  The reader now stays uninitialized in that case, so the writer can still offer these samples when the session
+  initializes the reader again.

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1446,9 +1446,8 @@ SessionI::subscriberInitialized(
     if (_traceLevels->session > 1)
     {
         Trace out(_traceLevels->logger, _traceLevels->sessionCat);
-        out << _id << ": initialized '" << element << "' from 'e" << elementId << '@' << topicId << "'";
+        out << _id << ": initializing '" << element << "' from 'e" << elementId << '@' << topicId << "'";
     }
-    elementSubscriber->initialized = true;
 
     // If the samples collection is empty, the element subscriber's lastId remains unchanged:
     // - If no samples have been received, lastId is 0.
@@ -1460,18 +1459,11 @@ SessionI::subscriberInitialized(
     // - These samples have not yet been processed by the element subscriber, according to the subscriber's lastId.
     if (samples.empty())
     {
+        elementSubscriber->initialized = true;
         return {};
     }
     else
     {
-        // A multi-key subscriber shares a single ElementSubscriber across its keys, and the peer acks one batch per
-        // key, so this runs once per key with sample ids interleaved across keys — a later batch need not strictly
-        // follow the previous one. Advance lastId monotonically to the newest id seen (samples are ordered by id).
-        if (samples.back().id > elementSubscriber->lastId)
-        {
-            elementSubscriber->lastId = samples.back().id;
-        }
-
         vector<shared_ptr<Sample>> samplesI;
         samplesI.reserve(samples.size());
         auto sampleFactory = element->getTopic()->getSampleFactory();
@@ -1494,6 +1486,20 @@ SessionI::subscriberInitialized(
                 sample.timestamp));
             assert(samplesI.back()->key);
         }
+
+        // Mark the subscriber initialized and advance its lastId only after its samples are decoded and built, like
+        // initSamples does: if a key decoder throws above, the subscriber keeps its previous state, so the peer still
+        // offers these samples on the next initialization instead of filtering them out as already received.
+        elementSubscriber->initialized = true;
+
+        // A multi-key subscriber shares a single ElementSubscriber across its keys, and the peer acks one batch per
+        // key, so this runs once per key with sample ids interleaved across keys — a later batch need not strictly
+        // follow the previous one. Advance lastId monotonically to the newest id seen (samples are ordered by id).
+        if (samples.back().id > elementSubscriber->lastId)
+        {
+            elementSubscriber->lastId = samples.back().id;
+        }
+
         return samplesI;
     }
 }


### PR DESCRIPTION
`SessionI::subscriberInitialized` marked the element subscriber initialized and advanced its last
received sample id *before* decoding the sample keys and building the samples. When decoding a key threw
— a custom `Decoder<Key>` specialization, or the default decoder on a malformed inline key — the
subscriber was left initialized with an advanced last id, so the writer filtered these samples out of
every later initialization and the reader lost them for good, including across a reconnect.

The subscriber is now marked initialized, and its last id advanced, only after its samples are decoded
and built — the ordering `SessionI::initSamples` already uses and documents.

### Notes

- **Reachability.** The keys of the initialization samples are decoded only when `key == nullptr`, which
  `TopicI::attachElementsAck` passes on exactly one branch (`spec.peerId <= 0 && spec.id < 0`): an
  any-key writer paired with an any-key or filtered-key reader, and only on the `attachElementsAck`
  path. It does not need a custom decoder — the default `Decoder<K>` unmarshals the peer-supplied
  `keyValue` and throws `MarshalException` on malformed bytes.

- **Why the loss is permanent.** `ElementSubscribers::addSubscriber` resets `initialized` on re-attach
  but preserves `lastId`, and `disconnectedImpl` never clears `_topics`. `getLastIds` reports the
  inflated id to the writer, whose `getSamples` skips both the history and the current per-key base at
  `id <= lastId`. The ack is a oneway call, so the dispatch failure produces no reply at all — the only
  symptom anywhere is the receiver-side `Ice.Warn.Dispatch` warning.

- **Behavior change, deliberate.** A reader whose key decoding fails now stays uninitialized, so it also
  stops receiving live samples from that writer (`SubscriberSessionI::s` gates on `initialized`) until
  the session initializes it again. That is the trade `initSamples` already made; the previous state —
  initialized with no per-key base — silently discarded every later partial update for those keys
  anyway.

- **No test.** A red→green test needs a throwing decoder plus a forced reconnect plus a pinned
  single-connection topology, and its redness rests on two invariants it cannot assert: that
  initialization arrives via the ack path rather than `initSamples`, and that the throw fires on that
  exact decode.

- The trace emitted before the decode loop now says `initializing` rather than `initialized`, matching
  the sibling path, since it precedes the step that can fail.

### Not addressed here

The same commit-before-delivery window remains one frame up: `TopicI::attachElementsAck` commits each
element's initialization inside the spec loop but runs the collected `initCallbacks` only after the loop,
so a throw in a later spec discards an earlier reader's already-built samples after that reader was
marked initialized. Filed as #6324.

Fixes #6308
