### PR TITLE
Fix three low-severity issues in the DataStorm session

### DIFF
--- a/changelog.d/datastorm/6326.md
+++ b/changelog.d/datastorm/6326.md
@@ -1,0 +1,5 @@
+- Fixed a bug where a reader lost all of its update tags when one of them failed to decode. A decoder that throws
+  discarded the tags that had decoded, along with the tags of the topic's other readers on the same node, and the
+  reader then delivered every partial update with the key's current value unchanged, without calling the updater
+  registered with `Topic::setUpdater`, until it reconnected to the peer. The reader now keeps every tag it can decode
+  and skips only the one it cannot, logging a warning.

--- a/changelog.d/datastorm/6326.md
+++ b/changelog.d/datastorm/6326.md
@@ -1,5 +1,0 @@
-- Fixed a bug where a reader lost all of its update tags when one of them failed to decode. A decoder that throws
-  discarded the tags that had decoded, along with the tags of the topic's other readers on the same node, and the
-  reader then delivered every partial update with the key's current value unchanged, without calling the updater
-  registered with `Topic::setUpdater`, until it reconnected to the peer. The reader now keeps every tag it can decode
-  and skips only the one it cannot, logging a warning.

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -314,7 +314,11 @@ SessionI::attachTags(int64_t topicId, ElementInfoSeq tags, bool initialize, cons
                 out << _id << ": attaching tags '[" << tags << "]@" << topicId << "' on topic '" << topic << "'";
             }
 
-            auto decoded = initialize ? map<int64_t, shared_ptr<Tag>>{} : subscriber.tags;
+            // An initializing call replaces the subscriber's tags, so it decodes into a temporary and installs it once
+            // every tag is decoded; the subscriber keeps its current tags until then. Any other call adds to the tags
+            // the subscriber already holds, and decodes into them directly.
+            map<int64_t, shared_ptr<Tag>> replacement;
+            auto& decoded = initialize ? replacement : subscriber.tags;
             for (const auto& tag : tags)
             {
                 try
@@ -323,17 +327,20 @@ SessionI::attachTags(int64_t topicId, ElementInfoSeq tags, bool initialize, cons
                 }
                 catch (const std::exception& ex)
                 {
-                    // The tag factory runs the application's decoder. Skip a tag it can't decode: letting the
-                    // exception escape would drop the tags that did decode, and abort runWithTopics before the
-                    // remaining subscribers of this topic get any. The peer resends its tags on reconnect; until
-                    // then a partial update carrying the skipped tag resolves to the key's current value.
+                    // The tag factory runs the application's decoder. Skip a tag it can't decode: the peer resends
+                    // its tags on reconnect; until then a partial update carrying the skipped tag resolves to the
+                    // key's current value.
                     Warning out(_traceLevels->logger);
                     out << "skipped update tag " << tag.id << " on topic '" << topic << "': the tag could not be "
                         << "decoded:\n"
                         << ex.what();
                 }
             }
-            subscriber.tags = std::move(decoded);
+
+            if (initialize)
+            {
+                subscriber.tags = std::move(replacement);
+            }
         });
 }
 

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -314,15 +314,26 @@ SessionI::attachTags(int64_t topicId, ElementInfoSeq tags, bool initialize, cons
                 out << _id << ": attaching tags '[" << tags << "]@" << topicId << "' on topic '" << topic << "'";
             }
 
-            if (initialize)
-            {
-                subscriber.tags.clear();
-            }
-
+            auto decoded = initialize ? map<int64_t, shared_ptr<Tag>>{} : subscriber.tags;
             for (const auto& tag : tags)
             {
-                subscriber.tags[tag.id] = topic->getTagFactory()->decode(_instance->getCommunicator(), tag.value);
+                try
+                {
+                    decoded[tag.id] = topic->getTagFactory()->decode(_instance->getCommunicator(), tag.value);
+                }
+                catch (const std::exception& ex)
+                {
+                    // The tag factory runs the application's decoder. Skip a tag it can't decode: letting the
+                    // exception escape would drop the tags that did decode, and abort runWithTopics before the
+                    // remaining subscribers of this topic get any. The peer resends its tags on reconnect; until
+                    // then a partial update carrying the skipped tag resolves to the key's current value.
+                    Warning out(_traceLevels->logger);
+                    out << "skipped update tag " << tag.id << " on topic '" << topic << "': the tag could not be "
+                        << "decoded:\n"
+                        << ex.what();
+                }
             }
+            subscriber.tags = std::move(decoded);
         });
 }
 

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -620,7 +620,7 @@ SessionI::initSamples(int64_t topicId, int64_t peerTopicId, DataSamplesSeq initi
                         sample.id,
                         sample.event,
                         key,
-                        subscriber.tags[sample.tag],
+                        subscriber.findTag(sample.tag),
                         sample.value,
                         sample.timestamp));
                 }
@@ -1489,7 +1489,7 @@ SessionI::subscriberInitialized(
                 sample.id,
                 sample.event,
                 key ? key : keyFactory->decode(_instance->getCommunicator(), sample.keyValue),
-                subscriber.tags[sample.tag],
+                subscriber.findTag(sample.tag),
                 sample.value,
                 sample.timestamp));
             assert(samplesI.back()->key);
@@ -1723,7 +1723,7 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
                         dataSample.id,
                         dataSample.event,
                         key,
-                        topicSubscriber.tags[dataSample.tag],
+                        topicSubscriber.findTag(dataSample.tag),
                         dataSample.value,
                         dataSample.timestamp);
                 };

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1768,7 +1768,18 @@ SubscriberSessionI::reconnect(NodePrx node)
         Trace out(_traceLevels->logger, _traceLevels->sessionCat);
         out << _id << ": trying to reconnect session with '" << node->ice_toString() << "'";
     }
-    _parent->createPublisherSession(node, nullptr, static_pointer_cast<SubscriberSessionI>(shared_from_this()));
+
+    try
+    {
+        _parent->createPublisherSession(node, nullptr, static_pointer_cast<SubscriberSessionI>(shared_from_this()));
+    }
+    catch (const SessionCreationException&)
+    {
+        // createPublisherSession throws for the benefit of its servant caller, which maps the exception to the
+        // initiateCreateSession reply. Here the caller is the session retry task, which has nothing to reply to: the
+        // failure was either already accounted for by retrySubscriberSessionCreation, or it reports that the node is
+        // shutting down, in which case there is nothing to retry.
+    }
 }
 
 void

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -185,6 +185,16 @@ namespace DataStormI
                 return p == keys.end() ? nullptr : p->second.first;
             }
 
+            /// Returns the local update tag matching a remote tag id, or `nullptr` when this session holds no tag for
+            /// that id. Like findKey, it never inserts: every sample resolves its tag through this method, and a
+            /// sample without an update tag carries the id 0, so an inserting lookup would leave a null entry behind
+            /// for every id it is asked about.
+            [[nodiscard]] std::shared_ptr<Tag> findTag(std::int64_t tagId) const
+            {
+                auto p = tags.find(tagId);
+                return p == tags.end() ? nullptr : p->second;
+            }
+
             // A map of remote keys to local keys and the number of local elements subscribing to a remote element.
             // - Key: The remote key ID.
             // - Value: A pair containing the local key and a map of remote element IDs to the number of local elements

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -186,9 +186,7 @@ namespace DataStormI
             }
 
             /// Returns the local update tag matching a remote tag id, or `nullptr` when this session holds no tag for
-            /// that id. Like findKey, it never inserts: every sample resolves its tag through this method, and a
-            /// sample without an update tag carries the id 0, so an inserting lookup would leave a null entry behind
-            /// for every id it is asked about.
+            /// that id. Misses are routine, since a sample without an update tag carries the tag id 0.
             [[nodiscard]] std::shared_ptr<Tag> findTag(std::int64_t tagId) const
             {
                 auto p = tags.find(tagId);

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -26,8 +26,50 @@ struct Counter
     int value = 0;
 };
 
+// An update tag type whose Decoder rejects one of the tag values. A writer sends its whole set of update tags to a
+// reader when they attach, so an undecodable tag arrives together with the tags the reader can decode.
+struct Op
+{
+    std::string name;
+
+    bool operator<(const Op& other) const { return name < other.name; }
+    bool operator==(const Op& other) const { return name == other.name; }
+};
+
 namespace DataStorm
 {
+    template<> struct Encoder<Op>
+    {
+        static Ice::ByteSeq encode(const Ice::CommunicatorPtr&, const Op& tag)
+        {
+            Ice::ByteSeq bytes;
+            bytes.reserve(tag.name.size());
+            for (char c : tag.name)
+            {
+                bytes.push_back(static_cast<std::byte>(c));
+            }
+            return bytes;
+        }
+    };
+
+    template<> struct Decoder<Op>
+    {
+        static Op decode(const Ice::CommunicatorPtr&, const Ice::ByteSeq& data)
+        {
+            std::string name;
+            name.reserve(data.size());
+            for (std::byte b : data)
+            {
+                name += static_cast<char>(b);
+            }
+            if (name == "undecodable")
+            {
+                throw std::runtime_error("undecodable update tag");
+            }
+            return Op{name};
+        }
+    };
+
     template<> struct Encoder<Counter>
     {
         static Ice::ByteSeq encode(const Ice::CommunicatorPtr&, const Counter& value)
@@ -526,6 +568,23 @@ void ::Reader::run(int argc, char* argv[])
         test(sample.getValue().value == 1);
         sample = reader2.getNextUnread();
         test(sample.getValue().value == 2);
+    }
+
+    // The writer's tag set contains a tag this reader's Decoder rejects. The reader skips that tag and keeps the one
+    // it can decode, so the partial update published with it is still applied.
+    Topic<string, Counter, Op> tagDecodeErrorTopic(node, "tagDecodeErrorTopic");
+    tagDecodeErrorTopic.setReaderDefaultConfig(config);
+    tagDecodeErrorTopic.setUpdater<int>(Op{"increment"}, [](Counter& counter, int delta) { counter.value += delta; });
+    {
+        auto reader = makeSingleKeyReader(tagDecodeErrorTopic, "key");
+
+        auto sample = reader.getNextUnread();
+        test(sample.getValue().value == 1);
+
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::PartialUpdate);
+        test(sample.getUpdateTag() == Op{"increment"});
+        test(sample.getValue().value == 6); // the undecodable tag did not cost the reader this one
     }
 }
 

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -30,8 +30,50 @@ struct Counter
     int value = 0;
 };
 
+// An update tag type whose Decoder rejects one of the tag values. A writer sends its whole set of update tags to a
+// reader when they attach, so an undecodable tag arrives together with the tags the reader can decode.
+struct Op
+{
+    std::string name;
+
+    bool operator<(const Op& other) const { return name < other.name; }
+    bool operator==(const Op& other) const { return name == other.name; }
+};
+
 namespace DataStorm
 {
+    template<> struct Encoder<Op>
+    {
+        static Ice::ByteSeq encode(const Ice::CommunicatorPtr&, const Op& tag)
+        {
+            Ice::ByteSeq bytes;
+            bytes.reserve(tag.name.size());
+            for (char c : tag.name)
+            {
+                bytes.push_back(static_cast<std::byte>(c));
+            }
+            return bytes;
+        }
+    };
+
+    template<> struct Decoder<Op>
+    {
+        static Op decode(const Ice::CommunicatorPtr&, const Ice::ByteSeq& data)
+        {
+            std::string name;
+            name.reserve(data.size());
+            for (std::byte b : data)
+            {
+                name += static_cast<char>(b);
+            }
+            if (name == "undecodable")
+            {
+                throw std::runtime_error("undecodable update tag");
+            }
+            return Op{name};
+        }
+    };
+
     template<> struct Encoder<Counter>
     {
         static Ice::ByteSeq encode(const Ice::CommunicatorPtr&, const Counter& value)
@@ -455,6 +497,22 @@ void ::Writer::run(int argc, char* argv[])
         writer.add(Counter{1});
         writer.update(Counter{0xFF}); // the reader's Decoder throws on this value
         writer.update(Counter{2});
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    // The writer sends both of its update tags when the reader attaches, and the reader's Decoder rejects one of
+    // them. The partial update published with the tag the reader can decode is still applied.
+    Topic<string, Counter, Op> tagDecodeErrorTopic(node, "tagDecodeErrorTopic");
+    tagDecodeErrorTopic.setWriterDefaultConfig(config);
+    tagDecodeErrorTopic.setUpdater<int>(Op{"undecodable"}, [](Counter& counter, int delta) { counter.value += delta; });
+    tagDecodeErrorTopic.setUpdater<int>(Op{"increment"}, [](Counter& counter, int delta) { counter.value += delta; });
+    cout << "testing update tag that fails to decode... " << flush;
+    {
+        auto writer = makeSingleKeyWriter(tagDecodeErrorTopic, "key");
+        writer.waitForReaders();
+        writer.add(Counter{1});
+        writer.partialUpdate<int>(Op{"increment"})(5);
         writer.waitForNoReaders();
     }
     cout << "ok" << endl;


### PR DESCRIPTION
Three small fixes to the DataStorm session, one commit each. All three are failure-path only: with an application
that doesn't throw and a peer that sends decodable bytes, none of them changes what the code does.

### Resolve sample tags with a non-inserting lookup

The three sample-construction paths read `TopicSubscriber::tags` with `map::operator[]`, which inserts a null tag for
every id it is asked about. A sample with no update tag carries the tag id 0, so every such sample left an entry
behind. `TopicSubscriber::findTag` now mirrors the `findKey` written for the same reason. A miss still yields
`nullptr`, so the samples these paths build are unchanged — this deliberately does not pre-empt #6213, which is
about what *should* happen when a partial update's tag can't be resolved.

### Keep a session reconnect failure out of the timer thread

`SubscriberSessionI::reconnect` runs on the Ice timer thread and called `NodeI::createPublisherSession` without
catching `SessionCreationException`. Only two throws are reachable from there: `NodeShutdown`, which must not retry,
and `Internal`, which `NodeI` already handed to `retrySubscriberSessionCreation` before rethrowing. So the exception
carried nothing left to act on and simply escaped into `IceInternal::Timer::run`'s catch-and-print.

The throws are kept — `NodeI::initiateCreateSession` maps them to the `initiateCreateSession` reply — and only this
call site catches. After this change every call to `createPublisherSession` in the tree is inside a catch.

### Skip an update tag the application's decoder cannot decode

`SessionI::attachTags` cleared the tag map and then decoded into it one tag at a time, so a decoder that threw part
way left the subscriber with a truncated set, and with none at all when the peer sent the full set. The throw also
escaped `runWithTopics`, so the remaining subscribers of that topic id got no tags either. The peer only sends the
tags again when the session reconnects, and until then every partial update carrying an unresolved tag resolved to a
copy of the previous value, silently.

Letting the exception escape reaches nobody: `TopicI::forward` invokes the listener session proxies with null
response and exception callbacks ("we don't need to check the result"), and `SessionI::attachTopic` calls
`attachTagsAsync` the same way, so the only effect is a dispatch warning on the receiving node. Each tag is now
decoded under its own catch — a tag the decoder rejects is skipped with a warning, and the tags that decode are
kept. `DataElementI` already handles a throwing updater or decoder this way when resolving a partial update.

A skipped tag stays unresolved, so a partial update carrying it still resolves to the key's current value. That is
#6213, unchanged by this PR.

### Notes

- #6326 is covered in `cpp/test/DataStorm/partial`: an update tag type whose `Decoder` rejects one of the writer's
  two tags, and the reader still applies the partial update published with the tag it can decode. One caveat — the
  tags travel in a single batch whose order follows the writer's `map<shared_ptr<Tag>, Updater>`, so against the
  previous code the test fails only when the undecodable tag happens to be decoded first: 4 runs out of 5 locally,
  green 8 out of 8 with the fix.
- No test for the other two. #6310 has no symptom to observe — both forms hand an identical `nullptr` downstream, so
  a probe would be green before the fix. #6311's only symptom is a line on `consoleErr` from Ice's own timer.
- No changelog fragment. All three are failure-path hardening: reaching any of them takes a buggy custom decoder
  or an encoder/decoder mismatch between processes, not normal operation.
- `SessionI::attachTopic` decodes a topic spec's tags the same way. It doesn't clear first, so a failure there leaves
  a superset rather than destroying the map, and the throw aborts `attachTopic` after the topic is attached and
  before its elements are — the commit-before-application-code class tracked by #6324. Left alone here.

Verified with the full `cpp/DataStorm` suite (11/11) on 838c8c9.

Fixes #6310
Fixes #6311
Fixes #6326


