### PR TITLE
Fail loudly on broken installations, report the Ice version, and fix the Windows configurations

### DIFF
--- a/cpp/config/IceConfig.cmake
+++ b/cpp/config/IceConfig.cmake
@@ -32,10 +32,4 @@ include("${CMAKE_CURRENT_LIST_DIR}/IceTargets.cmake")
 # Internal to IcePrefix/IceTargets; Ice_PREFIX is the documented result variable.
 unset(Ice_INCLUDE_ROOT)
 
-# IceTargets.cmake returns early when part of the installation is missing.
-if(DEFINED Ice_NOT_FOUND_MESSAGE)
-  set(Ice_FOUND FALSE)
-  return()
-endif()
-
 include("${CMAKE_CURRENT_LIST_DIR}/slice2cpp.cmake")

--- a/cpp/config/IceTargets.cmake
+++ b/cpp/config/IceTargets.cmake
@@ -10,24 +10,15 @@ if(WIN32 AND NOT DEFINED Ice_WIN32_PLATFORM)
   endif()
 endif()
 
-# No REQUIRED on the find_* calls below: a missing piece must leave Ice not found rather than abort
-# the configure step, or find_package(Ice QUIET) and optional use of Ice break.
+# REQUIRED throughout: this file only runs once find_package accepted the config file, and the
+# package installs as a unit, so we know exactly what ships next to it and assume it is available.
+# A missing piece is a broken installation and fails loudly right here. QUIET is no reason to
+# tolerate that - it only disables messages when the package cannot be found, and a package whose
+# config file was found but whose contents are gone is broken, not absent.
 find_path(Ice_INCLUDE_DIR NAMES Ice/Ice.h
   HINTS ${Ice_INCLUDE_ROOT} ${Ice_PREFIX} ${Ice_PREFIX}/build/native
   PATH_SUFFIXES include DOC "Directory containing Ice header files"
-  NO_DEFAULT_PATH)
-
-if(NOT Ice_INCLUDE_DIR)
-  set(Ice_NOT_FOUND_MESSAGE "Could not find the Ice header files under ${Ice_PREFIX}.")
-  return()
-endif()
-
-# Checked separately from Ice.h above, because file(STRINGS) below is a fatal error on a missing
-# file - even under find_package(Ice QUIET).
-if(NOT EXISTS "${Ice_INCLUDE_DIR}/Ice/Config.h")
-  set(Ice_NOT_FOUND_MESSAGE "Could not find Ice/Config.h under ${Ice_INCLUDE_DIR}.")
-  return()
-endif()
+  NO_DEFAULT_PATH REQUIRED)
 
 # Read Ice version variables from Ice/Config.h
 if(NOT DEFINED Ice_VERSION)
@@ -47,13 +38,8 @@ find_program(Ice_SLICE2CPP_EXECUTABLE slice2cpp
   HINTS ${Ice_PREFIX}
   PATH_SUFFIXES bin tools
   DOC "Path to the slice2cpp compiler"
-  NO_DEFAULT_PATH
+  NO_DEFAULT_PATH REQUIRED
 )
-
-if(NOT Ice_SLICE2CPP_EXECUTABLE)
-  set(Ice_NOT_FOUND_MESSAGE "Could not find the slice2cpp compiler under ${Ice_PREFIX}.")
-  return()
-endif()
 
 # The guard lets two subprojects in one directory scope each call find_package(Ice) without the
 # second failing on a duplicate target.
@@ -69,12 +55,7 @@ find_path(Ice_SLICE_DIR
   HINTS ${Ice_PREFIX}
   PATH_SUFFIXES slice share/ice/slice
   DOC "Path to the Ice Slice files directory"
-  NO_DEFAULT_PATH)
-
-if(NOT Ice_SLICE_DIR)
-  set(Ice_NOT_FOUND_MESSAGE "Could not find the Ice Slice files under ${Ice_PREFIX}.")
-  return()
-endif()
+  NO_DEFAULT_PATH REQUIRED)
 
 # Imported targets for the executables in the NuGet package's native/bin directory.
 if(WIN32)
@@ -227,18 +208,11 @@ function(add_ice_library component)
   include(SelectLibraryConfigurations)
   select_library_configurations(Ice_${component})
 
+  # Components vary by platform (IceBT ships on Linux only), so an absent component library is
+  # normal; everything a present component links is guaranteed by the package.
   if(NOT Ice_${component}_LIBRARY)
     return()
   endif()
-
-  # A component whose own library is present is still unusable if something it links is not. Naming a
-  # target that does not exist is a generate-time error, which would defeat the QUIET handling above,
-  # so treat the component as not found instead. Components are declared in dependency order below.
-  foreach(dependency IN LISTS ARGN)
-    if(dependency MATCHES "::" AND NOT TARGET ${dependency})
-      return()
-    endif()
-  endforeach()
 
   # find_package_handle_standard_args reads this to decide the component was found.
   set(Ice_${component}_FOUND TRUE PARENT_SCOPE)
@@ -252,15 +226,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 
 add_ice_library(Ice Threads::Threads)
-
-# The Ice runtime is the one component nothing works without. Every other component is optional, but
-# find_package_handle_standard_args only checks the components a consumer asked for, so without this
-# guard an installation with no libraries at all would still report Ice_FOUND.
-if(NOT TARGET Ice::Ice)
-  set(Ice_NOT_FOUND_MESSAGE "Could not find the Ice library under ${Ice_PREFIX}.")
-  return()
-endif()
-
 if(WIN32)
   # Bzip2 is included in the Ice NuGet package and is a runtime dependency of Ice.
   # This property can be used to copy the correct DLLs to the target directory at build time.


### PR DESCRIPTION
#6353 and #6354 merged while stacked here, so their squashes landed on this branch rather than `main`: this PR now delivers all three changes, one commit per original PR.

**Fail loudly when an Ice installation is broken** — follow-up to #6352, which merged with graceful not-found handling for states only a broken installation can produce. The package installs as a unit — the dev package ships the CMake files and slice2cpp together, with hard versioned dependencies on the runtime and Slice packages — so once find_package has accepted the config file, everything it references is present in any intact installation.

- The internal `find_path`/`find_program` calls are `REQUIRED` again, and the partial-install guards (missing `Ice/Config.h`, headers without libraries, `Ice::IceGrid` without `Ice::Glacier2`) are gone. A broken installation errors at the exact missing piece instead of reporting Ice as not found.
- `QUIET` is no reason to tolerate any of this: it only disables messages when the package cannot be found. Component libraries stay optional (the set varies by platform; IceBT is Linux-only) and the duplicate-target guards stay.

**Report the Ice version to find_package (#6353)** — every versioned `find_package(Ice)` was rejected because the package shipped no version file.

- `IceConfigVersion.cmake`: a request is compatible when it names the installed x.y and is not newer than it; every x.y is a major release line. Version ranges are honored on both endpoints.
- The version is baked into `IceVersion.cmake` (one more file to update at release time) rather than parsed from `Ice/Config.h`. `Ice_VERSION` includes any pre-release suffix; a pre-release does not satisfy `EXACT` for the release it precedes.
- `Ice_VERSION`/`Ice_SO_VERSION` are plain variables, not cache entries, and `find_package_handle_standard_args` handles version ranges.

**Fix Windows imported configurations and the icebox imported location (#6354)** — `IMPORTED_CONFIGURATIONS` was set once per configuration rather than accumulated, so it held only `DEBUG`.

- The properties are set once with both configurations — the NuGet package always ships both — with `RELEASE` first and the release-like configurations mapped explicitly, so `RelWithDebInfo`/`MinSizeRel` no longer link the debug Ice and mix CRTs.
- `ICE_RUNTIME_DLLS` yields a bzip2 DLL in every configuration.
- The base `IMPORTED_LOCATION` of `Ice::icebox_EXE` is a plain path instead of a generator expression that reached the build system verbatim (`ninja: error: bad $-escape`); the packaged executables are found `REQUIRED`.

Verified against staged installations on macOS (found/QUIET/version/range cases pass; deleting any shipped piece fails hard even under `QUIET`) and on `windows-2022` with MSVC against the NuGet package (all five configuration states resolve correctly, no unevaluated generator expressions, 29 demos build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
