### PR TITLE
Check the IcePy stub against the IcePy module

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -65,4 +65,4 @@ jobs:
       - name: Check the IcePy stub against the IcePy module
         working-directory: python
         run: |
-          PYTHONPATH=python uv run python checkIcePyStub.py
+          PYTHONPATH=python uv run python ../scripts/checkIcePyStub.py

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -61,3 +61,8 @@ jobs:
         working-directory: python
         run: |
           uv run pyright --project ..
+
+      - name: Check the IcePy stub against the IcePy module
+        working-directory: python
+        run: |
+          PYTHONPATH=python uv run python checkIcePyStub.py

--- a/python/checkIcePyStub.py
+++ b/python/checkIcePyStub.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+# Copyright (c) ZeroC, Inc.
+
+"""
+Check that the IcePy stub agrees with the IcePy module.
+
+IcePy is a C extension, so its documentation has to exist twice: Sphinx reads the docstrings the
+module ships, and pyright and the IDEs read IcePy-stubs/__init__.pyi. Nothing links the two, so they
+drift silently. This compares them and reports where they disagree.
+
+The signature is compared as well as the prose. autodoc cannot introspect a C extension -- it reads
+the first line of each docstring -- so that line is a signature the stub also spells out, and it can
+drift just as easily.
+
+Run it after building Ice for Python:
+
+    PYTHONPATH=python python3 checkIcePyStub.py
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import sys
+from pathlib import Path
+
+STUB = Path(__file__).parent / "python" / "IcePy-stubs" / "__init__.pyi"
+
+
+def signatureOf(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    """Render a stub def the way the first line of a C docstring spells it."""
+    args = copy.deepcopy(node.args)
+    if args.posonlyargs and args.posonlyargs[0].arg in ("self", "cls"):
+        del args.posonlyargs[0]
+    elif args.args and args.args[0].arg in ("self", "cls"):
+        del args.args[0]
+    rendered = f"{node.name}({ast.unparse(args)})"
+    return f"{rendered} -> {ast.unparse(node.returns)}" if node.returns else rendered
+
+
+def stubEntries() -> dict[str, tuple[str | None, str | None]]:
+    """Map each name in the stub to its (docstring, signature). Classes have no signature."""
+    entries: dict[str, tuple[str | None, str | None]] = {}
+    for node in ast.parse(STUB.read_text(encoding="utf-8")).body:
+        if isinstance(node, ast.ClassDef):
+            entries[node.name] = (ast.get_docstring(node), None)
+            for member in node.body:
+                if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    entries[f"{node.name}.{member.name}"] = (ast.get_docstring(member), signatureOf(member))
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            entries[node.name] = (ast.get_docstring(node), signatureOf(node))
+    return entries
+
+
+def shipped(name: str) -> tuple[bool, str | None]:
+    """Return whether IcePy defines name, and the docstring it ships for it."""
+    import IcePy
+
+    obj: object = IcePy
+    for part in name.split("."):
+        if not hasattr(obj, part):
+            return False, None
+        obj = getattr(obj, part)
+    return True, getattr(obj, "__doc__", None)
+
+
+def split(doc: str | None, name: str) -> tuple[str | None, str]:
+    """
+    Separate a shipped docstring into its signature line and its prose.
+
+    The line only counts as a signature if it opens with the name being documented. Python supplies
+    its own docstring for an undocumented dunder -- "Return hash(self)." -- which otherwise looks
+    close enough to one to be mistaken for it.
+    """
+    if not doc:
+        return None, ""
+    lines = doc.split("\n")
+    if lines and lines[0].startswith(f"{name.split('.')[-1]}("):
+        return lines[0].strip(), "\n".join(lines[1:]).strip()
+    return None, doc.strip()
+
+
+def normalize(signature: str) -> str:
+    """Ignore spacing around default values: the stub is formatted by ast, the docstring by hand."""
+    return signature.replace(" = ", "=")
+
+
+def main() -> int:
+    problems: list[str] = []
+    for name, (stubDoc, stubSignature) in sorted(stubEntries().items()):
+        defined, shippedDoc = shipped(name)
+        if not defined:
+            # Private helpers the stub declares for pyright are not always attributes of the module.
+            continue
+
+        signature, prose = split(shippedDoc, name)
+
+        if stubDoc and not prose:
+            problems.append(f"{name}: documented in the stub, but IcePy ships no description")
+        elif stubDoc and prose and stubDoc.strip() != prose:
+            problems.append(
+                f"{name}: descriptions differ\n    stub:  {stubDoc.strip()[:100]}\n    IcePy: {prose[:100]}"
+            )
+
+        if stubSignature and signature and normalize(stubSignature) != normalize(signature):
+            problems.append(f"{name}: signatures differ\n    stub:  {stubSignature}\n    IcePy: {signature}")
+
+    if problems:
+        print(f"{len(problems)} difference(s) between the IcePy stub and the IcePy module:\n", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        print(
+            "\nBoth are hand-written and have to say the same thing: Sphinx reads the module's"
+            "\ndocstrings, pyright and the IDEs read the stub.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("the IcePy stub matches the IcePy module")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/checkIcePyStub.py
+++ b/python/checkIcePyStub.py
@@ -81,6 +81,12 @@ def split(doc: str | None, name: str) -> tuple[str | None, str]:
     return None, doc.strip()
 
 
+def isDunder(name: str) -> bool:
+    """Python writes its own docstring for a dunder it generates, so those carry no signature."""
+    leaf = name.rsplit(".", maxsplit=1)[-1]
+    return leaf.startswith("__") and leaf.endswith("__")
+
+
 def normalize(signature: str) -> str:
     """Ignore spacing around default values: the stub is formatted by ast, the docstring by hand."""
     return signature.replace(" = ", "=")
@@ -91,7 +97,10 @@ def main() -> int:
     for name, (stubDoc, stubSignature) in sorted(stubEntries().items()):
         defined, shippedDoc = shipped(name)
         if not defined:
-            # Private helpers the stub declares for pyright are not always attributes of the module.
+            # A private helper the stub declares for pyright need not be an attribute of the module,
+            # but a public one going missing is the drift this is looking for.
+            if not name.rsplit(".", maxsplit=1)[-1].startswith("_"):
+                problems.append(f"{name}: declared in the stub, but IcePy does not define it")
             continue
 
         signature, prose = split(shippedDoc, name)
@@ -103,7 +112,12 @@ def main() -> int:
                 f"{name}: descriptions differ\n    stub:  {stubDoc.strip()[:100]}\n    IcePy: {prose[:100]}"
             )
 
-        if stubSignature and signature and normalize(stubSignature) != normalize(signature):
+        if stubSignature and not signature and not isDunder(name):
+            problems.append(
+                f"{name}: the stub gives a signature, but IcePy's docstring opens with no matching one."
+                "\n    Sphinx reads the signature from that line, so it has to be there."
+            )
+        elif stubSignature and signature and normalize(stubSignature) != normalize(signature):
             problems.append(f"{name}: signatures differ\n    stub:  {stubSignature}\n    IcePy: {signature}")
 
     if problems:

--- a/python/checkIcePyStub.py
+++ b/python/checkIcePyStub.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import ast
 import copy
+import difflib
 import sys
 from pathlib import Path
 
@@ -108,9 +109,13 @@ def main() -> int:
         if stubDoc and not prose:
             problems.append(f"{name}: documented in the stub, but IcePy ships no description")
         elif stubDoc and prose and stubDoc.strip() != prose:
-            problems.append(
-                f"{name}: descriptions differ\n    stub:  {stubDoc.strip()[:100]}\n    IcePy: {prose[:100]}"
+            diff = "\n".join(
+                f"    {line}"
+                for line in difflib.unified_diff(
+                    stubDoc.strip().splitlines(), prose.splitlines(), "stub", "IcePy", lineterm=""
+                )
             )
+            problems.append(f"{name}: descriptions differ\n{diff}")
 
         if stubSignature and not signature and not isDunder(name):
             problems.append(

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -65,7 +65,8 @@ Starts a graceful closure of this connection once all outstanding invocations ha
 Returns
 -------
 Awaitable[None]
-    A future that becomes available when the connection is closed.)";
+    A future that becomes available when the connection is closed. If the connection was lost or
+    aborted, awaiting this future raises the exception that caused the connection's closure.)";
 
     constexpr const char* connectionCreateProxy_doc = R"(createProxy(identity: Ice.Identity) -> Ice.ObjectPrx
 
@@ -112,8 +113,8 @@ adapter : Ice.ObjectAdapter | None
 Raises
 ------
 LocalException
-    If this connection is an incoming (server) connection: setAdapter can only be called on outgoing
-    connections.)";
+    When this connection is an incoming (server) connection: only outgoing (client) connections
+    support setting the object adapter.)";
 
     constexpr const char* connectionGetAdapter_doc = R"(getAdapter() -> Ice.ObjectAdapter | None
 
@@ -205,7 +206,7 @@ Returns
 Ice.ConnectionInfo
     The connection information.)";
 
-    constexpr const char* connectionGetEndpoint_doc = R"(getEndpoint() -> Endpoint
+    constexpr const char* connectionGetEndpoint_doc = R"(getEndpoint() -> Ice.Endpoint
 
 Gets the endpoint from which the connection was created.
 

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -113,7 +113,7 @@ adapter : Ice.ObjectAdapter | None
 Raises
 ------
 LocalException
-    When this connection is an incoming (server) connection: only outgoing (client) connections
+    If this connection is an incoming (server) connection: only outgoing (client) connections
     support setting the object adapter.)";
 
     constexpr const char* connectionGetAdapter_doc = R"(getAdapter() -> Ice.ObjectAdapter | None

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -63,7 +63,7 @@ defaults : Properties | None, optional
 
 Returns
 -------
-Ice.Properties
+Properties
     A new property set.)";
 
     constexpr const char* IcePy_stringToIdentity_doc = R"(stringToIdentity(str: str) -> Ice.Identity
@@ -111,7 +111,7 @@ Gets the per-process logger.
 
 Returns
 -------
-Ice.Logger
+Ice.Logger | Logger
     The current per-process logger instance.)";
 
     constexpr const char* IcePy_setProcessLogger_doc = R"(setProcessLogger(logger: Ice.Logger) -> None

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -50,7 +50,7 @@ int
     The Ice version.)";
 
     constexpr const char* IcePy_createProperties_doc =
-        R"(createProperties(args: list[str] | None = None, defaults: Ice.Properties | None = None) -> Ice.Properties
+        R"(createProperties(args: list[str] | None = None, defaults: Ice.Properties | None = None) -> Properties
 
 Creates a property set initialized from command-line arguments and a default property set.
 
@@ -105,7 +105,7 @@ Returns
 str
     The stringified identity.)";
 
-    constexpr const char* IcePy_getProcessLogger_doc = R"(getProcessLogger() -> Ice.Logger
+    constexpr const char* IcePy_getProcessLogger_doc = R"(getProcessLogger() -> Ice.Logger | Logger
 
 Gets the per-process logger.
 

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -58,7 +58,7 @@ Parameters
 ----------
 args : list[str] | None, optional
     The command-line arguments.
-defaults : Properties | None, optional
+defaults : Ice.Properties | None, optional
     Default values for the new property set.
 
 Returns

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -852,7 +852,7 @@ static PyMethodDef DispatchCallbackMethods[] = {
     {"response",
      reinterpret_cast<PyCFunction>(dispatchCallbackResponse),
      METH_VARARGS,
-     PyDoc_STR("response(*args: tuple) -> None")},
+     PyDoc_STR("response(result: Any) -> None")},
     {"exception",
      reinterpret_cast<PyCFunction>(dispatchCallbackException),
      METH_VARARGS,

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -1257,7 +1257,7 @@ static PyMethodDef ProxyMethods[] = {
     {"ice_identity",
      reinterpret_cast<PyCFunction>(proxyIceIdentity),
      METH_VARARGS,
-     PyDoc_STR("ice_identity(id: Ice.Identity) -> Ice.ObjectPrx")},
+     PyDoc_STR("ice_identity(newIdentity: Ice.Identity) -> Ice.ObjectPrx")},
     {"ice_getContext",
      reinterpret_cast<PyCFunction>(proxyIceGetContext),
      METH_NOARGS,
@@ -1420,13 +1420,13 @@ static PyMethodDef ProxyMethods[] = {
     {"ice_invoke",
      reinterpret_cast<PyCFunction>(proxyIceInvoke),
      METH_VARARGS | METH_KEYWORDS,
-     PyDoc_STR("ice_invoke(operation: str, mode: Ice.OperationMode, inParams: bytes, ctx: dict[str, str] | None) -> "
+     PyDoc_STR("ice_invoke(operation: str, mode: Ice.OperationMode, inParams: bytes, ctx: dict[str, str] | None = None) -> "
                "tuple[bool, bytes]")},
     {"ice_invokeAsync",
      reinterpret_cast<PyCFunction>(proxyIceInvokeAsync),
      METH_VARARGS | METH_KEYWORDS,
      PyDoc_STR(
-         "ice_invokeAsync(operation: str, mode: Ice.OperationMode, inParams: bytes, ctx: dict[str, str] | None) -> "
+         "ice_invokeAsync(operation: str, mode: Ice.OperationMode, inParams: bytes, ctx: dict[str, str] | None = None) -> "
          "Awaitable[tuple[bool, bytes]]")},
     {"newProxy",
      reinterpret_cast<PyCFunction>(proxyNewProxy),

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -1420,14 +1420,13 @@ static PyMethodDef ProxyMethods[] = {
     {"ice_invoke",
      reinterpret_cast<PyCFunction>(proxyIceInvoke),
      METH_VARARGS | METH_KEYWORDS,
-     PyDoc_STR("ice_invoke(operation: str, mode: Ice.OperationMode, inParams: bytes, ctx: dict[str, str] | None = None) -> "
-               "tuple[bool, bytes]")},
+     PyDoc_STR("ice_invoke(operation: str, mode: Ice.OperationMode, inParams: bytes, "
+               "ctx: dict[str, str] | None = None) -> tuple[bool, bytes]")},
     {"ice_invokeAsync",
      reinterpret_cast<PyCFunction>(proxyIceInvokeAsync),
      METH_VARARGS | METH_KEYWORDS,
-     PyDoc_STR(
-         "ice_invokeAsync(operation: str, mode: Ice.OperationMode, inParams: bytes, ctx: dict[str, str] | None = None) -> "
-         "Awaitable[tuple[bool, bytes]]")},
+     PyDoc_STR("ice_invokeAsync(operation: str, mode: Ice.OperationMode, inParams: bytes, "
+               "ctx: dict[str, str] | None = None) -> Awaitable[tuple[bool, bytes]]")},
     {"newProxy",
      reinterpret_cast<PyCFunction>(proxyNewProxy),
      METH_VARARGS | METH_STATIC,

--- a/python/python/IcePy-stubs/__init__.pyi
+++ b/python/python/IcePy-stubs/__init__.pyi
@@ -170,7 +170,7 @@ class Connection:
         Raises
         ------
         LocalException
-            When this connection is an incoming (server) connection: only outgoing (client) connections
+            If this connection is an incoming (server) connection: only outgoing (client) connections
             support setting the object adapter.
         """
         ...

--- a/scripts/checkIcePyStub.py
+++ b/scripts/checkIcePyStub.py
@@ -13,9 +13,9 @@ The signature is compared as well as the prose. autodoc cannot introspect a C ex
 the first line of each docstring -- so that line is a signature the stub also spells out, and it can
 drift just as easily.
 
-Run it after building Ice for Python:
+Run it from the repository root after building Ice for Python:
 
-    PYTHONPATH=python python3 checkIcePyStub.py
+    PYTHONPATH=python/python python3 scripts/checkIcePyStub.py
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ import difflib
 import sys
 from pathlib import Path
 
-STUB = Path(__file__).parent / "python" / "IcePy-stubs" / "__init__.pyi"
+STUB = Path(__file__).parents[1] / "python" / "python" / "IcePy-stubs" / "__init__.pyi"
 
 
 def signatureOf(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:


### PR DESCRIPTION
IcePy's documentation exists twice: Sphinx reads the docstrings the module ships, pyright and the IDEs read `IcePy-stubs/__init__.pyi`. Nothing links them, so they drift silently — they had.

- Add `scripts/checkIcePyStub.py`, run after the Pyright job, which already builds the extension. It imports IcePy and compares the docstrings actually shipped rather than parsing the C++, so there is no name mapping to get wrong. It compares signatures as well as prose: autodoc cannot introspect a C extension and takes the signature from the first line of each docstring, so that line drifts just as easily.
- `Connection.close` never said that awaiting the future re-raises whatever closed the connection, so the published documentation omitted it.
- `DispatchCallback.response` was documented as taking `*args`, but the implementation parses exactly one object.
- `createProperties` and `getProcessLogger` named return types their implementations do not return — `getProcessLogger` may return a Python logger directly rather than a wrapper, as its own comment says.
- `ice_invoke` and `ice_invokeAsync` omitted the default for `ctx`.
- `getEndpoint` left `Endpoint` unqualified, `ice_identity` called its parameter `id`, and `setAdapter` described the exception it raises differently in each copy.

All nine are resolved in favour of the stub, which was consistently the better maintained side. Only the types re-exported raw reach the published documentation (`Ice.Connection` *is* `IcePy.Connection`); the `createProperties`, `getProcessLogger` and `ice_invoke` fixes reach `help()` and IDE hover.

The alternative, generating the stub from the module (#4947), is a bigger change than it looks; I have left the numbers on that issue.