### PR TITLE
Ignore a Bluetooth connection failure delivered after close

### DIFF
--- a/changelog.d/cpp/6377.md
+++ b/changelog.d/cpp/6377.md
@@ -1,0 +1,2 @@
+- Fixed a crash in the IceBT transport: a Bluetooth connection attempt that failed after the connection was
+  closed - for example following a connect timeout - could crash the program.

--- a/changelog.d/cpp/6377.md
+++ b/changelog.d/cpp/6377.md
@@ -1,2 +1,2 @@
-- Fixed a crash in the IceBT transport: a Bluetooth connection attempt that failed after the connection was
-  closed - for example following a connect timeout - could crash the program.
+- Fixed a crash in the IceBT transport. A Bluetooth connection attempt that failed after its connection was
+  closed — for example after a connect timeout — crashed the program.

--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -226,12 +226,18 @@ void
 IceBT::TransceiverI::connectFailed(std::exception_ptr ex)
 {
     lock_guard lock(_mutex);
-    //
-    // Save the exception - it will be rethrown in initialize().
-    //
-    _exception = ex;
-    //
-    // Wake up the thread pool, which resumes the connection establishment by calling initialize().
-    //
-    _stream->ready(IceInternal::SocketOperationConnect, true);
+
+    // Ignore a failure delivered after the transceiver was closed: there is no connection establishment left to
+    // resume.
+    if (!_closed)
+    {
+        //
+        // Save the exception - it will be rethrown in initialize().
+        //
+        _exception = ex;
+        //
+        // Wake up the thread pool, which resumes the connection establishment by calling initialize().
+        //
+        _stream->ready(IceInternal::SocketOperationConnect, true);
+    }
 }


### PR DESCRIPTION
Fixes #6377.

`TransceiverI::connectFailed` now checks `_closed` under `_mutex`, mirroring `connectCompleted`: a failure delivered after the transceiver was closed is ignored.

Without the guard, the sequence is a crash in release builds:

1. A connect timeout (default 10 seconds) closes the connection: `ConnectionI::setState(StateClosed)` closes the transceiver — setting `_closed` — and the thread pool then clears the stream's ready callback (without a custom `Ice.Executor`, `ThreadPool::finish` runs `finished()` before `setReadyCallback(nullptr)`, so `_closed` is always set first; with an executor that queues the `finish(true)` call there is a pre-existing residual window where the callback is cleared before `_closed` is set — the same window that already defeats the `connectCompleted` guard, see the review discussion).
2. Nothing cancels the in-flight BlueZ `ConnectProfile` call — for a never-completed connect there is no `Connection` to close — so its result is always delivered eventually.
3. BlueZ routinely takes longer than the connect timeout to give up on an out-of-range or unresponsive device. The late failure reaches `connectFailed`, which called `_stream->ready(...)` on a stream whose ready callback was already cleared: `assert(_readyCallback)` in debug builds, a call through a null `shared_ptr` in release builds.

So "connect timeout against a dead peer, then crash" is the expected sequence, not a narrow race.

This is not a regression: the same unguarded `connectFailed` exists in 3.7 (with the same callback-clearing mechanism and the same `assert` in `NativeInfo::ready`), and in 3.8.0 `connectCompleted` was unguarded as well — #5701 introduced `_closed` and guarded the completed path only. A 3.7 backport is worth considering; it won't cherry-pick cleanly since 3.7's `connectFailed` has a different signature and locking, but the guard is equally simple there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
