### PR TITLE
Fix Windows imported configurations and the icebox imported location

### DIFF
--- a/cpp/config/IceTargets.cmake
+++ b/cpp/config/IceTargets.cmake
@@ -46,20 +46,16 @@ find_path(Ice_SLICE_DIR
 # Imported targets for the executables in the NuGet package's native/bin directory.
 if(WIN32)
   function(add_ice_executable name)
+    # The NuGet package always ships both configurations; a miss is a broken installation.
     find_program(Ice_${name}_EXE_RELEASE ${name}${CMAKE_EXECUTABLE_SUFFIX}
       HINTS "${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Release"
-      NO_DEFAULT_PATH
+      NO_DEFAULT_PATH REQUIRED
     )
 
     find_program(Ice_${name}_EXE_DEBUG ${name}${CMAKE_EXECUTABLE_SUFFIX}
       HINTS "${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug"
-      NO_DEFAULT_PATH
+      NO_DEFAULT_PATH REQUIRED
     )
-
-    # Better undefined than a target with no IMPORTED_LOCATION, which fails far less obviously.
-    if(NOT Ice_${name}_EXE_RELEASE AND NOT Ice_${name}_EXE_DEBUG)
-      return()
-    endif()
 
     if(TARGET Ice::${name}_EXE)
       return()
@@ -67,33 +63,16 @@ if(WIN32)
 
     add_executable(Ice::${name}_EXE IMPORTED)
 
-    set(imported_configurations "")
-
-    if(Ice_${name}_EXE_RELEASE)
-      list(APPEND imported_configurations RELEASE)
-      set_property(TARGET Ice::${name}_EXE PROPERTY
-        IMPORTED_LOCATION_RELEASE "${Ice_${name}_EXE_RELEASE}")
-    endif()
-
-    if(Ice_${name}_EXE_DEBUG)
-      list(APPEND imported_configurations DEBUG)
-      set_property(TARGET Ice::${name}_EXE PROPERTY
-        IMPORTED_LOCATION_DEBUG "${Ice_${name}_EXE_DEBUG}")
-    endif()
-
-    set_property(TARGET Ice::${name}_EXE PROPERTY
-      IMPORTED_CONFIGURATIONS "${imported_configurations}")
-
-    # A plain path, not a generator expression: IMPORTED_LOCATION is read as a literal, so a genex
-    # here ends up verbatim in the build system for any configuration the per-config properties do
-    # not cover. Debug and Release resolve through those; everything else falls back to this.
-    if(Ice_${name}_EXE_RELEASE)
-      set(location "${Ice_${name}_EXE_RELEASE}")
-    else()
-      set(location "${Ice_${name}_EXE_DEBUG}")
-    endif()
-
-    set_property(TARGET Ice::${name}_EXE PROPERTY IMPORTED_LOCATION "${location}")
+    # The base IMPORTED_LOCATION is a plain path, not a generator expression: the property is read
+    # as a literal, so a genex would end up verbatim in the build system for any configuration the
+    # per-config properties do not cover. Debug and Release resolve through those; everything else
+    # falls back to the release executable.
+    set_target_properties(Ice::${name}_EXE PROPERTIES
+      IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
+      IMPORTED_LOCATION_RELEASE "${Ice_${name}_EXE_RELEASE}"
+      IMPORTED_LOCATION_DEBUG "${Ice_${name}_EXE_DEBUG}"
+      IMPORTED_LOCATION "${Ice_${name}_EXE_RELEASE}"
+    )
   endfunction()
 
   add_ice_executable(icebox)
@@ -122,36 +101,19 @@ function(add_ice_target component)
   )
 
   if(WIN32)
-    set(imported_configurations "")
-
-    if(Ice_${component}_LIBRARY_RELEASE AND Ice_${component}_IMPLIB_RELEASE)
-      list(APPEND imported_configurations RELEASE)
-      set_target_properties(Ice::${component} PROPERTIES
-        IMPORTED_IMPLIB_RELEASE "${Ice_${component}_IMPLIB_RELEASE}"
-        IMPORTED_LOCATION_RELEASE "${Ice_${component}_LIBRARY_RELEASE}"
-      )
-    endif()
-
-    if(Ice_${component}_LIBRARY_DEBUG AND Ice_${component}_IMPLIB_DEBUG)
-      list(APPEND imported_configurations DEBUG)
-      set_target_properties(Ice::${component} PROPERTIES
-        IMPORTED_IMPLIB_DEBUG "${Ice_${component}_IMPLIB_DEBUG}"
-        IMPORTED_LOCATION_DEBUG "${Ice_${component}_LIBRARY_DEBUG}"
-      )
-    endif()
-
-    # One property, accumulated: setting IMPORTED_CONFIGURATIONS per configuration overwrites.
+    # A found component ships both configurations. Set IMPORTED_CONFIGURATIONS once - a per-config
+    # set() would overwrite, leaving DEBUG as the only entry - with RELEASE first, since CMake falls
+    # back to the first entry for an unmapped configuration. Map the release-like configurations
+    # explicitly too, so they cannot link the debug import library and mix CRTs.
     set_target_properties(Ice::${component} PROPERTIES
-      IMPORTED_CONFIGURATIONS "${imported_configurations}")
-
-    # CMake falls back to the first entry for an unmapped configuration, hence RELEASE first. Map the
-    # release-like ones explicitly too, so they cannot link the debug import library and mix CRTs.
-    if(RELEASE IN_LIST imported_configurations)
-      set_target_properties(Ice::${component} PROPERTIES
-        MAP_IMPORTED_CONFIG_RELWITHDEBINFO "Release"
-        MAP_IMPORTED_CONFIG_MINSIZEREL "Release"
-      )
-    endif()
+      IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
+      IMPORTED_IMPLIB_RELEASE "${Ice_${component}_IMPLIB_RELEASE}"
+      IMPORTED_LOCATION_RELEASE "${Ice_${component}_LIBRARY_RELEASE}"
+      IMPORTED_IMPLIB_DEBUG "${Ice_${component}_IMPLIB_DEBUG}"
+      IMPORTED_LOCATION_DEBUG "${Ice_${component}_LIBRARY_DEBUG}"
+      MAP_IMPORTED_CONFIG_RELWITHDEBINFO "Release"
+      MAP_IMPORTED_CONFIG_MINSIZEREL "Release"
+    )
   else()
     set_target_properties(Ice::${component} PROPERTIES
       IMPORTED_LOCATION "${Ice_${component}_LIBRARY_RELEASE}"
@@ -242,24 +204,10 @@ add_ice_library(Ice Threads::Threads)
 if(WIN32)
   # Bzip2 is included in the Ice NuGet package and is a runtime dependency of Ice.
   # This property can be used to copy the correct DLLs to the target directory at build time.
-  set(bzip2_debug "${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug/bzip2d.dll")
-  set(bzip2_release "${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Release/bzip2.dll")
-
-  # Only choose between the two when both exist, as for Ice::icebox_EXE above: the component check
-  # accepts a package carrying just one configuration, and naming the other one here would hand the
-  # consumer a path to copy that is not there. Everything other than Debug takes the release DLL,
-  # matching the configuration mapping above.
-  if(EXISTS "${bzip2_debug}" AND EXISTS "${bzip2_release}")
-    set_property(TARGET Ice::Ice PROPERTY ICE_RUNTIME_DLLS
-      "$<IF:$<CONFIG:Debug>,${bzip2_debug},${bzip2_release}>")
-  elseif(EXISTS "${bzip2_release}")
-    set_property(TARGET Ice::Ice PROPERTY ICE_RUNTIME_DLLS "${bzip2_release}")
-  elseif(EXISTS "${bzip2_debug}")
-    set_property(TARGET Ice::Ice PROPERTY ICE_RUNTIME_DLLS "${bzip2_debug}")
-  endif()
-
-  unset(bzip2_debug)
-  unset(bzip2_release)
+  # Everything other than Debug takes the release DLL, matching the configuration mapping above.
+  set_property(TARGET Ice::Ice PROPERTY ICE_RUNTIME_DLLS
+    "$<IF:$<CONFIG:Debug>,${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug/bzip2d.dll,${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Release/bzip2.dll>"
+  )
 endif()
 add_ice_library(DataStorm Ice::Ice)
 add_ice_library(Glacier2 Ice::Ice)

--- a/cpp/config/IceTargets.cmake
+++ b/cpp/config/IceTargets.cmake
@@ -67,21 +67,33 @@ if(WIN32)
 
     add_executable(Ice::${name}_EXE IMPORTED)
 
+    set(imported_configurations "")
+
     if(Ice_${name}_EXE_RELEASE)
+      list(APPEND imported_configurations RELEASE)
       set_property(TARGET Ice::${name}_EXE PROPERTY
         IMPORTED_LOCATION_RELEASE "${Ice_${name}_EXE_RELEASE}")
     endif()
 
     if(Ice_${name}_EXE_DEBUG)
+      list(APPEND imported_configurations DEBUG)
       set_property(TARGET Ice::${name}_EXE PROPERTY
         IMPORTED_LOCATION_DEBUG "${Ice_${name}_EXE_DEBUG}")
     endif()
 
-    # Set the appropriate location based on build type
-    if(Ice_${name}_EXE_RELEASE OR Ice_${name}_EXE_DEBUG)
-      set_property(TARGET Ice::${name}_EXE PROPERTY
-        IMPORTED_LOCATION "$<IF:$<CONFIG:Debug>,${Ice_${name}_EXE_DEBUG},${Ice_${name}_EXE_RELEASE}>")
+    set_property(TARGET Ice::${name}_EXE PROPERTY
+      IMPORTED_CONFIGURATIONS "${imported_configurations}")
+
+    # A plain path, not a generator expression: IMPORTED_LOCATION is read as a literal, so a genex
+    # here ends up verbatim in the build system for any configuration the per-config properties do
+    # not cover. Debug and Release resolve through those; everything else falls back to this.
+    if(Ice_${name}_EXE_RELEASE)
+      set(location "${Ice_${name}_EXE_RELEASE}")
+    else()
+      set(location "${Ice_${name}_EXE_DEBUG}")
     endif()
+
+    set_property(TARGET Ice::${name}_EXE PROPERTY IMPORTED_LOCATION "${location}")
   endfunction()
 
   add_ice_executable(icebox)
@@ -110,19 +122,34 @@ function(add_ice_target component)
   )
 
   if(WIN32)
-    if(Ice_${component}_LIBRARY_RELEASE)
+    set(imported_configurations "")
+
+    if(Ice_${component}_LIBRARY_RELEASE AND Ice_${component}_IMPLIB_RELEASE)
+      list(APPEND imported_configurations RELEASE)
       set_target_properties(Ice::${component} PROPERTIES
-        IMPORTED_CONFIGURATIONS RELEASE
         IMPORTED_IMPLIB_RELEASE "${Ice_${component}_IMPLIB_RELEASE}"
         IMPORTED_LOCATION_RELEASE "${Ice_${component}_LIBRARY_RELEASE}"
       )
     endif()
 
-    if(Ice_${component}_LIBRARY_DEBUG)
+    if(Ice_${component}_LIBRARY_DEBUG AND Ice_${component}_IMPLIB_DEBUG)
+      list(APPEND imported_configurations DEBUG)
       set_target_properties(Ice::${component} PROPERTIES
-        IMPORTED_CONFIGURATIONS DEBUG
         IMPORTED_IMPLIB_DEBUG "${Ice_${component}_IMPLIB_DEBUG}"
         IMPORTED_LOCATION_DEBUG "${Ice_${component}_LIBRARY_DEBUG}"
+      )
+    endif()
+
+    # One property, accumulated: setting IMPORTED_CONFIGURATIONS per configuration overwrites.
+    set_target_properties(Ice::${component} PROPERTIES
+      IMPORTED_CONFIGURATIONS "${imported_configurations}")
+
+    # CMake falls back to the first entry for an unmapped configuration, hence RELEASE first. Map the
+    # release-like ones explicitly too, so they cannot link the debug import library and mix CRTs.
+    if(RELEASE IN_LIST imported_configurations)
+      set_target_properties(Ice::${component} PROPERTIES
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO "Release"
+        MAP_IMPORTED_CONFIG_MINSIZEREL "Release"
       )
     endif()
   else()
@@ -215,10 +242,24 @@ add_ice_library(Ice Threads::Threads)
 if(WIN32)
   # Bzip2 is included in the Ice NuGet package and is a runtime dependency of Ice.
   # This property can be used to copy the correct DLLs to the target directory at build time.
-  set_property(TARGET Ice::Ice PROPERTY ICE_RUNTIME_DLLS
-    "$<$<CONFIG:Debug>:${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug/bzip2d.dll>"
-    "$<$<CONFIG:Release>:${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Release/bzip2.dll>"
-  )
+  set(bzip2_debug "${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug/bzip2d.dll")
+  set(bzip2_release "${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Release/bzip2.dll")
+
+  # Only choose between the two when both exist, as for Ice::icebox_EXE above: the component check
+  # accepts a package carrying just one configuration, and naming the other one here would hand the
+  # consumer a path to copy that is not there. Everything other than Debug takes the release DLL,
+  # matching the configuration mapping above.
+  if(EXISTS "${bzip2_debug}" AND EXISTS "${bzip2_release}")
+    set_property(TARGET Ice::Ice PROPERTY ICE_RUNTIME_DLLS
+      "$<IF:$<CONFIG:Debug>,${bzip2_debug},${bzip2_release}>")
+  elseif(EXISTS "${bzip2_release}")
+    set_property(TARGET Ice::Ice PROPERTY ICE_RUNTIME_DLLS "${bzip2_release}")
+  elseif(EXISTS "${bzip2_debug}")
+    set_property(TARGET Ice::Ice PROPERTY ICE_RUNTIME_DLLS "${bzip2_debug}")
+  endif()
+
+  unset(bzip2_debug)
+  unset(bzip2_release)
 endif()
 add_ice_library(DataStorm Ice::Ice)
 add_ice_library(Glacier2 Ice::Ice)


### PR DESCRIPTION
Stacked on #6353, which it targets; GitHub will retarget this to `main` as the stack merges.

- `RelWithDebInfo` and `MinSizeRel` link the release Ice on Windows. `IMPORTED_CONFIGURATIONS` was set once per configuration rather than accumulated, so it held only `DEBUG` and CMake fell back to it for every unmapped configuration, mixing `/MDd` with `/MD`. It is now set once with both configurations — the NuGet package always ships both — with `RELEASE` first and the release-like configurations mapped explicitly.
- `ICE_RUNTIME_DLLS` covers those configurations too. It named only Debug and Release, so a `RelWithDebInfo` build copied no bzip2 DLL and failed at runtime.
- `Ice::icebox_EXE` no longer corrupts the generated build system. `IMPORTED_LOCATION` is read literally rather than evaluated, so the generator expression it held reached the build files verbatim (`ninja: error: bad $-escape`) in any configuration other than Debug or Release, including a build with no configuration set. The base location is a plain path to the release executable, with Debug and Release resolved by the per-configuration properties, and the packaged executables are found `REQUIRED`.

Verified on `windows-2022` with MSVC against the `ZeroC.Ice.Cpp.3.8.2` NuGet package: all five configuration states resolve the right import library, DLL and bzip2 path, `build.ninja` carries no unevaluated generator expression, and all 29 C++ demos build under no configuration, Release and RelWithDebInfo.

Closes #6349

🤖 Generated with [Claude Code](https://claude.com/claude-code)