### PR TITLE
Reject negative discovery RetryCount properties at initialization

### DIFF
--- a/cpp/src/IceDiscovery/LookupI.cpp
+++ b/cpp/src/IceDiscovery/LookupI.cpp
@@ -197,6 +197,13 @@ LookupI::LookupI(LocatorRegistryIPtr registry, const LookupPrx& lookup, const Ic
     {
         throw PropertyException{__FILE__, __LINE__, "property 'IceDiscovery.Timeout' must be greater than 0"};
     }
+    if (_retryCount < 0)
+    {
+        throw PropertyException{
+            __FILE__,
+            __LINE__,
+            "property 'IceDiscovery.RetryCount' must be greater than or equal to 0"};
+    }
     if (_latencyMultiplier < 1)
     {
         throw PropertyException{

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -84,9 +84,9 @@ namespace
 
         LookupPrx _lookup;
         vector<pair<LookupPrx, LookupReplyPrx>> _lookups;
-        chrono::milliseconds _timeout;
-        int _retryCount;
-        chrono::milliseconds _retryDelay;
+        const chrono::milliseconds _timeout;
+        const int _retryCount;
+        const chrono::milliseconds _retryDelay;
         const IceInternal::TimerPtr _timer;
         const int _traceLevel;
 
@@ -415,7 +415,10 @@ LocatorI::LocatorI(
     }
     if (_retryCount < 0)
     {
-        _retryCount = 0;
+        throw Ice::PropertyException{
+            __FILE__,
+            __LINE__,
+            "property 'IceLocatorDiscovery.RetryCount' must be greater than or equal to 0"};
     }
     if (_retryDelay < chrono::milliseconds::zero())
     {

--- a/csharp/src/IceDiscovery/LookupI.cs
+++ b/csharp/src/IceDiscovery/LookupI.cs
@@ -226,13 +226,16 @@ internal class LookupI : LookupDisp_
     {
         _registry = registry;
         _lookup = lookup;
-        int timeout = properties.getIcePropertyAsInt("IceDiscovery.Timeout");
-        if (timeout <= 0)
+        _timeout = TimeSpan.FromMilliseconds(properties.getIcePropertyAsInt("IceDiscovery.Timeout"));
+        if (_timeout <= TimeSpan.Zero)
         {
             throw new Ice.PropertyException("property 'IceDiscovery.Timeout' must be greater than 0");
         }
-        _timeout = TimeSpan.FromMilliseconds(timeout);
         _retryCount = properties.getIcePropertyAsInt("IceDiscovery.RetryCount");
+        if (_retryCount < 0)
+        {
+            throw new Ice.PropertyException("property 'IceDiscovery.RetryCount' must be greater than or equal to 0");
+        }
         _latencyMultiplier = properties.getIcePropertyAsInt("IceDiscovery.LatencyMultiplier");
         if (_latencyMultiplier < 1)
         {

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -116,13 +116,13 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
         _timeout = TimeSpan.FromMilliseconds(properties.getIcePropertyAsInt("IceLocatorDiscovery.Timeout"));
         if (_timeout <= TimeSpan.Zero)
         {
-            throw new Ice.PropertyException(
-                "property 'IceLocatorDiscovery.Timeout' must be greater than 0");
+            throw new Ice.PropertyException("property 'IceLocatorDiscovery.Timeout' must be greater than 0");
         }
         _retryCount = properties.getIcePropertyAsInt("IceLocatorDiscovery.RetryCount");
         if (_retryCount < 0)
         {
-            _retryCount = 0;
+            throw new Ice.PropertyException(
+                "property 'IceLocatorDiscovery.RetryCount' must be greater than or equal to 0");
         }
         _retryDelay = properties.getIcePropertyAsInt("IceLocatorDiscovery.RetryDelay");
         if (_retryDelay < 0)
@@ -488,7 +488,7 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
                     {
                         var s = new StringBuilder("retrying locator lookup:\nlookup = ");
                         s.Append(_lookup);
-                        s.Append("\nretry count = ").Append(_retryCount);
+                        s.Append("\nretry count = ").Append(_pendingRetryCount);
                         if (_instanceName.Length > 0)
                         {
                             s.Append("\ninstance name = ").Append(_instanceName);

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
@@ -239,10 +239,12 @@ class LookupI implements Lookup {
         _lookup = lookup;
         _timeout = properties.getIcePropertyAsInt("IceDiscovery.Timeout");
         if (_timeout <= 0) {
-            throw new PropertyException(
-                "property 'IceDiscovery.Timeout' must be greater than 0");
+            throw new PropertyException("property 'IceDiscovery.Timeout' must be greater than 0");
         }
         _retryCount = properties.getIcePropertyAsInt("IceDiscovery.RetryCount");
+        if (_retryCount < 0) {
+            throw new PropertyException("property 'IceDiscovery.RetryCount' must be greater than or equal to 0");
+        }
         _latencyMultiplier = properties.getIcePropertyAsInt("IceDiscovery.LatencyMultiplier");
         if (_latencyMultiplier < 1) {
             throw new PropertyException(

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -138,12 +138,12 @@ class PluginI implements Plugin {
             _lookup = lookup;
             _timeout = properties.getIcePropertyAsInt("IceLocatorDiscovery.Timeout");
             if (_timeout <= 0) {
-                throw new PropertyException(
-                    "property 'IceLocatorDiscovery.Timeout' must be greater than 0");
+                throw new PropertyException("property 'IceLocatorDiscovery.Timeout' must be greater than 0");
             }
             _retryCount = properties.getIcePropertyAsInt("IceLocatorDiscovery.RetryCount");
             if (_retryCount < 0) {
-                _retryCount = 0;
+                throw new PropertyException(
+                    "property 'IceLocatorDiscovery.RetryCount' must be greater than or equal to 0");
             }
             _retryDelay = properties.getIcePropertyAsInt("IceLocatorDiscovery.RetryDelay");
             if (_retryDelay < 0) {
@@ -448,7 +448,7 @@ class PluginI implements Plugin {
                                 if (_traceLevel > 1) {
                                     StringBuilder s = new StringBuilder("retrying locator lookup:\nlookup = ");
                                     s.append(_lookup);
-                                    s.append("\nretry count = ").append(_retryCount);
+                                    s.append("\nretry count = ").append(_pendingRetryCount);
                                     if (!_instanceName.isEmpty()) {
                                         s.append("\ninstance name = ").append(_instanceName);
                                     }
@@ -502,12 +502,12 @@ class PluginI implements Plugin {
 
         private final LookupPrx _lookup;
         private final Map<LookupPrx, LookupReplyPrx> _lookups = new HashMap<>();
-        private int _timeout;
+        private final int _timeout;
         private Future<?> _future;
         private final ScheduledExecutorService _timer;
         private final int _traceLevel;
-        private int _retryCount;
-        private int _retryDelay;
+        private final int _retryCount;
+        private final int _retryDelay;
 
         private String _instanceName;
         private boolean _warned;


### PR DESCRIPTION
Fixes #6190.

`IceDiscovery.RetryCount` and `IceLocatorDiscovery.RetryCount` now reject a negative value at plugin initialization with a `PropertyException`, like the timeout properties since #6186. `0` remains valid and means no retries. For IceLocatorDiscovery, this replaces the silent clamp to 0 and enforces at the source the invariant that the `_pendingRetryCount == 0` assertion in `runTimerTask` relies on.

The "retrying locator lookup" trace now prints the remaining retry count in all three mappings; C# and Java previously printed the configured maximum while C++ printed the remaining count.

This PR also picks up the optional nits from the #6186 review:
- The C# `IceDiscovery` lookup constructor assigns `_timeout` first and then validates it, like the sibling `IceLocatorDiscovery` file.
- The C++ `IceLocatorDiscovery` `_timeout`, `_retryCount`, and `_retryDelay` fields are now `const` (the Java ones `final`) — all write-once now that the clamp is gone.
- Throws that fit under the 120-column limit with the shorter messages are unwrapped to one line.

No changelog entry: a negative retry count is an invalid configuration, per the ruling on #6186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
