### PR TITLE
Fix the documented null-return condition of ice_getCachedConnection

### DIFF
--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -578,6 +578,9 @@ namespace Ice
         /// @return The connection for this proxy.
         /// @remark You can call this function to establish a connection or associate the proxy with an existing
         /// connection and ignore the return value.
+        /// @remark When this proxy reaches its target object through collocation optimization (see
+        /// #ice_collocationOptimized), this function returns a null connection: collocated invocations don't use a
+        /// connection.
         Ice::ConnectionPtr ice_getConnection() const; // NOLINT(modernize-use-nodiscard)
 
         /// Gets the connection for this proxy. If the proxy does not yet have an established connection or its
@@ -592,6 +595,9 @@ namespace Ice
         /// @param sent The sent callback. The Ice runtime never calls this function: no request is sent to get a
         /// connection.
         /// @return A function that can be called to cancel the invocation locally.
+        /// @remark When this proxy reaches its target object through collocation optimization (see
+        /// #ice_collocationOptimized), the response callback receives a null connection: collocated invocations don't
+        /// use a connection.
         // NOLINTNEXTLINE(modernize-use-nodiscard)
         std::function<void()> ice_getConnectionAsync(
             std::function<void(Ice::ConnectionPtr)> response,
@@ -603,16 +609,22 @@ namespace Ice
         /// this function returns the connection this proxy is bound to, even when this connection is closed.
         /// @return A future that becomes available when the invocation completes. This future holds:
         /// - The connection for this proxy.
+        /// @remark When this proxy reaches its target object through collocation optimization (see
+        /// #ice_collocationOptimized), the future holds a null connection: collocated invocations don't use a
+        /// connection.
         [[nodiscard]] std::future<Ice::ConnectionPtr> ice_getConnectionAsync() const;
 
         /// @private
         void _iceI_getConnection(const std::shared_ptr<IceInternal::ProxyGetConnection>&) const;
 
-        /// Gets the cached Connection for this proxy. If the proxy does not yet have an established connection, it does
-        /// not attempt to create a connection. For a fixed proxy, this function returns the connection this proxy is
-        /// bound to, even when this connection is closed.
-        /// @return The cached connection for this proxy, or nullptr if the proxy does not have a cached connection.
-        /// The returned connection can be closed.
+        /// Gets the Connection cached by this proxy. This function never attempts to establish a connection. For a
+        /// fixed proxy, this function returns the connection this proxy is bound to.
+        /// @return The cached connection, or nullptr if this proxy doesn't have a cached connection. The returned
+        /// connection can be closed.
+        /// @remark A proxy with connection caching disabled (see #ice_connectionCached) never caches a connection: for
+        /// such a proxy, this function always returns nullptr. This function also returns nullptr when this proxy
+        /// reaches its target object through collocation optimization (see #ice_collocationOptimized): collocated
+        /// invocations don't use a connection.
         [[nodiscard]] Ice::ConnectionPtr ice_getCachedConnection() const noexcept;
 
         /// Flushes any pending batched requests for this proxy. The call blocks until the flush is complete.
@@ -700,8 +712,9 @@ namespace Ice
         /// @return The locator for this proxy. If no locator is configured, the return value is nullopt.
         [[nodiscard]] std::optional<LocatorPrx> ice_getLocator() const noexcept;
 
-        /// Determines whether this proxy uses collocation optimization.
-        /// @return `true` if the proxy uses collocation optimization, `false` otherwise.
+        /// Determines whether this proxy has collocation optimization enabled.
+        /// @return `true` if this proxy has collocation optimization enabled, `false` otherwise.
+        /// @see #ice_collocationOptimized
         [[nodiscard]] bool ice_isCollocationOptimized() const noexcept;
 
         /// Gets the invocation timeout of this proxy.

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -617,8 +617,11 @@ namespace Ice
         /// @private
         void _iceI_getConnection(const std::shared_ptr<IceInternal::ProxyGetConnection>&) const;
 
-        /// Gets the Connection cached by this proxy. This function never attempts to establish a connection. For a
-        /// fixed proxy, this function returns the connection this proxy is bound to.
+        /// Gets the Connection cached by this proxy. Once this proxy has been associated with a connection
+        /// (typically during its first invocation), it caches this connection and continues using it for subsequent
+        /// invocations, until an invocation on this proxy fails. This function never attempts to establish a
+        /// connection. For a fixed proxy, this function returns the connection this proxy is bound to, even when
+        /// this connection is closed.
         /// @return The cached connection, or nullptr if this proxy doesn't have a cached connection. The returned
         /// connection can be closed.
         /// @remark A proxy with connection caching disabled (see #ice_connectionCached) never caches a connection: for

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -469,9 +469,11 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     Task<Connection?> ice_getConnectionAsync(IProgress<bool>? progress = null, CancellationToken cancel = default);
 
     /// <summary>
-    /// Gets the cached <see cref="Connection"/> for this proxy. This method never attempts to establish a
-    /// connection. For a fixed proxy, this method returns the connection this proxy is bound to. This method never
-    /// throws.
+    /// Gets the cached <see cref="Connection"/> for this proxy. Once this proxy has been associated with a
+    /// connection (typically during its first invocation), it caches this connection and continues using it for
+    /// subsequent invocations, until an invocation on this proxy fails. This method never attempts to establish a
+    /// connection. For a fixed proxy, this method returns the connection this proxy is bound to, even when this
+    /// connection is closed. This method never throws.
     /// </summary>
     /// <returns>The cached connection, or null if this proxy doesn't have a cached connection. The returned
     /// connection can be closed.</returns>
@@ -1528,9 +1530,11 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     }
 
     /// <summary>
-    /// Gets the cached <see cref="Connection"/> for this proxy. This method never attempts to establish a
-    /// connection. For a fixed proxy, this method returns the connection this proxy is bound to. This method never
-    /// throws.
+    /// Gets the cached <see cref="Connection"/> for this proxy. Once this proxy has been associated with a
+    /// connection (typically during its first invocation), it caches this connection and continues using it for
+    /// subsequent invocations, until an invocation on this proxy fails. This method never attempts to establish a
+    /// connection. For a fixed proxy, this method returns the connection this proxy is bound to, even when this
+    /// connection is closed. This method never throws.
     /// </summary>
     /// <returns>The cached connection, or null if this proxy doesn't have a cached connection. The returned
     /// connection can be closed.</returns>

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -323,10 +323,11 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     ObjectPrx ice_locator(LocatorPrx? locator);
 
     /// <summary>
-    /// Returns whether this proxy uses collocation optimization.
+    /// Returns whether this proxy has collocation optimization enabled.
     /// </summary>
-    /// <returns><see langword="true"/> if the proxy uses collocation optimization; otherwise,
+    /// <returns><see langword="true"/> if this proxy has collocation optimization enabled; otherwise,
     /// <see langword="false"/>.</returns>
+    /// <seealso cref="ice_collocationOptimized(bool)"/>
     bool ice_isCollocationOptimized();
 
     /// <summary>
@@ -468,12 +469,16 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     Task<Connection?> ice_getConnectionAsync(IProgress<bool>? progress = null, CancellationToken cancel = default);
 
     /// <summary>
-    /// Gets the cached Connection for this proxy. If the proxy does not yet have an established
-    /// connection, it does not attempt to create a connection. For a fixed proxy, this method returns
-    /// the connection this proxy is bound to, even when this connection is closed.
+    /// Gets the cached <see cref="Connection"/> for this proxy. This method never attempts to establish a
+    /// connection. For a fixed proxy, this method returns the connection this proxy is bound to. This method never
+    /// throws.
     /// </summary>
-    /// <returns>The cached Connection for this proxy (null if the proxy does not have a cached connection). The
-    /// returned connection can be closed.</returns>
+    /// <returns>The cached connection, or null if this proxy doesn't have a cached connection. The returned
+    /// connection can be closed.</returns>
+    /// <remarks>A proxy with connection caching disabled (see <see cref="ice_connectionCached(bool)"/>) never caches
+    /// a connection: for such a proxy, this method always returns null. This method also returns null when this
+    /// proxy reaches its target object through collocation optimization (see
+    /// <see cref="ice_collocationOptimized(bool)"/>): collocated invocations don't use a connection.</remarks>
     Connection? ice_getCachedConnection();
 
     /// <summary>
@@ -1242,10 +1247,11 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     }
 
     /// <summary>
-    /// Returns whether this proxy uses collocation optimization.
+    /// Returns whether this proxy has collocation optimization enabled.
     /// </summary>
-    /// <returns><see langword="true"/> if the proxy uses collocation optimization; otherwise,
+    /// <returns><see langword="true"/> if this proxy has collocation optimization enabled; otherwise,
     /// <see langword="false"/>.</returns>
+    /// <seealso cref="ice_collocationOptimized(bool)"/>
     public bool ice_isCollocationOptimized() => _reference.getCollocationOptimized();
 
     /// <summary>
@@ -1522,12 +1528,16 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     }
 
     /// <summary>
-    /// Gets the cached Connection for this proxy. If the proxy does not yet have an established
-    /// connection, it does not attempt to create a connection. For a fixed proxy, this method returns
-    /// the connection this proxy is bound to, even when this connection is closed.
+    /// Gets the cached <see cref="Connection"/> for this proxy. This method never attempts to establish a
+    /// connection. For a fixed proxy, this method returns the connection this proxy is bound to. This method never
+    /// throws.
     /// </summary>
-    /// <returns>The cached Connection for this proxy (null if the proxy does not have
-    /// an established connection).</returns>
+    /// <returns>The cached connection, or null if this proxy doesn't have a cached connection. The returned
+    /// connection can be closed.</returns>
+    /// <remarks>A proxy with connection caching disabled (see <see cref="ice_connectionCached(bool)"/>) never caches
+    /// a connection: for such a proxy, this method always returns null. This method also returns null when this
+    /// proxy reaches its target object through collocation optimization (see
+    /// <see cref="ice_collocationOptimized(bool)"/>): collocated invocations don't use a connection.</remarks>
     public Connection? ice_getCachedConnection()
     {
         // A fixed proxy is bound to a single connection: return this connection as is, whatever its state.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -431,9 +431,10 @@ public interface ObjectPrx {
     ObjectPrx ice_locator(LocatorPrx locator);
 
     /**
-     * Determines whether this proxy uses collocation optimization.
+     * Determines whether this proxy has collocation optimization enabled.
      *
-     * @return {@code true} if the proxy uses collocation optimization, {@code false} otherwise
+     * @return {@code true} if this proxy has collocation optimization enabled, {@code false} otherwise
+     * @see #ice_collocationOptimized(boolean)
      */
     boolean ice_isCollocationOptimized();
 
@@ -549,6 +550,10 @@ public interface ObjectPrx {
      * <p>You can call this method to establish a connection or associate the proxy with an existing
      * connection and ignore the return value.
      *
+     * <p>When this proxy reaches its target object through collocation optimization (see
+     * {@link #ice_collocationOptimized(boolean)}), this method returns a null connection: collocated
+     * invocations don't use a connection.
+     *
      * @return The {@link Connection} for this proxy.
      */
     Connection ice_getConnection();
@@ -567,18 +572,25 @@ public interface ObjectPrx {
      * or its connection is closed or being closed, it first attempts to create a new connection. For a fixed
      * proxy, this method returns the connection this proxy is bound to, even when this connection is closed.
      *
+     * <p>When this proxy reaches its target object through collocation optimization (see
+     * {@link #ice_collocationOptimized(boolean)}), the future completes with a null connection: collocated
+     * invocations don't use a connection.
+     *
      * @return a future that completes with the {@link Connection} for this proxy
      */
     CompletableFuture<Connection> ice_getConnectionAsync();
 
     /**
-     * Gets the cached connection for this proxy. If the proxy does not yet have an established connection,
-     * it does not attempt to create a connection. For a fixed proxy, this method returns the connection this
-     * proxy is bound to, even when this connection is closed.
+     * Gets the {@link Connection} cached by this proxy. This method never attempts to establish a connection.
+     * For a fixed proxy, this method returns the connection this proxy is bound to. This method never throws.
      *
-     * @return the cached {@link Connection} for this proxy, or {@code null} if the proxy does not
-     *     have a cached connection; the returned connection can be closed
-     * @see Connection
+     * <p>A proxy with connection caching disabled (see {@link #ice_connectionCached(boolean)}) never caches a
+     * connection: for such a proxy, this method always returns null. This method also returns null when this
+     * proxy reaches its target object through collocation optimization (see
+     * {@link #ice_collocationOptimized(boolean)}): collocated invocations don't use a connection.
+     *
+     * @return the cached connection, or {@code null} if this proxy doesn't have a cached connection; the
+     *     returned connection can be closed
      */
     Connection ice_getCachedConnection();
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -581,8 +581,11 @@ public interface ObjectPrx {
     CompletableFuture<Connection> ice_getConnectionAsync();
 
     /**
-     * Gets the {@link Connection} cached by this proxy. This method never attempts to establish a connection.
-     * For a fixed proxy, this method returns the connection this proxy is bound to. This method never throws.
+     * Gets the {@link Connection} cached by this proxy. Once this proxy has been associated with a connection
+     * (typically during its first invocation), it caches this connection and continues using it for subsequent
+     * invocations, until an invocation on this proxy fails. This method never attempts to establish a connection.
+     * For a fixed proxy, this method returns the connection this proxy is bound to, even when this connection is
+     * closed. This method never throws.
      *
      * <p>A proxy with connection caching disabled (see {@link #ice_connectionCached(boolean)}) never caches a
      * connection: for such a proxy, this method always returns null. This method also returns null when this

--- a/js/packages/ice/src/Ice/ObjectPrx.d.ts
+++ b/js/packages/ice/src/Ice/ObjectPrx.d.ts
@@ -337,9 +337,11 @@ declare module "@zeroc/ice" {
             ice_getConnection(): AsyncResult<Connection>;
 
             /**
-             * Gets the cached Connection for this proxy. This function never attempts to establish a connection.
-             * For a fixed proxy, this function returns the connection this proxy is bound to. This function never
-             * throws.
+             * Gets the cached Connection for this proxy. Once this proxy has been associated with a connection
+             * (typically during its first invocation), it caches this connection and continues using it for
+             * subsequent invocations, until an invocation on this proxy fails. This function never attempts to
+             * establish a connection. For a fixed proxy, this function returns the connection this proxy is bound
+             * to, even when this connection is closed. This function never throws.
              *
              * @returns The cached connection, or `null` if this proxy doesn't have a cached connection. The
              * returned connection can be closed.

--- a/js/packages/ice/src/Ice/ObjectPrx.d.ts
+++ b/js/packages/ice/src/Ice/ObjectPrx.d.ts
@@ -337,12 +337,14 @@ declare module "@zeroc/ice" {
             ice_getConnection(): AsyncResult<Connection>;
 
             /**
-             * Gets the cached Connection for this proxy. If the proxy does not yet have an established connection,
-             * it does not attempt to create a connection. For a fixed proxy, this function returns the connection
-             * this proxy is bound to, even when this connection is closed.
+             * Gets the cached Connection for this proxy. This function never attempts to establish a connection.
+             * For a fixed proxy, this function returns the connection this proxy is bound to. This function never
+             * throws.
              *
-             * @returns The cached connection for this proxy, or `null` if the proxy does not have a cached
-             * connection. The returned connection can be closed.
+             * @returns The cached connection, or `null` if this proxy doesn't have a cached connection. The
+             * returned connection can be closed.
+             * @remarks A proxy with connection caching disabled (see {@link ice_connectionCached}) never caches a
+             * connection: for such a proxy, this function always returns `null`.
              */
             ice_getCachedConnection(): Connection | null;
 

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -1088,8 +1088,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
 
         function r = ice_getCachedConnection(obj)
             %ICE_GETCACHEDCONNECTION Returns the Connection cached by this proxy.
-            %   This method never attempts to establish a connection and never throws. For a fixed proxy, this
-            %   method returns the connection this proxy is bound to.
+            %   Once this proxy has been associated with a connection (typically during its first invocation), it
+            %   caches this connection and continues using it for subsequent invocations, until an invocation on
+            %   this proxy fails. This method never attempts to establish a connection and never throws. For a
+            %   fixed proxy, this method returns the connection this proxy is bound to, even when this connection
+            %   is closed.
             %
             %   A proxy with connection caching disabled (see ice_connectionCached) never caches a connection: for
             %   such a proxy, this method always returns an empty array.

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -1087,14 +1087,16 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getCachedConnection(obj)
-            %ICE_GETCACHEDCONNECTION Returns the cached Connection for this proxy.
-            %   If the proxy does not yet have an established connection, it does not attempt to create a connection.
-            %   For a fixed proxy, this method returns the connection this proxy is bound to, even when this
-            %   connection is closed.
+            %ICE_GETCACHEDCONNECTION Returns the Connection cached by this proxy.
+            %   This method never attempts to establish a connection and never throws. For a fixed proxy, this
+            %   method returns the connection this proxy is bound to.
+            %
+            %   A proxy with connection caching disabled (see ice_connectionCached) never caches a connection: for
+            %   such a proxy, this method always returns an empty array.
             %
             %   Output Arguments
-            %     r - The cached Connection for this proxy, or an empty array if the proxy does not have a cached
-            %       connection. The returned connection can be closed.
+            %     r - The cached connection, or an empty array if this proxy doesn't have a cached connection.
+            %       The returned connection can be closed.
             %       Ice.Connection scalar | empty array of Ice.Connection
 
             arguments

--- a/python/python/Ice/ObjectPrx.py
+++ b/python/python/Ice/ObjectPrx.py
@@ -919,9 +919,11 @@ class ObjectPrx(IcePy.ObjectPrx):
 
     def ice_getCachedConnection(self) -> Connection | None:
         """
-        Gets the Connection cached by this proxy. This function never attempts to establish a connection.
-        For a fixed proxy, this function returns the connection this proxy is bound to. This function never
-        raises an exception.
+        Gets the Connection cached by this proxy. Once this proxy has been associated with a connection
+        (typically during its first invocation), it caches this connection and continues using it for
+        subsequent invocations, until an invocation on this proxy fails. This function never attempts to
+        establish a connection. For a fixed proxy, this function returns the connection this proxy is bound
+        to, even when this connection is closed. This function never raises an exception.
 
         Returns
         -------

--- a/python/python/Ice/ObjectPrx.py
+++ b/python/python/Ice/ObjectPrx.py
@@ -672,12 +672,16 @@ class ObjectPrx(IcePy.ObjectPrx):
 
     def ice_isCollocationOptimized(self) -> bool:
         """
-        Determines whether this proxy uses collocation optimization.
+        Determines whether this proxy has collocation optimization enabled.
 
         Returns
         -------
         bool
-            ``True`` if the proxy uses collocation optimization, ``False`` otherwise.
+            ``True`` if this proxy has collocation optimization enabled, ``False`` otherwise.
+
+        See Also
+        --------
+        ice_collocationOptimized
         """
         return super().ice_isCollocationOptimized()
 
@@ -900,26 +904,37 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         Connection | None
-            The Connection for this proxy, or ``None`` when the target object is collocated.
+            The Connection for this proxy.
 
         Notes
         -----
         You can call this function to establish a connection or associate the proxy with an existing
         connection and ignore the return value.
+
+        When this proxy reaches its target object through collocation optimization (see
+        ``ice_collocationOptimized``), this function returns ``None``: collocated invocations don't use
+        a connection.
         """
         return super().ice_getConnection()
 
     def ice_getCachedConnection(self) -> Connection | None:
         """
-        Gets the cached Connection for this proxy. If the proxy does not yet have an established connection,
-        it does not attempt to create a connection. For a fixed proxy, this method returns the connection
-        this proxy is bound to, even when this connection is closed.
+        Gets the Connection cached by this proxy. This function never attempts to establish a connection.
+        For a fixed proxy, this function returns the connection this proxy is bound to. This function never
+        raises an exception.
 
         Returns
         -------
         Connection | None
-            The cached connection for this proxy, or ``None`` if the proxy does not have a cached connection.
-            The returned connection can be closed.
+            The cached connection, or ``None`` if this proxy doesn't have a cached connection. The returned
+            connection can be closed.
+
+        Notes
+        -----
+        A proxy with connection caching disabled (see ``ice_connectionCached``) never caches a connection:
+        for such a proxy, this function always returns ``None``. This function also returns ``None`` when
+        this proxy reaches its target object through collocation optimization (see
+        ``ice_collocationOptimized``): collocated invocations don't use a connection.
         """
         return super().ice_getCachedConnection()
 

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -231,8 +231,11 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject, Sendable {
     /// - Returns: `true` if this proxy is a fixed proxy, `false` otherwise.
     func ice_isFixed() -> Bool
 
-    /// Gets the cached ``Connection`` for this proxy. This method never attempts to establish a connection. For a
-    /// fixed proxy, this method returns the connection this proxy is bound to.
+    /// Gets the cached ``Connection`` for this proxy. Once this proxy has been associated with a connection
+    /// (typically during its first invocation), it caches this connection and continues using it for subsequent
+    /// invocations, until an invocation on this proxy fails. This method never attempts to establish a connection.
+    /// For a fixed proxy, this method returns the connection this proxy is bound to, even when this connection is
+    /// closed.
     ///
     /// A proxy with connection caching disabled (see ``ice_connectionCached(_:)``) never caches a connection: for
     /// such a proxy, this method always returns nil. This method also returns nil when this proxy reaches its

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -231,12 +231,16 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject, Sendable {
     /// - Returns: `true` if this proxy is a fixed proxy, `false` otherwise.
     func ice_isFixed() -> Bool
 
-    /// Gets the cached Connection for this proxy. If the proxy does not yet have an established connection, it does
-    /// not attempt to create a connection. For a fixed proxy, this function returns the connection this proxy is
-    /// bound to, even when this connection is closed.
+    /// Gets the cached ``Connection`` for this proxy. This method never attempts to establish a connection. For a
+    /// fixed proxy, this method returns the connection this proxy is bound to.
     ///
-    /// - Returns: The cached connection for this proxy, or nil if the proxy does not have a cached connection. The
-    ///   returned connection can be closed.
+    /// A proxy with connection caching disabled (see ``ice_connectionCached(_:)``) never caches a connection: for
+    /// such a proxy, this method always returns nil. This method also returns nil when this proxy reaches its
+    /// target object through collocation optimization (see ``ice_collocationOptimized(_:)``): collocated invocations
+    /// don't use a connection.
+    ///
+    /// - Returns: The cached connection, or nil if this proxy doesn't have a cached connection. The returned
+    ///   connection can be closed.
     func ice_getCachedConnection() -> Connection?
 
     /// Creates a stringified version of this proxy.
@@ -244,9 +248,9 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject, Sendable {
     /// - Returns: A stringified proxy.
     func ice_toString() -> String
 
-    /// Determines whether this proxy uses collocation optimization.
+    /// Determines whether this proxy has collocation optimization enabled (see ``ice_collocationOptimized(_:)``).
     ///
-    /// - Returns: `true` if the proxy uses collocation optimization, `false` otherwise.
+    /// - Returns: `true` if this proxy has collocation optimization enabled, `false` otherwise.
     func ice_isCollocationOptimized() -> Bool
 
     /// Creates a proxy that is identical to this proxy, except for collocation optimization.


### PR DESCRIPTION
The `ice_getCachedConnection` documentation gave the wrong condition for a null result ("the proxy does not have an established connection") and implied every proxy caches a connection. This PR rewrites it in all mappings (C++, C#, Java, JavaScript, Python, Swift, MATLAB):

- The summary now states the function never attempts to establish a connection, and that for a fixed proxy it returns the bound connection.
- A remark documents the cases where the function always returns null while invocations work fine: connection caching disabled (`ice_connectionCached`), and — where the mapping supports it — a proxy that reaches its target object through collocation optimization. JavaScript has no collocation optimization and MATLAB is client-side only, so their remarks cover only connection caching.
- The no-throw guarantee is now explicit where the signature cannot express it: C#, Java, JavaScript, MATLAB ("never throws") and Python ("never raises an exception"). C++ (`noexcept`) and Swift (non-`throws`) already express it in the signature.

Related fixes in the same files:

- `ice_getConnection` / `ice_getConnectionAsync` now document the null connection delivered for a collocation-optimized proxy where this was missing (C++ as remarks on the three overloads, Java, Python — C#, Swift already documented it). The behavior is the one the proxy test suite relies on (`if (b1->ice_getConnection()) // not colloc-optimized target`).
- `ice_isCollocationOptimized` said the proxy "uses" collocation optimization; it only reports whether the optimization is *enabled* — binding falls back to a regular connection when there is no collocated target. The docs now say "has collocation optimization enabled", with a see-also to `ice_collocationOptimized`.
- Cross-references are real links per mapping (Doxygen `#ref`, `<see cref>`, `{@link}`, DocC ` ``symbol`` `), and each file keeps its established "function"/"method" terminology — the terminology inconsistency with standard language usage in Python/JavaScript is tracked separately in #6336.

Docs only — no behavior change, no changelog entry.

Fixes #6305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
