### PR TITLE
Simplify the executor termination waits in the Java mapping

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
@@ -120,11 +120,7 @@ class EndpointHostResolver {
     void joinWithThread() throws InterruptedException {
         // Wait for the executor to terminate.
         try {
-            while (!_executor.isTerminated()) {
-                // A very long time.
-                _executor.awaitTermination(100000, TimeUnit.SECONDS);
-            }
-
+            _executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
         } finally {
             if (_observer != null) {
                 _observer.detach();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -981,10 +981,7 @@ public final class Instance {
                     _endpointHostResolver.joinWithThread();
                 }
                 if (_timer != null) {
-                    while (!_timer.isTerminated()) {
-                        // A very long time.
-                        _timer.awaitTermination(100000, TimeUnit.SECONDS);
-                    }
+                    _timer.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
                 }
             } catch (InterruptedException ex) {
                 if (interruptible) {

--- a/java/test/src/main/java/test/Ice/interrupt/AllTests.java
+++ b/java/test/src/main/java/test/Ice/interrupt/AllTests.java
@@ -198,9 +198,7 @@ public class AllTests {
             // The executor is all done.
             //
             executor.shutdown();
-            while (!executor.isTerminated()) {
-                executor.awaitTermination(1000, TimeUnit.SECONDS);
-            }
+            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
         }
         out.println("ok");
 
@@ -456,9 +454,7 @@ public class AllTests {
             cb.check();
 
             executor.shutdown();
-            while (!executor.isTerminated()) {
-                executor.awaitTermination(1000, TimeUnit.SECONDS);
-            }
+            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
         }
         out.println("ok");
 
@@ -593,9 +589,7 @@ public class AllTests {
             ic.destroy();
 
             executor.shutdown();
-            while (!executor.isTerminated()) {
-                executor.awaitTermination(1000, TimeUnit.SECONDS);
-            }
+            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
         }
         out.println("ok");
 


### PR DESCRIPTION
Fixes #6358.

Replaces the redundant two-call executor-termination waits — a `while (!executor.isTerminated()) { executor.awaitTermination(<arbitrary timeout>); }` loop — with the standard single "wait forever" call:

```java
executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
```

`awaitTermination` returns immediately when the executor has already terminated, blocks until it does otherwise, and propagates `InterruptedException` — so the behavior is identical, without the redundant `isTerminated()` check or the arbitrary 100000-second (27-hour) timeout the loop used to re-arm. `ExecutorService.close()` is not a substitute: on interrupt it calls `shutdownNow()` and swallows the `InterruptedException`, which would break the interrupt contract of communicator destruction.

This actually restores the original single-call form written in the 2014 interrupt-handling code (`b36ae21c88`); the loop was introduced later, by hand, during the Ice 3.7 "Java 8 mapping" rewrite (`e6cbf802f2`), and every commit since only reformatted it.

Occurrences updated: `EndpointHostResolver.joinWithThread`, `Instance.destroy` (the `_timer` wait), and three in `test/Ice/interrupt/AllTests.java`.

Internal cleanup only, so no changelog entry.
