### PR TITLE
Deliver a DataStorm sample to every matching reader when one reader's key filter throws

### DIFF
--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -1003,14 +1003,33 @@ DataReaderI::queue(
         }
         return;
     }
-    else if (checkKey && !matchKey(sample->key))
+    else if (checkKey)
     {
-        if (_traceLevels->data > 2)
+        bool matched;
+        try
         {
-            Trace out(_traceLevels->logger, _traceLevels->dataCat);
-            out << this << ": skipped sample " << sample->id << " (key doesn't match)";
+            matched = matchKey(sample->key);
         }
-        return;
+        catch (const std::exception& ex)
+        {
+            // Checking an inline key calls the reader's key filter, which is application code. A filter that throws
+            // drops the sample for this reader, like a filter that returns false. The session queues the sample with
+            // each reader subscribed to the writer element in turn, so letting the exception escape would also drop
+            // the sample for the readers queued after this one.
+            Warning out(_traceLevels->logger);
+            out << "dropped sample " << sample->id << ": the key filter failed:\n" << ex.what();
+            return;
+        }
+
+        if (!matched)
+        {
+            if (_traceLevels->data > 2)
+            {
+                Trace out(_traceLevels->logger, _traceLevels->dataCat);
+                out << this << ": skipped sample " << sample->id << " (key doesn't match)";
+            }
+            return;
+        }
     }
 
     if (_traceLevels->data > 2)

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -318,6 +318,36 @@ void ::Reader::run(int argc, char* argv[])
     }
 
     {
+        // Two readers of one any-key writer, each with a key filter that throws on the key the other one expects.
+        // Every sample reaches the reader whose filter accepts it, whichever order the writer element serves them in.
+        Topic<string, string> topic(node, "keyFilterThrow");
+        topic.setKeyFilter<string>(
+            "throwOnKey",
+            [](const string& boom)
+            {
+                return [boom](const string& key)
+                {
+                    if (key == boom)
+                    {
+                        throw runtime_error("the key filter failed");
+                    }
+                    return true;
+                };
+            });
+
+        auto reader1 = makeFilteredKeyReader(topic, Filter<string>("throwOnKey", "k1"), "", config);
+        auto reader2 = makeFilteredKeyReader(topic, Filter<string>("throwOnKey", "k2"), "", config);
+        reader1.waitForWriters(1);
+        reader2.waitForWriters(1);
+
+        test(reader1.getNextUnread().getKey() == "k2");
+        test(reader1.getNextUnread().getKey() == "sentinel");
+
+        test(reader2.getNextUnread().getKey() == "k1");
+        test(reader2.getNextUnread().getKey() == "sentinel");
+    }
+
+    {
         Topic<string, string> topic(node, "filtered reader key/value filter");
 
         {

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -335,6 +335,36 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // An any-key writer marshals the key with the sample, so each filtered reader matches the key itself. The readers
+    // subscribed to one writer element are served in turn, and a reader whose key filter throws must not stop the
+    // readers served after it from receiving the sample.
+    cout << "testing filtered reader whose key filter throws... " << flush;
+    {
+        Topic<string, string> topic(node, "keyFilterThrow");
+        topic.setKeyFilter<string>(
+            "throwOnKey",
+            [](const string& boom)
+            {
+                return [boom](const string& key)
+                {
+                    if (key == boom)
+                    {
+                        throw runtime_error("the key filter failed");
+                    }
+                    return true;
+                };
+            });
+
+        auto writer = makeAnyKeyWriter(topic, "", config);
+        writer.waitForReaders(2);
+
+        writer.add("k1", "v1");
+        writer.add("k2", "v2");
+        writer.add("sentinel", "v3");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
     cout << "testing filtered sample reader... " << flush;
     {
         Topic<string, string> topic(node, "filtered reader key/value filter");


### PR DESCRIPTION
An any-key writer marshals the key with the sample, so each reader subscribed to the writer element matches the key
itself. `SubscriberSessionI::s` queues the sample with those readers in turn, and `DataReaderI::queue` called the
reader's key filter — application code — without catching anything. A filter that threw ended the loop: every reader
ordered after it never received the sample.

`ElementSubscribers::getSubscribers` is a `std::map` with stable ordering, so this isn't a one-off. A filter that
throws deterministically for some key starves the same readers on every later sample.

A key filter that throws now drops the sample for its own reader, exactly as a filter returning `false` does, and the
remaining readers are served.

### Why not the fix the issue suggests

#6325 suggests assigning `lastId` only after `queue` returns. That doesn't fix this: `queue` already returns
normally, with `lastId` advanced, on several legitimate drop paths (facet mismatch, key mismatch, the discard
policies, an unusable partial update). Re-offering the sample would only push the same throw into the unguarded
`matchKey` on the initialization path. `lastId` is left where it is — the throwing reader is no worse off than
before, since the assignment already preceded `queue`.

The guard wraps only the `matchKey` call, not the whole `queue` body, so an unrelated exception still propagates.

### Test

`cpp/test/DataStorm/events`: an any-key writer and two filtered readers whose key filters each throw on the *other*
reader's key, plus a sentinel key neither rejects.

Whichever way the subscriber map happens to order the two readers, exactly one of them loses its key before the fix,
so one of the two assertions always fails — the redness doesn't depend on the ordering. The sentinel makes it fail by
assertion instead of blocking in `getNextUnread()`.

Confirmed red against unmodified sources:

```
testing filtered reader whose key filter throws... failed!
test/DataStorm/events/Reader.cpp:343: assertion `reader1.getNextUnread().getKey() == "k2"' failed
```

and green with the fix, with the full `cpp/DataStorm` suite (11/11) on 838c8c9.

### Not addressed here

`DataReaderI::initSamples` calls `matchKey` unguarded the same way on the initialization path. That one is #6324's,
because the reader there has already been marked initialized with its `lastId` advanced, so it needs the commit
ordering fixed as well as the guard.

No changelog fragment: this needs an application key filter that throws, and there are no field reports.

Fixes #6325
