### PR TITLE
Document the DataStorm sample history and sample filter limitations

### DIFF
--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -389,8 +389,9 @@ namespace DataStorm
 
         /// Sets a key filter factory. The given factory function must return a filter function that returns `true` if
         /// the key matches the filter criteria, `false` otherwise.
-        /// Register all key filters before creating any reader or writer for this topic: the set of filters is not
-        /// synchronized, so modifying it once the topic is in use races with the Ice threads that use the topic.
+        /// Register all key filter factories before creating any reader or writer for this topic: the set of
+        /// factories is not synchronized, so modifying it once the topic is in use races with the Ice threads that
+        /// use the topic.
         /// @param name The name of the key filter.
         /// @param factory The filter factory function.
         template<typename Criteria>
@@ -400,13 +401,15 @@ namespace DataStorm
 
         /// Sets a sample filter factory. The given factory function must return a filter function that returns `true`
         /// if the sample matches the filter criteria, `false` otherwise.
-        /// Register all sample filters before creating any reader or writer for this topic: the set of filters is not
-        /// synchronized, so modifying it once the topic is in use races with the Ice threads that use the topic.
-        /// A sample filter interacts with partial updates: a writer sends a reader that uses one only the samples the
-        /// reader matches, so the reader can receive a partial update for a key it never received a full value for. It
-        /// has nothing to resolve that update against and discards it, until it receives a full value for the key. A
-        /// partial update that matches after non-matching samples likewise resolves against the reader's own last
-        /// matching value rather than against the writer's current value.
+        /// Register all sample filter factories before creating any reader or writer for this topic: the set of
+        /// factories is not synchronized, so modifying it once the topic is in use races with the Ice threads that
+        /// use the topic.
+        /// A sample filter interacts with partial updates: a writer sends only the samples a reader's filter matches,
+        /// so the reader can receive a partial update for a key whose full value it never received. The reader has
+        /// nothing to resolve such updates against and discards them until it receives a full value for the key. And
+        /// when the filter rejects some samples for a key but a later partial update matches, the reader applies that
+        /// update to the last value it received for the key — not to the value the writer computed the update
+        /// against — so the reader's value can silently diverge from the writer's.
         /// @param name The name of the sample filter.
         /// @param factory The filter factory function.
         template<typename Criteria>
@@ -787,9 +790,9 @@ namespace DataStorm
         /// returned function is called: a full value was written for the key and the key was not since removed.
         /// Calling the returned function for a key with no current value is an application error that throws
         /// std::logic_error and publishes nothing.
-        /// A reader that uses a sample filter receives only the samples it matches, so it can have no current value
-        /// for the key even though the writer does; it discards the partial update in that case. See
-        /// Topic::setSampleFilter.
+        /// A reader that uses a sample filter receives only the samples its filter matches: such a reader can lack
+        /// a current value for the key even though the writer has one, and it discards partial updates until it
+        /// receives a full value for the key. See Topic::setSampleFilter.
         /// @param tag The partial update tag.
         template<typename UpdateValue>
         [[nodiscard]] std::function<void(const UpdateValue&)> partialUpdate(const UpdateTag& tag);
@@ -856,9 +859,9 @@ namespace DataStorm
         /// returned function is called: a full value was written for the key and the key was not since removed.
         /// Calling the returned function for a key with no current value is an application error that throws
         /// std::logic_error and publishes nothing.
-        /// A reader that uses a sample filter receives only the samples it matches, so it can have no current value
-        /// for the key even though the writer does; it discards the partial update in that case. See
-        /// Topic::setSampleFilter.
+        /// A reader that uses a sample filter receives only the samples its filter matches: such a reader can lack
+        /// a current value for the key even though the writer has one, and it discards partial updates until it
+        /// receives a full value for the key. See Topic::setSampleFilter.
         /// @param tag The partial update tag.
         template<typename UpdateValue>
         [[nodiscard]] std::function<void(const Key&, const UpdateValue&)> partialUpdate(const UpdateTag& tag);

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -402,6 +402,11 @@ namespace DataStorm
         /// if the sample matches the filter criteria, `false` otherwise.
         /// Register all sample filters before creating any reader or writer for this topic: the set of filters is not
         /// synchronized, so modifying it once the topic is in use races with the Ice threads that use the topic.
+        /// A sample filter interacts with partial updates: a writer sends a reader that uses one only the samples the
+        /// reader matches, so the reader can receive a partial update for a key it never received a full value for. It
+        /// has nothing to resolve that update against and discards it, until it receives a full value for the key. A
+        /// partial update that matches after non-matching samples likewise resolves against the reader's own last
+        /// matching value rather than against the writer's current value.
         /// @param name The name of the sample filter.
         /// @param factory The filter factory function.
         template<typename Criteria>
@@ -782,6 +787,9 @@ namespace DataStorm
         /// returned function is called: a full value was written for the key and the key was not since removed.
         /// Calling the returned function for a key with no current value is an application error that throws
         /// std::logic_error and publishes nothing.
+        /// A reader that uses a sample filter receives only the samples it matches, so it can have no current value
+        /// for the key even though the writer does; it discards the partial update in that case. See
+        /// Topic::setSampleFilter.
         /// @param tag The partial update tag.
         template<typename UpdateValue>
         [[nodiscard]] std::function<void(const UpdateValue&)> partialUpdate(const UpdateTag& tag);
@@ -848,6 +856,9 @@ namespace DataStorm
         /// returned function is called: a full value was written for the key and the key was not since removed.
         /// Calling the returned function for a key with no current value is an application error that throws
         /// std::logic_error and publishes nothing.
+        /// A reader that uses a sample filter receives only the samples it matches, so it can have no current value
+        /// for the key even though the writer does; it discards the partial update in that case. See
+        /// Topic::setSampleFilter.
         /// @param tag The partial update tag.
         template<typename UpdateValue>
         [[nodiscard]] std::function<void(const Key&, const UpdateValue&)> partialUpdate(const UpdateTag& tag);

--- a/cpp/include/DataStorm/Types.h
+++ b/cpp/include/DataStorm/Types.h
@@ -48,11 +48,11 @@ namespace DataStorm
         /// Clear the sample history when a new sample which is not a partial update is received.
         OnAllExceptPartialUpdate,
 
-        /// Never clear the sample history. The history is then bounded only by Config::sampleCount and
-        /// Config::sampleLifetime, both unbounded by default, so an element configured this way and left with the
-        /// default bounds accumulates samples for as long as it lives: every sample it publishes, for a writer, and
-        /// every sample it receives that the application has not yet read, for a reader. Set Config::sampleCount or
-        /// Config::sampleLifetime on a long-lived element that writes or receives a high volume of samples.
+        /// Never clear the sample history. Only Config::sampleCount and Config::sampleLifetime then bound the
+        /// history, and both are unbounded by default: with the defaults, a writer accumulates every sample it
+        /// publishes and a reader accumulates every sample the application has not yet read, for as long as the
+        /// element lives. Set Config::sampleCount or Config::sampleLifetime on a long-lived element that writes or
+        /// receives a high volume of samples.
         Never
     };
 

--- a/cpp/include/DataStorm/Types.h
+++ b/cpp/include/DataStorm/Types.h
@@ -48,7 +48,11 @@ namespace DataStorm
         /// Clear the sample history when a new sample which is not a partial update is received.
         OnAllExceptPartialUpdate,
 
-        /// Never clear the sample history.
+        /// Never clear the sample history. The history is then bounded only by Config::sampleCount and
+        /// Config::sampleLifetime, both unbounded by default, so an element configured this way and left with the
+        /// default bounds accumulates samples for as long as it lives: every sample it publishes, for a writer, and
+        /// every sample it receives that the application has not yet read, for a reader. Set Config::sampleCount or
+        /// Config::sampleLifetime on a long-lived element that writes or receives a high volume of samples.
         Never
     };
 


### PR DESCRIPTION
Documentation only — no code change.

### `ClearHistoryPolicy::Never`

The enumerator was documented as "Never clear the sample history" and nothing more. With `sampleCount` and
`sampleLifetime` left at their defaults, nothing else bounds the history either: the `DataStorm.Topic.SampleCount`
and `DataStorm.Topic.SampleLifetime` defaults that `mergeConfigs` applies are `-1` and `0`, and `DataWriterI::publish`
trims only for a count or lifetime greater than zero. An element configured that way accumulates samples for as long
as it lives. The note says so, and points at the two settings that bound it.

### The sample filter / partial update interaction

A writer sends a reader that uses a sample filter only the samples that reader matches, so the reader can receive a
partial update for a key it never received a full value for. It has nothing to resolve the update against and
discards it. Neither `Topic::setSampleFilter` nor either `partialUpdate` overload mentioned this. #6309 tracks the
behavior fix; this documents the current behavior.

### On #6177

#6177 proposes rejecting the merged configuration `clearHistory=Never` with `sampleCount=-1` and `sampleLifetime=0`
outright. I don't think we should:

- It is the only way to express what `Writer::getAll()` documents — "all the written samples kept in the writer
  history".
- On the reader side that history *is* the unread queue that `getAllUnread`/`getNextUnread`/`hasUnread` read. Under
  the `OnAll` default `DataReaderI::queue` clears the queue on every arrival, so a reader that must not drop samples
  has no other option.
- Our own suite uses it, in 17 files under `cpp/test/DataStorm`, including one with the comment "Keep all the samples
  in the history."
- The check can't live where the issue says it must: `Topic::setWriterDefaultConfig` is `noexcept`, so throwing at the
  merge point calls `std::terminate`. `cpp/test/DataStorm/types/Writer.cpp` drives exactly that path with exactly
  that configuration.

A warning log is out for the same reason — it would fire on our own writer suites and on every legitimate use. The
issue's own premise that a late joiner already receives the full current state under the default `OnAll` policy holds
(`getSamples` appends `collectBases`, and `_lastByKey` is maintained before any trimming), which is what makes
documenting it sufficient.

Refs #6177
Refs #6309

