### PR TITLE
Removed Dead Import-Related Fields from 'slice2py' `CodeVisitor`

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2843,10 +2843,7 @@ Slice::Python::compile(
 
                 if (compilationKind == CompilationKind::All || compilationKind == CompilationKind::Module)
                 {
-                    CodeVisitor codeVisitor{
-                        importVisitor.getRuntimeImports(),
-                        importVisitor.getTypingImports(),
-                        importVisitor.getAllImportNames()};
+                    CodeVisitor codeVisitor{importVisitor.getAllImportNames()};
                     unit->visit(&codeVisitor);
 
                     const vector<CodeFragment>& newFragments = codeVisitor.codeFragments();

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -364,13 +364,8 @@ namespace Slice::Python
     class CodeVisitor final : public ParserVisitor
     {
     public:
-        CodeVisitor(
-            ImportsMap runtimeImports,
-            ImportsMap typingImports,
-            std::map<std::string, std::map<std::string, std::string>> allImports)
-            : _runtimeImports(std::move(runtimeImports)),
-              _typingImports(std::move(typingImports)),
-              _allImports(std::move(allImports))
+        CodeVisitor(std::map<std::string, std::map<std::string, std::string>> allImports)
+            : _allImports(std::move(allImports))
         {
         }
 
@@ -459,9 +454,6 @@ namespace Slice::Python
         // The list of generated Python code fragments in the current translation unit.
         // Each fragment corresponds to a Python module generated from a Slice definition with the same name.
         std::vector<CodeFragment> _codeFragments;
-
-        ImportsMap _runtimeImports;
-        ImportsMap _typingImports;
 
         /// A map of all import names for each source module.
         /// - Key: the Python generated module name.


### PR DESCRIPTION
These fields are truly dead, the only reason I'm opening a PR is to make sure that this is a case of "these are leftover and correctly dead" and not a case of "oh these shouldn't be dead and we forgot to hook these up properly".