### PR TITLE
Remove dead code from the IceBT D-Bus wrapper

### DIFF
--- a/cpp/src/IceBT/DBus.cpp
+++ b/cpp/src/IceBT/DBus.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 #include "DBus.h"
+#include <map>
 
 #include <dbus/dbus.h>
 

--- a/cpp/src/IceBT/DBus.cpp
+++ b/cpp/src/IceBT/DBus.cpp
@@ -1,11 +1,12 @@
 // Copyright (c) ZeroC, Inc.
 
 #include "DBus.h"
-#include <map>
 
 #include <dbus/dbus.h>
 
+#include <cassert>
 #include <condition_variable>
+#include <map>
 #include <mutex>
 #include <stack>
 #include <thread>

--- a/cpp/src/IceBT/DBus.cpp
+++ b/cpp/src/IceBT/DBus.cpp
@@ -31,8 +31,6 @@ namespace
     public:
         ExceptionI(const ErrorWrapper& w) { init(w.err); }
 
-        ExceptionI(const DBusError& err) { init(err); }
-
         ExceptionI(const string& s) : Exception(s) {}
 
     private:
@@ -154,12 +152,6 @@ namespace
             return t == DBUS_MESSAGE_TYPE_METHOD_CALL;
         }
 
-        [[nodiscard]] bool isMethodReturn() const override
-        {
-            const int t = ::dbus_message_get_type(const_cast<DBusMessage*>(_message));
-            return t == DBUS_MESSAGE_TYPE_METHOD_RETURN;
-        }
-
         [[nodiscard]] string getPath() const override
         {
             const char* s = ::dbus_message_get_path(const_cast<DBusMessage*>(_message));
@@ -178,12 +170,6 @@ namespace
             return s ? string(s) : string();
         }
 
-        [[nodiscard]] string getDestination() const override
-        {
-            const char* s = ::dbus_message_get_destination(const_cast<DBusMessage*>(_message));
-            return s ? string(s) : string();
-        }
-
         void write(const ValuePtr& v) override
         {
             DBusMessageIter iter;
@@ -199,17 +185,6 @@ namespace
             {
                 writeValue(value, &iter);
             }
-        }
-
-        [[nodiscard]] bool checkTypes(const vector<TypePtr>& types) const override
-        {
-            string msgSig = ::dbus_message_get_signature(_message);
-            string sig;
-            for (const auto& type : types)
-            {
-                sig += type->getSignature();
-            }
-            return sig == msgSig;
         }
 
         ValuePtr read() override
@@ -792,18 +767,6 @@ namespace
 
         ~AsyncResultI() { ::dbus_pending_call_unref(_call); }
 
-        bool isPending() const override
-        {
-            lock_guard lock(_mutex);
-            return _status == StatusPending;
-        }
-
-        bool isComplete() const override
-        {
-            lock_guard lock(_mutex);
-            return _status == StatusComplete;
-        }
-
         MessagePtr waitUntilFinished() const override
         {
             unique_lock lock(_mutex);
@@ -1050,8 +1013,6 @@ namespace
 
             _thread = std::thread(&ConnectionI::run, this);
         }
-
-        DBusConnection* connection() { return _connection; }
 
         DBusHandlerResult handleMessage(DBusMessage* m)
         {

--- a/cpp/src/IceBT/DBus.h
+++ b/cpp/src/IceBT/DBus.h
@@ -5,7 +5,6 @@
 
 #include <cassert>
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -127,8 +126,6 @@ namespace IceBT::DBus
     public:
         [[nodiscard]] virtual TypePtr getType() const = 0;
 
-        [[nodiscard]] virtual ValuePtr clone() const = 0;
-
         [[nodiscard]] virtual std::string toString() const = 0;
 
     protected:
@@ -157,8 +154,6 @@ namespace IceBT::DBus
         PrimitiveValue(E val) : v(std::move(val)), kind(K) {}
 
         [[nodiscard]] TypePtr getType() const final { return Type::getPrimitive(kind); }
-
-        [[nodiscard]] ValuePtr clone() const final { return make_shared<PrimitiveValue>(v); }
 
         [[nodiscard]] std::string toString() const final
         {
@@ -213,8 +208,6 @@ namespace IceBT::DBus
 
         [[nodiscard]] TypePtr getType() const override { return _type; }
 
-        [[nodiscard]] ValuePtr clone() const override { return make_shared<VariantValue>(v ? v->clone() : nullptr); }
-
         [[nodiscard]] std::string toString() const override { return v ? v->toString() : "nil"; }
 
         ValuePtr v;
@@ -243,14 +236,6 @@ namespace IceBT::DBus
 
         [[nodiscard]] TypePtr getType() const override { return _type; }
 
-        [[nodiscard]] ValuePtr clone() const override
-        {
-            DictEntryValuePtr r = make_shared<DictEntryValue>(_type);
-            r->key = key->clone();
-            r->value = value->clone();
-            return r;
-        }
-
         [[nodiscard]] std::string toString() const override
         {
             std::ostringstream out;
@@ -278,16 +263,6 @@ namespace IceBT::DBus
 
         [[nodiscard]] TypePtr getType() const override { return _type; }
 
-        [[nodiscard]] ValuePtr clone() const override
-        {
-            auto r = make_shared<ArrayValue>(_type);
-            for (const auto& element : elements)
-            {
-                r->elements.push_back(element->clone());
-            }
-            return r;
-        }
-
         [[nodiscard]] std::string toString() const override
         {
             std::ostringstream out;
@@ -300,18 +275,6 @@ namespace IceBT::DBus
                 out << (*p)->toString();
             }
             return out.str();
-        }
-
-        void toStringMap(std::map<std::string, ValuePtr>& m)
-        {
-            for (const auto& element : elements)
-            {
-                auto de = dynamic_pointer_cast<DictEntryValue>(element);
-                assert(de);
-                auto s = dynamic_pointer_cast<StringValue>(de->key);
-                assert(s);
-                m[s->v] = de->value;
-            }
         }
 
         std::vector<ValuePtr> elements;
@@ -338,16 +301,6 @@ namespace IceBT::DBus
         StructValue(StructTypePtr t) : _type(std::move(t)) {}
 
         [[nodiscard]] TypePtr getType() const final { return _type; }
-
-        [[nodiscard]] ValuePtr clone() const final
-        {
-            auto r = make_shared<StructValue>(_type);
-            for (const auto& member : members)
-            {
-                r->members.push_back(member->clone());
-            }
-            return r;
-        }
 
         [[nodiscard]] std::string toString() const final
         {
@@ -392,12 +345,10 @@ namespace IceBT::DBus
 
         [[nodiscard]] virtual bool isSignal() const = 0;
         [[nodiscard]] virtual bool isMethodCall() const = 0;
-        [[nodiscard]] virtual bool isMethodReturn() const = 0;
 
         [[nodiscard]] virtual std::string getPath() const = 0;
         [[nodiscard]] virtual std::string getInterface() const = 0;
         [[nodiscard]] virtual std::string getMember() const = 0;
-        [[nodiscard]] virtual std::string getDestination() const = 0;
 
         //
         // Writing arguments.
@@ -408,7 +359,6 @@ namespace IceBT::DBus
         //
         // Reading arguments.
         //
-        [[nodiscard]] virtual bool checkTypes(const std::vector<TypePtr>&) const = 0;
         virtual ValuePtr read() = 0;
         virtual std::vector<ValuePtr> readAll() = 0;
 
@@ -432,9 +382,6 @@ namespace IceBT::DBus
     class AsyncResult
     {
     public:
-        [[nodiscard]] virtual bool isPending() const = 0;
-        [[nodiscard]] virtual bool isComplete() const = 0;
-
         [[nodiscard]] virtual MessagePtr waitUntilFinished() const = 0;
 
         [[nodiscard]] virtual MessagePtr getReply() const = 0;

--- a/cpp/src/IceBT/DBus.h
+++ b/cpp/src/IceBT/DBus.h
@@ -3,7 +3,6 @@
 #ifndef ICE_BT_DBUS_H
 #define ICE_BT_DBUS_H
 
-#include <cassert>
 #include <cstdint>
 #include <memory>
 #include <sstream>
@@ -431,9 +430,8 @@ namespace IceBT::DBus
         virtual void removeService(const std::string&) = 0;
 
         //
-        // Asynchronously invokes a method call. The returned AsyncResult can be used
-        // to determine completion status and obtain the reply, or supply a callback
-        // to be notified when the call completes.
+        // Asynchronously invokes a method call. The returned AsyncResult can be used to wait for
+        // the reply and obtain it, or supply a callback to be notified when the call completes.
         //
         virtual AsyncResultPtr callAsync(const MessagePtr&, const AsyncCallbackPtr& = nullptr) = 0;
 

--- a/cpp/src/IceBT/Engine.cpp
+++ b/cpp/src/IceBT/Engine.cpp
@@ -8,6 +8,7 @@
 #include "Util.h"
 
 #include <algorithm>
+#include <cassert>
 #include <map>
 #include <mutex>
 #include <thread>

--- a/cpp/src/IceBT/Engine.cpp
+++ b/cpp/src/IceBT/Engine.cpp
@@ -8,6 +8,8 @@
 #include "Util.h"
 
 #include <algorithm>
+#include <map>
+#include <mutex>
 #include <thread>
 
 using namespace std;

--- a/cpp/src/IceBT/Engine.cpp
+++ b/cpp/src/IceBT/Engine.cpp
@@ -455,24 +455,6 @@ namespace IceBT
             return false;
         }
 
-        bool deviceExists(const string& addr) const
-        {
-            lock_guard lock(_mutex);
-
-            //
-            // Check if a remote device exists with the given device address.
-            //
-            for (const auto& remoteDevice : _remoteDevices)
-            {
-                if (remoteDevice.second.getAddress() == IceInternal::toUpper(addr))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         //
         // Calling registerProfile will advertise a service (SDP) profile with the Bluetooth daemon.
         //
@@ -704,7 +686,6 @@ namespace IceBT
 
                 _adapters.clear();
                 _remoteDevices.clear();
-                _defaultAdapterAddress.clear();
 
                 //
                 // The return value of GetManagedObjects is a dictionary structured like this:
@@ -1228,7 +1209,6 @@ namespace IceBT
 
         AdapterMap _adapters;
         RemoteDeviceMap _remoteDevices;
-        string _defaultAdapterAddress;
         vector<thread> _connectThreads;
     };
 }
@@ -1265,12 +1245,6 @@ bool
 IceBT::Engine::adapterExists(const string& addr) const
 {
     return _service->adapterExists(addr);
-}
-
-bool
-IceBT::Engine::deviceExists(const string& addr) const
-{
-    return _service->deviceExists(addr);
 }
 
 string

--- a/cpp/src/IceBT/Engine.h
+++ b/cpp/src/IceBT/Engine.h
@@ -53,13 +53,13 @@ namespace IceBT
     public:
         Engine(Ice::CommunicatorPtr);
 
-        Ice::CommunicatorPtr communicator() const;
+        [[nodiscard]] Ice::CommunicatorPtr communicator() const;
 
         void initialize();
-        bool initialized() const;
+        [[nodiscard]] bool initialized() const;
 
-        std::string getDefaultAdapterAddress() const;
-        bool adapterExists(const std::string&) const;
+        [[nodiscard]] std::string getDefaultAdapterAddress() const;
+        [[nodiscard]] bool adapterExists(const std::string&) const;
 
         std::string registerProfile(const std::string&, const std::string&, int, const ProfileCallbackPtr&);
         void unregisterProfile(const std::string&);
@@ -69,7 +69,7 @@ namespace IceBT
         void startDiscovery(const std::string&, std::function<void(const std::string&, const PropertyMap&)>);
         void stopDiscovery(const std::string&);
 
-        DeviceMap getDevices() const;
+        [[nodiscard]] DeviceMap getDevices() const;
 
         void destroy();
 

--- a/cpp/src/IceBT/Engine.h
+++ b/cpp/src/IceBT/Engine.h
@@ -10,7 +10,6 @@
 #include "IceBT/Types.h"
 
 #include <atomic>
-#include <mutex>
 
 namespace IceBT
 {
@@ -62,8 +61,6 @@ namespace IceBT
         std::string getDefaultAdapterAddress() const;
         bool adapterExists(const std::string&) const;
 
-        bool deviceExists(const std::string&) const;
-
         std::string registerProfile(const std::string&, const std::string&, int, const ProfileCallbackPtr&);
         void unregisterProfile(const std::string&);
 
@@ -79,7 +76,6 @@ namespace IceBT
     private:
         const Ice::CommunicatorPtr _communicator;
         std::atomic<bool> _initialized{false};
-        mutable std::mutex _mutex;
         BluetoothServicePtr _service;
     };
 }

--- a/cpp/src/IceBT/TransceiverI.h
+++ b/cpp/src/IceBT/TransceiverI.h
@@ -7,6 +7,7 @@
 #include "Engine.h"
 #include "InstanceF.h"
 #include "StreamSocket.h"
+#include <mutex>
 
 namespace IceBT
 {

--- a/cpp/src/IceBT/TransceiverI.h
+++ b/cpp/src/IceBT/TransceiverI.h
@@ -7,6 +7,7 @@
 #include "Engine.h"
 #include "InstanceF.h"
 #include "StreamSocket.h"
+
 #include <mutex>
 
 namespace IceBT


### PR DESCRIPTION
Fixes #6423.

`DBus.h` is internal to `cpp/src` and `Engine.cpp` is its only consumer, so anything Engine does not call is unreachable. All of this has been dead since the wrapper's initial commit.

- The `Value::clone()` hierarchy — every call site was inside another `clone()` override, so the recursion had no root caller. (`EndpointFactoryI::clone` is unrelated and untouched.)
- Five uncalled virtuals: `isMethodReturn`, `getDestination`, `checkTypes`, `isPending`, `isComplete`.
- `ArrayValue::toStringMap`, `ConnectionI::connection`, and the `ExceptionI(const DBusError&)` overload.
- Engine-side leftovers: the unused `Engine::_mutex` (the lock sites belong to the nested `BluetoothService`, which has its own), the write-only `_defaultAdapterAddress`, and the uncalled `deviceExists` chain.

Scoped to self-contained removals per @bernardnormier's review. The entangled pieces — the `AsyncCallback` completion layer, `removeFilter`, `getSessionBus`, and the `shared_ptr` aliases — are left alone for the eventual wrapper refactor.

**Draft pending CI.** IceBT is Linux/BlueZ-only, so this does not compile on macOS and Linux CI is the first compiler to see it.