### PR TITLE
Read the TCP buffer-size properties before creating sockets

### DIFF
--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -3,7 +3,6 @@
 #include "Network.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/LoggerUtil.h" // For setTcpBufSize
-#include "Ice/Properties.h" // For setTcpBufSize
 #include "Ice/StringUtil.h"
 #include "NetworkProxy.h"
 #include "ProtocolInstance.h" // For setTcpBufSize
@@ -1084,26 +1083,6 @@ IceInternal::isMulticast(const Address& addr)
         return IN6_IS_ADDR_MULTICAST(&addr.saIn6.sin6_addr);
     }
     return false;
-}
-
-void
-IceInternal::setTcpBufSize(SOCKET fd, const ProtocolInstancePtr& instance)
-{
-    assert(fd != INVALID_SOCKET);
-
-    //
-    // By default, on Windows we use a 128KB buffer size. On Unix
-    // platforms, we use the system defaults.
-    //
-#ifdef _WIN32
-    const int dfltBufSize = 128 * 1024;
-#else
-    const int dfltBufSize = 0;
-#endif
-    int32_t rcvSize = instance->properties()->getPropertyAsIntWithDefault("Ice.TCP.RcvSize", dfltBufSize);
-    int32_t sndSize = instance->properties()->getPropertyAsIntWithDefault("Ice.TCP.SndSize", dfltBufSize);
-
-    setTcpBufSize(fd, rcvSize, sndSize, instance);
 }
 
 void

--- a/cpp/src/Ice/Network.h
+++ b/cpp/src/Ice/Network.h
@@ -5,9 +5,7 @@
 
 #include "Ice/Config.h"
 #include "Ice/EndpointTypes.h"
-#include "Ice/Logger.h"      // For setTcpBufSize
-#include "Ice/PropertiesF.h" // For setTcpBufSize
-#include "Ice/StringUtil.h"  // For ErrorCode
+#include "Ice/StringUtil.h" // For ErrorCode
 #include "NetworkF.h"
 #include "NetworkProxyF.h"
 #include "Protocol.h"
@@ -212,7 +210,6 @@ namespace IceInternal
     ICE_API void setPort(Address&, int);
 
     ICE_API bool isMulticast(const Address&);
-    ICE_API void setTcpBufSize(SOCKET, const ProtocolInstancePtr&);
     ICE_API void setTcpBufSize(SOCKET, int, int, const ProtocolInstancePtr&);
 
     ICE_API void setBlock(SOCKET, bool);

--- a/cpp/src/Ice/NetworkProxy.h
+++ b/cpp/src/Ice/NetworkProxy.h
@@ -4,6 +4,7 @@
 #define ICE_NETWORK_PROXY_H
 
 #include "Ice/Buffer.h"
+#include "Ice/PropertiesF.h"
 #include "Network.h"
 
 namespace IceInternal

--- a/cpp/src/Ice/StreamSocket.cpp
+++ b/cpp/src/Ice/StreamSocket.cpp
@@ -10,7 +10,8 @@ StreamSocket::StreamSocket(
     ProtocolInstancePtr instance,
     const NetworkProxyPtr& proxy,
     const Address& addr,
-    const Address& sourceAddr)
+    const Address& sourceAddr,
+    const TcpBufSize& bufSize)
     : NativeInfo(createSocket(false, proxy ? proxy->getAddress() : addr)),
       _instance(std::move(instance)),
       _proxy(proxy),
@@ -23,7 +24,7 @@ StreamSocket::StreamSocket(
       _write(SocketOperationWrite)
 #endif
 {
-    init();
+    init(bufSize);
 #if !defined(ICE_USE_IOCP)
     if (doConnect(_fd, _proxy ? _proxy->getAddress() : _addr, sourceAddr))
     {
@@ -41,7 +42,7 @@ StreamSocket::StreamSocket(
     }
 }
 
-StreamSocket::StreamSocket(ProtocolInstancePtr instance, SOCKET fd)
+StreamSocket::StreamSocket(ProtocolInstancePtr instance, SOCKET fd, const TcpBufSize& bufSize)
     : NativeInfo(fd),
       _instance(std::move(instance)),
       _addr(),
@@ -53,7 +54,7 @@ StreamSocket::StreamSocket(ProtocolInstancePtr instance, SOCKET fd)
       _write(SocketOperationWrite)
 #endif
 {
-    init();
+    init(bufSize);
     try
     {
         _desc = fdToString(fd);
@@ -445,10 +446,10 @@ StreamSocket::toString() const
 }
 
 void
-StreamSocket::init()
+StreamSocket::init(const TcpBufSize& bufSize)
 {
     setBlock(_fd, false);
-    setTcpBufSize(_fd, _instance);
+    setTcpBufSize(_fd, bufSize.rcvSize(), bufSize.sndSize(), _instance);
 }
 
 StreamSocket::State

--- a/cpp/src/Ice/StreamSocket.h
+++ b/cpp/src/Ice/StreamSocket.h
@@ -6,6 +6,7 @@
 #include "Ice/Buffer.h"
 #include "Network.h"
 #include "ProtocolInstanceF.h"
+#include "TcpBufSize.h"
 
 #include <memory>
 
@@ -14,8 +15,8 @@ namespace IceInternal
     class StreamSocket : public NativeInfo
     {
     public:
-        StreamSocket(ProtocolInstancePtr, const NetworkProxyPtr&, const Address&, const Address&);
-        StreamSocket(ProtocolInstancePtr, SOCKET);
+        StreamSocket(ProtocolInstancePtr, const NetworkProxyPtr&, const Address&, const Address&, const TcpBufSize&);
+        StreamSocket(ProtocolInstancePtr, SOCKET, const TcpBufSize&);
         ~StreamSocket() override;
 
         SocketOperation connect(Buffer&, Buffer&);
@@ -40,7 +41,7 @@ namespace IceInternal
         [[nodiscard]] const std::string& toString() const;
 
     private:
-        void init();
+        void init(const TcpBufSize&);
 
         enum State
         {

--- a/cpp/src/Ice/TcpAcceptor.cpp
+++ b/cpp/src/Ice/TcpAcceptor.cpp
@@ -132,14 +132,14 @@ IceInternal::TcpAcceptor::accept()
 
     SOCKET fd = _acceptFd;
     _acceptFd = INVALID_SOCKET;
-    return make_shared<TcpTransceiver>(_instance, make_shared<StreamSocket>(_instance, fd));
+    return make_shared<TcpTransceiver>(_instance, make_shared<StreamSocket>(_instance, fd, _bufSize));
 }
 #    else
 
 TransceiverPtr
 IceInternal::TcpAcceptor::accept()
 {
-    return make_shared<TcpTransceiver>(_instance, make_shared<StreamSocket>(_instance, doAccept(_fd)));
+    return make_shared<TcpTransceiver>(_instance, make_shared<StreamSocket>(_instance, doAccept(_fd), _bufSize));
 }
 
 #    endif
@@ -177,7 +177,8 @@ IceInternal::TcpAcceptor::TcpAcceptor(
     int port)
     : _endpoint(std::move(endpoint)),
       _instance(instance),
-      _addr(getAddressForServer(host, port, _instance->protocolSupport(), instance->preferIPv6(), true))
+      _addr(getAddressForServer(host, port, _instance->protocolSupport(), instance->preferIPv6(), true)),
+      _bufSize(instance->properties())
 #    ifdef ICE_USE_IOCP
       ,
       _acceptFd(INVALID_SOCKET),
@@ -192,7 +193,7 @@ IceInternal::TcpAcceptor::TcpAcceptor(
 #    endif
 
     setBlock(_fd, false);
-    setTcpBufSize(_fd, _instance);
+    setTcpBufSize(_fd, _bufSize.rcvSize(), _bufSize.sndSize(), _instance);
 
 #    ifndef _WIN32
     // Set SO_REUSEADDR socket option on Unix platforms to allow re-using the address even if the socket remains in

--- a/cpp/src/Ice/TcpAcceptor.h
+++ b/cpp/src/Ice/TcpAcceptor.h
@@ -6,6 +6,7 @@
 #include "Acceptor.h"
 #include "Network.h"
 #include "ProtocolInstanceF.h"
+#include "TcpBufSize.h"
 #include "TransceiverF.h"
 
 namespace IceInternal
@@ -42,6 +43,7 @@ namespace IceInternal
         TcpEndpointIPtr _endpoint;
         const ProtocolInstancePtr _instance;
         const Address _addr;
+        const TcpBufSize _bufSize;
 
         int _backlog;
 #if defined(ICE_USE_IOCP)

--- a/cpp/src/Ice/TcpBufSize.h
+++ b/cpp/src/Ice/TcpBufSize.h
@@ -1,0 +1,40 @@
+// Copyright (c) ZeroC, Inc.
+
+#ifndef ICE_TCP_BUF_SIZE_H
+#define ICE_TCP_BUF_SIZE_H
+
+#include "Ice/Properties.h"
+
+#include <cstdint>
+
+namespace IceInternal
+{
+    // The TCP send and receive buffer sizes, as configured by the Ice.TCP.SndSize and Ice.TCP.RcvSize properties.
+    class TcpBufSize
+    {
+    public:
+        // Reads the Ice.TCP.RcvSize and Ice.TCP.SndSize properties. Throws PropertyException if a value is not a
+        // valid integer.
+        explicit TcpBufSize(const Ice::PropertiesPtr& properties)
+            : _rcvSize(properties->getPropertyAsIntWithDefault("Ice.TCP.RcvSize", dfltBufSize)),
+              _sndSize(properties->getPropertyAsIntWithDefault("Ice.TCP.SndSize", dfltBufSize))
+        {
+        }
+
+        [[nodiscard]] std::int32_t rcvSize() const noexcept { return _rcvSize; }
+        [[nodiscard]] std::int32_t sndSize() const noexcept { return _sndSize; }
+
+    private:
+        // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system defaults.
+#ifdef _WIN32
+        static constexpr std::int32_t dfltBufSize = 128 * 1024;
+#else
+        static constexpr std::int32_t dfltBufSize = 0;
+#endif
+
+        std::int32_t _rcvSize;
+        std::int32_t _sndSize;
+    };
+}
+
+#endif

--- a/cpp/src/Ice/TcpConnector.cpp
+++ b/cpp/src/Ice/TcpConnector.cpp
@@ -22,7 +22,9 @@ using namespace IceInternal;
 TransceiverPtr
 IceInternal::TcpConnector::connect()
 {
-    return make_shared<TcpTransceiver>(_instance, make_shared<StreamSocket>(_instance, _proxy, _addr, _sourceAddr));
+    return make_shared<TcpTransceiver>(
+        _instance,
+        make_shared<StreamSocket>(_instance, _proxy, _addr, _sourceAddr, _bufSize));
 }
 
 int16_t
@@ -120,7 +122,8 @@ IceInternal::TcpConnector::TcpConnector(
       _proxy(std::move(proxy)),
       _sourceAddr(sourceAddr),
       _timeout(timeout),
-      _connectionId(std::move(connectionId))
+      _connectionId(std::move(connectionId)),
+      _bufSize(_instance->properties())
 {
 }
 

--- a/cpp/src/Ice/TcpConnector.h
+++ b/cpp/src/Ice/TcpConnector.h
@@ -6,6 +6,7 @@
 #include "Connector.h"
 #include "Network.h"
 #include "ProtocolInstanceF.h"
+#include "TcpBufSize.h"
 #include "TransceiverF.h"
 
 namespace IceInternal
@@ -30,6 +31,7 @@ namespace IceInternal
         const Address _sourceAddr;
         const std::int32_t _timeout;
         const std::string _connectionId;
+        const TcpBufSize _bufSize;
     };
 }
 

--- a/cpp/src/Ice/ios/StreamAcceptor.cpp
+++ b/cpp/src/Ice/ios/StreamAcceptor.cpp
@@ -59,7 +59,7 @@ IceObjC::StreamAcceptor::accept()
 {
     SOCKET fd = doAccept(_fd);
     setBlock(fd, false);
-    setTcpBufSize(fd, _instance);
+    setTcpBufSize(fd, _bufSize.rcvSize(), _bufSize.sndSize(), _instance);
 
     //
     // Create the read/write streams
@@ -115,6 +115,7 @@ IceObjC::StreamAcceptor::StreamAcceptor(
     int port)
     : _endpoint(endpoint),
       _instance(instance),
+      _bufSize(instance->properties()),
       _addr(getAddressForServer(host, port, instance->protocolSupport(), instance->preferIPv6(), true))
 {
     _backlog = instance->properties()->getIcePropertyAsInt("Ice.TCP.Backlog");
@@ -123,7 +124,7 @@ IceObjC::StreamAcceptor::StreamAcceptor(
     {
         _fd = createSocket(false, _addr);
         setBlock(_fd, false);
-        setTcpBufSize(_fd, _instance);
+        setTcpBufSize(_fd, _bufSize.rcvSize(), _bufSize.sndSize(), _instance);
         setReuseAddress(_fd, true);
     }
     catch (...)

--- a/cpp/src/Ice/ios/StreamAcceptor.h
+++ b/cpp/src/Ice/ios/StreamAcceptor.h
@@ -4,6 +4,7 @@
 #define ICE_STREAM_ACCEPTOR_H
 
 #include "../Acceptor.h"
+#include "../TcpBufSize.h"
 #include "../TransceiverF.h"
 #include "StreamEndpointI.h"
 
@@ -35,6 +36,7 @@ namespace IceObjC
 
         StreamEndpointIPtr _endpoint;
         const InstancePtr _instance;
+        const IceInternal::TcpBufSize _bufSize;
         int _backlog;
         IceInternal::Address _addr;
     };

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -257,6 +257,12 @@ IceObjC::StreamTransceiver::initialize(Buffer& /*readBuffer*/, Buffer& /*writeBu
             UniqueRef<CFDataRef> d(static_cast<CFDataRef>(
                 CFReadStreamCopyProperty(_readStream.get(), kCFStreamPropertySocketNativeHandle)));
             CFDataGetBytes(d.get(), CFRangeMake(0, sizeof(SOCKET)), reinterpret_cast<UInt8*>(&_fd));
+
+            // Configure the socket of this outgoing connection. For an incoming connection, the acceptor
+            // configures the socket before creating the transceiver.
+            setBlock(_fd, false);
+            TcpBufSize bufSize{_instance->properties()};
+            setTcpBufSize(_fd, bufSize.rcvSize(), bufSize.sndSize(), _instance);
         }
 
         ostringstream s;
@@ -279,10 +285,6 @@ IceObjC::StreamTransceiver::initialize(Buffer& /*readBuffer*/, Buffer& /*writeBu
             s << "\nremote address = " << _host << ":" << _port;
         }
         _desc = s.str();
-
-        setBlock(_fd, false);
-        TcpBufSize bufSize{_instance->properties()};
-        setTcpBufSize(_fd, bufSize.rcvSize(), bufSize.sndSize(), _instance);
     }
     assert(_state == StateConnected);
     return SocketOperationNone;

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -5,6 +5,7 @@
 #if TARGET_OS_IPHONE != 0
 
 #    include "../Network.h"
+#    include "../TcpBufSize.h"
 #    include "../TraceLevels.h"
 #    include "Ice/Buffer.h"
 #    include "Ice/Connection.h"
@@ -280,7 +281,8 @@ IceObjC::StreamTransceiver::initialize(Buffer& /*readBuffer*/, Buffer& /*writeBu
         _desc = s.str();
 
         setBlock(_fd, false);
-        setTcpBufSize(_fd, _instance);
+        TcpBufSize bufSize{_instance->properties()};
+        setTcpBufSize(_fd, bufSize.rcvSize(), bufSize.sndSize(), _instance);
     }
     assert(_state == StateConnected);
     return SocketOperationNone;

--- a/csharp/src/Ice/Internal/Network.cs
+++ b/csharp/src/Ice/Internal/Network.cs
@@ -570,22 +570,6 @@ internal sealed class Network
         }
     }
 
-    internal static void setTcpBufSize(Socket socket, ProtocolInstance instance)
-    {
-        //
-        // By default, on Windows we use a 128KB buffer size. On Unix
-        // platforms, we use the system defaults.
-        //
-        int dfltBufSize = 0;
-        if (AssemblyUtil.isWindows)
-        {
-            dfltBufSize = 128 * 1024;
-        }
-        int rcvSize = instance.properties().getPropertyAsIntWithDefault("Ice.TCP.RcvSize", dfltBufSize);
-        int sndSize = instance.properties().getPropertyAsIntWithDefault("Ice.TCP.SndSize", dfltBufSize);
-        setTcpBufSize(socket, rcvSize, sndSize, instance);
-    }
-
     internal static void setTcpBufSize(Socket socket, int rcvSize, int sndSize, ProtocolInstance instance)
     {
         if (rcvSize > 0)

--- a/csharp/src/Ice/Internal/StreamSocket.cs
+++ b/csharp/src/Ice/Internal/StreamSocket.cs
@@ -10,7 +10,12 @@ namespace Ice.Internal;
 internal sealed class StreamSocket
 #pragma warning restore CA1001
 {
-    public StreamSocket(ProtocolInstance instance, NetworkProxy proxy, EndPoint addr, EndPoint sourceAddr)
+    public StreamSocket(
+        ProtocolInstance instance,
+        NetworkProxy proxy,
+        EndPoint addr,
+        EndPoint sourceAddr,
+        TcpBufSize bufSize)
     {
         _instance = instance;
         _proxy = proxy;
@@ -19,10 +24,10 @@ internal sealed class StreamSocket
         _fd = Network.createSocket(false, (_proxy != null ? _proxy.getAddress() : _addr).AddressFamily);
         _state = StateNeedConnect;
 
-        init();
+        init(bufSize);
     }
 
-    public StreamSocket(ProtocolInstance instance, Socket fd)
+    public StreamSocket(ProtocolInstance instance, Socket fd, TcpBufSize bufSize)
     {
         _instance = instance;
         _fd = fd;
@@ -36,7 +41,7 @@ internal sealed class StreamSocket
             Network.closeSocketNoThrow(_fd);
             throw;
         }
-        init();
+        init(bufSize);
     }
 
     public int connect(Buffer readBuffer, Buffer writeBuffer, ref bool moreData)
@@ -405,10 +410,10 @@ internal sealed class StreamSocket
         }
     }
 
-    private void init()
+    private void init(TcpBufSize bufSize)
     {
         Network.setBlock(_fd, false);
-        Network.setTcpBufSize(_fd, _instance);
+        Network.setTcpBufSize(_fd, bufSize.rcvSize, bufSize.sndSize, _instance);
 
         _readEventArgs = new SocketAsyncEventArgs();
         _readEventArgs.Completed += new EventHandler<SocketAsyncEventArgs>(ioCompleted);

--- a/csharp/src/Ice/Internal/TcpAcceptor.cs
+++ b/csharp/src/Ice/Internal/TcpAcceptor.cs
@@ -84,7 +84,7 @@ internal class TcpAcceptor : Acceptor
         Socket acceptFd = _acceptFd;
         _acceptFd = null;
         _acceptError = null;
-        return new TcpTransceiver(_instance, new StreamSocket(_instance, acceptFd));
+        return new TcpTransceiver(_instance, new StreamSocket(_instance, acceptFd, _bufSize));
     }
 
     public string protocol() => _instance.protocol();
@@ -100,6 +100,7 @@ internal class TcpAcceptor : Acceptor
         _endpoint = endpoint;
         _instance = instance;
         _backlog = instance.properties().getIcePropertyAsInt("Ice.TCP.Backlog");
+        _bufSize = new TcpBufSize(instance.properties());
 
         try
         {
@@ -107,7 +108,7 @@ internal class TcpAcceptor : Acceptor
             _addr = (IPEndPoint)Network.getAddressForServer(host, port, protocol, _instance.preferIPv6());
             _fd = Network.createServerSocket(false, _addr.AddressFamily, protocol);
             Network.setBlock(_fd, false);
-            Network.setTcpBufSize(_fd, _instance);
+            Network.setTcpBufSize(_fd, _bufSize.rcvSize, _bufSize.sndSize, _instance);
         }
         catch (System.Exception)
         {
@@ -122,6 +123,7 @@ internal class TcpAcceptor : Acceptor
     private Socket _acceptFd;
     private Ice.SocketException _acceptError;
     private readonly int _backlog;
+    private readonly TcpBufSize _bufSize;
     private IPEndPoint _addr;
     private IAsyncResult _result;
 }

--- a/csharp/src/Ice/Internal/TcpBufSize.cs
+++ b/csharp/src/Ice/Internal/TcpBufSize.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ZeroC, Inc.
+
+namespace Ice.Internal;
+
+/// <summary>
+/// The TCP send and receive buffer sizes, as configured by the Ice.TCP.SndSize and Ice.TCP.RcvSize properties.
+/// </summary>
+internal sealed class TcpBufSize
+{
+    internal int rcvSize { get; }
+
+    internal int sndSize { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TcpBufSize" /> class by reading the Ice.TCP.RcvSize and
+    /// Ice.TCP.SndSize properties. Throws PropertyException if a value is not a valid integer.
+    /// </summary>
+    internal TcpBufSize(Properties properties)
+    {
+        // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system defaults.
+        int dfltBufSize = AssemblyUtil.isWindows ? 128 * 1024 : 0;
+
+        rcvSize = properties.getPropertyAsIntWithDefault("Ice.TCP.RcvSize", dfltBufSize);
+        sndSize = properties.getPropertyAsIntWithDefault("Ice.TCP.SndSize", dfltBufSize);
+    }
+}

--- a/csharp/src/Ice/Internal/TcpBufSize.cs
+++ b/csharp/src/Ice/Internal/TcpBufSize.cs
@@ -13,8 +13,9 @@ internal sealed class TcpBufSize
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpBufSize" /> class by reading the Ice.TCP.RcvSize and
-    /// Ice.TCP.SndSize properties. Throws PropertyException if a value is not a valid integer.
+    /// Ice.TCP.SndSize properties.
     /// </summary>
+    /// <exception cref="PropertyException">Thrown when a property value is not a valid integer.</exception>
     internal TcpBufSize(Properties properties)
     {
         // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system defaults.

--- a/csharp/src/Ice/Internal/TcpConnector.cs
+++ b/csharp/src/Ice/Internal/TcpConnector.cs
@@ -7,7 +7,7 @@ namespace Ice.Internal;
 internal sealed class TcpConnector : Connector
 {
     public Transceiver connect() =>
-        new TcpTransceiver(_instance, new StreamSocket(_instance, _proxy, _addr, _sourceAddr));
+        new TcpTransceiver(_instance, new StreamSocket(_instance, _proxy, _addr, _sourceAddr, _bufSize));
 
     public short type() => _instance.type();
 
@@ -28,6 +28,7 @@ internal sealed class TcpConnector : Connector
         _sourceAddr = sourceAddr;
         _timeout = timeout;
         _connectionId = connectionId;
+        _bufSize = new TcpBufSize(instance.properties());
     }
 
     public override bool Equals(object obj)
@@ -82,4 +83,5 @@ internal sealed class TcpConnector : Connector
     private readonly EndPoint _sourceAddr;
     private readonly int _timeout;
     private readonly string _connectionId;
+    private readonly TcpBufSize _bufSize;
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
@@ -631,19 +631,6 @@ public final class Network {
         }
     }
 
-    public static void setTcpBufSize(SocketChannel socket, ProtocolInstance instance) {
-        // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system defaults.
-        int dfltBufSize = 0;
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            dfltBufSize = 128 * 1024;
-        }
-
-        int rcvSize = instance.properties().getPropertyAsIntWithDefault("Ice.TCP.RcvSize", dfltBufSize);
-        int sndSize = instance.properties().getPropertyAsIntWithDefault("Ice.TCP.SndSize", dfltBufSize);
-
-        setTcpBufSize(socket, rcvSize, sndSize, instance);
-    }
-
     public static void setTcpBufSize(SocketChannel socket, int rcvSize, int sndSize, ProtocolInstance instance) {
         if (rcvSize > 0) {
             // Try to set the buffer size. The kernel will silently adjust the size to an acceptable
@@ -679,15 +666,7 @@ public final class Network {
         }
     }
 
-    public static void setTcpBufSize(ServerSocketChannel socket, ProtocolInstance instance) {
-        // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system defaults.
-        int dfltBufSize = 0;
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            dfltBufSize = 128 * 1024;
-        }
-
-        // Get property for buffer size.
-        int sizeRequested = instance.properties().getPropertyAsIntWithDefault("Ice.TCP.RcvSize", dfltBufSize);
+    public static void setTcpBufSize(ServerSocketChannel socket, int sizeRequested, ProtocolInstance instance) {
         if (sizeRequested > 0) {
             // Try to set the buffer size. The kernel will silently adjust the size to an acceptable
             // value. Then read the size back to get the size that was actually set.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/StreamSocket.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/StreamSocket.java
@@ -15,13 +15,15 @@ class StreamSocket {
      * @param proxy The network proxy, or null if not using a proxy.
      * @param addr The remote address to connect to.
      * @param sourceAddr The local address to bind to, or null for default.
+     * @param bufSize The TCP buffer sizes to apply to the socket.
      * @throws LocalException if the socket cannot be created or connected.
      */
     public StreamSocket(
             ProtocolInstance instance,
             NetworkProxy proxy,
             InetSocketAddress addr,
-            InetSocketAddress sourceAddr) {
+            InetSocketAddress sourceAddr,
+            TcpBufSize bufSize) {
         _instance = instance;
         _proxy = proxy;
         _addr = addr;
@@ -29,7 +31,7 @@ class StreamSocket {
         _state = StateNeedConnect;
 
         try {
-            init();
+            init(bufSize);
             if (Network.doConnect(_fd, _proxy != null ? _proxy.getAddress() : _addr, sourceAddr)) {
                 _state = _proxy != null ? StateProxyWrite : StateConnected;
             }
@@ -46,9 +48,10 @@ class StreamSocket {
      *
      * @param instance The protocol instance.
      * @param fd The connected SocketChannel.
+     * @param bufSize The TCP buffer sizes to apply to the socket.
      * @throws LocalException if initialization fails.
      */
-    public StreamSocket(ProtocolInstance instance, SocketChannel fd) {
+    public StreamSocket(ProtocolInstance instance, SocketChannel fd, TcpBufSize bufSize) {
         _instance = instance;
         _proxy = null;
         _addr = null;
@@ -56,7 +59,7 @@ class StreamSocket {
         _state = StateConnected;
 
         try {
-            init();
+            init(bufSize);
         } catch (LocalException ex) {
             assert (!_fd.isOpen());
             throw ex;
@@ -256,9 +259,9 @@ class StreamSocket {
         return _desc;
     }
 
-    private void init() {
+    private void init(TcpBufSize bufSize) {
         Network.setBlock(_fd, false);
-        Network.setTcpBufSize(_fd, _instance);
+        Network.setTcpBufSize(_fd, bufSize.rcvSize(), bufSize.sndSize(), _instance);
     }
 
     private int toState(int operation) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
@@ -38,7 +38,7 @@ class TcpAcceptor implements Acceptor {
 
     @Override
     public Transceiver accept() {
-        return new TcpTransceiver(_instance, new StreamSocket(_instance, Network.doAccept(_fd)));
+        return new TcpTransceiver(_instance, new StreamSocket(_instance, Network.doAccept(_fd), _bufSize));
     }
 
     @Override
@@ -66,11 +66,12 @@ class TcpAcceptor implements Acceptor {
         _endpoint = endpoint;
         _instance = instance;
         _backlog = instance.properties().getIcePropertyAsInt("Ice.TCP.Backlog");
+        _bufSize = new TcpBufSize(instance.properties());
 
         try {
             _fd = Network.createTcpServerSocket();
             Network.setBlock(_fd, false);
-            Network.setTcpBufSize(_fd, instance);
+            Network.setTcpBufSize(_fd, _bufSize.rcvSize(), instance);
             if (!System.getProperty("os.name").startsWith("Windows")) {
                 // Set SO_REUSEADDR socket option on Unix platforms to allow re-using the address even if the socket
                 // remains in the TIME_WAIT state. On Windows this isn't necessary.
@@ -91,5 +92,6 @@ class TcpAcceptor implements Acceptor {
     private final ProtocolInstance _instance;
     private ServerSocketChannel _fd;
     private final int _backlog;
+    private final TcpBufSize _bufSize;
     private InetSocketAddress _addr;
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpBufSize.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpBufSize.java
@@ -16,8 +16,9 @@ final class TcpBufSize {
     private final int _sndSize;
 
     /**
-     * Reads the Ice.TCP.RcvSize and Ice.TCP.SndSize properties. Throws PropertyException if a value
-     * is not a valid integer.
+     * Reads the Ice.TCP.RcvSize and Ice.TCP.SndSize properties.
+     *
+     * @throws PropertyException if a property value is not a valid integer
      */
     TcpBufSize(Properties properties) {
         _rcvSize = properties.getPropertyAsIntWithDefault("Ice.TCP.RcvSize", dfltBufSize);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpBufSize.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpBufSize.java
@@ -1,0 +1,34 @@
+// Copyright (c) ZeroC, Inc.
+
+package com.zeroc.Ice;
+
+/**
+ * The TCP send and receive buffer sizes, as configured by the Ice.TCP.SndSize and Ice.TCP.RcvSize
+ * properties.
+ */
+final class TcpBufSize {
+    // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system
+    // defaults.
+    private static final int dfltBufSize =
+        System.getProperty("os.name").startsWith("Windows") ? 128 * 1024 : 0;
+
+    private final int _rcvSize;
+    private final int _sndSize;
+
+    /**
+     * Reads the Ice.TCP.RcvSize and Ice.TCP.SndSize properties. Throws PropertyException if a value
+     * is not a valid integer.
+     */
+    TcpBufSize(Properties properties) {
+        _rcvSize = properties.getPropertyAsIntWithDefault("Ice.TCP.RcvSize", dfltBufSize);
+        _sndSize = properties.getPropertyAsIntWithDefault("Ice.TCP.SndSize", dfltBufSize);
+    }
+
+    int rcvSize() {
+        return _rcvSize;
+    }
+
+    int sndSize() {
+        return _sndSize;
+    }
+}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpConnector.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpConnector.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 final class TcpConnector implements Connector {
     @Override
     public Transceiver connect() {
-        return new TcpTransceiver(_instance, new StreamSocket(_instance, _proxy, _addr, _sourceAddr));
+        return new TcpTransceiver(_instance, new StreamSocket(_instance, _proxy, _addr, _sourceAddr, _bufSize));
     }
 
     @Override
@@ -50,6 +50,7 @@ final class TcpConnector implements Connector {
         _sourceAddr = sourceAddr;
         _timeout = timeout;
         _connectionId = connectionId;
+        _bufSize = new TcpBufSize(instance.properties());
     }
 
     @Override
@@ -84,4 +85,5 @@ final class TcpConnector implements Connector {
     private final InetSocketAddress _sourceAddr;
     private final int _timeout;
     private String _connectionId = "";
+    private final TcpBufSize _bufSize;
 }


### PR DESCRIPTION
An invalid `Ice.TCP.SndSize` value (e.g. `Ice.TCP.SndSize=abc`) turned a Java server into a listening-but-broken endpoint that leaked one file descriptor per incoming connection: the `StreamSocket` constructor read the property with the accepted socket already created, and the `PropertyException` escaped before anything owned that socket. The outgoing `StreamSocket` constructors had the same gap in C++, C#, and Java — one leaked descriptor per connection attempt.

Rather than adding close-on-throw guards around the property reads, this PR moves the reads out of the socket-handling code entirely:

- The new internal `TcpBufSize` class (C++, C#, Java) reads `Ice.TCP.RcvSize` and `Ice.TCP.SndSize` (with the 128KB-on-Windows default) in its constructor.
- Acceptors and connectors construct it in their own constructors, before any socket exists, and pass it through to `StreamSocket`. The C++ iOS CFStream transport gets the same treatment.
- The property-reading `setTcpBufSize` overloads are removed; `Network` no longer reads any property.

Since a property read can no longer fire while an unowned socket is in flight, the leak is structurally gone. Behavior changes for invalid values, all three mappings:

- Server side: an invalid `Ice.TCP.SndSize` now fails at object adapter creation with `PropertyException`, matching the existing behavior for an invalid `Ice.TCP.RcvSize` (C++ and C# already failed at startup; Java previously started and broke per-accept).
- Client side: the `PropertyException` now surfaces at connection establishment before any socket is created, instead of after.

There is also an observable change for valid values: the acceptor previously re-read the properties on every accepted connection, so a runtime property update affected subsequently accepted connections. The buffer sizes are now snapshotted when the acceptor or connector is created.

Java keeps a separate `ServerSocketChannel` variant of `setTcpBufSize` because `ServerSocket` has no send-buffer option; in C++/C# the acceptor uses the same function as the stream sockets.

No changelog entry: the trigger is an invalid property value.

Fixes #6288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
