### PR TITLE
Fix weakened, inverted, and unreachable test assertions

### DIFF
--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -597,6 +597,7 @@ testCertificateVerification(
         try
         {
             server->ice_ping();
+            test(false);
         }
         catch (const Ice::SecurityException&)
         {
@@ -620,6 +621,7 @@ testCertificateVerification(
         try
         {
             server->ice_ping();
+            test(false);
         }
         catch (const Ice::SecurityException&)
         {

--- a/cpp/test/IceUtil/timer/Client.cpp
+++ b/cpp/test/IceUtil/timer/Client.cpp
@@ -171,19 +171,20 @@ Client::run(int, char*[])
             task->waitForRun();
             task->clear();
             //
-            // Verify that the same task cannot be scheduled more than once.
+            // Verify that the same task cannot be scheduled more than once. The long delay ensures the task is
+            // still scheduled when we schedule it again.
             //
-            timer->schedule(task, chrono::milliseconds(100));
+            timer->schedule(task, chrono::hours(1));
             try
             {
                 timer->schedule(task, chrono::seconds::zero());
+                test(false);
             }
             catch (const invalid_argument&)
             {
                 // Expected.
             }
-            task->waitForRun();
-            task->clear();
+            timer->cancel(task);
         }
 
         {
@@ -253,14 +254,11 @@ Client::run(int, char*[])
             DestroyTaskPtr destroyTask = make_shared<DestroyTask>(timer);
             timer->schedule(destroyTask, chrono::seconds::zero());
             destroyTask->waitForRun();
-            try
-            {
-                timer->schedule(destroyTask, chrono::seconds::zero());
-            }
-            catch (const invalid_argument&)
-            {
-                // Expected;
-            }
+
+            // The destroy call from the timer task failed, and the timer remains usable.
+            TestTaskPtr task = make_shared<TestTask>();
+            timer->schedule(task, chrono::seconds::zero());
+            task->waitForRun();
             timer->destroy();
         }
         {
@@ -271,6 +269,7 @@ Client::run(int, char*[])
             try
             {
                 timer->schedule(testTask, chrono::seconds::zero());
+                test(false);
             }
             catch (const invalid_argument&)
             {

--- a/csharp/test/Ice/echo/BlobjectI.cs
+++ b/csharp/test/Ice/echo/BlobjectI.cs
@@ -8,7 +8,7 @@ public class BlobjectI : Ice.BlobjectAsync
 {
     public void startBatch()
     {
-        Debug.Assert(_batchProxy != null);
+        Debug.Assert(_batchProxy == null);
         _startBatch = true;
     }
 

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -215,7 +215,7 @@ public class Client : Test.TestHelper
             properties.setProperty("Foo", "bar");
             try
             {
-                properties.getIcePropertyAsInt("Foo");
+                properties.getPropertyAsInt("Foo");
                 test(false);
             }
             catch (Ice.PropertyException)

--- a/csharp/test/Ice/seqMapping/Custom.cs
+++ b/csharp/test/Ice/seqMapping/Custom.cs
@@ -19,40 +19,7 @@ public class Custom<T> : IEnumerable<T>
 
     public void Add(T element) => _list.Add(element);
 
-    public override bool Equals(object obj)
-    {
-        try
-        {
-            var tmp = (Custom<T>)obj;
-            IEnumerator<T> e = tmp.GetEnumerator();
-            foreach (T element in _list)
-            {
-                if (!e.MoveNext())
-                {
-                    return false;
-                }
-                if (element == null)
-                {
-                    if (e.Current != null)
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    if (!element.Equals(e.Current))
-                    {
-                        return false;
-                    }
-                }
-            }
-            return !e.MoveNext();
-        }
-        catch (Exception)
-        {
-            return false;
-        }
-    }
+    public override bool Equals(object obj) => obj is Custom<T> other && _list.SequenceEqual(other._list);
 
     public override int GetHashCode()
     {

--- a/csharp/test/Ice/seqMapping/Custom.cs
+++ b/csharp/test/Ice/seqMapping/Custom.cs
@@ -17,7 +17,7 @@ public class Custom<T> : IEnumerable<T>
         set => _list[index] = value;
     }
 
-    public void Add(T elmt) => _list.Add(elmt);
+    public void Add(T element) => _list.Add(element);
 
     public override bool Equals(object obj)
     {
@@ -25,13 +25,13 @@ public class Custom<T> : IEnumerable<T>
         {
             var tmp = (Custom<T>)obj;
             IEnumerator<T> e = tmp.GetEnumerator();
-            foreach (T elmt in _list)
+            foreach (T element in _list)
             {
                 if (!e.MoveNext())
                 {
                     return false;
                 }
-                if (elmt == null)
+                if (element == null)
                 {
                     if (e.Current != null)
                     {
@@ -40,13 +40,13 @@ public class Custom<T> : IEnumerable<T>
                 }
                 else
                 {
-                    if (!elmt.Equals(e.Current))
+                    if (!element.Equals(e.Current))
                     {
                         return false;
                     }
                 }
             }
-            return true;
+            return !e.MoveNext();
         }
         catch (Exception)
         {
@@ -54,7 +54,15 @@ public class Custom<T> : IEnumerable<T>
         }
     }
 
-    public override int GetHashCode() => base.GetHashCode();
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (T element in _list)
+        {
+            hash.Add(element);
+        }
+        return hash.ToHashCode();
+    }
 
     private readonly List<T> _list = new List<T>();
 }

--- a/java/test/src/main/java/test/Ice/properties/Client.java
+++ b/java/test/src/main/java/test/Ice/properties/Client.java
@@ -208,7 +208,7 @@ public class Client extends TestHelper {
             Properties properties = new Properties();
             properties.setProperty("Foo", "bar");
             try {
-                properties.getIcePropertyAsInt("Foo");
+                properties.getPropertyAsInt("Foo");
                 test(false);
             } catch (PropertyException ex) {}
             System.out.println("ok");

--- a/swift/test/Ice/ami/AllTests.swift
+++ b/swift/test/Ice/ami/AllTests.swift
@@ -61,6 +61,7 @@ func allTests(_ helper: TestHelper, collocated: Bool = false) async throws {
     do {
         let indirect = p.ice_adapterId("dummy")
         try await indirect.op()
+        try test(false)
     } catch is Ice.NoEndpointException {}
 
     do {

--- a/swift/test/Ice/ami/TestI.swift
+++ b/swift/test/Ice/ami/TestI.swift
@@ -68,7 +68,7 @@ actor State {
     }
 
     func sleep(ms: Int32) async throws {
-        try await Task.sleep(for: .milliseconds(100))
+        try await Task.sleep(for: .milliseconds(ms))
     }
 }
 

--- a/swift/test/Ice/stream/Client.swift
+++ b/swift/test/Ice/stream/Client.swift
@@ -48,7 +48,7 @@ public class Client: TestHelperI, @unchecked Sendable {
             do {
                 _ = try inS.read() as Bool
                 try test(false)
-            } catch {}
+            } catch is Ice.MarshalException {}
         }
 
         do {


### PR DESCRIPTION
## Summary

Fixes the eight test-suite defects from the audit batch — weakened, inverted, or unreachable assertions across C++, C#, Java, and Swift. The first three could have masked real product regressions; their strengthened assertions now re-verify the guards they protect (all suites pass, so none has regressed).

- **IceSSL configuration (C++)**: the `ca1/server_cn2` and `ca1/server_cn3` (`__APPLE__`) hostname-verification cases now assert that `ice_ping` fails; previously a `CheckCertName` regression would have passed silently. `ca1/server_cn4` already had the correct shape.
- **IceUtil timer (C++)**: the duplicate-schedule and schedule-after-destroy checks now assert the rejection (`test(false)` after the call). The duplicate-schedule check is also race-free: the task is scheduled with a long delay and cancelled afterwards, so it cannot fire before the duplicate `schedule` call. The self-destroy block's follow-up was dead (the re-schedule legitimately succeeds since the task already ran and the timer survived the in-task `destroy`); it now asserts something real — the timer remains usable after the rejected destroy. The destroy-from-task guard itself was already asserted inside `DestroyTask`.
- **stream (Swift)**: the empty-stream read check caught everything, including the `TestFailed` thrown by `try test(false)`; it now catches only `Ice.MarshalException`, like the C++ counterpart.
- **ami (Swift)**: the local-exception check asserts that the invocation on an unknown adapter ID throws, and `TestI.sleep` honors its `ms` argument instead of always sleeping 100 ms.
- **echo (C#)**: `startBatch` asserted `_batchProxy != null`; the C++ and Java siblings assert the opposite, and `startBatch` runs before any batch proxy exists. Flipped to `== null`. (The method currently has no callers in any mapping — the unused echo batch support is tracked separately in #6434.)
- **properties (C#, Java)**: the non-numeric-value test called `getIcePropertyAsInt("Foo")`, which rejects `Foo` as an unknown Ice property before parsing anything; it now uses `getPropertyAsInt` like C++, so the parse path is actually exercised.
- **seqMapping (C#)**: `Custom<T>.Equals` never checked that the other enumerator was exhausted, so a sequence equaled any longer sequence with a matching prefix; and `GetHashCode` was reference-based while `Equals` is by value. Both fixed.

Test-only changes; no changelog entry.

Fixes #6137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
