### PR TITLE
Fix two build-tooling defects: makeprops.py dropped endElement, coverage-script dead guard

### DIFF
--- a/config/makeprops.py
+++ b/config/makeprops.py
@@ -609,6 +609,11 @@ class MultiHandler(ContentHandler):
         for f in self.handlers:
             f.startElement(name, attrs)
 
+    @override
+    def endElement(self, name: str) -> None:
+        for f in self.handlers:
+            f.endElement(name)
+
     def cleanup(self) -> None:
         for f in self.handlers:
             f.cleanup()

--- a/scripts/generate-cpp-code-coverage.sh
+++ b/scripts/generate-cpp-code-coverage.sh
@@ -37,7 +37,7 @@ case "$arg" in
         echo ""
         echo "Generates a code coverage report for the specified binary or library. The report is generated in the coverage/html directory."
         echo "The script builds the current working directory with code coverage instrumentation, runs the tests, and generates the report."
-        echo "The llvm package must be installed."
+        echo "The Xcode Command Line Tools must be installed."
         echo ""
         echo "example: generate code coverage report for libIce"
         echo "  cd cpp && ../scripts/generate-cpp-code-coverage.sh lib/libIce.dylib"
@@ -48,8 +48,8 @@ esac
 
 CLI_TOOLS=/Library/Developer/CommandLineTools/usr/bin
 
-if [ -z "$CLI_TOOLS" ]; then
-    echo "Xcode Command Line Tools not found. Run 'xcode-select --install' to install the tools."
+if [ ! -x "${CLI_TOOLS}/llvm-profdata" ] || [ ! -x "${CLI_TOOLS}/llvm-cov" ]; then
+    echo "llvm-profdata or llvm-cov not found in ${CLI_TOOLS}. Run 'xcode-select --install' to install the Xcode Command Line Tools."
     exit 1
 fi
 


### PR DESCRIPTION
Closes #6132.

The issue listed three items. Item 1 — the ten `print(sys.stderr, ...)` calls that sent diagnostics to stdout — was already fixed on `main` by #6234, so this PR addresses only items 2 and 3.

### `MultiHandler` never forwards `endElement`

`MultiHandler` forwarded `startElement` to its child `PropertyHandler`s but defined no `endElement`, so `PropertyHandler.endElement` never ran and `parentNodeName` was left pointing at the most recently opened section. A `<property>` placed after a `<section>` or `<class>` closed was silently added to that stale array instead of tripping the `property element outside a section or class` assertion.

The current `PropertyNames.xml` has no such element — 20 containers, 346 properties, no nesting, no orphans — so the generated `PropertyNames.{h,cpp,java,cs,js}` are unchanged. I re-ran `config/makeprops.py` after the change and confirmed the checked-in output is byte-identical.

Against a deliberately malformed XML with an orphan `<property>`, the old dispatch absorbed it into the preceding section; the new one raises.

### Dead emptiness guard in `generate-cpp-code-coverage.sh`

`CLI_TOOLS` is assigned a non-empty literal, so the `[ -z "$CLI_TOOLS" ]` guard two lines below it could never fire. On a machine without the Xcode Command Line Tools the script instead failed later with a raw "not found" on `${CLI_TOOLS}/llvm-profdata`. It now tests for the two tools it actually runs.

The `--help` text still claimed the Homebrew `llvm` package was required, which no longer matches the script — the comment at the top was corrected to Xcode Command Line Tools earlier, but this line was missed.

No changelog fragment or test, matching the recent comparable build-tooling changes (#6319, #6234, #6153).
