### PR TITLE
Cancel the reap task when unregistering a communicator's last ID

### DIFF
--- a/changelog.d/php/6366.md
+++ b/changelog.d/php/6366.md
@@ -1,0 +1,2 @@
+- Fixed a leak: unregistering a communicator that was registered with an expiration time left this communicator
+  alive until the process exited, along with its connections and other resources.

--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -1062,6 +1062,10 @@ ZEND_FUNCTION(Ice_unregister)
 
     string id(s, sLen);
 
+    // Declared before the lock: releasing the last reference destroys the communicator, which we must not do
+    // while holding _registeredCommunicatorsMutex.
+    ActiveCommunicatorPtr ac;
+
     lock_guard lock(_registeredCommunicatorsMutex);
 
     RegisteredCommunicatorMap::iterator p = _registeredCommunicators.find(id);
@@ -1076,7 +1080,7 @@ ZEND_FUNCTION(Ice_unregister)
     //
     // Remove the ID from the ActiveCommunicator's list of registered IDs.
     //
-    ActiveCommunicatorPtr ac = p->second;
+    ac = p->second;
     vector<string>::iterator q = find(ac->ids.begin(), ac->ids.end(), id);
     assert(q != ac->ids.end());
     ac->ids.erase(q);

--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -1083,6 +1083,15 @@ ZEND_FUNCTION(Ice_unregister)
 
     _registeredCommunicators.erase(p);
 
+    if (ac->ids.empty() && ac->reapTask)
+    {
+        // This was the communicator's last registration: cancel the reap task to break the
+        // ActiveCommunicator <-> ReapCommunicatorTimerTask ownership cycle, which would otherwise keep the
+        // communicator alive until the task fires.
+        _timer->cancel(ac->reapTask);
+        ac->reapTask = nullptr;
+    }
+
     RETURN_TRUE;
 }
 


### PR DESCRIPTION
Fixes #6366.

Registering a communicator with an expiration time creates a deliberate ownership cycle: `ActiveCommunicator` → `reapTask` → `ReapCommunicatorTimerTask` → `ActiveCommunicator`. Every path that stops reaping breaks this cycle (the reap task itself on expiration, `Communicator::destroy`, and `Ice\register` before scheduling a replacement task) — except `Ice\unregister`, which removed the registration but left the cycle intact, keeping the communicator alive until process exit.

`Ice\unregister` now cancels the reap task and clears `reapTask`, under the `_registeredCommunicatorsMutex` it already holds — but only when it removes the communicator's **last** registered ID. This differs from the sketch in #6366, which suggested cancelling unconditionally: a communicator registered under several IDs shares one reap task, so an unconditional cancel would silently disable expiration for the remaining registrations. The leak can only occur once no registration holds the communicator in the map, so the `ids.empty()` guard covers it fully.

### Test

The existing `php/test/Ice/registeredCommunicator` test already exercises this exact sequence (`register("Hello7", 40000)` followed by `unregister`), and printed `!! error: communicator not destroyed during global destruction.` on every run. With this fix the warning is gone. The full PHP test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)