### PR TITLE
Fix and extend slice2cpp_generate

### DIFF
--- a/changelog.d/cpp/cmake-slice2cpp-generate.md
+++ b/changelog.d/cpp/cmake-slice2cpp-generate.md
@@ -1,0 +1,7 @@
+- Fixed the CMake `slice2cpp_generate` function to compile Slice files that live in subdirectories. It previously
+  wrote every generated file into one flat directory, so the `#include` directives `slice2cpp` emits did not resolve,
+  and two Slice files with the same name collided.
+- `slice2cpp_generate` now accepts `INCLUDE_DIRS`, `OPTIONS`, `HEADER_OUTPUT_DIR`, `INCLUDE_DIR` and `INCLUDE_SCOPE`,
+  to pass additional include directories and options to `slice2cpp`, write the generated headers to their own
+  directory, and export them from a library. The Slice dependency scan runs with the same options as the compile, so
+  `-D` conditional includes produce correct dependencies.

--- a/changelog.d/cpp/cmake-slice2cpp-generate.md
+++ b/changelog.d/cpp/cmake-slice2cpp-generate.md
@@ -1,0 +1,5 @@
+- Fixed the CMake `slice2cpp_generate` function to compile Slice files that live in subdirectories: generated
+  files now mirror the layout of the `.ice` files found through the new `INCLUDE_DIRS` argument.
+- `slice2cpp_generate` now accepts `INCLUDE_DIRS`, `OPTIONS`, `HEADER_OUTPUT_DIR`, `INCLUDE_DIR` and
+  `INCLUDE_SCOPE`, to pass include directories and options to `slice2cpp`, write the generated headers to their
+  own directory, and export them to the target's consumers.

--- a/changelog.d/cpp/cmake-slice2cpp-generate.md
+++ b/changelog.d/cpp/cmake-slice2cpp-generate.md
@@ -1,7 +1,0 @@
-- Fixed the CMake `slice2cpp_generate` function to compile Slice files that live in subdirectories. It previously
-  wrote every generated file into one flat directory, so the `#include` directives `slice2cpp` emits did not resolve,
-  and two Slice files with the same name collided.
-- `slice2cpp_generate` now accepts `INCLUDE_DIRS`, `OPTIONS`, `HEADER_OUTPUT_DIR`, `INCLUDE_DIR` and `INCLUDE_SCOPE`,
-  to pass additional include directories and options to `slice2cpp`, write the generated headers to their own
-  directory, and export them from a library. The Slice dependency scan runs with the same options as the compile, so
-  `-D` conditional includes produce correct dependencies.

--- a/cpp/config/slice2cpp.cmake
+++ b/cpp/config/slice2cpp.cmake
@@ -30,13 +30,24 @@
 # includes, so a Slice file included from a shared directory needs a target that compiles it, and
 # `demo` links that target to pick up its headers.
 #
-# Generated files mirror the layout of the .ice files under the include directory that reaches them,
-# so the #include directives slice2cpp emits resolve. Headers land in HEADER_OUTPUT_DIR/INCLUDE_DIR
-# when either is given, and that root goes on the target's include path.
+# Generated files mirror the layout of the .ice files under the INCLUDE_DIRS directory that reaches
+# them, so the #include directives slice2cpp emits resolve; a file under no such directory generates
+# flat, and two flat files sharing a name is reported at configure time. Headers land under
+# HEADER_OUTPUT_DIR/INCLUDE_DIR when given, and both that directory and HEADER_OUTPUT_DIR go on the
+# target's include path.
+#
+# A PUBLIC INCLUDE_SCOPE covers the build tree only; installing or exporting the target additionally
+# needs the caller to install the generated headers and add an INSTALL_INTERFACE directory.
 #
 # The generated file names are declared to CMake at configure time: --header-ext and --source-ext
 # in OPTIONS are honored, options that relocate the outputs or suppress generation are rejected, and
 # cpp:header-ext metadata that contradicts the declared name is reported when the file compiles.
+
+# Checked up front with a readable message: this file is loaded by every consumer of the Ice
+# package, not only the ones that generate Slice.
+if(CMAKE_VERSION VERSION_LESS 3.21)
+  message(FATAL_ERROR "The Ice CMake package requires CMake 3.21 or later.")
+endif()
 
 # The function records the policies in force when it is defined; pin them so a consumer with an older
 # policy baseline gets the same behavior. include() scopes this to the current file.
@@ -49,8 +60,24 @@ function(slice2cpp_generate target)
     message(FATAL_ERROR "slice2cpp_generate: '${target}' is not a target.")
   endif()
 
+  get_target_property(aliased ${target} ALIASED_TARGET)
+  if(aliased)
+    message(FATAL_ERROR "slice2cpp_generate: '${target}' is an alias of '${aliased}'; pass that target.")
+  endif()
+
+  # target_sources(PRIVATE) below needs a target that compiles; anything else fails later, from
+  # inside this function, with a far less direct message.
+  get_target_property(target_type ${target} TYPE)
+  if(NOT target_type MATCHES "^(EXECUTABLE|STATIC_LIBRARY|SHARED_LIBRARY|MODULE_LIBRARY|OBJECT_LIBRARY)$")
+    message(FATAL_ERROR "slice2cpp_generate: '${target}' is a ${target_type}, which cannot compile Slice.")
+  endif()
+
   if(arg_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "slice2cpp_generate: unexpected arguments: ${arg_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(arg_KEYWORDS_MISSING_VALUES)
+    message(FATAL_ERROR "slice2cpp_generate: missing value for: ${arg_KEYWORDS_MISSING_VALUES}")
   endif()
 
   if(NOT arg_INCLUDE_SCOPE)
@@ -58,6 +85,13 @@ function(slice2cpp_generate target)
   elseif(NOT arg_INCLUDE_SCOPE MATCHES "^(PRIVATE|PUBLIC)$")
     # Not INTERFACE: the target compiles the generated sources, so it needs the directory itself.
     message(FATAL_ERROR "slice2cpp_generate: INCLUDE_SCOPE must be PRIVATE or PUBLIC.")
+  endif()
+
+  # INCLUDE_DIR names a directory created under the header root and the prefix the generated sources
+  # include it by, so it has to stay a relative path that does not climb out of that root.
+  if(arg_INCLUDE_DIR AND (IS_ABSOLUTE "${arg_INCLUDE_DIR}" OR arg_INCLUDE_DIR MATCHES "(^|[\\/])\.\.([\\/]|$)"))
+    message(FATAL_ERROR
+      "slice2cpp_generate: INCLUDE_DIR must be a relative path without '..', got '${arg_INCLUDE_DIR}'.")
   endif()
 
   # The outputs are declared to CMake below, so an option that changes what slice2cpp writes has to
@@ -125,18 +159,29 @@ function(slice2cpp_generate target)
   endif()
   file(MAKE_DIRECTORY ${header_output_dir})
 
+  # header_root resolves the INCLUDE_DIR-prefixed include each generated source uses for its own
+  # header; header_output_dir resolves the includes slice2cpp emits for other generated headers,
+  # which carry no such prefix. BUILD_INTERFACE keeps these build paths out of a PUBLIC consumer's
+  # exported usage requirements.
   set(generated_include_dirs ${output_dir})
-  if(NOT header_root STREQUAL output_dir)
-    list(APPEND generated_include_dirs ${header_root})
-  endif()
-
-  # BUILD_INTERFACE keeps these build paths out of a PUBLIC consumer's exported usage requirements.
+  foreach(dir IN ITEMS ${header_root} ${header_output_dir})
+    if(NOT dir IN_LIST generated_include_dirs)
+      list(APPEND generated_include_dirs ${dir})
+    endif()
+  endforeach()
   foreach(dir IN LISTS generated_include_dirs)
     target_include_directories(${target} ${arg_INCLUDE_SCOPE} $<BUILD_INTERFACE:${dir}>)
   endforeach()
 
+  # Absolute once, here: this list is both the -I set slice2cpp receives and the roots the generated
+  # layout mirrors. A relative entry would otherwise reach slice2cpp unchanged and resolve against
+  # the build directory, while the mirror resolved it against the source directory.
   # Ice first, so #include <Ice/...> keeps working.
-  set(include_dirs ${Ice_SLICE_DIR} ${arg_INCLUDE_DIRS})
+  set(include_dirs "")
+  foreach(dir IN LISTS Ice_SLICE_DIR arg_INCLUDE_DIRS)
+    get_filename_component(dir "${dir}" ABSOLUTE)
+    list(APPEND include_dirs "${dir}")
+  endforeach()
   set(include_options "")
   foreach(dir IN LISTS include_dirs)
     list(APPEND include_options "-I${dir}")
@@ -146,29 +191,32 @@ function(slice2cpp_generate target)
   list(JOIN include_dirs "$<SEMICOLON>" include_dirs_arg)
   list(JOIN arg_OPTIONS "$<SEMICOLON>" options_arg)
 
-  # Roots the layout can mirror. The source directory counts: "sub/Foo.ice" resolves relative to the
-  # including file.
-  set(mirror_roots "")
-  foreach(dir IN LISTS include_dirs CMAKE_CURRENT_SOURCE_DIR)
-    get_filename_component(dir "${dir}" ABSOLUTE)
-    list(APPEND mirror_roots "${dir}")
-  endforeach()
-
   foreach(file IN LISTS sources)
     if(file MATCHES "\\.ice$")
 
-      get_filename_component(slice_file_name ${file} NAME_WE)
       get_filename_component(slice_file_path ${file} ABSOLUTE)
       get_filename_component(slice_file_dir ${slice_file_path} DIRECTORY)
 
-      # Mirror against the deepest include root holding this file: that is the relative path
-      # slice2cpp used, and generating flat would collide same-named .ice files.
-      set(slice_file_subdir "")
+      # NAME_WLE, not NAME_WE: slice2cpp strips only the final extension, so Foo.v1.ice generates
+      # Foo.v1.h, and NAME_WE would declare an output named Foo.h that is never written.
+      get_filename_component(slice_file_name ${slice_file_path} NAME_WLE)
+
+      # Subdirectory this file mirrors into; "." is the root. Only an INCLUDE_DIRS directory can
+      # drive the layout, because the #include slice2cpp emits for an included Slice file is derived
+      # from the -I list alone. Match its rule: the root giving the shortest relative path wins, and
+      # an exact root scores zero so it beats a broader root giving an equally short name. A file
+      # under no -I directory generates flat, as it always has.
+      set(slice_file_subdir ".")
       set(best_length -1)
-      foreach(root IN LISTS mirror_roots)
+      foreach(root IN LISTS include_dirs)
         file(RELATIVE_PATH candidate "${root}" "${slice_file_dir}")
-        if(NOT candidate MATCHES "^\\.\\.$|^\\.\\.[\\\\/]" AND NOT IS_ABSOLUTE "${candidate}")
+        if(candidate STREQUAL "" OR candidate STREQUAL ".")
+          set(candidate ".")
+          set(candidate_length 0)
+        else()
           string(LENGTH "${candidate}" candidate_length)
+        endif()
+        if(NOT candidate MATCHES "^\\.\\.$|^\\.\\.[\\\\/]" AND NOT IS_ABSOLUTE "${candidate}")
           if(best_length LESS 0 OR candidate_length LESS best_length)
             set(slice_file_subdir "${candidate}")
             set(best_length ${candidate_length})
@@ -176,7 +224,7 @@ function(slice2cpp_generate target)
         endif()
       endforeach()
 
-      if(slice_file_subdir STREQUAL "" OR slice_file_subdir STREQUAL ".")
+      if(slice_file_subdir STREQUAL ".")
         set(file_output_dir ${output_dir})
         set(file_header_dir ${header_output_dir})
       else()
@@ -194,12 +242,34 @@ function(slice2cpp_generate target)
       set(header_file ${file_header_dir}/${slice_file_name}.${header_ext})
       set(source_file ${file_output_dir}/${slice_file_name}.${source_ext})
 
+      # Two commands writing one header races under Makefile generators and is a hard error under
+      # Ninja, and neither message names the targets or Slice files involved. Claim each header
+      # globally and report what actually clashed; two same-named flat .ice files land here too.
+      # Hash the path rather than MAKE_C_IDENTIFIER, which folds /a/b and /a_b together; store one
+      # preformatted string so a ';' in a path cannot split it into a list.
+      string(SHA256 header_key "${header_file}")
+      set(owner_property "_slice2cpp_generate_owner_${header_key}")
+      get_property(owner GLOBAL PROPERTY ${owner_property})
+      if(owner)
+        if(owner STREQUAL "${target}|${slice_file_path}")
+          # The same .ice listed twice for this target; declaring the command again would give the
+          # outputs two rules.
+          continue()
+        endif()
+        message(FATAL_ERROR
+          "slice2cpp_generate: '${header_file}' would be generated twice: once for ${owner}, and "
+          "again for ${target}|${slice_file_path} (target|Slice file). Give the targets separate "
+          "HEADER_OUTPUT_DIR directories, or add an INCLUDE_DIRS directory that tells the two "
+          "Slice files apart.")
+      endif()
+      set_property(GLOBAL PROPERTY ${owner_property} "${target}|${slice_file_path}")
+
       # Prefix for the #include each generated source uses to reach its own header. It has to follow
       # the mirrored layout, since only the roots above are on the include path. A separate header
       # directory means the source can no longer find the header beside itself, so a mirrored file
       # needs the prefix even without INCLUDE_DIR.
       set(include_prefix "${arg_INCLUDE_DIR}")
-      if(NOT slice_file_subdir STREQUAL "" AND NOT slice_file_subdir STREQUAL ".")
+      if(NOT slice_file_subdir STREQUAL ".")
         if(include_prefix)
           set(include_prefix "${include_prefix}/${slice_file_subdir}")
         elseif(NOT header_root STREQUAL output_dir)

--- a/cpp/config/slice2cpp.cmake
+++ b/cpp/config/slice2cpp.cmake
@@ -5,7 +5,7 @@
 #
 #   slice2cpp_generate(<target>
 #     [INCLUDE_DIRS <dir>...]     # extra -I directories
-#     [OPTIONS <option>...]       # extra slice2cpp options, e.g. -DFOO
+#     [OPTIONS <option>...]       # extra slice2cpp options, e.g. -DFOO or --header-ext hpp
 #     [HEADER_OUTPUT_DIR <dir>]   # put the headers here instead of with the sources
 #     [INCLUDE_DIR <dir>]         # slice2cpp --include-dir
 #     [INCLUDE_SCOPE <scope>]     # PRIVATE (default) or PUBLIC
@@ -33,6 +33,10 @@
 # Generated files mirror the layout of the .ice files under the include directory that reaches them,
 # so the #include directives slice2cpp emits resolve. Headers land in HEADER_OUTPUT_DIR/INCLUDE_DIR
 # when either is given, and that root goes on the target's include path.
+#
+# The generated file names are declared to CMake at configure time: --header-ext and --source-ext
+# in OPTIONS are honored, options that relocate the outputs or suppress generation are rejected, and
+# cpp:header-ext metadata that contradicts the declared name is reported when the file compiles.
 
 # The function records the policies in force when it is defined; pin them so a consumer with an older
 # policy baseline gets the same behavior. include() scopes this to the current file.
@@ -55,6 +59,48 @@ function(slice2cpp_generate target)
     # Not INTERFACE: the target compiles the generated sources, so it needs the directory itself.
     message(FATAL_ERROR "slice2cpp_generate: INCLUDE_SCOPE must be PRIVATE or PUBLIC.")
   endif()
+
+  # The outputs are declared to CMake below, so an option that changes what slice2cpp writes has to
+  # be reflected there or the declared files are never written - which Ninja then retries on every
+  # build without saying why. --header-ext and --source-ext are read and honored, the way the MSBuild
+  # task treats them; options that relocate the outputs or replace generation are rejected.
+  set(header_ext "h")
+  set(source_ext "cpp")
+  list(LENGTH arg_OPTIONS options_count)
+  set(option_index 0)
+  while(option_index LESS options_count)
+    list(GET arg_OPTIONS ${option_index} option)
+    set(option_value "")
+
+    if(option MATCHES "^--(header|source)-ext=(.+)$")
+      set(option_kind "${CMAKE_MATCH_1}")
+      set(option_value "${CMAKE_MATCH_2}")
+    elseif(option MATCHES "^--(header|source)-ext$")
+      set(option_kind "${CMAKE_MATCH_1}")
+      math(EXPR option_index "${option_index} + 1")
+      if(NOT option_index LESS options_count)
+        message(FATAL_ERROR "slice2cpp_generate: '${option}' is missing its argument.")
+      endif()
+      list(GET arg_OPTIONS ${option_index} option_value)
+    endif()
+
+    if(option_value)
+      if(NOT option_value MATCHES "^[A-Za-z0-9]+$")
+        message(FATAL_ERROR "slice2cpp_generate: '${option_value}' is not a valid ${option_kind} extension.")
+      endif()
+      set(${option_kind}_ext "${option_value}")
+    elseif(option MATCHES "^(-I|--output-dir|--include-dir|--depend)")
+      message(FATAL_ERROR
+        "slice2cpp_generate: '${option}' is managed by slice2cpp_generate and cannot be passed in "
+        "OPTIONS; use INCLUDE_DIRS, HEADER_OUTPUT_DIR or INCLUDE_DIR instead.")
+    elseif(option MATCHES "^(-h|--help|-v|--version|--validate)$" OR option MATCHES "\\.ice$")
+      message(FATAL_ERROR
+        "slice2cpp_generate: OPTIONS takes slice2cpp options that affect code generation; "
+        "'${option}' suppresses generation or names an input file.")
+    endif()
+
+    math(EXPR option_index "${option_index} + 1")
+  endwhile()
 
   get_target_property(sources ${target} SOURCES)
   if(NOT sources)
@@ -145,8 +191,8 @@ function(slice2cpp_generate target)
       file(RELATIVE_PATH output_dir_relative ${CMAKE_CURRENT_LIST_DIR} ${file_output_dir})
       file(RELATIVE_PATH header_dir_relative ${CMAKE_CURRENT_LIST_DIR} ${file_header_dir})
 
-      set(header_file ${file_header_dir}/${slice_file_name}.h)
-      set(source_file ${file_output_dir}/${slice_file_name}.cpp)
+      set(header_file ${file_header_dir}/${slice_file_name}.${header_ext})
+      set(source_file ${file_output_dir}/${slice_file_name}.${source_ext})
 
       # Prefix for the #include each generated source uses to reach its own header. It has to follow
       # the mirrored layout, since only the roots above are on the include path. A separate header
@@ -175,8 +221,8 @@ function(slice2cpp_generate target)
       set(move_header_commands "")
       if(NOT file_header_dir STREQUAL file_output_dir)
         set(move_header_commands
-          COMMAND ${CMAKE_COMMAND} -E copy ${file_output_dir}/${slice_file_name}.h ${header_file}
-          COMMAND ${CMAKE_COMMAND} -E rm -f ${file_output_dir}/${slice_file_name}.h)
+          COMMAND ${CMAKE_COMMAND} -E copy ${file_output_dir}/${slice_file_name}.${header_ext} ${header_file}
+          COMMAND ${CMAKE_COMMAND} -E rm -f ${file_output_dir}/${slice_file_name}.${header_ext})
       endif()
 
       add_custom_command(
@@ -187,6 +233,7 @@ function(slice2cpp_generate target)
           -DSLICE_INCLUDE_DIRS=${include_dirs_arg}
           -DSLICE_OPTIONS=${options_arg}
           -DHEADER_DIR=${file_header_dir}
+          -DEXPECTED_HEADER=${slice_file_name}.${header_ext}
           -DDEPFILE=${depfile}
           -P ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/slice2cpp_depend.cmake
         COMMAND $<TARGET_FILE:Ice::slice2cpp> ${include_options} ${include_dir_options} ${arg_OPTIONS}
@@ -195,7 +242,7 @@ function(slice2cpp_generate target)
         DEPENDS ${slice_file_path} $<TARGET_FILE:Ice::slice2cpp>
         DEPFILE ${depfile}
         VERBATIM
-        COMMENT "Compiling Slice ${file} -> ${output_dir_relative}/${slice_file_name}.cpp ${header_dir_relative}/${slice_file_name}.h"
+        COMMENT "Compiling Slice ${file} -> ${output_dir_relative}/${slice_file_name}.${source_ext} ${header_dir_relative}/${slice_file_name}.${header_ext}"
       )
 
       target_sources(${target} PRIVATE ${output_files})

--- a/cpp/config/slice2cpp.cmake
+++ b/cpp/config/slice2cpp.cmake
@@ -1,52 +1,201 @@
 # Copyright (c) ZeroC, Inc.
 
-# Function to generate C++ source files from Slice (.ice) files for a target using slice2cpp
-# The target must have the Slice files in its sources
-# The generated files are added to the target sources
-# Usage:
-# add_executable(a_target source1.cpp source2.ice source3.ice)
-# slice2cpp_generate(a_target)
+# Compiles the Slice (.ice) files in a target's sources and adds the generated C++ to the target.
+# Only sees the sources present when it is called.
+#
+#   slice2cpp_generate(<target>
+#     [INCLUDE_DIRS <dir>...]     # extra -I directories
+#     [OPTIONS <option>...]       # extra slice2cpp options, e.g. -DFOO
+#     [HEADER_OUTPUT_DIR <dir>]   # put the headers here instead of with the sources
+#     [INCLUDE_DIR <dir>]         # slice2cpp --include-dir
+#     [INCLUDE_SCOPE <scope>]     # PRIVATE (default) or PUBLIC
+#   )
+#
+# Example:
+#   add_executable(a_target source1.cpp source2.ice source3.ice)
+#   slice2cpp_generate(a_target)
+#
+# A library whose Slice includes files from a shared directory, publishing its generated headers to
+# its own consumers under a "Demo/" prefix:
+#
+#   add_library(demo Greeter.ice)
+#   slice2cpp_generate(demo
+#     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../slice
+#     OPTIONS -DENABLE_EXTRAS
+#     HEADER_OUTPUT_DIR ${CMAKE_BINARY_DIR}/include
+#     INCLUDE_DIR Demo
+#     INCLUDE_SCOPE PUBLIC)
+#
+# Only the .ice files in the target's own sources are compiled. INCLUDE_DIRS just resolves the
+# includes, so a Slice file included from a shared directory needs a target that compiles it, and
+# `demo` links that target to pick up its headers.
+#
+# Generated files mirror the layout of the .ice files under the include directory that reaches them,
+# so the #include directives slice2cpp emits resolve. Headers land in HEADER_OUTPUT_DIR/INCLUDE_DIR
+# when either is given, and that root goes on the target's include path.
+
+# The function records the policies in force when it is defined; pin them so a consumer with an older
+# policy baseline gets the same behavior. include() scopes this to the current file.
+cmake_policy(VERSION 3.21)
+
 function(slice2cpp_generate target)
+  cmake_parse_arguments(PARSE_ARGV 1 arg "" "INCLUDE_SCOPE;HEADER_OUTPUT_DIR;INCLUDE_DIR" "INCLUDE_DIRS;OPTIONS")
 
-  # Get the list of source files for the target
+  if(NOT TARGET ${target})
+    message(FATAL_ERROR "slice2cpp_generate: '${target}' is not a target.")
+  endif()
+
+  if(arg_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "slice2cpp_generate: unexpected arguments: ${arg_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(NOT arg_INCLUDE_SCOPE)
+    set(arg_INCLUDE_SCOPE PRIVATE)
+  elseif(NOT arg_INCLUDE_SCOPE MATCHES "^(PRIVATE|PUBLIC)$")
+    # Not INTERFACE: the target compiles the generated sources, so it needs the directory itself.
+    message(FATAL_ERROR "slice2cpp_generate: INCLUDE_SCOPE must be PRIVATE or PUBLIC.")
+  endif()
+
   get_target_property(sources ${target} SOURCES)
+  if(NOT sources)
+    return()
+  endif()
 
-  # Get the output directory for the generated files
   set(output_dir ${CMAKE_CURRENT_BINARY_DIR}/generated/${target})
-  file(RELATIVE_PATH output_dir_relative ${CMAKE_CURRENT_LIST_DIR} ${output_dir})
+  file(MAKE_DIRECTORY ${output_dir})
 
-  # Create a directory to store the generated files
-  make_directory(${output_dir})
+  # Root the headers are written under. INCLUDE_DIR names a directory created beneath it, rather than
+  # a suffix the caller has to repeat in HEADER_OUTPUT_DIR, so the prefix each generated source uses
+  # always resolves against a directory that is on the include path.
+  if(arg_HEADER_OUTPUT_DIR)
+    get_filename_component(header_root "${arg_HEADER_OUTPUT_DIR}" ABSOLUTE)
+  else()
+    set(header_root ${output_dir})
+  endif()
 
-  # Add the generated headers files to the target include directories
-  target_include_directories(${target} PRIVATE ${output_dir})
+  set(header_output_dir ${header_root})
+  if(arg_INCLUDE_DIR)
+    set(header_output_dir ${header_root}/${arg_INCLUDE_DIR})
+  endif()
+  file(MAKE_DIRECTORY ${header_output_dir})
 
-  # Process each Slice (.ice) file in the source list
-  # 1. Run slice2cpp --depend to generate a dependency file for incremental builds
-  # 2. Run the slice2cpp command to generate the header and source files
-  # 3. Add the generated files to the target sources
+  set(generated_include_dirs ${output_dir})
+  if(NOT header_root STREQUAL output_dir)
+    list(APPEND generated_include_dirs ${header_root})
+  endif()
+
+  # BUILD_INTERFACE keeps these build paths out of a PUBLIC consumer's exported usage requirements.
+  foreach(dir IN LISTS generated_include_dirs)
+    target_include_directories(${target} ${arg_INCLUDE_SCOPE} $<BUILD_INTERFACE:${dir}>)
+  endforeach()
+
+  # Ice first, so #include <Ice/...> keeps working.
+  set(include_dirs ${Ice_SLICE_DIR} ${arg_INCLUDE_DIRS})
+  set(include_options "")
+  foreach(dir IN LISTS include_dirs)
+    list(APPEND include_options "-I${dir}")
+  endforeach()
+
+  # $<SEMICOLON> survives argument splitting, so the -P script receives one real list.
+  list(JOIN include_dirs "$<SEMICOLON>" include_dirs_arg)
+  list(JOIN arg_OPTIONS "$<SEMICOLON>" options_arg)
+
+  # Roots the layout can mirror. The source directory counts: "sub/Foo.ice" resolves relative to the
+  # including file.
+  set(mirror_roots "")
+  foreach(dir IN LISTS include_dirs CMAKE_CURRENT_SOURCE_DIR)
+    get_filename_component(dir "${dir}" ABSOLUTE)
+    list(APPEND mirror_roots "${dir}")
+  endforeach()
+
   foreach(file IN LISTS sources)
     if(file MATCHES "\\.ice$")
 
       get_filename_component(slice_file_name ${file} NAME_WE)
       get_filename_component(slice_file_path ${file} ABSOLUTE)
+      get_filename_component(slice_file_dir ${slice_file_path} DIRECTORY)
 
-      set(output_files ${output_dir}/${slice_file_name}.h ${output_dir}/${slice_file_name}.cpp)
-      set(depfile ${output_dir}/${slice_file_name}.d)
+      # Mirror against the deepest include root holding this file: that is the relative path
+      # slice2cpp used, and generating flat would collide same-named .ice files.
+      set(slice_file_subdir "")
+      set(best_length -1)
+      foreach(root IN LISTS mirror_roots)
+        file(RELATIVE_PATH candidate "${root}" "${slice_file_dir}")
+        if(NOT candidate MATCHES "^\\.\\.$|^\\.\\.[\\\\/]" AND NOT IS_ABSOLUTE "${candidate}")
+          string(LENGTH "${candidate}" candidate_length)
+          if(best_length LESS 0 OR candidate_length LESS best_length)
+            set(slice_file_subdir "${candidate}")
+            set(best_length ${candidate_length})
+          endif()
+        endif()
+      endforeach()
+
+      if(slice_file_subdir STREQUAL "" OR slice_file_subdir STREQUAL ".")
+        set(file_output_dir ${output_dir})
+        set(file_header_dir ${header_output_dir})
+      else()
+        set(file_output_dir ${output_dir}/${slice_file_subdir})
+        set(file_header_dir ${header_output_dir}/${slice_file_subdir})
+      endif()
+      get_filename_component(file_output_dir ${file_output_dir} ABSOLUTE)
+      get_filename_component(file_header_dir ${file_header_dir} ABSOLUTE)
+      file(MAKE_DIRECTORY ${file_output_dir})
+      file(MAKE_DIRECTORY ${file_header_dir})
+
+      file(RELATIVE_PATH output_dir_relative ${CMAKE_CURRENT_LIST_DIR} ${file_output_dir})
+      file(RELATIVE_PATH header_dir_relative ${CMAKE_CURRENT_LIST_DIR} ${file_header_dir})
+
+      set(header_file ${file_header_dir}/${slice_file_name}.h)
+      set(source_file ${file_output_dir}/${slice_file_name}.cpp)
+
+      # Prefix for the #include each generated source uses to reach its own header. It has to follow
+      # the mirrored layout, since only the roots above are on the include path. A separate header
+      # directory means the source can no longer find the header beside itself, so a mirrored file
+      # needs the prefix even without INCLUDE_DIR.
+      set(include_prefix "${arg_INCLUDE_DIR}")
+      if(NOT slice_file_subdir STREQUAL "" AND NOT slice_file_subdir STREQUAL ".")
+        if(include_prefix)
+          set(include_prefix "${include_prefix}/${slice_file_subdir}")
+        elseif(NOT header_root STREQUAL output_dir)
+          set(include_prefix "${slice_file_subdir}")
+        endif()
+      endif()
+
+      set(include_dir_options "")
+      if(include_prefix)
+        set(include_dir_options --include-dir ${include_prefix})
+      endif()
+
+      # Header first: Ninja requires the depfile target to match the first output.
+      set(output_files ${header_file} ${source_file})
+      set(depfile ${file_output_dir}/${slice_file_name}.d)
+
+      # slice2cpp has no separate header option, so move it afterwards as the MSBuild task does.
+      # Copy then remove, since rename is limited to a single volume.
+      set(move_header_commands "")
+      if(NOT file_header_dir STREQUAL file_output_dir)
+        set(move_header_commands
+          COMMAND ${CMAKE_COMMAND} -E copy ${file_output_dir}/${slice_file_name}.h ${header_file}
+          COMMAND ${CMAKE_COMMAND} -E rm -f ${file_output_dir}/${slice_file_name}.h)
+      endif()
 
       add_custom_command(
         OUTPUT ${output_files}
         COMMAND ${CMAKE_COMMAND}
           -DSLICE2CPP=$<TARGET_FILE:Ice::slice2cpp>
           -DSLICE_FILE=${slice_file_path}
-          -DSLICE_INCLUDE_DIR=${Ice_SLICE_DIR}
-          -DOUTPUT_DIR=${output_dir}
+          -DSLICE_INCLUDE_DIRS=${include_dirs_arg}
+          -DSLICE_OPTIONS=${options_arg}
+          -DHEADER_DIR=${file_header_dir}
           -DDEPFILE=${depfile}
           -P ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/slice2cpp_depend.cmake
-        COMMAND $<TARGET_FILE:Ice::slice2cpp> -I${Ice_SLICE_DIR} ${slice_file_path} --output-dir ${output_dir}
+        COMMAND $<TARGET_FILE:Ice::slice2cpp> ${include_options} ${include_dir_options} ${arg_OPTIONS}
+          ${slice_file_path} --output-dir ${file_output_dir}
+        ${move_header_commands}
         DEPENDS ${slice_file_path} $<TARGET_FILE:Ice::slice2cpp>
         DEPFILE ${depfile}
-        COMMENT "Compiling Slice ${file} -> ${output_dir_relative}/${slice_file_name}.cpp ${output_dir_relative}/${slice_file_name}.h"
+        VERBATIM
+        COMMENT "Compiling Slice ${file} -> ${output_dir_relative}/${slice_file_name}.cpp ${header_dir_relative}/${slice_file_name}.h"
       )
 
       target_sources(${target} PRIVATE ${output_files})

--- a/cpp/config/slice2cpp.cmake
+++ b/cpp/config/slice2cpp.cmake
@@ -38,6 +38,7 @@
 #
 # --header-ext and --source-ext in OPTIONS are honored; options that relocate the outputs or
 # suppress generation are rejected, and contradicting cpp:header-ext metadata is a build-time error.
+# cpp:source-ext metadata is not supported.
 
 # This file is loaded by every consumer of the Ice package, not only the ones that generate Slice.
 if(CMAKE_VERSION VERSION_LESS 3.21)
@@ -109,7 +110,7 @@ function(slice2cpp_generate target)
     endif()
 
     if(option_value)
-      if(NOT option_value MATCHES "^[A-Za-z0-9]+$")
+      if(NOT option_value MATCHES "^[A-Za-z0-9+]+$")
         message(FATAL_ERROR "slice2cpp_generate: '${option_value}' is not a valid ${option_kind} extension.")
       endif()
       set(${option_kind}_ext "${option_value}")
@@ -126,6 +127,20 @@ function(slice2cpp_generate target)
     math(EXPR option_index "${option_index} + 1")
   endwhile()
 
+  if(header_ext STREQUAL source_ext)
+    message(FATAL_ERROR
+      "slice2cpp_generate: --header-ext and --source-ext are both '${header_ext}'; slice2cpp would "
+      "write one file over the other.")
+  endif()
+
+  # A source extension CMake does not recognize would build green with the generated code never
+  # compiled, failing only when something needs a symbol from it.
+  if(DEFINED CMAKE_CXX_SOURCE_FILE_EXTENSIONS AND NOT source_ext IN_LIST CMAKE_CXX_SOURCE_FILE_EXTENSIONS)
+    message(FATAL_ERROR
+      "slice2cpp_generate: CMake does not compile '.${source_ext}' as C++ "
+      "(known: ${CMAKE_CXX_SOURCE_FILE_EXTENSIONS}).")
+  endif()
+
   get_target_property(sources ${target} SOURCES)
   if(NOT sources)
     return()
@@ -137,7 +152,9 @@ function(slice2cpp_generate target)
   # INCLUDE_DIR names a directory created under the header root, so the prefix each generated source
   # uses always resolves against a directory on the include path.
   if(arg_HEADER_OUTPUT_DIR)
-    get_filename_component(header_root "${arg_HEADER_OUTPUT_DIR}" ABSOLUTE)
+    # An output, so a relative value resolves against the build directory like output_dir does;
+    # get_filename_component(ABSOLUTE) alone would resolve it against the source directory.
+    get_filename_component(header_root "${arg_HEADER_OUTPUT_DIR}" ABSOLUTE BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
   else()
     set(header_root ${output_dir})
   endif()
@@ -149,10 +166,11 @@ function(slice2cpp_generate target)
   file(MAKE_DIRECTORY ${header_output_dir})
 
   # header_root resolves the INCLUDE_DIR-prefixed self-includes; header_output_dir resolves the
-  # unprefixed includes slice2cpp emits for other generated headers. BUILD_INTERFACE keeps these
-  # build paths out of exported usage requirements.
+  # unprefixed includes slice2cpp emits for other generated headers, and comes first so a target's
+  # own headers outrank another target's under a shared root. BUILD_INTERFACE keeps these build
+  # paths out of exported usage requirements.
   set(generated_include_dirs ${output_dir})
-  foreach(dir IN ITEMS ${header_root} ${header_output_dir})
+  foreach(dir IN ITEMS ${header_output_dir} ${header_root})
     if(NOT dir IN_LIST generated_include_dirs)
       list(APPEND generated_include_dirs ${dir})
     endif()
@@ -245,13 +263,14 @@ function(slice2cpp_generate target)
       endif()
       set_property(GLOBAL PROPERTY ${owner_property} "${target}|${slice_file_path}")
 
-      # Prefix for the generated source's include of its own header; follows the mirrored layout. A
-      # header moved away from its source needs the prefix even without INCLUDE_DIR.
+      # Prefix for the generated source's include of its own header; follows the mirrored layout.
+      # Mirrored files get it unconditionally, because it also namespaces the include guard - two
+      # same-named headers in different subdirectories must not share one.
       set(include_prefix "${arg_INCLUDE_DIR}")
       if(NOT slice_file_subdir STREQUAL ".")
         if(include_prefix)
           set(include_prefix "${include_prefix}/${slice_file_subdir}")
-        elseif(NOT header_root STREQUAL output_dir)
+        else()
           set(include_prefix "${slice_file_subdir}")
         endif()
       endif()

--- a/cpp/config/slice2cpp.cmake
+++ b/cpp/config/slice2cpp.cmake
@@ -32,25 +32,19 @@
 #
 # Generated files mirror the layout of the .ice files under the INCLUDE_DIRS directory that reaches
 # them, so the #include directives slice2cpp emits resolve; a file under no such directory generates
-# flat, and two flat files sharing a name is reported at configure time. Headers land under
-# HEADER_OUTPUT_DIR/INCLUDE_DIR when given, and both that directory and HEADER_OUTPUT_DIR go on the
-# target's include path.
+# flat. Headers land under HEADER_OUTPUT_DIR/INCLUDE_DIR, and both go on the target's include path.
 #
-# A PUBLIC INCLUDE_SCOPE covers the build tree only; installing or exporting the target additionally
-# needs the caller to install the generated headers and add an INSTALL_INTERFACE directory.
+# A PUBLIC INCLUDE_SCOPE covers the build tree only; installing the headers is the caller's.
 #
-# The generated file names are declared to CMake at configure time: --header-ext and --source-ext
-# in OPTIONS are honored, options that relocate the outputs or suppress generation are rejected, and
-# cpp:header-ext metadata that contradicts the declared name is reported when the file compiles.
+# --header-ext and --source-ext in OPTIONS are honored; options that relocate the outputs or
+# suppress generation are rejected, and contradicting cpp:header-ext metadata is a build-time error.
 
-# Checked up front with a readable message: this file is loaded by every consumer of the Ice
-# package, not only the ones that generate Slice.
+# This file is loaded by every consumer of the Ice package, not only the ones that generate Slice.
 if(CMAKE_VERSION VERSION_LESS 3.21)
   message(FATAL_ERROR "The Ice CMake package requires CMake 3.21 or later.")
 endif()
 
-# The function records the policies in force when it is defined; pin them so a consumer with an older
-# policy baseline gets the same behavior. include() scopes this to the current file.
+# The function records the policies in force at definition; include() scopes this to the file.
 cmake_policy(VERSION 3.21)
 
 function(slice2cpp_generate target)
@@ -65,8 +59,7 @@ function(slice2cpp_generate target)
     message(FATAL_ERROR "slice2cpp_generate: '${target}' is an alias of '${aliased}'; pass that target.")
   endif()
 
-  # target_sources(PRIVATE) below needs a target that compiles; anything else fails later, from
-  # inside this function, with a far less direct message.
+  # target_sources(PRIVATE) below needs a target that compiles.
   get_target_property(target_type ${target} TYPE)
   if(NOT target_type MATCHES "^(EXECUTABLE|STATIC_LIBRARY|SHARED_LIBRARY|MODULE_LIBRARY|OBJECT_LIBRARY)$")
     message(FATAL_ERROR "slice2cpp_generate: '${target}' is a ${target_type}, which cannot compile Slice.")
@@ -87,17 +80,14 @@ function(slice2cpp_generate target)
     message(FATAL_ERROR "slice2cpp_generate: INCLUDE_SCOPE must be PRIVATE or PUBLIC.")
   endif()
 
-  # INCLUDE_DIR names a directory created under the header root and the prefix the generated sources
-  # include it by, so it has to stay a relative path that does not climb out of that root.
+  # Also the prefix the generated sources include headers by, so it cannot leave the header root.
   if(arg_INCLUDE_DIR AND (IS_ABSOLUTE "${arg_INCLUDE_DIR}" OR arg_INCLUDE_DIR MATCHES "(^|[\\/])\.\.([\\/]|$)"))
     message(FATAL_ERROR
       "slice2cpp_generate: INCLUDE_DIR must be a relative path without '..', got '${arg_INCLUDE_DIR}'.")
   endif()
 
-  # The outputs are declared to CMake below, so an option that changes what slice2cpp writes has to
-  # be reflected there or the declared files are never written - which Ninja then retries on every
-  # build without saying why. --header-ext and --source-ext are read and honored, the way the MSBuild
-  # task treats them; options that relocate the outputs or replace generation are rejected.
+  # The declared outputs must match what slice2cpp writes, or Ninja retries the command on every
+  # build without saying why. --header-ext/--source-ext are honored, as in the MSBuild task.
   set(header_ext "h")
   set(source_ext "cpp")
   list(LENGTH arg_OPTIONS options_count)
@@ -144,9 +134,8 @@ function(slice2cpp_generate target)
   set(output_dir ${CMAKE_CURRENT_BINARY_DIR}/generated/${target})
   file(MAKE_DIRECTORY ${output_dir})
 
-  # Root the headers are written under. INCLUDE_DIR names a directory created beneath it, rather than
-  # a suffix the caller has to repeat in HEADER_OUTPUT_DIR, so the prefix each generated source uses
-  # always resolves against a directory that is on the include path.
+  # INCLUDE_DIR names a directory created under the header root, so the prefix each generated source
+  # uses always resolves against a directory on the include path.
   if(arg_HEADER_OUTPUT_DIR)
     get_filename_component(header_root "${arg_HEADER_OUTPUT_DIR}" ABSOLUTE)
   else()
@@ -159,10 +148,9 @@ function(slice2cpp_generate target)
   endif()
   file(MAKE_DIRECTORY ${header_output_dir})
 
-  # header_root resolves the INCLUDE_DIR-prefixed include each generated source uses for its own
-  # header; header_output_dir resolves the includes slice2cpp emits for other generated headers,
-  # which carry no such prefix. BUILD_INTERFACE keeps these build paths out of a PUBLIC consumer's
-  # exported usage requirements.
+  # header_root resolves the INCLUDE_DIR-prefixed self-includes; header_output_dir resolves the
+  # unprefixed includes slice2cpp emits for other generated headers. BUILD_INTERFACE keeps these
+  # build paths out of exported usage requirements.
   set(generated_include_dirs ${output_dir})
   foreach(dir IN ITEMS ${header_root} ${header_output_dir})
     if(NOT dir IN_LIST generated_include_dirs)
@@ -173,9 +161,8 @@ function(slice2cpp_generate target)
     target_include_directories(${target} ${arg_INCLUDE_SCOPE} $<BUILD_INTERFACE:${dir}>)
   endforeach()
 
-  # Absolute once, here: this list is both the -I set slice2cpp receives and the roots the generated
-  # layout mirrors. A relative entry would otherwise reach slice2cpp unchanged and resolve against
-  # the build directory, while the mirror resolved it against the source directory.
+  # Absolute once: this list is both slice2cpp's -I set and the mirror roots, and a relative entry
+  # would resolve against the build directory for one and the source directory for the other.
   # Ice first, so #include <Ice/...> keeps working.
   set(include_dirs "")
   foreach(dir IN LISTS Ice_SLICE_DIR arg_INCLUDE_DIRS)
@@ -197,15 +184,12 @@ function(slice2cpp_generate target)
       get_filename_component(slice_file_path ${file} ABSOLUTE)
       get_filename_component(slice_file_dir ${slice_file_path} DIRECTORY)
 
-      # NAME_WLE, not NAME_WE: slice2cpp strips only the final extension, so Foo.v1.ice generates
-      # Foo.v1.h, and NAME_WE would declare an output named Foo.h that is never written.
+      # NAME_WLE: slice2cpp strips only the final extension, so Foo.v1.ice generates Foo.v1.h.
       get_filename_component(slice_file_name ${slice_file_path} NAME_WLE)
 
-      # Subdirectory this file mirrors into; "." is the root. Only an INCLUDE_DIRS directory can
-      # drive the layout, because the #include slice2cpp emits for an included Slice file is derived
-      # from the -I list alone. Match its rule: the root giving the shortest relative path wins, and
-      # an exact root scores zero so it beats a broader root giving an equally short name. A file
-      # under no -I directory generates flat, as it always has.
+      # Mirror subdirectory; "." is the root. Only -I directories drive the layout, matching how
+      # slice2cpp derives the #includes it emits: shortest relative path wins, an exact root scores
+      # zero, and a file under no -I directory generates flat.
       set(slice_file_subdir ".")
       set(best_length -1)
       foreach(root IN LISTS include_dirs)
@@ -242,18 +226,15 @@ function(slice2cpp_generate target)
       set(header_file ${file_header_dir}/${slice_file_name}.${header_ext})
       set(source_file ${file_output_dir}/${slice_file_name}.${source_ext})
 
-      # Two commands writing one header races under Makefile generators and is a hard error under
-      # Ninja, and neither message names the targets or Slice files involved. Claim each header
-      # globally and report what actually clashed; two same-named flat .ice files land here too.
-      # Hash the path rather than MAKE_C_IDENTIFIER, which folds /a/b and /a_b together; store one
-      # preformatted string so a ';' in a path cannot split it into a list.
+      # Claim each header globally: two commands writing one file is a silent race under Makefile
+      # generators. Hash the path (MAKE_C_IDENTIFIER folds /a/b and /a_b together) and store one
+      # preformatted string, so a ';' in a path cannot split it.
       string(SHA256 header_key "${header_file}")
       set(owner_property "_slice2cpp_generate_owner_${header_key}")
       get_property(owner GLOBAL PROPERTY ${owner_property})
       if(owner)
         if(owner STREQUAL "${target}|${slice_file_path}")
-          # The same .ice listed twice for this target; declaring the command again would give the
-          # outputs two rules.
+          # The same .ice listed twice for this target.
           continue()
         endif()
         message(FATAL_ERROR
@@ -264,10 +245,8 @@ function(slice2cpp_generate target)
       endif()
       set_property(GLOBAL PROPERTY ${owner_property} "${target}|${slice_file_path}")
 
-      # Prefix for the #include each generated source uses to reach its own header. It has to follow
-      # the mirrored layout, since only the roots above are on the include path. A separate header
-      # directory means the source can no longer find the header beside itself, so a mirrored file
-      # needs the prefix even without INCLUDE_DIR.
+      # Prefix for the generated source's include of its own header; follows the mirrored layout. A
+      # header moved away from its source needs the prefix even without INCLUDE_DIR.
       set(include_prefix "${arg_INCLUDE_DIR}")
       if(NOT slice_file_subdir STREQUAL ".")
         if(include_prefix)
@@ -286,8 +265,7 @@ function(slice2cpp_generate target)
       set(output_files ${header_file} ${source_file})
       set(depfile ${file_output_dir}/${slice_file_name}.d)
 
-      # slice2cpp has no separate header option, so move it afterwards as the MSBuild task does.
-      # Copy then remove, since rename is limited to a single volume.
+      # slice2cpp has no separate header option, so move it afterwards, as the MSBuild task does.
       set(move_header_commands "")
       if(NOT file_header_dir STREQUAL file_output_dir)
         set(move_header_commands

--- a/cpp/config/slice2cpp_depend.cmake
+++ b/cpp/config/slice2cpp_depend.cmake
@@ -34,49 +34,27 @@ endif()
 # Rewrite the target to the full header path, which Ninja requires it to match the first OUTPUT.
 # Match ": \" rather than ":" so Windows drive letters like C:/... are not mistaken for the
 # separator (there the colon is followed by / or \, never by " \").
-if(NOT depend_output MATCHES "^([^:]+)(: \\\\)")
+if(NOT depend_output MATCHES "^([^:]+): \\\\")
     message(FATAL_ERROR "slice2cpp --depend produced unexpected output for ${SLICE_FILE}:\n${depend_output}")
 endif()
+set(actual_header "${CMAKE_MATCH_1}")
 
 # --depend names the header slice2cpp will actually write, cpp:header-ext metadata included. Report
 # a mismatch here rather than rerun forever a command whose declared output never appears.
-if(NOT CMAKE_MATCH_1 STREQUAL EXPECTED_HEADER)
+if(NOT actual_header STREQUAL EXPECTED_HEADER)
     message(FATAL_ERROR
-        "slice2cpp generates '${CMAKE_MATCH_1}' for ${SLICE_FILE}, but slice2cpp_generate declared "
+        "slice2cpp generates '${actual_header}' for ${SLICE_FILE}, but slice2cpp_generate declared "
         "'${EXPECTED_HEADER}'. Set the extension with OPTIONS --header-ext; cpp:header-ext metadata "
         "that contradicts it is not supported.")
 endif()
 
-string(REGEX REPLACE "^([^:]+)(: \\\\)" "${HEADER_DIR}/\\1\\2" depend_output "${depend_output}")
+# The prefix is a path slice2cpp never sees, so escape it here the way compiler depfiles escape
+# paths. The paths slice2cpp itself writes are its own to escape (zeroc-ice/ice#6374).
+set(header_dir_escaped "${HEADER_DIR}")
+string(REPLACE "$" "$$" header_dir_escaped "${header_dir_escaped}")
+string(REPLACE "#" "\\#" header_dir_escaped "${header_dir_escaped}")
+string(REPLACE " " "\\ " header_dir_escaped "${header_dir_escaped}")
 
-# Escape spaces the way compiler depfiles do, or a path with a space reads as several dependencies
-# that never exist and the file recompiles on every build. Drop the continuations before splitting
-# into lines, and protect a real ';' in a path from that split.
-string(REPLACE "\r" "" depend_output "${depend_output}")
-string(REGEX REPLACE " \\\\\n" "\n" depend_output "${depend_output}")
-string(REPLACE ";" "@SLICE2CPP_SEMI@" depend_output "${depend_output}")
-string(REPLACE "\n" ";" depend_lines "${depend_output}")
-
-set(escaped_output "")
-set(seen_target FALSE)
-foreach(line IN LISTS depend_lines)
-    if(line STREQUAL "")
-        continue()
-    endif()
-    if(NOT seen_target)
-        # "<target>:" - strip only the trailing separator.
-        string(REGEX REPLACE ":$" "" line "${line}")
-        string(REPLACE " " "\\ " line "${line}")
-        set(escaped_output "${line}:")
-        set(seen_target TRUE)
-    else()
-        # " <dependency>" - strip only the single leading space slice2cpp writes.
-        string(REGEX REPLACE "^ " "" line "${line}")
-        string(REPLACE " " "\\ " line "${line}")
-        string(APPEND escaped_output " \\\n ${line}")
-    endif()
-endforeach()
-string(APPEND escaped_output "\n")
-string(REPLACE "@SLICE2CPP_SEMI@" ";" depend_output "${escaped_output}")
-
-file(WRITE "${DEPFILE}" "${depend_output}")
+string(LENGTH "${actual_header}" target_length)
+string(SUBSTRING "${depend_output}" ${target_length} -1 depend_tail)
+file(WRITE "${DEPFILE}" "${header_dir_escaped}/${actual_header}${depend_tail}")

--- a/cpp/config/slice2cpp_depend.cmake
+++ b/cpp/config/slice2cpp_depend.cmake
@@ -5,8 +5,7 @@
 #   SLICE2CPP          - path to the slice2cpp executable
 #   SLICE_FILE         - the .ice source file (absolute path)
 #   SLICE_INCLUDE_DIRS - list of Slice include directories (one -I flag each)
-#   SLICE_OPTIONS      - extra slice2cpp options; -D/-U change which includes the preprocessor sees,
-#                        so --depend needs them to compute the same dependencies as the compile
+#   SLICE_OPTIONS      - extra slice2cpp options; -D/-U change which includes --depend sees
 #   HEADER_DIR         - directory the generated header ends up in
 #   EXPECTED_HEADER    - header name declared to CMake, checked against what slice2cpp will write
 #   DEPFILE            - output path for the generated .d file
@@ -39,9 +38,8 @@ if(NOT depend_output MATCHES "^([^:]+)(: \\\\)")
     message(FATAL_ERROR "slice2cpp --depend produced unexpected output for ${SLICE_FILE}:\n${depend_output}")
 endif()
 
-# --depend names the header slice2cpp will actually write, which honors cpp:header-ext metadata over
-# the --header-ext option. CMake committed to a name at configure time; report a mismatch here rather
-# than rerun a command forever whose declared output is never created.
+# --depend names the header slice2cpp will actually write, cpp:header-ext metadata included. Report
+# a mismatch here rather than rerun forever a command whose declared output never appears.
 if(NOT CMAKE_MATCH_1 STREQUAL EXPECTED_HEADER)
     message(FATAL_ERROR
         "slice2cpp generates '${CMAKE_MATCH_1}' for ${SLICE_FILE}, but slice2cpp_generate declared "
@@ -51,10 +49,9 @@ endif()
 
 string(REGEX REPLACE "^([^:]+)(: \\\\)" "${HEADER_DIR}/\\1\\2" depend_output "${depend_output}")
 
-# slice2cpp writes the paths verbatim; escape spaces the way compiler depfiles do, or a path with a
-# space reads as several dependencies that never exist and the file recompiles on every build.
-# Rebuild the file from its lines: drop the continuations before splitting, since a trailing
-# backslash would escape the ';' the split inserts, and protect a real ';' in a path from the split.
+# Escape spaces the way compiler depfiles do, or a path with a space reads as several dependencies
+# that never exist and the file recompiles on every build. Drop the continuations before splitting
+# into lines, and protect a real ';' in a path from that split.
 string(REPLACE "\r" "" depend_output "${depend_output}")
 string(REGEX REPLACE " \\\\\n" "\n" depend_output "${depend_output}")
 string(REPLACE ";" "@SLICE2CPP_SEMI@" depend_output "${depend_output}")

--- a/cpp/config/slice2cpp_depend.cmake
+++ b/cpp/config/slice2cpp_depend.cmake
@@ -51,4 +51,35 @@ endif()
 
 string(REGEX REPLACE "^([^:]+)(: \\\\)" "${HEADER_DIR}/\\1\\2" depend_output "${depend_output}")
 
+# slice2cpp writes the paths verbatim; escape spaces the way compiler depfiles do, or a path with a
+# space reads as several dependencies that never exist and the file recompiles on every build.
+# Rebuild the file from its lines: drop the continuations before splitting, since a trailing
+# backslash would escape the ';' the split inserts, and protect a real ';' in a path from the split.
+string(REPLACE "\r" "" depend_output "${depend_output}")
+string(REGEX REPLACE " \\\\\n" "\n" depend_output "${depend_output}")
+string(REPLACE ";" "@SLICE2CPP_SEMI@" depend_output "${depend_output}")
+string(REPLACE "\n" ";" depend_lines "${depend_output}")
+
+set(escaped_output "")
+set(seen_target FALSE)
+foreach(line IN LISTS depend_lines)
+    if(line STREQUAL "")
+        continue()
+    endif()
+    if(NOT seen_target)
+        # "<target>:" - strip only the trailing separator.
+        string(REGEX REPLACE ":$" "" line "${line}")
+        string(REPLACE " " "\\ " line "${line}")
+        set(escaped_output "${line}:")
+        set(seen_target TRUE)
+    else()
+        # " <dependency>" - strip only the single leading space slice2cpp writes.
+        string(REGEX REPLACE "^ " "" line "${line}")
+        string(REPLACE " " "\\ " line "${line}")
+        string(APPEND escaped_output " \\\n ${line}")
+    endif()
+endforeach()
+string(APPEND escaped_output "\n")
+string(REPLACE "@SLICE2CPP_SEMI@" ";" depend_output "${escaped_output}")
+
 file(WRITE "${DEPFILE}" "${depend_output}")

--- a/cpp/config/slice2cpp_depend.cmake
+++ b/cpp/config/slice2cpp_depend.cmake
@@ -8,6 +8,7 @@
 #   SLICE_OPTIONS      - extra slice2cpp options; -D/-U change which includes the preprocessor sees,
 #                        so --depend needs them to compute the same dependencies as the compile
 #   HEADER_DIR         - directory the generated header ends up in
+#   EXPECTED_HEADER    - header name declared to CMake, checked against what slice2cpp will write
 #   DEPFILE            - output path for the generated .d file
 
 set(include_options "")
@@ -34,6 +35,20 @@ endif()
 # Rewrite the target to the full header path, which Ninja requires it to match the first OUTPUT.
 # Match ": \" rather than ":" so Windows drive letters like C:/... are not mistaken for the
 # separator (there the colon is followed by / or \, never by " \").
+if(NOT depend_output MATCHES "^([^:]+)(: \\\\)")
+    message(FATAL_ERROR "slice2cpp --depend produced unexpected output for ${SLICE_FILE}:\n${depend_output}")
+endif()
+
+# --depend names the header slice2cpp will actually write, which honors cpp:header-ext metadata over
+# the --header-ext option. CMake committed to a name at configure time; report a mismatch here rather
+# than rerun a command forever whose declared output is never created.
+if(NOT CMAKE_MATCH_1 STREQUAL EXPECTED_HEADER)
+    message(FATAL_ERROR
+        "slice2cpp generates '${CMAKE_MATCH_1}' for ${SLICE_FILE}, but slice2cpp_generate declared "
+        "'${EXPECTED_HEADER}'. Set the extension with OPTIONS --header-ext; cpp:header-ext metadata "
+        "that contradicts it is not supported.")
+endif()
+
 string(REGEX REPLACE "^([^:]+)(: \\\\)" "${HEADER_DIR}/\\1\\2" depend_output "${depend_output}")
 
 file(WRITE "${DEPFILE}" "${depend_output}")

--- a/cpp/config/slice2cpp_depend.cmake
+++ b/cpp/config/slice2cpp_depend.cmake
@@ -2,14 +2,21 @@
 
 # Helper script to generate a dependency file for Slice compilation.
 # Invoked at build time via cmake -P with the following variables:
-#   SLICE2CPP        - path to the slice2cpp executable
-#   SLICE_FILE       - the .ice source file (absolute path)
-#   SLICE_INCLUDE_DIR - path to Ice Slice directory (for -I flag)
-#   OUTPUT_DIR       - directory where generated files are placed
-#   DEPFILE          - output path for the generated .d file
+#   SLICE2CPP          - path to the slice2cpp executable
+#   SLICE_FILE         - the .ice source file (absolute path)
+#   SLICE_INCLUDE_DIRS - list of Slice include directories (one -I flag each)
+#   SLICE_OPTIONS      - extra slice2cpp options; -D/-U change which includes the preprocessor sees,
+#                        so --depend needs them to compute the same dependencies as the compile
+#   HEADER_DIR         - directory the generated header ends up in
+#   DEPFILE            - output path for the generated .d file
+
+set(include_options "")
+foreach(dir IN LISTS SLICE_INCLUDE_DIRS)
+    list(APPEND include_options "-I${dir}")
+endforeach()
 
 execute_process(
-    COMMAND "${SLICE2CPP}" "-I${SLICE_INCLUDE_DIR}" --depend "${SLICE_FILE}"
+    COMMAND "${SLICE2CPP}" ${include_options} ${SLICE_OPTIONS} --depend "${SLICE_FILE}"
     OUTPUT_VARIABLE depend_output
     ERROR_VARIABLE depend_error
     RESULT_VARIABLE result
@@ -24,9 +31,9 @@ endif()
 #    /path/to/Locator.ice \
 #    /path/to/Identity.ice
 #
-# Replace the target with the full output path so it matches the OUTPUT of add_custom_command.
-# We match ": \" (the depfile target separator) instead of just ":" to avoid matching the drive
-# letter in Windows paths like C:/... (where the colon is followed by / or \, never by " \").
-string(REGEX REPLACE "^([^:]+)(: \\\\)" "${OUTPUT_DIR}/\\1\\2" depend_output "${depend_output}")
+# Rewrite the target to the full header path, which Ninja requires it to match the first OUTPUT.
+# Match ": \" rather than ":" so Windows drive letters like C:/... are not mistaken for the
+# separator (there the colon is followed by / or \, never by " \").
+string(REGEX REPLACE "^([^:]+)(: \\\\)" "${HEADER_DIR}/\\1\\2" depend_output "${depend_output}")
 
 file(WRITE "${DEPFILE}" "${depend_output}")

--- a/cpp/config/slice2cpp_depend.cmake
+++ b/cpp/config/slice2cpp_depend.cmake
@@ -49,7 +49,7 @@ if(NOT actual_header STREQUAL EXPECTED_HEADER)
 endif()
 
 # The prefix is a path slice2cpp never sees, so escape it here the way compiler depfiles escape
-# paths. The paths slice2cpp itself writes are its own to escape (zeroc-ice/ice#6374).
+# paths. The paths slice2cpp itself writes are its own to escape (zeroc-ice/ice#6329).
 set(header_dir_escaped "${HEADER_DIR}")
 string(REPLACE "$" "$$" header_dir_escaped "${header_dir_escaped}")
 string(REPLACE "#" "\\#" header_dir_escaped "${header_dir_escaped}")


### PR DESCRIPTION
`slice2cpp_generate` could not compile a project whose `.ice` files live in subdirectories, and offered no way to pass options to `slice2cpp`.

- Generated files mirror the layout of the `.ice` files under the `INCLUDE_DIRS` directory that reaches them, matching how `slice2cpp` derives the `#include` directives it emits; a file under no such directory generates flat, as before. Two flat files sharing a name, or two targets generating one header, is a configure-time error naming both sides instead of a silent race.
- `INCLUDE_DIRS` passes extra `-I` directories, made absolute once so `slice2cpp` and the mirrored layout agree; `OPTIONS` passes other `slice2cpp` options. `--header-ext` and `--source-ext` are honored in the declared outputs; options that relocate the outputs or suppress generation are rejected, and `cpp:header-ext` metadata that contradicts the declared name is reported at build time instead of silently re-running the command on every build.
- `HEADER_OUTPUT_DIR` writes the generated headers to their own directory, and `INCLUDE_DIR` maps to `slice2cpp --include-dir`, with both directories on the target's include path so cross-includes between generated headers resolve.
- `INCLUDE_SCOPE PUBLIC` lets a library export its generated headers to its own consumers in the build tree; installing them is the caller's.
- The Slice dependency scan runs with the same `OPTIONS` as the compile, and the helper escapes the header-directory prefix it prepends to the depfile target. Escaping the dependency paths `slice2cpp` itself writes is #6329.
- `NAME_WLE` so `Foo.v1.ice` declares the `Foo.v1.h` that `slice2cpp` writes; alias and non-compiling targets are rejected with direct messages; the CMake 3.21 requirement is stated up front; `VERBATIM` on the generated commands.

Closes #5063
Closes #5064

🤖 Generated with [Claude Code](https://claude.com/claude-code)

