### PR TITLE
Fix GC root leak when unmarshaling user exceptions in Ruby

### DIFF
--- a/changelog.d/ruby/exception-reader-gc-root.md
+++ b/changelog.d/ruby/exception-reader-gc-root.md
@@ -1,0 +1,2 @@
+- Fixed a bug where receiving a Slice user exception leaked memory. A program that received many user exceptions
+  became progressively slower and could eventually crash.

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -2748,7 +2748,10 @@ IceRuby::ExceptionInfo::printMembers(VALUE value, IceInternal::Output& out, Prin
 //
 // ExceptionReader implementation.
 //
-IceRuby::ExceptionReader::ExceptionReader(const ExceptionInfoPtr& info) : _info(info) {}
+IceRuby::ExceptionReader::ExceptionReader(const ExceptionInfoPtr& info) : _info(info), _ex(Qnil)
+{
+    rb_gc_register_address(&_ex);
+}
 
 IceRuby::ExceptionReader::ExceptionReader(const ExceptionReader& reader) : _info(reader._info), _ex(reader._ex)
 {
@@ -2779,9 +2782,7 @@ void
 IceRuby::ExceptionReader::_read(Ice::InputStream* is)
 {
     is->startException();
-
-    const_cast<VALUE&>(_ex) = _info->unmarshal(is);
-    rb_gc_register_address(&_ex);
+    _ex = _info->unmarshal(is);
 }
 
 bool

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -507,9 +507,14 @@ namespace IceRuby
     class ExceptionReader final : public Ice::UserException
     {
     public:
+        // Each constructor registers a GC root tied to the address of the new instance's _ex member, and the
+        // destructor unregisters it. The copy constructor must remain available: the exception machinery copies the
+        // reader into the exception storage.
         ExceptionReader(const ExceptionInfoPtr&);
         ExceptionReader(const ExceptionReader&);
         ~ExceptionReader();
+
+        ExceptionReader& operator=(const ExceptionReader&) = delete;
 
         const char* ice_id() const noexcept final;
         void ice_throw() const final;

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -509,12 +509,15 @@ namespace IceRuby
     public:
         // Each constructor registers a GC root tied to the address of the new instance's _ex member, and the
         // destructor unregisters it. The copy constructor must remain available: the exception machinery copies the
-        // reader into the exception storage.
+        // reader into the exception storage. The other special members are deleted so that none can transfer or
+        // assign _ex without the matching registration.
         ExceptionReader(const ExceptionInfoPtr&);
         ExceptionReader(const ExceptionReader&);
         ~ExceptionReader();
 
+        ExceptionReader(ExceptionReader&&) = delete;
         ExceptionReader& operator=(const ExceptionReader&) = delete;
+        ExceptionReader& operator=(ExceptionReader&&) = delete;
 
         const char* ice_id() const noexcept final;
         void ice_throw() const final;


### PR DESCRIPTION
`ExceptionReader` holds the unmarshaled Ruby exception in a `VALUE _ex` member and protects it from the GC with `rb_gc_register_address(&_ex)`. The registration was in the wrong place: `_read` runs *after* `DefaultSliceLoader::newExceptionInstance` has copied the reader into the C++ exception storage via `make_exception_ptr`. As a result:

- The primary constructor left `_ex` uninitialized and unregistered.
- The copy constructor registered the copy's `_ex` while it still held a garbage value.
- `_read` then registered the same address a second time.
- The destructor unregistered only once.

Net effect: every Slice user exception a Ruby client unmarshaled permanently leaked one registered address pointing into freed C++ exception storage. The GC then read that freed memory on every collection, and because `rb_gc_unregister_address` searches the global registration list linearly, each received exception made every subsequent exception and GC slower.

The fix makes the invariant per-instance: every constructor registers the new instance's `_ex` address exactly once (initialized to `Qnil` in the primary constructor), the destructor unregisters it, and `_read` just assigns. The copy constructor must remain available — the C++ exception machinery copies the reader into the exception storage and requires the type to be copy-constructible — so the assignment operator is deleted instead. This differs from the sibling `ValueReader`/`ValueWriter`, which the runtime only handles through `shared_ptr` and which therefore delete copy and move outright.

Measured with a loopback client/server unmarshaling 200,000 user exceptions (after a 100,000-exception warmup, Ruby 4.0.5, arm64-darwin):

| | RSS growth | wall time |
|---|---|---|
| before | 34.7 MB | 64.3 s |
| after | 31.5 MB | 15.6 s |

The remaining RSS growth is ordinary Ruby heap expansion from the allocation churn; the eliminated ~3 MB is the leaked registration nodes, and the 4x wall-time difference is the linear search over the ever-growing registration list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
