### PR TITLE
Raise RuntimeException when an Ice class lookup fails in IcePHP

### DIFF
--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -453,8 +453,11 @@ ZEND_METHOD(Ice_Communicator, identityToString)
     CommunicatorInfoIPtr _this = Wrapper<CommunicatorInfoIPtr>::value(getThis());
     assert(_this);
 
-    zend_class_entry* identityClass = nameToClass("\\Ice\\Identity");
-    assert(identityClass);
+    zend_class_entry* identityClass = lookupClass("\\Ice\\Identity");
+    if (!identityClass)
+    {
+        RETURN_NULL();
+    }
 
     zval* zv;
     if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("O"), &zv, identityClass) != SUCCESS)
@@ -849,8 +852,9 @@ ZEND_FUNCTION(Ice_initialize)
         RETURN_NULL();
     }
 
+    // initClass is null when the application didn't load the Ice library files; a null initClass matches no
+    // argument below.
     zend_class_entry* initClass = nameToClass("\\Ice\\InitializationData");
-    assert(initClass);
 
     //
     // Retrieve the arguments.
@@ -1193,8 +1197,11 @@ ZEND_FUNCTION(Ice_getProperties)
 
 ZEND_FUNCTION(Ice_identityToString)
 {
-    zend_class_entry* identityClass = nameToClass("\\Ice\\Identity");
-    assert(identityClass);
+    zend_class_entry* identityClass = lookupClass("\\Ice\\Identity");
+    if (!identityClass)
+    {
+        RETURN_NULL();
+    }
 
     zval* zv;
     zend_long mode = 0;

--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -852,9 +852,11 @@ ZEND_FUNCTION(Ice_initialize)
         RETURN_NULL();
     }
 
-    // initClass is null when the application didn't load the Ice library files; a null initClass matches no
-    // argument below.
-    zend_class_entry* initClass = nameToClass("\\Ice\\InitializationData");
+    zend_class_entry* initClass = lookupClass("\\Ice\\InitializationData");
+    if (!initClass)
+    {
+        RETURN_NULL();
+    }
 
     //
     // Retrieve the arguments.

--- a/php/src/Endpoint.cpp
+++ b/php/src/Endpoint.cpp
@@ -369,7 +369,10 @@ IcePHP::createEndpointInfo(zval* zv, const Ice::EndpointInfoPtr& p)
         if ((status = object_init_ex(zv, opaqueEndpointInfoClassEntry)) == SUCCESS)
         {
             zval rawEncoding;
-            createEncodingVersion(&rawEncoding, info->rawEncoding);
+            if (!createEncodingVersion(&rawEncoding, info->rawEncoding))
+            {
+                return false;
+            }
             add_property_zval(zv, "rawEncoding", &rawEncoding);
             zval_ptr_dtor(&rawEncoding); // add_property_zval increased the refcount of rawEncoding
 

--- a/php/src/Endpoint.cpp
+++ b/php/src/Endpoint.cpp
@@ -371,6 +371,8 @@ IcePHP::createEndpointInfo(zval* zv, const Ice::EndpointInfoPtr& p)
             zval rawEncoding;
             if (!createEncodingVersion(&rawEncoding, info->rawEncoding))
             {
+                zval_ptr_dtor(zv);
+                ZVAL_UNDEF(zv);
                 return false;
             }
             add_property_zval(zv, "rawEncoding", &rawEncoding);

--- a/php/src/Proxy.cpp
+++ b/php/src/Proxy.cpp
@@ -134,8 +134,11 @@ ZEND_METHOD(Ice_ObjectPrx, ice_identity)
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
     assert(_this);
 
-    zend_class_entry* cls = nameToClass("\\Ice\\Identity");
-    assert(cls);
+    zend_class_entry* cls = lookupClass("\\Ice\\Identity");
+    if (!cls)
+    {
+        RETURN_NULL();
+    }
 
     zval* zid;
 
@@ -627,8 +630,11 @@ ZEND_METHOD(Ice_ObjectPrx, ice_encodingVersion)
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
     assert(_this);
 
-    zend_class_entry* cls = nameToClass("\\Ice\\EncodingVersion");
-    assert(cls);
+    zend_class_entry* cls = lookupClass("\\Ice\\EncodingVersion");
+    if (!cls)
+    {
+        RETURN_NULL();
+    }
 
     zval* zv;
     if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("O"), &zv, cls) == FAILURE)

--- a/php/src/Proxy.cpp
+++ b/php/src/Proxy.cpp
@@ -122,7 +122,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getIdentity)
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
     assert(_this);
 
-    createIdentity(return_value, _this->proxy->ice_getIdentity());
+    if (!createIdentity(return_value, _this->proxy->ice_getIdentity()))
+    {
+        RETURN_NULL();
+    }
 }
 
 ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_identity_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))

--- a/php/src/Proxy.cpp
+++ b/php/src/Proxy.cpp
@@ -681,8 +681,6 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getRouter)
                 RETURN_NULL();
             }
 
-            assert(info);
-
             if (!createProxy(return_value, std::move(router.value()), std::move(info), _this->communicator))
             {
                 RETURN_NULL();
@@ -1475,7 +1473,13 @@ IcePHP::Proxy::create(zval* zv, Ice::ObjectPrx p, ProxyInfoPtr info, Communicato
     if (!prxInfo)
     {
         prxInfo = getProxyInfo("::Ice::Object");
-        assert(prxInfo);
+        if (!prxInfo)
+        {
+            // The proxy type registry is populated by PHP code; it's empty when the application didn't load the
+            // Ice library files. Failing here ensures a Proxy object always has type information.
+            runtimeError("no definition for Ice::Object");
+            return false;
+        }
     }
 
     if (object_init_ex(zv, proxyClassEntry) != SUCCESS)

--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -75,8 +75,11 @@ namespace
             return false;
         }
 
-        zend_class_entry* cls = nameToClass(type);
-        assert(cls);
+        zend_class_entry* cls = lookupClass(type);
+        if (!cls)
+        {
+            return false;
+        }
 
         zend_class_entry* ce = Z_OBJCE_P(zv);
         if (ce != cls)
@@ -131,8 +134,11 @@ namespace
 
     template<typename T> bool createVersion(zval* zv, const T& version, const char* type)
     {
-        zend_class_entry* cls = nameToClass(type);
-        assert(cls);
+        zend_class_entry* cls = lookupClass(type);
+        if (!cls)
+        {
+            return false;
+        }
 
         if (object_init_ex(zv, cls) != SUCCESS)
         {
@@ -183,11 +189,25 @@ IcePHP::nameToClass(const string& name)
     return result;
 }
 
+zend_class_entry*
+IcePHP::lookupClass(const string& name)
+{
+    zend_class_entry* cls = nameToClass(name);
+    if (!cls)
+    {
+        runtimeError("unable to find PHP class '" + name + "'");
+    }
+    return cls;
+}
+
 bool
 IcePHP::createIdentity(zval* zv, const Ice::Identity& id)
 {
-    zend_class_entry* cls = nameToClass("\\Ice\\Identity");
-    assert(cls);
+    zend_class_entry* cls = lookupClass("\\Ice\\Identity");
+    if (!cls)
+    {
+        return false;
+    }
 
     if (object_init_ex(zv, cls) != SUCCESS)
     {
@@ -210,8 +230,11 @@ IcePHP::extractIdentity(zval* zv, Ice::Identity& id)
         return false;
     }
 
-    zend_class_entry* cls = nameToClass("\\Ice\\Identity");
-    assert(cls);
+    zend_class_entry* cls = lookupClass("\\Ice\\Identity");
+    if (!cls)
+    {
+        return false;
+    }
 
     zend_class_entry* ce = Z_OBJCE_P(zv);
     if (ce != cls)

--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -481,6 +481,8 @@ IcePHP::convertException(zval* zex, std::exception_ptr ex)
         if (!createIdentity(&id, e.id()))
         {
             zval_ptr_dtor(&id);
+            zval_ptr_dtor(zex);
+            ZVAL_UNDEF(zex);
             return;
         }
 

--- a/php/src/Util.h
+++ b/php/src/Util.h
@@ -51,6 +51,10 @@ namespace IcePHP
 
     zend_class_entry* nameToClass(const std::string&);
 
+    // Like nameToClass, but raises a RuntimeException and returns nullptr when the class is not defined - typically
+    // because the application didn't load the Ice library files.
+    zend_class_entry* lookupClass(const std::string&);
+
     bool createIdentity(zval*, const Ice::Identity&);
     bool extractIdentity(zval*, Ice::Identity&);
 

--- a/php/src/Util.h
+++ b/php/src/Util.h
@@ -52,8 +52,8 @@ namespace IcePHP
     zend_class_entry* nameToClass(const std::string&);
 
     // Like nameToClass, but fails when the class is not defined - typically because the application didn't load the
-    // Ice library files. On failure, this function raises a RuntimeException in the PHP interpreter (which doesn't
-    // throw a C++ exception) and returns nullptr; the caller must check for nullptr and propagate the failure.
+    // Ice library files. On failure, this function raises a RuntimeException in the PHP interpreter and returns
+    // nullptr; the caller must check for nullptr and propagate the failure.
     zend_class_entry* lookupClass(const std::string&);
 
     bool createIdentity(zval*, const Ice::Identity&);

--- a/php/src/Util.h
+++ b/php/src/Util.h
@@ -51,8 +51,9 @@ namespace IcePHP
 
     zend_class_entry* nameToClass(const std::string&);
 
-    // Like nameToClass, but raises a RuntimeException and returns nullptr when the class is not defined - typically
-    // because the application didn't load the Ice library files.
+    // Like nameToClass, but fails when the class is not defined - typically because the application didn't load the
+    // Ice library files. On failure, this function raises a RuntimeException in the PHP interpreter (which doesn't
+    // throw a C++ exception) and returns nullptr; the caller must check for nullptr and propagate the failure.
     zend_class_entry* lookupClass(const std::string&);
 
     bool createIdentity(zval*, const Ice::Identity&);


### PR DESCRIPTION
## Summary

When the ice extension runs without the Ice language library (for example `php -n -d extension=ice.so`, without including `Ice.php`), the PHP classes the extension looks up don't resolve. Most native lookups were guarded by an `assert` alone, so a release build passed a null `zend_class_entry*` to Zend and segfaulted — for example `ice_getIdentity` and `ice_getEncodingVersion` on any proxy.

Following the pattern #6382 established for the exception conversion path, the new `lookupClass` helper looks up the class and raises a `RuntimeException` (`unable to find PHP class '...'`) when it is not defined; the callers propagate the failure. Applied to the reachable assert-only sites:

- `Util.cpp`: `createIdentity`, `extractIdentity`, and the `createVersion`/`getVersion` templates
- `Proxy.cpp`: `ice_identity`, `ice_encodingVersion` (the lookup feeds `zend_parse_parameters`'s `O` specifier)
- `Communicator.cpp`: both `identityToString` entry points and `Ice\initialize`'s `InitializationData` lookup

The guards beyond `Ice\initialize` are not dead code. `Ice.php` is a chain of `require_once` and `Ice/Proxy.php` requires nothing itself, so a partial load can define `\Ice\InitializationData` — letting `initialize` succeed — while `\Ice\Identity` or the proxy registry's `::Ice::Object` entry are still missing. Each entry point therefore guards its own lookups. The policy is fail-early: any Ice call made without the full language library raises, regardless of which classes that particular call happens to touch — which is also why `Ice\initialize` performs its lookup before argument parsing.

When a lookup fails partway through building a result, the failure path now rolls back the output zval (`convertException`, `createEndpointInfo`) so the pending `RuntimeException` propagates instead of a half-built exception object or a leaked `EndpointInfo`.

Per the review discussion on the issue, the class-lookup helper alone doesn't cover operation dispatch: the proxy type registry (populated by `Ice.php` via `IcePHP_defineProxy`) is also empty, so `Proxy::create` stored a null `ProxyInfo` into every proxy and `handleGetMethod` crashed on the first Slice operation call (`$c->stringToProxy(...)->ice_ping()`). Rather than guarding each downstream use, `Proxy::create` now fails with `RuntimeException` (`no definition for Ice::Object`) when the registry has no `::Ice::Object` entry — establishing the invariant that a `Proxy` object always has type information. `handleGetMethod`'s assert thereby becomes a true invariant and stays. The trade-off: without `Ice.php`, `stringToProxy` itself now fails cleanly instead of returning a half-usable proxy whose native methods (`ice_toString`, ...) only worked accidentally.

Two categories deliberately keep their asserts:

- Lookups of PHP built-in classes (`RuntimeException`, `InvalidArgumentException` in `throwError`/`createInvalidArgumentException`) — always defined, with or without `Ice.php`.
- The deferred resolutions in `Types.cpp` (`StreamUtil` statics, `ClassInfo`/`ExceptionInfo` class entries) — all three resolve the generated class's own name, which the generated file defines immediately before calling `IcePHP_define*`, so they hold in any load configuration (generated files don't require `Ice.php`, and generated structs and enums extend nothing).

Verified with both repros: every former SIGSEGV path now raises a catchable `RuntimeException`, and running without `Ice.php` fails at the first Ice call. All 20 PHP test suites pass. No changelog entry: running without `Ice.php` is a misconfiguration, per the #6382 precedent.

Fixes #6394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
