### PR TITLE
Document why create-xcode-project-targets is absent

### DIFF
--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -162,8 +162,9 @@ get-iostest-program-targets = $2/$1.bundle/$1.dylib $2/$1.bundle/Info.plist
 #
 # make-projects dispatches twice per project: once to create-<type>-project-targets and once to
 # make-<type>-project. Xcode projects deliberately define only the second: xcodebuild compiles the
-# sources itself, so there are no per-source targets to create and create-xcode-project-targets is
-# intentionally absent (make-projects falls back to expanding nothing for it).
+# sources itself, so there are no per-source targets to create. create-xcode-project-targets was an
+# empty macro until 9a02628927 removed it; $(or ...) still selects that name, and $(call) on an
+# undefined macro expands to nothing. It does not fall back to create-project-targets.
 #
 
 #

--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -160,6 +160,13 @@ get-iostest-program-targets = $2/$1.bundle/$1.dylib $2/$1.bundle/Info.plist
 ## Xcode projects
 
 #
+# make-projects dispatches twice per project: once to create-<type>-project-targets and once to
+# make-<type>-project. Xcode projects deliberately define only the second: xcodebuild compiles the
+# sources itself, so there are no per-source targets to create and create-xcode-project-targets is
+# intentionally absent (make-projects falls back to expanding nothing for it).
+#
+
+#
 # $(call make-xcode-project-with-config,$1=project,$2=platform,$3=config)
 #
 define make-xcode-project-with-config


### PR DESCRIPTION
Supersedes the original deletion in this PR, which was wrong — see @pepone's review.

`make-projects` (`config/Make.project.rules:921-922`) dispatches twice per project. Only the first dispatch (`create-xcode-project-targets`) is undefined for Xcode projects; the second (`make-xcode-project`) is defined here and does build the iOS Test Controller. Removing these macros dropped all four `test/ios/controller[...]` rules.

Rather than delete live code, this records why the first dispatch has no Xcode counterpart: `xcodebuild` compiles the sources, so there are no per-source targets to create.

Closes #6404.