### PR TITLE
Build the unrecognized-layout message as one string

### DIFF
--- a/cpp/config/IceConfig.cmake
+++ b/cpp/config/IceConfig.cmake
@@ -17,7 +17,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/IcePrefix.cmake")
 
 if(NOT DEFINED Ice_PREFIX)
   set(Ice_FOUND FALSE)
-  set(Ice_NOT_FOUND_MESSAGE
+  string(CONCAT Ice_NOT_FOUND_MESSAGE
     "Could not locate the Ice installation: ${CMAKE_CURRENT_LIST_DIR} is not in a recognized "
     "installation layout, or the installation is missing Ice/Ice.h.")
   return()


### PR DESCRIPTION
`set()` with two quoted arguments makes a list, so the not-found message for an unrecognized installation layout rendered with a stray `;` — `... is not in a recognized ;installation layout ...`. `string(CONCAT)` as suggested in the #6352 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)