### PR TITLE
Make class stringification safe under GC heap compaction in Ruby

### DIFF
--- a/changelog.d/ruby/6372.md
+++ b/changelog.d/ruby/6372.md
@@ -1,2 +1,2 @@
-- Fixed the stringification of class instances (`inspect`, `to_s`): when GC compaction ran during the
-  stringification, a shared instance could be printed in full a second time instead of as a back reference.
+- Fixed the stringification of class instances (`inspect`): when GC compaction ran during the stringification, a
+  shared instance could be printed in full a second time instead of as a back reference.

--- a/changelog.d/ruby/6372.md
+++ b/changelog.d/ruby/6372.md
@@ -1,0 +1,2 @@
+- Fixed the stringification of class instances (`inspect`, `to_s`): when GC compaction ran during the
+  stringification, a shared instance could be printed in full a second time instead of as a back reference.

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -157,6 +157,14 @@ addExceptionInfo(const string& id, const ExceptionInfoPtr& info)
 }
 
 //
+// PrintObjectHistory implementation
+//
+IceRuby::PrintObjectHistory::PrintObjectHistory() : objects(callRuby(rb_hash_new))
+{
+    callRuby(rb_funcall, objects, rb_intern("compare_by_identity"), 0);
+}
+
+//
 // StreamUtil implementation
 //
 VALUE IceRuby::StreamUtil::_slicedDataType = Qnil;
@@ -2134,10 +2142,10 @@ IceRuby::ClassInfo::print(VALUE value, IceInternal::Output& out, PrintObjectHist
     }
     else
     {
-        map<VALUE, int>::iterator q = history->objects.find(value);
-        if (q != history->objects.end())
+        volatile VALUE printedIndex = callRuby(rb_hash_lookup2, history->objects, value, Qnil);
+        if (!NIL_P(printedIndex))
         {
-            out << "<object #" << q->second << ">";
+            out << "<object #" << FIX2INT(printedIndex) << ">";
         }
         else
         {
@@ -2148,7 +2156,7 @@ IceRuby::ClassInfo::print(VALUE value, IceInternal::Output& out, PrintObjectHist
             info = dynamic_pointer_cast<ClassInfo>(getType(type));
             assert(info);
             out << "object #" << history->index << " (" << info->id << ')';
-            history->objects.insert(map<VALUE, int>::value_type(value, history->index));
+            callRuby(rb_hash_aset, history->objects, value, INT2FIX(history->index));
             ++history->index;
             out.sb();
             info->printMembers(value, out, history);
@@ -2764,7 +2772,6 @@ IceRuby::ExceptionInfo::print(VALUE value, IceInternal::Output& out)
     }
 
     PrintObjectHistory history;
-    history.index = 0;
 
     out << "exception " << id;
     out.sb();
@@ -3045,7 +3052,6 @@ IceRuby_stringify(VALUE /*self*/, VALUE obj, VALUE type)
         ostringstream ostr;
         IceInternal::Output out(ostr);
         PrintObjectHistory history;
-        history.index = 0;
         info->print(obj, out, &history);
 
         string str = ostr.str();

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -2142,7 +2142,7 @@ IceRuby::ClassInfo::print(VALUE value, IceInternal::Output& out, PrintObjectHist
     }
     else
     {
-        volatile VALUE printedIndex = callRuby(rb_hash_lookup2, history->objects, value, Qnil);
+        volatile VALUE printedIndex = callRuby(rb_hash_lookup, history->objects, value);
         if (!NIL_P(printedIndex))
         {
             out << "<object #" << FIX2INT(printedIndex) << ">";

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -37,10 +37,15 @@ namespace IceRuby
     class ValueReader;
     class StreamUtil;
 
+    // Tracks the class instances already printed during a stringification, to detect shared instances and cycles.
+    // The instances are keyed in a Ruby identity hash (instance => index): the GC updates this hash when compaction
+    // moves an instance.
     struct PrintObjectHistory
     {
-        int index;
-        std::map<VALUE, int> objects;
+        PrintObjectHistory();
+
+        int index{0};  // the index to assign to the next class instance printed for the first time
+        VALUE objects; // Ruby identity hash
     };
 
     //

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -38,8 +38,8 @@ namespace IceRuby
     class StreamUtil;
 
     // Tracks the class instances already printed during a stringification, to detect shared instances and cycles.
-    // The instances are keyed in a Ruby identity hash (instance => index): the GC updates this hash when compaction
-    // moves an instance.
+    // The instances are keyed in a Ruby identity hash (instance => index), whose keys remain valid when GC
+    // compaction runs during the stringification.
     struct PrintObjectHistory
     {
         PrintObjectHistory();

--- a/ruby/test/Ice/objects/AllTests.rb
+++ b/ruby/test/Ice/objects/AllTests.rb
@@ -335,16 +335,16 @@ def allTests(helper, communicator)
     STDOUT.flush
     if compactionSupported
         # A shared instance must be printed as a back reference on its second occurrence, even when GC compaction
-        # moves it in the middle of the stringification. The mover's to_str compacts the heap while a2 is printed:
+        # runs in the middle of the stringification. The compactor's to_str compacts the heap while a2 is printed:
         # after the shared instance was printed as a1, and before it is looked up again as a3.
-        mover = Object.new
-        def mover.to_str
+        compactor = Object.new
+        def compactor.to_str
             GC.verify_compaction_references(expand_heap: true, toward: :empty)
-            "moved"
+            "compacted"
         end
         # The shared instance is referenced only from holder's members: a reference from a local variable would pin
         # it through conservative stack marking, and it could then never move.
-        holder = Test::D1.new(Test::A1.new("shared"), Test::A1.new(mover))
+        holder = Test::D1.new(Test::A1.new("shared"), Test::A1.new(compactor))
         holder.a3 = holder.a1
         # holder is object #0 and the shared instance is object #1; a3 must print as a back reference to object #1.
         test(holder.inspect.include?("a3 = <object #1>"))

--- a/ruby/test/Ice/objects/AllTests.rb
+++ b/ruby/test/Ice/objects/AllTests.rb
@@ -331,5 +331,25 @@ def allTests(helper, communicator)
     end
     puts "ok"
 
+    print "testing GC compaction during stringification... "
+    STDOUT.flush
+    if compactionSupported
+        # A shared instance must be printed as a back reference on its second occurrence, even when GC compaction
+        # moves it in the middle of the stringification. The mover's to_str compacts the heap while a2 is printed:
+        # after the shared instance was printed as a1, and before it is looked up again as a3.
+        mover = Object.new
+        def mover.to_str
+            GC.verify_compaction_references(expand_heap: true, toward: :empty)
+            "moved"
+        end
+        # The shared instance is referenced only from holder's members: a reference from a local variable would pin
+        # it through conservative stack marking, and it could then never move.
+        holder = Test::D1.new(Test::A1.new("shared"), Test::A1.new(mover))
+        holder.a3 = holder.a1
+        # holder is object #0 and the shared instance is object #1; a3 must print as a back reference to object #1.
+        test(holder.inspect.include?("a3 = <object #1>"))
+    end
+    puts "ok"
+
     return initial
 end

--- a/ruby/test/Ice/objects/AllTests.rb
+++ b/ruby/test/Ice/objects/AllTests.rb
@@ -347,7 +347,10 @@ def allTests(helper, communicator)
         holder = Test::D1.new(Test::A1.new("shared"), Test::A1.new(compactor))
         holder.a3 = holder.a1
         # holder is object #0 and the shared instance is object #1; a3 must print as a back reference to object #1.
-        test(holder.inspect.include?("a3 = <object #1>"))
+        # The first assertion checks that the compactor's to_str ran, i.e. that the compaction actually happened.
+        s = holder.inspect
+        test(s.include?("'compacted'"))
+        test(s.include?("a3 = <object #1>"))
     end
     puts "ok"
 


### PR DESCRIPTION
Fixes #6372.

`PrintObjectHistory` now tracks the already-printed class instances in a Ruby identity hash instead of a `std::map<VALUE, int>`: the GC updates and rehashes an identity hash when compaction moves an instance, so a shared instance is still found on its second occurrence and prints as an `<object #n>` back reference. The hash is created by a new `PrintObjectHistory` constructor and is kept alive (and pinned) by the conservative scan of the stringification's own stack frames, while its entries stay movable — no GC registration needed on any path.

One deviation from the issue's suggestion: `rb_ident_hash_new` is exported from libruby but not declared in any public header, so the hash is created with `rb_hash_new` + `Hash#compare_by_identity`, the fully public equivalent.

### Test

The Ice/objects test gains a "GC compaction during stringification" case: a `D1` shares an `A1` instance between `a1` and `a3`, and `a2`'s string member holds an object whose `to_str` runs `GC.verify_compaction_references(expand_heap: true, toward: :empty)` — Ruby code running in the middle of the stringification, after the shared instance was recorded and before it is revisited. The shared instance is deliberately reachable only through the holder's members: a reference from a Ruby local would pin it through conservative stack marking and the compaction could never move it.

The test fails on the base revision (the second occurrence prints in full) and passes with the fix; the full Ruby test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)