### PR TITLE
Fix two IceRuby marshaling issues

### DIFF
--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -2436,10 +2436,6 @@ IceRuby::ValueWriter::ValueWriter(VALUE object, ValueMap* valueMap, const ClassI
       _map(valueMap),
       _formal(formal)
 {
-    //
-    // Mark the object as in use for the lifetime of this wrapper.
-    //
-    rb_gc_register_address(&_object);
     if (!_formal || !_formal->interface)
     {
         volatile VALUE cls = CLASS_OF(object);
@@ -2448,6 +2444,9 @@ IceRuby::ValueWriter::ValueWriter(VALUE object, ValueMap* valueMap, const ClassI
         _info = dynamic_pointer_cast<ClassInfo>(getType(type));
         assert(_info);
     }
+
+    // Mark the object as in use for the lifetime of this wrapper. We register last, in case the code above throws.
+    rb_gc_register_address(&_object);
 }
 
 IceRuby::ValueWriter::~ValueWriter() { rb_gc_unregister_address(&_object); }
@@ -2861,6 +2860,7 @@ IceRuby::ExceptionReader::_read(Ice::InputStream* is)
 {
     is->startException();
     _ex = _info->unmarshal(is);
+    is->endException();
 }
 
 bool


### PR DESCRIPTION
## Summary

Two small IceRuby fixes from the cross-review of the earlier ExceptionReader GC fix:

- `ExceptionReader::_read` now calls `InputStream::endException()` after unmarshaling the exception, pairing the `startException()` call like IcePy, IcePHP, and Ruby itself prior to the 3.8 SliceLoader refactor. Without it the decoder is left mid-instance; nothing observes that state today, so this is a consistency fix with no user-visible change.
- `ValueWriter`'s constructor now registers its GC root as the last statement. The `ICE_TYPE` lookup runs through `callRuby` and can throw `RubyException` (reachable with a null formal type via a hand-built `SlicedData`); throwing after `rb_gc_register_address` would skip the destructor and leak a registration pointing at freed storage. This matches `ValueReader` and `RubySliceLoader`, which already register last.

No changelog entries: neither change affects valid programs during normal operations.

Fixes #6369.
Fixes #6370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
