### PR TITLE
Remove three test driver configs for deleted tests

### DIFF
--- a/scripts/tests/Glacier2/application.py
+++ b/scripts/tests/Glacier2/application.py
@@ -1,5 +1,0 @@
-# Copyright (c) ZeroC, Inc.
-
-from Glacier2Util import Glacier2TestSuite
-
-Glacier2TestSuite(__name__, routerProps={"Glacier2.Client.Connection.IdleTimeout": 30})

--- a/scripts/tests/Glacier2/sessionHelper.py
+++ b/scripts/tests/Glacier2/sessionHelper.py
@@ -1,5 +1,0 @@
-# Copyright (c) ZeroC, Inc.
-
-from Glacier2Util import Glacier2TestSuite
-
-Glacier2TestSuite(__name__, routerProps={"Glacier2.Client.Connection.IdleTimeout": 30})

--- a/scripts/tests/Ice/interceptor.py
+++ b/scripts/tests/Ice/interceptor.py
@@ -1,9 +1,0 @@
-# Copyright (c) ZeroC, Inc.
-
-from Util import Client, ClientTestCase, TestSuite
-
-TestSuite(
-    __name__,
-    [ClientTestCase(client=Client(props={"Ice.Warn.Dispatch": 0}))],
-    libDirs=["interceptortest"],
-)


### PR DESCRIPTION
Fixes #6405.

The driver imports `scripts/tests/<testId>.py` only when a mapping has a matching test directory; `Ice/interceptor`, `Glacier2/application` and `Glacier2/sessionHelper` no longer exist in any mapping (removed in #2285, #1801 and #2757). `Glacier2/router.py` and the package `__init__.py` are live and stay.