### PR TITLE
Report the Ice version to find_package

### DIFF
--- a/cpp/config/IceConfig.cmake
+++ b/cpp/config/IceConfig.cmake
@@ -13,21 +13,8 @@ if(CMAKE_VERSION VERSION_LESS 3.21)
   return()
 endif()
 
-# OPTIONAL with a guard: a sibling file missing from a mangled installation must report Ice as not
-# found, not abort the configure step - include() of a missing file is a hard error even under QUIET.
-include("${CMAKE_CURRENT_LIST_DIR}/IcePrefix.cmake" OPTIONAL RESULT_VARIABLE _ice_prefix_included)
-include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake" OPTIONAL RESULT_VARIABLE _ice_version_included)
-
-if(NOT _ice_prefix_included OR NOT _ice_version_included)
-  set(Ice_FOUND FALSE)
-  set(Ice_NOT_FOUND_MESSAGE
-    "The Ice installation at ${CMAKE_CURRENT_LIST_DIR} is missing IcePrefix.cmake or IceVersion.cmake.")
-  unset(_ice_prefix_included)
-  unset(_ice_version_included)
-  return()
-endif()
-unset(_ice_prefix_included)
-unset(_ice_version_included)
+include("${CMAKE_CURRENT_LIST_DIR}/IcePrefix.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake")
 
 set(Ice_SO_VERSION "${_ice_package_so_version}")
 

--- a/cpp/config/IceConfig.cmake
+++ b/cpp/config/IceConfig.cmake
@@ -13,8 +13,21 @@ if(CMAKE_VERSION VERSION_LESS 3.21)
   return()
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/IcePrefix.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake")
+# OPTIONAL with a guard: a sibling file missing from a mangled installation must report Ice as not
+# found, not abort the configure step - include() of a missing file is a hard error even under QUIET.
+include("${CMAKE_CURRENT_LIST_DIR}/IcePrefix.cmake" OPTIONAL RESULT_VARIABLE _ice_prefix_included)
+include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake" OPTIONAL RESULT_VARIABLE _ice_version_included)
+
+if(NOT _ice_prefix_included OR NOT _ice_version_included)
+  set(Ice_FOUND FALSE)
+  set(Ice_NOT_FOUND_MESSAGE
+    "The Ice installation at ${CMAKE_CURRENT_LIST_DIR} is missing IcePrefix.cmake or IceVersion.cmake.")
+  unset(_ice_prefix_included)
+  unset(_ice_version_included)
+  return()
+endif()
+unset(_ice_prefix_included)
+unset(_ice_version_included)
 
 set(Ice_SO_VERSION "${_ice_package_so_version}")
 

--- a/cpp/config/IceConfig.cmake
+++ b/cpp/config/IceConfig.cmake
@@ -14,6 +14,16 @@ if(CMAKE_VERSION VERSION_LESS 3.21)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/IcePrefix.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake")
+
+set(Ice_SO_VERSION "${_ice_package_so_version}")
+
+# Unconditionally: under find_package this matches what IceConfigVersion.cmake reported, and a
+# leftover cache entry from an older installation must not win over the installed version.
+set(Ice_VERSION "${_ice_package_version}")
+
+unset(_ice_package_version)
+unset(_ice_package_so_version)
 
 if(NOT DEFINED Ice_PREFIX)
   set(Ice_FOUND FALSE)

--- a/cpp/config/IceConfigVersion.cmake
+++ b/cpp/config/IceConfigVersion.cmake
@@ -8,7 +8,9 @@
 # the COMPATIBILITY SameMinorVersion policy; version ranges are honored on both endpoints, where
 # SameMinorVersion would reject an upper endpoint in a later x.y.
 
-include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake")
+# OPTIONAL: an installation missing IceVersion.cmake must reject version requests rather than
+# abort the configure step - include() of a missing file is a hard error even under QUIET.
+include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake" OPTIONAL)
 
 # Report the full version, pre-release suffix included, so Ice_VERSION matches what Ice reports
 # everywhere else. CMake's version comparison ignores the suffix and still derives
@@ -54,10 +56,10 @@ if(PACKAGE_VERSION)
       set(PACKAGE_VERSION_COMPATIBLE TRUE)
     endif()
 
-    # VERSION_EQUAL rather than STREQUAL, so a request for 3.9.0 matches a 3.9.0-alpha.0 build. A
-    # find_package version argument cannot carry a pre-release suffix: CMake rejects it as invalid.
-    # EXACT never combines with a range; find_package refuses that itself.
-    if(PACKAGE_FIND_VERSION VERSION_EQUAL PACKAGE_VERSION)
+    # STREQUAL, as in CMake's own generated version files: a pre-release must not satisfy EXACT
+    # for the release it precedes, so 3.9.0-alpha.0 does not answer 3.9.0 EXACT. Plain requests
+    # still accept it. EXACT never combines with a range; find_package refuses that itself.
+    if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
       set(PACKAGE_VERSION_EXACT TRUE)
     endif()
   endif()

--- a/cpp/config/IceConfigVersion.cmake
+++ b/cpp/config/IceConfigVersion.cmake
@@ -1,0 +1,69 @@
+# Copyright (c) ZeroC, Inc.
+
+# Reports this installation's version to find_package. Without this file every
+# find_package(Ice <version>) fails with "version: unknown".
+#
+# CMake's own way to produce this file is write_basic_package_version_file(), but that runs inside a
+# CMake build and the Ice C++ build has none, so the file is maintained by hand. Plain requests follow
+# the COMPATIBILITY SameMinorVersion policy; version ranges are honored on both endpoints, where
+# SameMinorVersion would reject an upper endpoint in a later x.y.
+
+include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake")
+
+# Report the full version, pre-release suffix included, so Ice_VERSION matches what Ice reports
+# everywhere else. CMake's version comparison ignores the suffix and still derives
+# Ice_VERSION_MAJOR/MINOR/PATCH from the numeric part.
+set(PACKAGE_VERSION "${_ice_package_version}")
+
+if(PACKAGE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)")
+  set(_ice_version_major "${CMAKE_MATCH_1}")
+  set(_ice_version_minor "${CMAKE_MATCH_2}")
+else()
+  # Fail closed on a malformed IceVersion.cmake rather than compare against stale CMAKE_MATCH values.
+  set(_ice_version_major "")
+  set(_ice_version_minor "")
+endif()
+
+set(PACKAGE_VERSION_COMPATIBLE FALSE)
+set(PACKAGE_VERSION_EXACT FALSE)
+
+# A request is compatible when it names this x.y and is not newer than this installation. Ice
+# treats every x.y as a major release: 3.8 and 3.9 are not binary compatible and install side by
+# side (Ice-3.8, Ice-3.9); only patch releases within an x.y line are compatible. With 3.9.2
+# installed, requests for 3.9, 3.9.0 and 3.9.2 match; 3.9.5, 3.8, 3.7, 4.0 and a bare 3 do not.
+if(PACKAGE_VERSION)
+  if(PACKAGE_FIND_VERSION_RANGE)
+    # Same rule on the range's lower endpoint, plus this version must not exceed the upper one.
+    if(PACKAGE_FIND_VERSION_MIN_MAJOR STREQUAL _ice_version_major AND
+       PACKAGE_FIND_VERSION_MIN_MINOR STREQUAL _ice_version_minor AND
+       NOT PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION_MIN)
+      if(PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE" AND
+         NOT PACKAGE_VERSION VERSION_GREATER PACKAGE_FIND_VERSION_MAX)
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+      elseif(PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE" AND
+             PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION_MAX)
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+      endif()
+    endif()
+  else()
+    if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+      # Older than asked for.
+      set(PACKAGE_VERSION_COMPATIBLE FALSE)
+    elseif(PACKAGE_FIND_VERSION_MAJOR STREQUAL _ice_version_major AND
+           PACKAGE_FIND_VERSION_MINOR STREQUAL _ice_version_minor)
+      set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    endif()
+
+    # VERSION_EQUAL rather than STREQUAL, so a request for 3.9.0 matches a 3.9.0-alpha.0 build. A
+    # find_package version argument cannot carry a pre-release suffix: CMake rejects it as invalid.
+    # EXACT never combines with a range; find_package refuses that itself.
+    if(PACKAGE_FIND_VERSION VERSION_EQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+  endif()
+endif()
+
+unset(_ice_version_major)
+unset(_ice_version_minor)
+unset(_ice_package_version)
+unset(_ice_package_so_version)

--- a/cpp/config/IceConfigVersion.cmake
+++ b/cpp/config/IceConfigVersion.cmake
@@ -8,9 +8,7 @@
 # the COMPATIBILITY SameMinorVersion policy; version ranges are honored on both endpoints, where
 # SameMinorVersion would reject an upper endpoint in a later x.y.
 
-# OPTIONAL: an installation missing IceVersion.cmake must reject version requests rather than
-# abort the configure step - include() of a missing file is a hard error even under QUIET.
-include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake" OPTIONAL)
+include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake")
 
 # Report the full version, pre-release suffix included, so Ice_VERSION matches what Ice reports
 # everywhere else. CMake's version comparison ignores the suffix and still derives

--- a/cpp/config/IceTargets.cmake
+++ b/cpp/config/IceTargets.cmake
@@ -20,20 +20,6 @@ find_path(Ice_INCLUDE_DIR NAMES Ice/Ice.h
   PATH_SUFFIXES include DOC "Directory containing Ice header files"
   NO_DEFAULT_PATH REQUIRED)
 
-# Read Ice version variables from Ice/Config.h
-if(NOT DEFINED Ice_VERSION)
-  file(STRINGS "${Ice_INCLUDE_DIR}/Ice/Config.h" _ice_config_h_content REGEX "#define ICE_([A-Z]+)_VERSION ")
-
-  if("${_ice_config_h_content}" MATCHES "#define ICE_STRING_VERSION \"([^\"]+)\"")
-    set(Ice_VERSION "${CMAKE_MATCH_1}" CACHE STRING "Ice version")
-  endif()
-
-  if("${_ice_config_h_content}" MATCHES "#define ICE_SO_VERSION \"([^\"]+)\"")
-    set(Ice_SO_VERSION "${CMAKE_MATCH_1}" CACHE STRING "Ice SO version")
-  endif()
-  unset(_ice_config_h_content)
-endif()
-
 find_program(Ice_SLICE2CPP_EXECUTABLE slice2cpp
   HINTS ${Ice_PREFIX}
   PATH_SUFFIXES bin tools
@@ -244,4 +230,4 @@ add_ice_library(IceStorm Ice::Ice)
 add_ice_library(IceBT Ice::Ice)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Ice HANDLE_COMPONENTS CONFIG_MODE)
+find_package_handle_standard_args(Ice HANDLE_COMPONENTS HANDLE_VERSION_RANGE CONFIG_MODE)

--- a/cpp/config/IceVersion.cmake
+++ b/cpp/config/IceVersion.cmake
@@ -1,0 +1,10 @@
+# Copyright (c) ZeroC, Inc.
+
+# The version of the Ice installation these files ship with. Update at release time, along with the
+# other version strings in the source tree (config/version.env, config/Make.rules, and so on).
+#
+#   Ice_VERSION      matches ICE_STRING_VERSION in Ice/Config.h, pre-release suffix included
+#   Ice_SO_VERSION   matches ICE_SO_VERSION, and forms the Windows library names
+
+set(_ice_package_version "3.9.0-alpha.0")
+set(_ice_package_so_version "39a0")


### PR DESCRIPTION
Stacked on #6421, which it targets; GitHub will retarget this to `main` when that merges.

Every versioned `find_package(Ice)` was rejected, including a request for the version actually installed, because the package shipped no version file and CMake saw `version: unknown`.

- Adds `IceConfigVersion.cmake`. A request is compatible when it names the installed x.y and is not newer than it: Ice treats every x.y as a major release line, and only patch releases within a line are compatible. Version ranges are honored on both endpoints.
- The version is baked into the new `IceVersion.cmake` rather than parsed out of `Ice/Config.h` at find time, since these files ship with a single Ice version. This adds one more file to update at release time, alongside `config/version.env` and the others.
- `Ice_VERSION` reports the full version including any pre-release suffix, matching what Ice reports elsewhere; CMake still derives `Ice_VERSION_MAJOR`/`MINOR`/`PATCH` from the numeric part. A pre-release does not satisfy an `EXACT` request for the release it precedes.
- `Ice_VERSION` and `Ice_SO_VERSION` are plain variables rather than cache entries, so a stale value from an earlier installation cannot survive an upgrade, and `find_package_handle_standard_args` is told about version ranges so an accepted range does not warn.

Closes #6348

🤖 Generated with [Claude Code](https://claude.com/claude-code)
