### PR TITLE
Restore the version reporting and Windows fixes dropped from #6421

### DIFF
--- a/cpp/config/IceConfig.cmake
+++ b/cpp/config/IceConfig.cmake
@@ -14,6 +14,16 @@ if(CMAKE_VERSION VERSION_LESS 3.21)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/IcePrefix.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake")
+
+set(Ice_SO_VERSION "${_ice_package_so_version}")
+
+# Unconditionally: under find_package this matches what IceConfigVersion.cmake reported, and a
+# leftover cache entry from an older installation must not win over the installed version.
+set(Ice_VERSION "${_ice_package_version}")
+
+unset(_ice_package_version)
+unset(_ice_package_so_version)
 
 if(NOT DEFINED Ice_PREFIX)
   set(Ice_FOUND FALSE)

--- a/cpp/config/IceConfigVersion.cmake
+++ b/cpp/config/IceConfigVersion.cmake
@@ -1,0 +1,69 @@
+# Copyright (c) ZeroC, Inc.
+
+# Reports this installation's version to find_package. Without this file every
+# find_package(Ice <version>) fails with "version: unknown".
+#
+# CMake's own way to produce this file is write_basic_package_version_file(), but that runs inside a
+# CMake build and the Ice C++ build has none, so the file is maintained by hand. Plain requests follow
+# the COMPATIBILITY SameMinorVersion policy; version ranges are honored on both endpoints, where
+# SameMinorVersion would reject an upper endpoint in a later x.y.
+
+include("${CMAKE_CURRENT_LIST_DIR}/IceVersion.cmake")
+
+# Report the full version, pre-release suffix included, so Ice_VERSION matches what Ice reports
+# everywhere else. CMake's version comparison ignores the suffix and still derives
+# Ice_VERSION_MAJOR/MINOR/PATCH from the numeric part.
+set(PACKAGE_VERSION "${_ice_package_version}")
+
+if(PACKAGE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)")
+  set(_ice_version_major "${CMAKE_MATCH_1}")
+  set(_ice_version_minor "${CMAKE_MATCH_2}")
+else()
+  # Fail closed on a malformed IceVersion.cmake rather than compare against stale CMAKE_MATCH values.
+  set(_ice_version_major "")
+  set(_ice_version_minor "")
+endif()
+
+set(PACKAGE_VERSION_COMPATIBLE FALSE)
+set(PACKAGE_VERSION_EXACT FALSE)
+
+# A request is compatible when it names this x.y and is not newer than this installation. Ice
+# treats every x.y as a major release: 3.8 and 3.9 are not binary compatible and install side by
+# side (Ice-3.8, Ice-3.9); only patch releases within an x.y line are compatible. With 3.9.2
+# installed, requests for 3.9, 3.9.0 and 3.9.2 match; 3.9.5, 3.8, 3.7, 4.0 and a bare 3 do not.
+if(PACKAGE_VERSION)
+  if(PACKAGE_FIND_VERSION_RANGE)
+    # Same rule on the range's lower endpoint, plus this version must not exceed the upper one.
+    if(PACKAGE_FIND_VERSION_MIN_MAJOR STREQUAL _ice_version_major AND
+       PACKAGE_FIND_VERSION_MIN_MINOR STREQUAL _ice_version_minor AND
+       NOT PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION_MIN)
+      if(PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE" AND
+         NOT PACKAGE_VERSION VERSION_GREATER PACKAGE_FIND_VERSION_MAX)
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+      elseif(PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE" AND
+             PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION_MAX)
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+      endif()
+    endif()
+  else()
+    if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+      # Older than asked for.
+      set(PACKAGE_VERSION_COMPATIBLE FALSE)
+    elseif(PACKAGE_FIND_VERSION_MAJOR STREQUAL _ice_version_major AND
+           PACKAGE_FIND_VERSION_MINOR STREQUAL _ice_version_minor)
+      set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    endif()
+
+    # STREQUAL, as in CMake's own generated version files: a pre-release must not satisfy EXACT
+    # for the release it precedes, so 3.9.0-alpha.0 does not answer 3.9.0 EXACT. Plain requests
+    # still accept it. EXACT never combines with a range; find_package refuses that itself.
+    if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+  endif()
+endif()
+
+unset(_ice_version_major)
+unset(_ice_version_minor)
+unset(_ice_package_version)
+unset(_ice_package_so_version)

--- a/cpp/config/IceTargets.cmake
+++ b/cpp/config/IceTargets.cmake
@@ -46,20 +46,16 @@ find_path(Ice_SLICE_DIR
 # Imported targets for the executables in the NuGet package's native/bin directory.
 if(WIN32)
   function(add_ice_executable name)
+    # The NuGet package always ships both configurations; a miss is a broken installation.
     find_program(Ice_${name}_EXE_RELEASE ${name}${CMAKE_EXECUTABLE_SUFFIX}
       HINTS "${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Release"
-      NO_DEFAULT_PATH
+      NO_DEFAULT_PATH REQUIRED
     )
 
     find_program(Ice_${name}_EXE_DEBUG ${name}${CMAKE_EXECUTABLE_SUFFIX}
       HINTS "${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug"
-      NO_DEFAULT_PATH
+      NO_DEFAULT_PATH REQUIRED
     )
-
-    # Better undefined than a target with no IMPORTED_LOCATION, which fails far less obviously.
-    if(NOT Ice_${name}_EXE_RELEASE AND NOT Ice_${name}_EXE_DEBUG)
-      return()
-    endif()
 
     if(TARGET Ice::${name}_EXE)
       return()
@@ -67,21 +63,16 @@ if(WIN32)
 
     add_executable(Ice::${name}_EXE IMPORTED)
 
-    if(Ice_${name}_EXE_RELEASE)
-      set_property(TARGET Ice::${name}_EXE PROPERTY
-        IMPORTED_LOCATION_RELEASE "${Ice_${name}_EXE_RELEASE}")
-    endif()
-
-    if(Ice_${name}_EXE_DEBUG)
-      set_property(TARGET Ice::${name}_EXE PROPERTY
-        IMPORTED_LOCATION_DEBUG "${Ice_${name}_EXE_DEBUG}")
-    endif()
-
-    # Set the appropriate location based on build type
-    if(Ice_${name}_EXE_RELEASE OR Ice_${name}_EXE_DEBUG)
-      set_property(TARGET Ice::${name}_EXE PROPERTY
-        IMPORTED_LOCATION "$<IF:$<CONFIG:Debug>,${Ice_${name}_EXE_DEBUG},${Ice_${name}_EXE_RELEASE}>")
-    endif()
+    # The base IMPORTED_LOCATION is a plain path, not a generator expression: the property is read
+    # as a literal, so a genex would end up verbatim in the build system for any configuration the
+    # per-config properties do not cover. Debug and Release resolve through those; everything else
+    # falls back to the release executable.
+    set_target_properties(Ice::${name}_EXE PROPERTIES
+      IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
+      IMPORTED_LOCATION_RELEASE "${Ice_${name}_EXE_RELEASE}"
+      IMPORTED_LOCATION_DEBUG "${Ice_${name}_EXE_DEBUG}"
+      IMPORTED_LOCATION "${Ice_${name}_EXE_RELEASE}"
+    )
   endfunction()
 
   add_ice_executable(icebox)
@@ -110,21 +101,19 @@ function(add_ice_target component)
   )
 
   if(WIN32)
-    if(Ice_${component}_LIBRARY_RELEASE)
-      set_target_properties(Ice::${component} PROPERTIES
-        IMPORTED_CONFIGURATIONS RELEASE
-        IMPORTED_IMPLIB_RELEASE "${Ice_${component}_IMPLIB_RELEASE}"
-        IMPORTED_LOCATION_RELEASE "${Ice_${component}_LIBRARY_RELEASE}"
-      )
-    endif()
-
-    if(Ice_${component}_LIBRARY_DEBUG)
-      set_target_properties(Ice::${component} PROPERTIES
-        IMPORTED_CONFIGURATIONS DEBUG
-        IMPORTED_IMPLIB_DEBUG "${Ice_${component}_IMPLIB_DEBUG}"
-        IMPORTED_LOCATION_DEBUG "${Ice_${component}_LIBRARY_DEBUG}"
-      )
-    endif()
+    # A found component ships both configurations. Set IMPORTED_CONFIGURATIONS once - a per-config
+    # set() would overwrite, leaving DEBUG as the only entry - with RELEASE first, since CMake falls
+    # back to the first entry for an unmapped configuration. Map the release-like configurations
+    # explicitly too, so they cannot link the debug import library and mix CRTs.
+    set_target_properties(Ice::${component} PROPERTIES
+      IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
+      IMPORTED_IMPLIB_RELEASE "${Ice_${component}_IMPLIB_RELEASE}"
+      IMPORTED_LOCATION_RELEASE "${Ice_${component}_LIBRARY_RELEASE}"
+      IMPORTED_IMPLIB_DEBUG "${Ice_${component}_IMPLIB_DEBUG}"
+      IMPORTED_LOCATION_DEBUG "${Ice_${component}_LIBRARY_DEBUG}"
+      MAP_IMPORTED_CONFIG_RELWITHDEBINFO "Release"
+      MAP_IMPORTED_CONFIG_MINSIZEREL "Release"
+    )
   else()
     set_target_properties(Ice::${component} PROPERTIES
       IMPORTED_LOCATION "${Ice_${component}_LIBRARY_RELEASE}"
@@ -215,9 +204,9 @@ add_ice_library(Ice Threads::Threads)
 if(WIN32)
   # Bzip2 is included in the Ice NuGet package and is a runtime dependency of Ice.
   # This property can be used to copy the correct DLLs to the target directory at build time.
+  # Everything other than Debug takes the release DLL, matching the configuration mapping above.
   set_property(TARGET Ice::Ice PROPERTY ICE_RUNTIME_DLLS
-    "$<$<CONFIG:Debug>:${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug/bzip2d.dll>"
-    "$<$<CONFIG:Release>:${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Release/bzip2.dll>"
+    "$<IF:$<CONFIG:Debug>,${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug/bzip2d.dll,${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Release/bzip2.dll>"
   )
 endif()
 add_ice_library(DataStorm Ice::Ice)

--- a/cpp/config/IceTargets.cmake
+++ b/cpp/config/IceTargets.cmake
@@ -20,20 +20,6 @@ find_path(Ice_INCLUDE_DIR NAMES Ice/Ice.h
   PATH_SUFFIXES include DOC "Directory containing Ice header files"
   NO_DEFAULT_PATH REQUIRED)
 
-# Read Ice version variables from Ice/Config.h
-if(NOT DEFINED Ice_VERSION)
-  file(STRINGS "${Ice_INCLUDE_DIR}/Ice/Config.h" _ice_config_h_content REGEX "#define ICE_([A-Z]+)_VERSION ")
-
-  if("${_ice_config_h_content}" MATCHES "#define ICE_STRING_VERSION \"([^\"]+)\"")
-    set(Ice_VERSION "${CMAKE_MATCH_1}" CACHE STRING "Ice version")
-  endif()
-
-  if("${_ice_config_h_content}" MATCHES "#define ICE_SO_VERSION \"([^\"]+)\"")
-    set(Ice_SO_VERSION "${CMAKE_MATCH_1}" CACHE STRING "Ice SO version")
-  endif()
-  unset(_ice_config_h_content)
-endif()
-
 find_program(Ice_SLICE2CPP_EXECUTABLE slice2cpp
   HINTS ${Ice_PREFIX}
   PATH_SUFFIXES bin tools
@@ -244,4 +230,4 @@ add_ice_library(IceStorm Ice::Ice)
 add_ice_library(IceBT Ice::Ice)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Ice HANDLE_COMPONENTS CONFIG_MODE)
+find_package_handle_standard_args(Ice HANDLE_COMPONENTS HANDLE_VERSION_RANGE CONFIG_MODE)

--- a/cpp/config/IceVersion.cmake
+++ b/cpp/config/IceVersion.cmake
@@ -1,0 +1,10 @@
+# Copyright (c) ZeroC, Inc.
+
+# The version of the Ice installation these files ship with. Update at release time, along with the
+# other version strings in the source tree (config/version.env, config/Make.rules, and so on).
+#
+#   Ice_VERSION      matches ICE_STRING_VERSION in Ice/Config.h, pre-release suffix included
+#   Ice_SO_VERSION   matches ICE_SO_VERSION, and forms the Windows library names
+
+set(_ice_package_version "3.9.0-alpha.0")
+set(_ice_package_so_version "39a0")


### PR DESCRIPTION
#6421 was rebase-merged from a stale snapshot of its head branch: GitHub's PR object never registered the two later commits, so only the first one reached `main`. The same event-processing lag is what earlier folded the #6353 squash without #6354's content.

This restores the two dropped commits verbatim from `claude/cmake-package-strict`: the version reporting from #6353 (issue #6348) and the Windows imported-configuration fixes from #6354 (issue #6349). Both are the already-reviewed squashes, untouched. `cpp/config` on this branch matches the fully tested stack tip exactly, apart from `slice2cpp*.cmake`, which are `main`'s newer #6332 versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
