### PR TITLE
Fix the JSON and XML dependency output of the Slice compilers

### DIFF
--- a/changelog.d/general/6122.md
+++ b/changelog.d/general/6122.md
@@ -1,0 +1,2 @@
+- The dependency information written by the Slice compilers is now always well-formed. `--depend-json` omitted the
+  commas between entries, and neither `--depend-json` nor `--depend-xml` escaped special characters in file names.

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -10,6 +10,7 @@
 #include <cctype>
 #include <climits>
 #include <cstring>
+#include <iomanip>
 
 #ifndef _MSC_VER
 #    include <unistd.h> // For readlink()
@@ -39,6 +40,83 @@ namespace
             of << dependencies;
             of.close();
         }
+    }
+
+    // Escapes a file name for use in a double-quoted XML attribute value.
+    string escapeXMLAttribute(string_view name)
+    {
+        ostringstream os;
+        for (char c : name)
+        {
+            switch (c)
+            {
+                case '&':
+                    os << "&amp;";
+                    break;
+                case '<':
+                    os << "&lt;";
+                    break;
+                case '>':
+                    os << "&gt;";
+                    break;
+                case '"':
+                    os << "&quot;";
+                    break;
+                default:
+                    os << c;
+                    break;
+            }
+        }
+        return os.str();
+    }
+
+    // Escapes a file name and wraps it in double quotes, to produce a JSON string.
+    string toJSONString(string_view name)
+    {
+        ostringstream os;
+        os << '"';
+        for (char c : name)
+        {
+            switch (c)
+            {
+                case '"':
+                    os << "\\\"";
+                    break;
+                case '\\':
+                    os << "\\\\";
+                    break;
+                case '\b':
+                    os << "\\b";
+                    break;
+                case '\f':
+                    os << "\\f";
+                    break;
+                case '\n':
+                    os << "\\n";
+                    break;
+                case '\r':
+                    os << "\\r";
+                    break;
+                case '\t':
+                    os << "\\t";
+                    break;
+                default:
+                    if (static_cast<unsigned char>(c) < 0x20)
+                    {
+                        // The remaining control characters have no short escape sequence.
+                        os << "\\u" << setfill('0') << setw(4) << hex << static_cast<int>(static_cast<unsigned char>(c))
+                           << dec;
+                    }
+                    else
+                    {
+                        // Any other character is written as is, including the bytes of a multi-byte UTF-8 sequence.
+                        os << c;
+                    }
+                    break;
+            }
+        }
+        os << '"';
+        return os.str();
     }
 }
 
@@ -673,11 +751,10 @@ Slice::DependencyGenerator::writeXMLDependencies(const string& dependFile)
     {
         string source = dependencies.front();
         dependencies.pop_front();
-        string dirName = Slice::dirName(source);
-        os << endl << "  <source name=\"" << source << "\">";
+        os << endl << "  <source name=\"" << escapeXMLAttribute(source) << "\">";
         for (const auto& dependency : dependencies)
         {
-            os << endl << "    <dependsOn name=\"" << dependency << "\" />";
+            os << endl << "    <dependsOn name=\"" << escapeXMLAttribute(dependency) << "\" />";
         }
         os << endl << "  </source>";
     }
@@ -690,14 +767,19 @@ Slice::DependencyGenerator::writeJSONDependencies(const string& dependFile)
 {
     ostringstream os;
     os << "{";
+    bool firstSource = true;
     for (auto [_, dependencies] : _dependencyMap)
     {
         string source = dependencies.front();
         dependencies.pop_front();
-        os << endl << "  \"" << source << "\" : [";
+        os << (firstSource ? "" : ",") << endl << "  " << toJSONString(source) << " : [";
+        firstSource = false;
+
+        bool firstDependency = true;
         for (const auto& dependency : dependencies)
         {
-            os << endl << "    \"" << dependency << "\"";
+            os << (firstDependency ? "" : ",") << endl << "    " << toJSONString(dependency);
+            firstDependency = false;
         }
         os << endl << "  ]";
     }

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -62,6 +62,17 @@ namespace
                 case '"':
                     os << "&quot;";
                     break;
+                // An XML parser replaces a literal tab, line feed or carriage return in an attribute value by a
+                // space. Character references survive this normalization.
+                case '\t':
+                    os << "&#x9;";
+                    break;
+                case '\n':
+                    os << "&#xA;";
+                    break;
+                case '\r':
+                    os << "&#xD;";
+                    break;
                 default:
                     os << c;
                     break;

--- a/cpp/test/Slice/dependencies/a&b/e.ice
+++ b/cpp/test/Slice/dependencies/a&b/e.ice
@@ -1,0 +1,10 @@
+#include "../slices/a.ice"
+#include "f.ice"
+
+module Test
+{
+    interface E
+    {
+        void op(A a, F f);
+    }
+}

--- a/cpp/test/Slice/dependencies/a&b/f.ice
+++ b/cpp/test/Slice/dependencies/a&b/f.ice
@@ -1,0 +1,8 @@
+#pragma once
+
+module Test
+{
+    class F
+    {
+    }
+}

--- a/cpp/test/Slice/dependencies/slices/a.ice
+++ b/cpp/test/Slice/dependencies/slices/a.ice
@@ -1,0 +1,8 @@
+#pragma once
+
+module Test
+{
+    class A
+    {
+    }
+}

--- a/cpp/test/Slice/dependencies/slices/b.ice
+++ b/cpp/test/Slice/dependencies/slices/b.ice
@@ -1,0 +1,8 @@
+#pragma once
+
+module Test
+{
+    class B
+    {
+    }
+}

--- a/cpp/test/Slice/dependencies/slices/c.ice
+++ b/cpp/test/Slice/dependencies/slices/c.ice
@@ -1,0 +1,10 @@
+#include "a.ice"
+#include "b.ice"
+
+module Test
+{
+    interface C
+    {
+        void op(A a, B b);
+    }
+}

--- a/cpp/test/Slice/dependencies/slices/d.ice
+++ b/cpp/test/Slice/dependencies/slices/d.ice
@@ -1,0 +1,9 @@
+#include "a.ice"
+
+module Test
+{
+    interface D
+    {
+        void op(A a);
+    }
+}

--- a/cpp/test/Slice/dependencies/test.py
+++ b/cpp/test/Slice/dependencies/test.py
@@ -8,13 +8,16 @@ from Util import ClientTestCase, SliceTranslator, TestSuite
 
 # e.ice and f.ice sit in a directory whose name holds an XML-significant character, so both the source and the
 # dependency entries of e.ice are only parsable when the compiler escapes the file names it writes.
-escapedDirectory = "a&b"
+ampersandDirectory = "a&b"
 
 # The expected dependencies of the compiled sources, keyed by the directory and file name of the source.
 expectedDependencies = {
     os.path.join("slices", "c.ice"): [os.path.join("slices", "a.ice"), os.path.join("slices", "b.ice")],
     os.path.join("slices", "d.ice"): [os.path.join("slices", "a.ice")],
-    os.path.join(escapedDirectory, "e.ice"): [os.path.join("slices", "a.ice"), os.path.join(escapedDirectory, "f.ice")],
+    os.path.join(ampersandDirectory, "e.ice"): [
+        os.path.join("slices", "a.ice"),
+        os.path.join(ampersandDirectory, "f.ice"),
+    ],
 }
 
 
@@ -22,30 +25,10 @@ class SliceDependenciesTestCase(ClientTestCase):
     def runClientSide(self, current):
         slice2js = SliceTranslator("slice2js")
 
-        current.mkdirs(escapedDirectory)
-        current.createFile(
-            os.path.join(escapedDirectory, "f.ice"),
-            ["#pragma once", "module Test", "{", "    class F", "    {", "    }", "}"],
-        )
-        current.createFile(
-            os.path.join(escapedDirectory, "e.ice"),
-            [
-                '#include "../slices/a.ice"',
-                '#include "f.ice"',
-                "module Test",
-                "{",
-                "    interface E",
-                "    {",
-                "        void op(A a, F f);",
-                "    }",
-                "}",
-            ],
-        )
-
         sources = [
             os.path.join("slices", "c.ice"),
             os.path.join("slices", "d.ice"),
-            os.path.join(escapedDirectory, "e.ice"),
+            os.path.join(ampersandDirectory, "e.ice"),
         ]
 
         current.write("testing dependencies in JSON format... ")
@@ -64,7 +47,7 @@ class SliceDependenciesTestCase(ClientTestCase):
 
     def checkDependencies(self, dependencies):
         # The sources and their dependencies are reported as absolute paths; compare the directory and file name,
-        # so that a directory holding an escaped character must come back spelled exactly as it is on disk.
+        # so that a directory holding an XML-significant character must come back spelled exactly as it is on disk.
         actual = {
             self.tail(source): sorted(self.tail(dependency) for dependency in dependsOn)
             for source, dependsOn in dependencies.items()

--- a/cpp/test/Slice/dependencies/test.py
+++ b/cpp/test/Slice/dependencies/test.py
@@ -1,0 +1,42 @@
+# Copyright (c) ZeroC, Inc.
+
+import json
+import os
+import xml.etree.ElementTree as ElementTree
+
+from Util import ClientTestCase, SliceTranslator, TestSuite
+
+# The expected dependencies of the Slice files in the "slices" directory, keyed by file name.
+expectedDependencies = {"c.ice": ["a.ice", "b.ice"], "d.ice": ["a.ice"]}
+
+
+class SliceDependenciesTestCase(ClientTestCase):
+    def runClientSide(self, current):
+        slice2js = SliceTranslator("slice2js")
+        sources = [os.path.join("slices", "c.ice"), os.path.join("slices", "d.ice")]
+
+        current.write("testing dependencies in JSON format... ")
+        slice2js.run(current, args=["--depend-json", "--depend-file", "depend.json"] + sources)
+        with open("depend.json", encoding="utf-8") as file:
+            self.checkDependencies(json.load(file))
+        os.remove("depend.json")
+        current.writeln("ok")
+
+        current.write("testing dependencies in XML format... ")
+        slice2js.run(current, args=["--depend-xml", "--depend-file", "depend.xml"] + sources)
+        root = ElementTree.parse("depend.xml").getroot()
+        self.checkDependencies({source.get("name"): [dependsOn.get("name") for dependsOn in source] for source in root})
+        os.remove("depend.xml")
+        current.writeln("ok")
+
+    def checkDependencies(self, dependencies):
+        # The sources and their dependencies are reported as absolute paths; only compare the file names.
+        actual = {
+            os.path.basename(source): sorted(os.path.basename(dependency) for dependency in dependsOn)
+            for source, dependsOn in dependencies.items()
+        }
+        if actual != expectedDependencies:
+            raise RuntimeError("failed! expected {0} but got {1}".format(expectedDependencies, actual))
+
+
+TestSuite(__name__, [SliceDependenciesTestCase()], chdir=True)

--- a/cpp/test/Slice/dependencies/test.py
+++ b/cpp/test/Slice/dependencies/test.py
@@ -6,14 +6,38 @@ import xml.etree.ElementTree as ElementTree
 
 from Util import ClientTestCase, SliceTranslator, TestSuite
 
-# The expected dependencies of the Slice files in the "slices" directory, keyed by file name.
-expectedDependencies = {"c.ice": ["a.ice", "b.ice"], "d.ice": ["a.ice"]}
+# The expected dependencies of the compiled sources, keyed by file name.
+expectedDependencies = {"c.ice": ["a.ice", "b.ice"], "d.ice": ["a.ice"], "e.ice": ["a.ice"]}
+
+# e.ice is compiled from a directory whose name holds an XML-significant character, so its dependency entry is
+# only parsable when the compiler escapes the file names it writes.
+escapedDirectory = "a&b"
 
 
 class SliceDependenciesTestCase(ClientTestCase):
     def runClientSide(self, current):
         slice2js = SliceTranslator("slice2js")
-        sources = [os.path.join("slices", "c.ice"), os.path.join("slices", "d.ice")]
+
+        current.mkdirs(escapedDirectory)
+        current.createFile(
+            os.path.join(escapedDirectory, "e.ice"),
+            [
+                '#include "../slices/a.ice"',
+                "module Test",
+                "{",
+                "    interface E",
+                "    {",
+                "        void op(A a);",
+                "    }",
+                "}",
+            ],
+        )
+
+        sources = [
+            os.path.join("slices", "c.ice"),
+            os.path.join("slices", "d.ice"),
+            os.path.join(escapedDirectory, "e.ice"),
+        ]
 
         current.write("testing dependencies in JSON format... ")
         slice2js.run(current, args=["--depend-json", "--depend-file", "depend.json"] + sources)

--- a/cpp/test/Slice/dependencies/test.py
+++ b/cpp/test/Slice/dependencies/test.py
@@ -6,12 +6,16 @@ import xml.etree.ElementTree as ElementTree
 
 from Util import ClientTestCase, SliceTranslator, TestSuite
 
-# The expected dependencies of the compiled sources, keyed by file name.
-expectedDependencies = {"c.ice": ["a.ice", "b.ice"], "d.ice": ["a.ice"], "e.ice": ["a.ice"]}
-
-# e.ice is compiled from a directory whose name holds an XML-significant character, so its dependency entry is
-# only parsable when the compiler escapes the file names it writes.
+# e.ice and f.ice sit in a directory whose name holds an XML-significant character, so both the source and the
+# dependency entries of e.ice are only parsable when the compiler escapes the file names it writes.
 escapedDirectory = "a&b"
+
+# The expected dependencies of the compiled sources, keyed by the directory and file name of the source.
+expectedDependencies = {
+    os.path.join("slices", "c.ice"): [os.path.join("slices", "a.ice"), os.path.join("slices", "b.ice")],
+    os.path.join("slices", "d.ice"): [os.path.join("slices", "a.ice")],
+    os.path.join(escapedDirectory, "e.ice"): [os.path.join("slices", "a.ice"), os.path.join(escapedDirectory, "f.ice")],
+}
 
 
 class SliceDependenciesTestCase(ClientTestCase):
@@ -20,14 +24,19 @@ class SliceDependenciesTestCase(ClientTestCase):
 
         current.mkdirs(escapedDirectory)
         current.createFile(
+            os.path.join(escapedDirectory, "f.ice"),
+            ["#pragma once", "module Test", "{", "    class F", "    {", "    }", "}"],
+        )
+        current.createFile(
             os.path.join(escapedDirectory, "e.ice"),
             [
                 '#include "../slices/a.ice"',
+                '#include "f.ice"',
                 "module Test",
                 "{",
                 "    interface E",
                 "    {",
-                "        void op(A a);",
+                "        void op(A a, F f);",
                 "    }",
                 "}",
             ],
@@ -54,13 +63,18 @@ class SliceDependenciesTestCase(ClientTestCase):
         current.writeln("ok")
 
     def checkDependencies(self, dependencies):
-        # The sources and their dependencies are reported as absolute paths; only compare the file names.
+        # The sources and their dependencies are reported as absolute paths; compare the directory and file name,
+        # so that a directory holding an escaped character must come back spelled exactly as it is on disk.
         actual = {
-            os.path.basename(source): sorted(os.path.basename(dependency) for dependency in dependsOn)
+            self.tail(source): sorted(self.tail(dependency) for dependency in dependsOn)
             for source, dependsOn in dependencies.items()
         }
-        if actual != expectedDependencies:
-            raise RuntimeError("failed! expected {0} but got {1}".format(expectedDependencies, actual))
+        expected = {source: sorted(dependsOn) for source, dependsOn in expectedDependencies.items()}
+        if actual != expected:
+            raise RuntimeError("failed! expected {0} but got {1}".format(expected, actual))
+
+    def tail(self, path):
+        return os.path.join(os.path.basename(os.path.dirname(path)), os.path.basename(path))
 
 
 TestSuite(__name__, [SliceDependenciesTestCase()], chdir=True)

--- a/cpp/test/Slice/dependencies/test.py
+++ b/cpp/test/Slice/dependencies/test.py
@@ -1,10 +1,12 @@
 # Copyright (c) ZeroC, Inc.
 
+from __future__ import annotations
+
 import json
 import os
 import xml.etree.ElementTree as ElementTree
 
-from Util import ClientTestCase, SliceTranslator, TestSuite
+from Util import ClientTestCase, Driver, SliceTranslator, TestSuite
 
 # e.ice and f.ice sit in a directory whose name holds an XML-significant character, so both the source and the
 # dependency entries of e.ice are only parsable when the compiler escapes the file names it writes.
@@ -22,7 +24,7 @@ expectedDependencies = {
 
 
 class SliceDependenciesTestCase(ClientTestCase):
-    def runClientSide(self, current):
+    def runClientSide(self, current: Driver.Current) -> None:
         slice2js = SliceTranslator("slice2js")
 
         sources = [
@@ -41,11 +43,13 @@ class SliceDependenciesTestCase(ClientTestCase):
         current.write("testing dependencies in XML format... ")
         slice2js.run(current, args=["--depend-xml", "--depend-file", "depend.xml"] + sources)
         root = ElementTree.parse("depend.xml").getroot()
-        self.checkDependencies({source.get("name"): [dependsOn.get("name") for dependsOn in source] for source in root})
+        self.checkDependencies(
+            {source.attrib["name"]: [dependsOn.attrib["name"] for dependsOn in source] for source in root}
+        )
         os.remove("depend.xml")
         current.writeln("ok")
 
-    def checkDependencies(self, dependencies):
+    def checkDependencies(self, dependencies: dict[str, list[str]]) -> None:
         # The sources and their dependencies are reported as absolute paths; compare the directory and file name,
         # so that a directory holding an XML-significant character must come back spelled exactly as it is on disk.
         actual = {
@@ -56,7 +60,7 @@ class SliceDependenciesTestCase(ClientTestCase):
         if actual != expected:
             raise RuntimeError("failed! expected {0} but got {1}".format(expected, actual))
 
-    def tail(self, path):
+    def tail(self, path: str) -> str:
         return os.path.join(os.path.basename(os.path.dirname(path)), os.path.basename(path))
 
 


### PR DESCRIPTION
Fixes #6122.

## The bug

`--depend-json` wrote no comma between the elements of a dependency array, and none between the source objects. Any source with two or more dependencies, or any run with two or more sources, produced a document `JSON.parse` and `jq` reject — with the compiler still exiting 0.

Neither `--depend-json` nor `--depend-xml` escaped the file names they interpolate, so a path holding `&`, `<`, `>` or `"` produced output an XML or JSON parser rejects. That one is not theoretical for XML: `--depend-xml` output is fed to `XmlDocument.LoadXml` by the MSBuild Slice tasks (`SliceCompilerTask.cs`, `SliceDependTask.cs`) and to a DOM parser by the Gradle slice-tools plugin, so a project path containing `&` makes those tasks throw.

Before, for two sources with two and one dependencies:

```json
{
  "…/Main.ice" : [
    "…/sub/A.ice"
    "…/sub/B.ice"
  ]
  "…/Other.ice" : [
    "…/sub/A.ice"
  ]
}
```

## The fix

`writeJSONDependencies` and `writeXMLDependencies` now run every file name through a JSON-string / XML-attribute escaper, and the JSON writer emits the separators. Also drops a dead local in `writeXMLDependencies`.

## Tests

New `cpp/test/Slice/dependencies` suite: compiles two sources with overlapping includes, then parses the `--depend-json` and `--depend-xml` output with `json` and `ElementTree` and compares the resulting dependency graph. Red before the fix (`Expecting ',' delimiter: line 4 column 5`), green after.