### PR TITLE
Fix crash when the exception class lookup fails in PHP

### DIFF
--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -367,27 +367,24 @@ namespace
     zend_class_entry* createPHPException(zval* ex, const char* typeId, bool fallbackToLocalException = false)
     {
         // Convert the exception's typeId to its mapped PHP type by replacing "::Ice::" with "\Ice\".
-        // This function should only ever be called on Ice local exceptions which don't use 'php:identifier'.
         string result = typeId;
         assert(result.find("::Ice::") == 0);
         result.replace(0, 7, "\\Ice\\");
         assert(result.find(':') == string::npos); // Assert that there weren't any intermediate scopes.
 
         zend_class_entry* cls = nameToClass(result);
+        if (!cls && fallbackToLocalException)
+        {
+            cls = nameToClass("\\Ice\\LocalException");
+        }
         if (!cls)
         {
-            if (fallbackToLocalException)
-            {
-                cls = nameToClass("\\Ice\\LocalException");
-                assert(cls);
-            }
-            else
-            {
-                ostringstream os;
-                os << "unable to create PHP exception class for type ID " << typeId;
-                runtimeError(os.str());
-                return nullptr;
-            }
+            // The classes are defined in PHP code: they don't resolve when the application didn't load the Ice
+            // library files.
+            ostringstream os;
+            os << "unable to create PHP exception class for type ID " << typeId;
+            runtimeError(os.str());
+            return nullptr;
         }
 
         if (object_init_ex(ex, cls) != SUCCESS)
@@ -518,6 +515,7 @@ void
 IcePHP::throwException(std::exception_ptr ex)
 {
     zval zex;
+    ZVAL_UNDEF(&zex);
     convertException(&zex, ex);
     if (!Z_ISUNDEF(zex))
     {

--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -454,6 +454,7 @@ IcePHP::convertException(zval* zex, std::exception_ptr ex)
         setLongMember(zex, "replyStatus", static_cast<zend_long>(e.replyStatus()));
 
         zval id;
+        ZVAL_UNDEF(&id);
         if (!createIdentity(&id, e.id()))
         {
             zval_ptr_dtor(&id);

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -550,30 +550,27 @@ namespace
     createPythonException(const char* typeId, std::array<PyObject*, N> args, bool fallbackToLocalException = false)
     {
         // Convert the exception's typeId to its mapped Python type by replacing "::Ice::" with "Ice.".
-        // This function should only ever be called on Ice local exceptions which don't use 'python:identifier'.
         string result = typeId;
         assert(result.find("::Ice::") == 0);
         result.replace(0, 7, "Ice.");
         assert(result.find(':') == string::npos); // Assert that there weren't any intermediate scopes.
 
         PyObject* type{IcePy::lookupType(result)};
+        if (!type && fallbackToLocalException)
+        {
+            type = IcePy::lookupType("Ice.LocalException");
+        }
         if (!type)
         {
-            if (fallbackToLocalException)
+            // The classes are defined in Python code: they don't resolve when the Ice module is not importable.
+            for (PyObject* pArg : args)
             {
-                type = IcePy::lookupType("Ice.LocalException");
+                Py_DECREF(pArg);
             }
-            else
-            {
-                for (PyObject* pArg : args)
-                {
-                    Py_DECREF(pArg);
-                }
 
-                ostringstream os;
-                os << "unable to create Python exception class for type ID " << typeId;
-                return PyObject_CallFunction(PyExc_Exception, "s", os.str().c_str());
-            }
+            ostringstream os;
+            os << "unable to create Python exception class for type ID " << typeId;
+            return PyObject_CallFunction(PyExc_Exception, "s", os.str().c_str());
         }
         IcePy::PyObjectHandle pArgs{PyTuple_New(N)};
         for (size_t i = 0; i < N; ++i)

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -556,21 +556,23 @@ namespace
         assert(result.find(':') == string::npos); // Assert that there weren't any intermediate scopes.
 
         PyObject* type{IcePy::lookupType(result)};
-        if (!type && fallbackToLocalException)
-        {
-            type = IcePy::lookupType("Ice.LocalException");
-        }
         if (!type)
         {
-            // The classes are defined in Python code: they don't resolve when the Ice module is not importable.
-            for (PyObject* pArg : args)
+            if (fallbackToLocalException)
             {
-                Py_DECREF(pArg);
+                type = IcePy::lookupType("Ice.LocalException");
             }
+            else
+            {
+                for (PyObject* pArg : args)
+                {
+                    Py_DECREF(pArg);
+                }
 
-            ostringstream os;
-            os << "unable to create Python exception class for type ID " << typeId;
-            return PyObject_CallFunction(PyExc_Exception, "s", os.str().c_str());
+                ostringstream os;
+                os << "unable to create Python exception class for type ID " << typeId;
+                return PyObject_CallFunction(PyExc_Exception, "s", os.str().c_str());
+            }
         }
         IcePy::PyObjectHandle pArgs{PyTuple_New(N)};
         for (size_t i = 0; i < N; ++i)

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -426,7 +426,6 @@ namespace
     VALUE createRubyException(const char* typeId, std::array<VALUE, N> args, bool fallbackToLocalException = false)
     {
         // Convert the exception's typeId to its mapped Ruby type by removing the leading "::".
-        // This function should only ever be called on Ice local exceptions which don't use 'ruby:identifier'.
         string className = string{typeId}.substr(2);
         assert(className.starts_with("Ice::"));
 


### PR DESCRIPTION
Fixes #6371.

The Ice exception classes of the PHP mapping are defined in PHP code, so they don't resolve when the extension is loaded without the Ice language library (a misconfiguration, but one that should produce a language-level error rather than a segfault).

### PHP

`createPHPException` guarded its `\Ice\LocalException` fallback lookup with nothing but an `assert`, so a release build passed a null class entry to `object_init_ex`. The fallback branch now takes the same error path as the non-fallback branch: `runtimeError` (which throws PHP's built-in `RuntimeException`) and a null return that callers already handle.

Fixing that exposed two latent bugs on the same conversion path, both zvals declared as uninitialized stack memory and destroyed on failure: `throwException`'s `zex` (while `convertException` leaves the zval untouched on failure, so the `Z_ISUNDEF` guard read an uninitialized type byte and threw garbage — "Need to supply an object when throwing an exception") and the `id` zval in `convertException`'s `RequestFailedException` branch (`zval_ptr_dtor` on uninitialized memory when `createIdentity` fails). Both are now initialized with `ZVAL_UNDEF`, matching the existing caller in Operation.cpp.

With these fixes, the repro from #6371 goes from SIGSEGV to an uncaught `RuntimeException: unable to create PHP exception class for type ID ::Ice::CommunicatorDestroyedException`.

This PR fixes the exception conversion path only — the path #6371 reported, and the one every failure funnels through. The mapping's other class lookups (`ice_getIdentity`, `ice_getEncodingVersion`, ...) are still guarded by asserts alone and can segfault the same way; they are tracked by #6394.

### Python

`createPythonException` has the same shape of defect: its `Ice.LocalException` fallback lookup has no null guard, and the failure path leaks the `args` references. However, the path is not reachable in practice: IcePy assumes the `Ice` package is importable throughout (roughly forty unguarded `lookupType` calls), so with the package missing, the first proxy operation crashes long before any exception conversion runs. Guarding two sites would not make the mapping fail gracefully, so the Python side is left unchanged here and the whole family is tracked by #6395. This PR only removes an inaccurate comment (see below).

### Ruby and MATLAB

Audited for the same defect: Ruby's `createRubyException` is safe — `callRuby(rb_path2class, ...)` throws a `RubyException` on lookup failure instead of returning a sentinel. MATLAB's `createMatlabException` fails through `mexCallMATLAB`, which raises a MATLAB-level error. No code change in either; this PR only removes a nonsensical comment that had been copied into the PHP, Python, and Ruby versions of this function ("should only ever be called on Ice local exceptions which don't use 'xxx:identifier'" — local exceptions are not defined in Slice in 3.8, so identifier metadata cannot apply to them).

### No changelog entry

The crash requires running the extension without its language library — a broken configuration in which nothing works; the fix only improves the failure mode. The full PHP, Python, and Ruby test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
