### PR TITLE
Fix `--interface` parsing order and remove an unreachable test filter

### DIFF
--- a/scripts/Component.py
+++ b/scripts/Component.py
@@ -121,7 +121,7 @@ class Ice(Util.Component):
             "iphoneos",
         ]:
             return (
-                ["Ice/.*", "IceSSL/configuration", "Slice/*"],
+                ["Ice/.*", "IceSSL/configuration", "Slice/.*"],
                 ["Ice/properties", "Ice/udp"],
             )
         return ([], [])

--- a/scripts/Component.py
+++ b/scripts/Component.py
@@ -116,14 +116,6 @@ class Ice(Util.Component):
             )
         elif isinstance(mapping, Util.JavaScriptMapping):
             return ([], ["typescript/.*"])
-        elif isinstance(mapping, Util.SwiftMapping) and config.buildPlatform in [
-            "iphonesimulator",
-            "iphoneos",
-        ]:
-            return (
-                ["Ice/.*", "IceSSL/configuration", "Slice/.*"],
-                ["Ice/properties", "Ice/udp"],
-            )
         return ([], [])
 
     def canRun(self, testId: str, mapping: Util.Mapping, current: Util.Driver.Current) -> bool:

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3883,6 +3883,7 @@ class Driver:
         self.rlanguages: list[str] = []
         self.failures: list[Any] = []
         self.keepLogs = False
+        self.interface = ""
         self.configs: dict[Mapping, Mapping.Config]
 
         logDir = os.path.join(toplevel, "logs")
@@ -3916,7 +3917,6 @@ class Driver:
         )
 
         self.communicator: Ice.Communicator | None = None
-        self.interface = ""
         self.processControllers: dict[type[ProcessController], ProcessController] = {}
 
     def setConfigs(self, configs: dict[Mapping, Mapping.Config]) -> None:


### PR DESCRIPTION
Fixes #6402.

- `Driver.__init__` assigned `self.interface` only after its `parseOptions` call, so the reflective parse never matched `--interface`; it worked only because `LocalDriver`/`ControllerDriver` re-parse the leftovers. The default now sits with the other option-backed attributes, before the parse.
- Removed the `SwiftMapping` branch in `Component.py`'s `getFilters`. It required `buildPlatform` to be `iphoneos`/`iphonesimulator`, but the method returns for exactly those platforms several branches earlier, so it never ran.