### PR TITLE
Log and swallow exceptions thrown by the ice_getConnectionAsync response callback

### DIFF
--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -84,13 +84,16 @@ namespace IceInternal
         {
             _response = [this, response = std::move(response)](bool)
             {
-                try
+                if (response)
                 {
-                    response(getConnection());
-                }
-                catch (...)
-                {
-                    warning("response", std::current_exception());
+                    try
+                    {
+                        response(getConnection());
+                    }
+                    catch (...)
+                    {
+                        warning("response", std::current_exception());
+                    }
                 }
             };
         }

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -82,7 +82,17 @@ namespace IceInternal
             : ProxyGetConnection(std::move(proxy)),
               LambdaInvoke(std::move(ex), std::move(sent))
         {
-            _response = [&, response = std::move(response)](bool) { response(getConnection()); };
+            _response = [this, response = std::move(response)](bool)
+            {
+                try
+                {
+                    response(getConnection());
+                }
+                catch (...)
+                {
+                    warning("response", std::current_exception());
+                }
+            };
         }
     };
 

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -787,6 +787,27 @@ allTests(TestHelper* helper, bool collocated)
                     test(false);
                 }
             }
+
+            {
+                promise<void> promise;
+                p->ice_getConnectionAsync(
+                    [&, i](const Ice::ConnectionPtr&)
+                    {
+                        promise.set_value();
+                        thrower(throwEx[i]);
+                    },
+                    [&](exception_ptr) { test(false); });
+
+                try
+                {
+                    promise.get_future().get();
+                }
+                catch (const exception& ex)
+                {
+                    cerr << ex.what() << endl;
+                    test(false);
+                }
+            }
         }
     }
     cout << "ok" << endl;

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -742,8 +742,6 @@ allTests(TestHelper* helper, bool collocated)
 
     cout << "testing unexpected exceptions from callback... " << flush;
     {
-        TestIntfPrx q = p->ice_adapterId("dummy");
-
         for (int i = 0; i < 4; ++i) // NOLINT(modernize-loop-convert): clang-tidy confusion
         {
             {


### PR DESCRIPTION
For generated operations, an exception thrown by the response callback of a lambda invocation is logged as an `Ice.Warn.AMICallback` warning and swallowed — the exception callback only ever reports invocation failures. `LambdaOutgoing` implements this contract by wrapping the call to the response callback:

https://github.com/zeroc-ice/ice/blob/cd2f7a99d6b6237bac0dbb4327effe35762fdfa9/cpp/include/Ice/OutgoingAsync.h#L383-L390

`ProxyGetConnectionLambda` did not follow this contract: it called the response callback with no guard, so the exception escaped into `OutgoingAsyncBase::invokeResponse` and was routed to the exception callback, as if the invocation had failed.

This PR wraps the response callback call in `ProxyGetConnectionLambda` the same way, and extends the "unexpected exceptions from callback" section of the AMI test with an `ice_getConnectionAsync` case: the response callback throws each of the four exception kinds and the exception callback asserts it is never called. The case runs in both the client/server and collocated configurations.

The future-based overload is unaffected (`set_value` runs no user code), and the other language mappings don't have this gap.

No changelog entry: only applications whose response callback itself throws can observe the change.

Fixes #6318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
