### PR TITLE
Fix stale fd handling in the C++ transports

### DIFF
--- a/cpp/src/Ice/Network.h
+++ b/cpp/src/Ice/Network.h
@@ -145,6 +145,10 @@ namespace IceInternal
 
         [[nodiscard]] SOCKET fd() const { return _fd; }
 
+        // Forgets the fd. Called when a failed socket operation has already closed the fd, so that close() does not
+        // close an unrelated descriptor later assigned the same number.
+        void clearFd() noexcept { _fd = INVALID_SOCKET; }
+
         void setReadyCallback(const ReadyCallbackPtr& callback);
 
         void ready(SocketOperation operation, bool value)

--- a/cpp/src/Ice/StreamSocket.cpp
+++ b/cpp/src/Ice/StreamSocket.cpp
@@ -435,16 +435,19 @@ StreamSocket::finishRead(Buffer& buf)
 void
 StreamSocket::close()
 {
-    assert(_fd != INVALID_SOCKET);
-    try
+    // _fd can be INVALID_SOCKET when a failed socket operation already closed the fd.
+    if (_fd != INVALID_SOCKET)
     {
-        closeSocket(_fd);
-        _fd = INVALID_SOCKET;
-    }
-    catch (const Ice::SocketException&)
-    {
-        _fd = INVALID_SOCKET;
-        throw;
+        try
+        {
+            closeSocket(_fd);
+            _fd = INVALID_SOCKET;
+        }
+        catch (const Ice::SocketException&)
+        {
+            _fd = INVALID_SOCKET;
+            throw;
+        }
     }
 }
 

--- a/cpp/src/Ice/StreamSocket.cpp
+++ b/cpp/src/Ice/StreamSocket.cpp
@@ -117,7 +117,16 @@ StreamSocket::connect(Buffer& readBuffer, Buffer& writeBuffer)
 void
 StreamSocket::setBufferSize(int rcvSize, int sndSize)
 {
-    setTcpBufSize(_fd, rcvSize, sndSize, _instance);
+    try
+    {
+        setTcpBufSize(_fd, rcvSize, sndSize, _instance);
+    }
+    catch (const Ice::SocketException&)
+    {
+        // The failing call closed the fd.
+        clearFd();
+        throw;
+    }
 }
 
 SocketOperation

--- a/cpp/src/Ice/TcpTransceiver.cpp
+++ b/cpp/src/Ice/TcpTransceiver.cpp
@@ -108,21 +108,30 @@ IceInternal::TcpTransceiver::getInfo(bool incoming, string adapterName, string c
     }
     else
     {
-        string localAddress;
-        int localPort;
-        string remoteAddress;
-        int remotePort;
-        fdToAddressAndPort(_stream->fd(), localAddress, localPort, remoteAddress, remotePort);
-        return make_shared<TCPConnectionInfo>(
-            incoming,
-            std::move(adapterName),
-            std::move(connectionId),
-            std::move(localAddress),
-            localPort,
-            std::move(remoteAddress),
-            remotePort,
-            getRecvBufferSize(_stream->fd()),
-            getSendBufferSize(_stream->fd()));
+        try
+        {
+            string localAddress;
+            int localPort;
+            string remoteAddress;
+            int remotePort;
+            fdToAddressAndPort(_stream->fd(), localAddress, localPort, remoteAddress, remotePort);
+            return make_shared<TCPConnectionInfo>(
+                incoming,
+                std::move(adapterName),
+                std::move(connectionId),
+                std::move(localAddress),
+                localPort,
+                std::move(remoteAddress),
+                remotePort,
+                getRecvBufferSize(_stream->fd()),
+                getSendBufferSize(_stream->fd()));
+        }
+        catch (const SocketException&)
+        {
+            // The failing call closed the fd.
+            _stream->clearFd();
+            throw;
+        }
     }
 }
 

--- a/cpp/src/Ice/TcpTransceiver.cpp
+++ b/cpp/src/Ice/TcpTransceiver.cpp
@@ -108,23 +108,18 @@ IceInternal::TcpTransceiver::getInfo(bool incoming, string adapterName, string c
     }
     else
     {
+        string localAddress;
+        int localPort;
+        string remoteAddress;
+        int remotePort;
+        fdToAddressAndPort(_stream->fd(), localAddress, localPort, remoteAddress, remotePort);
+
+        int rcvSize;
+        int sndSize;
         try
         {
-            string localAddress;
-            int localPort;
-            string remoteAddress;
-            int remotePort;
-            fdToAddressAndPort(_stream->fd(), localAddress, localPort, remoteAddress, remotePort);
-            return make_shared<TCPConnectionInfo>(
-                incoming,
-                std::move(adapterName),
-                std::move(connectionId),
-                std::move(localAddress),
-                localPort,
-                std::move(remoteAddress),
-                remotePort,
-                getRecvBufferSize(_stream->fd()),
-                getSendBufferSize(_stream->fd()));
+            rcvSize = getRecvBufferSize(_stream->fd());
+            sndSize = getSendBufferSize(_stream->fd());
         }
         catch (const SocketException&)
         {
@@ -132,6 +127,17 @@ IceInternal::TcpTransceiver::getInfo(bool incoming, string adapterName, string c
             _stream->clearFd();
             throw;
         }
+
+        return make_shared<TCPConnectionInfo>(
+            incoming,
+            std::move(adapterName),
+            std::move(connectionId),
+            std::move(localAddress),
+            localPort,
+            std::move(remoteAddress),
+            remotePort,
+            rcvSize,
+            sndSize);
     }
 }
 

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -594,54 +594,64 @@ IceInternal::UdpTransceiver::setBufferSize(int rcvSize, int sndSize)
 {
     assert(_fd != INVALID_SOCKET);
 
-    // The default size is the size currently configured on the socket. We don't set the buffer size when the requested
-    // size matches the default: re-setting it would needlessly grow the buffer on systems (e.g. Linux) where the kernel
-    // doubles the value on each set.
+    try
+    {
+        // The default size is the size currently configured on the socket. We don't set the buffer size when the
+        // requested size matches the default: re-setting it would needlessly grow the buffer on systems (e.g. Linux)
+        // where the kernel doubles the value on each set.
 
-    int rcvDefault = getRecvBufferSize(_fd);
-    rcvSize = adjustBufferSize(rcvSize, rcvDefault, "Ice.UDP.RcvSize");
-    if (rcvSize == rcvDefault)
-    {
-        _rcvSize = rcvDefault;
-    }
-    else
-    {
-        // The kernel silently adjusts the size to an acceptable value, so read it back to get the size actually set.
-        setRecvBufferSize(_fd, rcvSize);
-        _rcvSize = getRecvBufferSize(_fd);
-        if (_rcvSize < rcvSize)
+        int rcvDefault = getRecvBufferSize(_fd);
+        rcvSize = adjustBufferSize(rcvSize, rcvDefault, "Ice.UDP.RcvSize");
+        if (rcvSize == rcvDefault)
         {
-            // The kernel reduced the requested size; warn unless we already warned for this size.
-            BufSizeWarnInfo winfo = _instance->getBufSizeWarn(UDPEndpointType);
-            if (!winfo.rcvWarn || winfo.rcvSize != rcvSize)
+            _rcvSize = rcvDefault;
+        }
+        else
+        {
+            // The kernel silently adjusts the size to an acceptable value, so read it back to get the size actually
+            // set.
+            setRecvBufferSize(_fd, rcvSize);
+            _rcvSize = getRecvBufferSize(_fd);
+            if (_rcvSize < rcvSize)
             {
-                Warning out(_instance->logger());
-                out << "UDP receive buffer size: requested size of " << rcvSize << " adjusted to " << _rcvSize;
-                _instance->setRcvBufSizeWarn(UDPEndpointType, rcvSize);
+                // The kernel reduced the requested size; warn unless we already warned for this size.
+                BufSizeWarnInfo winfo = _instance->getBufSizeWarn(UDPEndpointType);
+                if (!winfo.rcvWarn || winfo.rcvSize != rcvSize)
+                {
+                    Warning out(_instance->logger());
+                    out << "UDP receive buffer size: requested size of " << rcvSize << " adjusted to " << _rcvSize;
+                    _instance->setRcvBufSizeWarn(UDPEndpointType, rcvSize);
+                }
+            }
+        }
+
+        int sndDefault = getSendBufferSize(_fd);
+        sndSize = adjustBufferSize(sndSize, sndDefault, "Ice.UDP.SndSize");
+        if (sndSize == sndDefault)
+        {
+            _sndSize = sndDefault;
+        }
+        else
+        {
+            setSendBufferSize(_fd, sndSize);
+            _sndSize = getSendBufferSize(_fd);
+            if (_sndSize < sndSize)
+            {
+                BufSizeWarnInfo winfo = _instance->getBufSizeWarn(UDPEndpointType);
+                if (!winfo.sndWarn || winfo.sndSize != sndSize)
+                {
+                    Warning out(_instance->logger());
+                    out << "UDP send buffer size: requested size of " << sndSize << " adjusted to " << _sndSize;
+                    _instance->setSndBufSizeWarn(UDPEndpointType, sndSize);
+                }
             }
         }
     }
-
-    int sndDefault = getSendBufferSize(_fd);
-    sndSize = adjustBufferSize(sndSize, sndDefault, "Ice.UDP.SndSize");
-    if (sndSize == sndDefault)
+    catch (const SocketException&)
     {
-        _sndSize = sndDefault;
-    }
-    else
-    {
-        setSendBufferSize(_fd, sndSize);
-        _sndSize = getSendBufferSize(_fd);
-        if (_sndSize < sndSize)
-        {
-            BufSizeWarnInfo winfo = _instance->getBufSizeWarn(UDPEndpointType);
-            if (!winfo.sndWarn || winfo.sndSize != sndSize)
-            {
-                Warning out(_instance->logger());
-                out << "UDP send buffer size: requested size of " << sndSize << " adjusted to " << _sndSize;
-                _instance->setSndBufSizeWarn(UDPEndpointType, sndSize);
-            }
-        }
+        // The failing call closed the fd.
+        clearFd();
+        throw;
     }
 }
 

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -242,6 +242,10 @@ IceObjC::StreamTransceiver::initialize(Buffer& /*readBuffer*/, Buffer& /*writeBu
 
         if (_fd == INVALID_SOCKET)
         {
+            // Read the properties while the streams still own the native socket: if the read fails, closing the
+            // streams releases the socket.
+            TcpBufSize bufSize{_instance->properties()};
+
             if (!CFReadStreamSetProperty(
                     _readStream.get(),
                     kCFStreamPropertyShouldCloseNativeSocket,
@@ -256,13 +260,15 @@ IceObjC::StreamTransceiver::initialize(Buffer& /*readBuffer*/, Buffer& /*writeBu
 
             UniqueRef<CFDataRef> d(static_cast<CFDataRef>(
                 CFReadStreamCopyProperty(_readStream.get(), kCFStreamPropertySocketNativeHandle)));
-            CFDataGetBytes(d.get(), CFRangeMake(0, sizeof(SOCKET)), reinterpret_cast<UInt8*>(&_fd));
+            SOCKET fd;
+            CFDataGetBytes(d.get(), CFRangeMake(0, sizeof(SOCKET)), reinterpret_cast<UInt8*>(&fd));
 
             // Configure the socket of this outgoing connection. For an incoming connection, the acceptor
-            // configures the socket before creating the transceiver.
-            setBlock(_fd, false);
-            TcpBufSize bufSize{_instance->properties()};
-            setTcpBufSize(_fd, bufSize.rcvSize(), bufSize.sndSize(), _instance);
+            // configures the socket before creating the transceiver. Each of these calls closes the fd before
+            // throwing, so record the fd only once they all succeed.
+            setBlock(fd, false);
+            setTcpBufSize(fd, bufSize.rcvSize(), bufSize.sndSize(), _instance);
+            _fd = fd;
         }
 
         ostringstream s;
@@ -449,22 +455,31 @@ IceObjC::StreamTransceiver::getInfo(bool incoming, string adapterName, string co
     }
     else
     {
-        string localAddress;
-        int localPort;
-        string remoteAddress;
-        int remotePort;
-        fdToAddressAndPort(_fd, localAddress, localPort, remoteAddress, remotePort);
+        try
+        {
+            string localAddress;
+            int localPort;
+            string remoteAddress;
+            int remotePort;
+            fdToAddressAndPort(_fd, localAddress, localPort, remoteAddress, remotePort);
 
-        return make_shared<TCPConnectionInfo>(
-            incoming,
-            std::move(adapterName),
-            std::move(connectionId),
-            std::move(localAddress),
-            localPort,
-            std::move(remoteAddress),
-            remotePort,
-            getRecvBufferSize(_fd),
-            getSendBufferSize(_fd));
+            return make_shared<TCPConnectionInfo>(
+                incoming,
+                std::move(adapterName),
+                std::move(connectionId),
+                std::move(localAddress),
+                localPort,
+                std::move(remoteAddress),
+                remotePort,
+                getRecvBufferSize(_fd),
+                getSendBufferSize(_fd));
+        }
+        catch (const SocketException&)
+        {
+            // The failing call closed the fd.
+            const_cast<StreamTransceiver*>(this)->clearFd();
+            throw;
+        }
     }
 }
 
@@ -476,7 +491,16 @@ IceObjC::StreamTransceiver::checkSendSize(const Buffer& /*buf*/)
 void
 IceObjC::StreamTransceiver::setBufferSize(int rcvSize, int sndSize)
 {
-    setTcpBufSize(_fd, rcvSize, sndSize, _instance);
+    try
+    {
+        setTcpBufSize(_fd, rcvSize, sndSize, _instance);
+    }
+    catch (const SocketException&)
+    {
+        // The failing call closed the fd.
+        clearFd();
+        throw;
+    }
 }
 
 IceObjC::StreamTransceiver::StreamTransceiver(

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -455,24 +455,18 @@ IceObjC::StreamTransceiver::getInfo(bool incoming, string adapterName, string co
     }
     else
     {
+        string localAddress;
+        int localPort;
+        string remoteAddress;
+        int remotePort;
+        fdToAddressAndPort(_fd, localAddress, localPort, remoteAddress, remotePort);
+
+        int rcvSize;
+        int sndSize;
         try
         {
-            string localAddress;
-            int localPort;
-            string remoteAddress;
-            int remotePort;
-            fdToAddressAndPort(_fd, localAddress, localPort, remoteAddress, remotePort);
-
-            return make_shared<TCPConnectionInfo>(
-                incoming,
-                std::move(adapterName),
-                std::move(connectionId),
-                std::move(localAddress),
-                localPort,
-                std::move(remoteAddress),
-                remotePort,
-                getRecvBufferSize(_fd),
-                getSendBufferSize(_fd));
+            rcvSize = getRecvBufferSize(_fd);
+            sndSize = getSendBufferSize(_fd);
         }
         catch (const SocketException&)
         {
@@ -480,6 +474,17 @@ IceObjC::StreamTransceiver::getInfo(bool incoming, string adapterName, string co
             const_cast<StreamTransceiver*>(this)->clearFd();
             throw;
         }
+
+        return make_shared<TCPConnectionInfo>(
+            incoming,
+            std::move(adapterName),
+            std::move(connectionId),
+            std::move(localAddress),
+            localPort,
+            std::move(remoteAddress),
+            remotePort,
+            rcvSize,
+            sndSize);
     }
 }
 

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -264,10 +264,24 @@ IceObjC::StreamTransceiver::initialize(Buffer& /*readBuffer*/, Buffer& /*writeBu
             CFDataGetBytes(d.get(), CFRangeMake(0, sizeof(SOCKET)), reinterpret_cast<UInt8*>(&fd));
 
             // Configure the socket of this outgoing connection. For an incoming connection, the acceptor
-            // configures the socket before creating the transceiver. Each of these calls closes the fd before
-            // throwing, so record the fd only once they all succeed.
-            setBlock(fd, false);
-            setTcpBufSize(fd, bufSize.rcvSize(), bufSize.sndSize(), _instance);
+            // configures the socket before creating the transceiver. Record the fd only once the configuration
+            // succeeds.
+            try
+            {
+                setBlock(fd, false);
+                setTcpBufSize(fd, bufSize.rcvSize(), bufSize.sndSize(), _instance);
+            }
+            catch (const SocketException&)
+            {
+                throw; // The failing call closed the fd.
+            }
+            catch (...)
+            {
+                // For example a CommunicatorDestroyedException from the buffer-size warning check, which closes
+                // nothing.
+                closeSocketNoThrow(fd);
+                throw;
+            }
             _fd = fd;
         }
 

--- a/cpp/src/IceBT/StreamSocket.cpp
+++ b/cpp/src/IceBT/StreamSocket.cpp
@@ -252,11 +252,9 @@ IceBT::StreamSocket::setFd(SOCKET fd)
         throw;
     }
 
-    // Each of these calls closes the fd before throwing, so record the fd only once they all succeed.
+    // setBlock and setBufferSize close the fd before throwing, so record the fd only once all these calls succeed.
     IceInternal::setBlock(fd, false);
     setBufferSize(fd, rcvSize, sndSize);
-    string desc = fdToString(fd);
-
+    _desc = fdToString(fd);
     setNewFd(fd);
-    _desc = std::move(desc);
 }

--- a/cpp/src/IceBT/StreamSocket.cpp
+++ b/cpp/src/IceBT/StreamSocket.cpp
@@ -237,24 +237,23 @@ IceBT::StreamSocket::setFd(SOCKET fd)
     assert(fd != INVALID_SOCKET);
     assert(_fd == INVALID_SOCKET);
 
-    int rcvSize;
-    int sndSize;
+    // Record the fd only once the configuration succeeds.
     try
     {
         BTBufSize bufSize{_instance->properties()};
-        rcvSize = bufSize.rcvSize();
-        sndSize = bufSize.sndSize();
+        IceInternal::setBlock(fd, false);
+        setBufferSize(fd, bufSize.rcvSize(), bufSize.sndSize());
+    }
+    catch (const Ice::SocketException&)
+    {
+        throw; // The failing call closed the fd.
     }
     catch (...)
     {
-        // The property read doesn't close the fd, and it's not recorded anywhere yet.
+        // Nothing closed the fd: neither the property read nor the buffer-size warning check closes it.
         IceInternal::closeSocketNoThrow(fd);
         throw;
     }
-
-    // setBlock and setBufferSize close the fd before throwing, so record the fd only once all these calls succeed.
-    IceInternal::setBlock(fd, false);
-    setBufferSize(fd, rcvSize, sndSize);
     _desc = fdToString(fd);
     setNewFd(fd);
 }

--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -135,23 +135,32 @@ IceBT::TransceiverI::getInfo(bool incoming, string adapterName, string connectio
     }
     else
     {
-        string localAddress;
-        int localChannel;
-        string remoteAddress;
-        int remoteChannel;
-        fdToAddressAndChannel(_stream->fd(), localAddress, localChannel, remoteAddress, remoteChannel);
+        try
+        {
+            string localAddress;
+            int localChannel;
+            string remoteAddress;
+            int remoteChannel;
+            fdToAddressAndChannel(_stream->fd(), localAddress, localChannel, remoteAddress, remoteChannel);
 
-        return make_shared<ConnectionInfo>(
-            incoming,
-            std::move(adapterName),
-            std::move(connectionId),
-            std::move(localAddress),
-            localChannel,
-            std::move(remoteAddress),
-            remoteChannel,
-            _uuid,
-            IceInternal::getRecvBufferSize(_stream->fd()),
-            IceInternal::getSendBufferSize(_stream->fd()));
+            return make_shared<ConnectionInfo>(
+                incoming,
+                std::move(adapterName),
+                std::move(connectionId),
+                std::move(localAddress),
+                localChannel,
+                std::move(remoteAddress),
+                remoteChannel,
+                _uuid,
+                IceInternal::getRecvBufferSize(_stream->fd()),
+                IceInternal::getSendBufferSize(_stream->fd()));
+        }
+        catch (const Ice::SocketException&)
+        {
+            // The failing call closed the fd.
+            _stream->clearFd();
+            throw;
+        }
     }
 }
 
@@ -163,7 +172,16 @@ IceBT::TransceiverI::checkSendSize(const IceInternal::Buffer&)
 void
 IceBT::TransceiverI::setBufferSize(int rcvSize, int sndSize)
 {
-    _stream->setBufferSize(_stream->fd(), rcvSize, sndSize);
+    try
+    {
+        _stream->setBufferSize(_stream->fd(), rcvSize, sndSize);
+    }
+    catch (const Ice::SocketException&)
+    {
+        // The failing call closed the fd.
+        _stream->clearFd();
+        throw;
+    }
 }
 
 IceBT::TransceiverI::TransceiverI(InstancePtr instance, StreamSocketPtr stream, ConnectionPtr conn, string uuid)

--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -135,25 +135,18 @@ IceBT::TransceiverI::getInfo(bool incoming, string adapterName, string connectio
     }
     else
     {
+        string localAddress;
+        int localChannel;
+        string remoteAddress;
+        int remoteChannel;
+        fdToAddressAndChannel(_stream->fd(), localAddress, localChannel, remoteAddress, remoteChannel);
+
+        int rcvSize;
+        int sndSize;
         try
         {
-            string localAddress;
-            int localChannel;
-            string remoteAddress;
-            int remoteChannel;
-            fdToAddressAndChannel(_stream->fd(), localAddress, localChannel, remoteAddress, remoteChannel);
-
-            return make_shared<ConnectionInfo>(
-                incoming,
-                std::move(adapterName),
-                std::move(connectionId),
-                std::move(localAddress),
-                localChannel,
-                std::move(remoteAddress),
-                remoteChannel,
-                _uuid,
-                IceInternal::getRecvBufferSize(_stream->fd()),
-                IceInternal::getSendBufferSize(_stream->fd()));
+            rcvSize = IceInternal::getRecvBufferSize(_stream->fd());
+            sndSize = IceInternal::getSendBufferSize(_stream->fd());
         }
         catch (const Ice::SocketException&)
         {
@@ -161,6 +154,18 @@ IceBT::TransceiverI::getInfo(bool incoming, string adapterName, string connectio
             _stream->clearFd();
             throw;
         }
+
+        return make_shared<ConnectionInfo>(
+            incoming,
+            std::move(adapterName),
+            std::move(connectionId),
+            std::move(localAddress),
+            localChannel,
+            std::move(remoteAddress),
+            remoteChannel,
+            _uuid,
+            rcvSize,
+            sndSize);
     }
 }
 

--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -224,8 +224,8 @@ IceBT::TransceiverI::connectCompleted(int fd, const ConnectionPtr& conn)
             catch (...)
             {
                 //
-                // setFd already released the fd. initialize() rethrows this exception and the connection
-                // establishment fails with the actual error.
+                // A throwing setFd does not record the fd, so there is nothing to clean up here. initialize()
+                // rethrows this exception and the connection establishment fails with the actual error.
                 //
                 _exception = current_exception();
             }

--- a/cpp/src/IceBT/Util.cpp
+++ b/cpp/src/IceBT/Util.cpp
@@ -98,7 +98,6 @@ namespace
         auto len = static_cast<socklen_t>(sizeof(SocketAddress));
         if (::getsockname(fd, reinterpret_cast<struct sockaddr*>(&addr), &len) == SOCKET_ERROR)
         {
-            IceInternal::closeSocketNoThrow(fd);
             throw SocketException(__FILE__, __LINE__, IceInternal::getSocketErrno());
         }
     }
@@ -114,7 +113,6 @@ namespace
             }
             else
             {
-                IceInternal::closeSocketNoThrow(fd);
                 throw SocketException(__FILE__, __LINE__, IceInternal::getSocketErrno());
             }
         }


### PR DESCRIPTION
Fixes #6376.

The buffer-size helpers in `Network.cpp` (`setRecvBufferSize`, `getRecvBufferSize`, `setSendBufferSize`, `getSendBufferSize`, and `setTcpBufSize` which calls them) close the fd before throwing `SocketException`. That convention serves the connection-establishment paths, but several transceivers also call these helpers on an installed, live fd — `getInfo` and `setBufferSize`. When such a call failed, the fd was closed but remained recorded, and the transceiver's later `close()` closed the same descriptor number a second time — potentially an unrelated descriptor another thread had been assigned in the meantime.

The fix pattern is uniform: a new `NativeInfo::clearFd()` forgets the fd, and each live-fd call site catches `SocketException` around the calls that close the fd, clears, and rethrows:

- **IceBT** `TransceiverI::getInfo` / `setBufferSize`.
- **TCP** `TcpTransceiver::getInfo` and `StreamSocket::setBufferSize` — these also cover WS and both SSL transceivers, which delegate.
- **UDP** `UdpTransceiver::setBufferSize`. UDP's `getInfo` doesn't call the helpers (it returns the cached sizes).
- **iOS** `StreamTransceiver::getInfo` / `setBufferSize`.

Following review, the fd-ownership rule is now uniform across all transports: **the address-reading helpers (`fdToString`, `fdToAddressAndPort`, `fdToAddressAndChannel`, `fdToLocalAddress`, `fdToRemoteAddress`) never close the fd, while the socket configuration helpers close it before throwing.** Concretely:

- Every `getInfo` reads the addresses outside the try block: an address lookup failure leaves the fd open, and the transceiver's normal `close()` remains responsible for it.
- IceBT's `fdToLocalAddress`/`fdToRemoteAddress` no longer close the fd before throwing — they now behave exactly like their `Network.cpp` namesakes.
- `IceInternal::StreamSocket::close()` tolerates a cleared fd, like the IceBT, UDP, and iOS close implementations already did.
- In the IceBT `StreamSocket` constructor and `setFd`, a `fdToString` failure now leaves the fd open instead of closing it. This is deliberate: these lookups don't fail on a healthy socket, and an fd leak on this never-taken path is preferable to keeping two conventions alive.

In addition, the iOS `StreamTransceiver::initialize` recorded `_fd` before running `setBlock`/`setTcpBufSize` on it, so a configuration failure on an outgoing connection led to the same double close; and the `TcpBufSize` property read sat between fd extraction and configuration, where a `PropertyException` (which closes nothing) would leak the fd. The properties are now read while the streams still own the native socket, the socket is configured through a local variable, and `_fd` is recorded only once nothing can throw.

Audited and left unchanged: the acceptor and transceiver constructors (a constructor throw means no object, so the failing helper's close is the only close — the iOS acceptor's catch already forgets the fd) and UDP's constructors.

No changelog entry: these calls fail only when `getsockopt`/`setsockopt` fails on a live socket, which does not happen during normal operations.

Built and tested on macOS (`Ice/info`, `Ice/udp`); the IceBT and iOS files are compile-verified by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
