### PR TITLE
Log and swallow exceptions thrown by an ice_invokeAsync response callback

### DIFF
--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -190,13 +190,14 @@ namespace IceInternal
             {
                 _response = [this, response = std::move(response)](bool ok)
                 {
-                    if (this->_is.b.empty())
+                    R v = this->_is.b.empty() ? R{ok, {}} : this->_read(ok, &this->_is);
+                    try
                     {
-                        response(R{ok, {}});
+                        response(std::move(v));
                     }
-                    else
+                    catch (...)
                     {
-                        response(this->_read(ok, &this->_is));
+                        this->warning("response", std::current_exception());
                     }
                 };
             }

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -806,6 +806,31 @@ allTests(TestHelper* helper, bool collocated)
                     test(false);
                 }
             }
+
+            {
+                promise<void> promise;
+                p->ice_invokeAsync(
+                    "op",
+                    OperationMode::Normal,
+                    vector<byte>{},
+                    [&, i](bool, vector<byte>)
+                    {
+                        promise.set_value();
+                        thrower(throwEx[i]);
+                    },
+                    [&](exception_ptr) { test(false); });
+
+                try
+                {
+                    promise.get_future().get();
+                }
+                catch (const exception& ex)
+                {
+                    cerr << ex.what() << endl;
+                    test(false);
+                }
+            }
+
         }
     }
     cout << "ok" << endl;

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -813,7 +813,7 @@ allTests(TestHelper* helper, bool collocated)
                     "op",
                     OperationMode::Normal,
                     vector<byte>{},
-                    [&, i](bool, vector<byte>)
+                    [&, i](bool, const vector<byte>&)
                     {
                         promise.set_value();
                         thrower(throwEx[i]);
@@ -830,7 +830,6 @@ allTests(TestHelper* helper, bool collocated)
                     test(false);
                 }
             }
-
         }
     }
     cout << "ok" << endl;


### PR DESCRIPTION
For generated operations, an exception thrown by the response callback of a lambda invocation is logged as an `Ice.Warn.AMICallback` warning and swallowed — the exception callback only ever reports invocation failures. The callback-taking `ice_invokeAsync` overloads did not follow this contract: `InvokeLambdaOutgoing::_response` called the response callback with no guard, so the exception escaped into `OutgoingAsyncBase::invokeResponse` and was routed to the exception callback, as if the invocation had failed.

This PR wraps the response callback call in `InvokeLambdaOutgoing` the same way `LambdaOutgoing` and `ProxyGetConnectionLambda` do. The result is read before entering the guard, so unmarshaling failures keep reaching the exception callback. Since the guard is in the shared `InvokeLambdaOutgoing<R>` template, both callback-taking overloads (`std::vector<std::byte>` and zero-copy `std::pair<const std::byte*, const std::byte*>`) are fixed.

The AMI test's "unexpected exceptions from callback" section gains an `ice_invokeAsync` case mirroring the `ice_getConnectionAsync` one: the response callback throws each of the four exception kinds and the exception callback asserts it is never called. It runs in both the client/server and collocated configurations. Only the `vector` overload is exercised, as both overloads share the same code.

The promise-based overloads are unaffected, and the other language mappings have no callback-taking dynamic invocation API.

No changelog entry: only applications whose response callback itself throws can observe the change.

Fixes #6355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
