### PR TITLE
Remove stale issue references from code comments

### DIFF
--- a/certs/makecerts.sh
+++ b/certs/makecerts.sh
@@ -84,7 +84,7 @@ add_cert_chain() {
 # on-disk container. The test suites run many short-lived processes in parallel, and a process exiting deletes that
 # shared container out from under a process that is still handshaking, which makes Schannel fail with 0x8009030D. With
 # no friendlyName, Windows names the container after a freshly generated GUID, so each import gets its own. This
-# mirrors the fix .NET applied to its own test data. See https://github.com/zeroc-ice/ice/issues/5973.
+# mirrors the fix .NET applied to its own test data.
 #
 # keytool takes the JKS alias from the PKCS12 friendlyName, so the JKS is converted from a temporary named copy.
 export_pkcs12_and_jks() {

--- a/cpp/include/Ice/OutgoingAsync.h
+++ b/cpp/include/Ice/OutgoingAsync.h
@@ -25,7 +25,6 @@
 #    pragma warning(disable : 4251) // class ... needs to have dll-interface to be used by clients of class ...
 #elif defined(__clang__)
 #    pragma clang diagnostic push
-// See #2747
 #    pragma clang diagnostic ignored "-Wshadow-uncaptured-local"
 #    pragma clang diagnostic ignored "-Wweak-vtables"
 #endif

--- a/cpp/src/Ice/SSL/SchannelEngine.cpp
+++ b/cpp/src/Ice/SSL/SchannelEngine.cpp
@@ -813,11 +813,8 @@ Schannel::SSLEngine::~SSLEngine()
 void
 Schannel::SSLEngine::initialize()
 {
-    //
-    // BUGFIX: we use a global mutex for the initialization of Schannel to
-    // avoid crashes occurring with last Schannel updates see:
-    // https://github.com/zeroc-ice/ice/issues/242
-    //
+    // We use a global mutex for the initialization of Schannel to avoid crashes observed with some Schannel
+    // updates.
     lock_guard globalLock(globalMutex);
 
     Ice::SSL::SSLEngine::initialize();

--- a/cpp/src/Ice/SystemdJournalI.cpp
+++ b/cpp/src/Ice/SystemdJournalI.cpp
@@ -59,7 +59,7 @@ Ice::SystemdJournalI::write(int priority, const string& message) const
         priority,
         "SYSLOG_IDENTIFIER=%s",
         _prefix.c_str(),
-        NULL); // Using NULL is necessary for EL7, see #293
+        NULL); // The sd_journal_send argument list must be NULL-terminated.
 }
 
 #endif

--- a/cpp/src/Ice/Timer.cpp
+++ b/cpp/src/Ice/Timer.cpp
@@ -139,7 +139,7 @@ Timer::run()
             {
                 // If the task is not a repeated task, clear the task reference now rather than
                 // in the synchronization block above. Clearing the task reference might end up
-                // calling user code which could trigger a deadlock. See also issue #352.
+                // calling user code which could trigger a deadlock.
                 token.task = nullptr;
             }
         }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4467,7 +4467,6 @@ Slice::Unit::setCurrentFile(string currentFile, int lineNumber)
         if (!IceInternal::fileExists(resolvedFilename))
         {
             // MCPP may report incorrect absolute paths when files are included using relative paths.
-            // See: https://github.com/zeroc-ice/ice/issues/4253
 
             // If the path is absolute but the file doesn't exist, treat it as relative to the current definition
             // context.

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -757,7 +757,8 @@ CodeVisitor::visitDictionary(const DictionaryPtr& p)
 
     if (!dynamic_pointer_cast<Builtin>(keyType) && !dynamic_pointer_cast<Enum>(keyType))
     {
-        // See https://github.com/zeroc-ice/ice/issues/254
+        // A PHP array key can only be an int or a string, so the PHP mapping only supports dictionary key types
+        // that map to int or string (builtin types and enums).
         p->unit()->warning(p->file(), p->line(), All, "dictionary key type not supported in PHP");
     }
 

--- a/cpp/test/Ice/timeout/Server.cpp
+++ b/cpp/test/Ice/timeout/Server.cpp
@@ -25,7 +25,7 @@ Server::run(int argc, char** argv)
 
 #ifdef _WIN32
     // Turn off stack trace collection and printing on Windows with ws(s): they slow down the logging so much that this
-    // test can fail. See #3048.
+    // test can fail.
     if (getTestProtocol(properties).find("ws") == 0)
     {
         properties->setProperty("Ice.PrintStackTraces", "0");

--- a/cpp/test/IceStorm/rep1/test.py
+++ b/cpp/test/IceStorm/rep1/test.py
@@ -3,9 +3,8 @@
 #
 # Make sure IceStorm and the subscriber use the same buffer size for
 # sending/receiving datagrams. This ensures the test works with bogus
-# OS configurations where the reicever buffer size is smaller than the
-# send buffer size (causing the received messages to be
-# truncated). See also bug #6070.
+# OS configurations where the receive buffer size is smaller than the
+# send buffer size (causing the received messages to be truncated).
 #
 
 from __future__ import annotations

--- a/cpp/test/IceStorm/repstress/test.py
+++ b/cpp/test/IceStorm/repstress/test.py
@@ -3,9 +3,8 @@
 #
 # Make sure IceStorm and the subscriber use the same buffer size for
 # sending/receiving datagrams. This ensures the test works with bogus
-# OS configurations where the reicever buffer size is smaller than the
-# send buffer size (causing the received messages to be
-# truncated). See also bug #6070.
+# OS configurations where the receive buffer size is smaller than the
+# send buffer size (causing the received messages to be truncated).
 #
 from __future__ import annotations
 

--- a/cpp/test/IceStorm/single/test.py
+++ b/cpp/test/IceStorm/single/test.py
@@ -4,8 +4,7 @@
 # Make sure the subscriber uses a larger size receive buffer size then
 # the IceStorm send buffer size. This ensures the test works with bogus
 # OS configurations where the receiver buffer size is smaller than the
-# send buffer size (causing the received messages to be truncated). See
-# bug #6070 and #7558.
+# send buffer size (causing the received messages to be truncated).
 #
 from __future__ import annotations
 

--- a/cpp/test/Slice/utf8BOM/test.py
+++ b/cpp/test/Slice/utf8BOM/test.py
@@ -36,7 +36,7 @@ class SliceUtf8BomTestCase(ClientTestCase):
             lines = output.strip().splitlines()
 
             # There is a known issue with MCPP on certain Linux platforms which causes the Slice compiler to erroneously
-            # report valid UTF-8 BOMS. See https://github.com/zeroc-ice/ice/issues/3940
+            # report valid UTF-8 BOMS. See #3940.
             if len(lines) == 2 and isinstance(platform, Linux):
                 if lines[0].endswith(
                     "Test.ice:2: encountered unexpected UTF-8 BOM in input; BOMs can only appear at the beginning of files"

--- a/csharp/test/Ice/namespacemd/AllTests.cs
+++ b/csharp/test/Ice/namespacemd/AllTests.cs
@@ -65,7 +65,7 @@ public class AllTests : global::Test.AllTests
             output.Flush();
             {
                 // A type in a module nested under a cs:namespace-tagged module must resolve at
-                // WithNamespace.Inner.S (single prefix), not a doubled prefix (regression test for #5478).
+                // WithNamespace.Inner.S (single prefix), not a doubled prefix.
                 test(typeof(WithNamespace.Inner.S).Namespace == "Ice.namespacemd.WithNamespace.Inner");
                 test(typeof(global::ZeroC.Foo.Bar.S).Namespace == "ZeroC.Foo.Bar");
                 test(typeof(global::ZeroC.Other.Bar.S).Namespace == "ZeroC.Other.Bar");

--- a/csharp/test/Ice/namespacemd/Namespace.ice
+++ b/csharp/test/Ice/namespacemd/Namespace.ice
@@ -28,7 +28,7 @@ module WithNamespace
     }
 
     // A module nested under a cs:namespace-tagged module: its types must map to
-    // WithNamespace.Inner.*, not a doubled-prefix namespace (regression test for #5478).
+    // WithNamespace.Inner.*, not a doubled-prefix namespace.
     module Inner
     {
         struct S

--- a/java/test/src/main/java/test/IceUtil/inputUtil/Client.java
+++ b/java/test/src/main/java/test/IceUtil/inputUtil/Client.java
@@ -214,7 +214,7 @@ public class Client extends TestHelper {
             test(!StringUtil.match("bar", "*bar", false));
             test(StringUtil.match("bar", "*bar", true));
 
-            // Wildcard with a non-empty tail (regression test for #5505).
+            // Wildcard with a non-empty tail.
             test(StringUtil.match("fooXXXbar", "foo*bar", false));
             test(!StringUtil.match("fooXXXbaz", "foo*bar", false));
 

--- a/js/packages/ice/src/Ice/TcpTransceiver.js
+++ b/js/packages/ice/src/Ice/TcpTransceiver.js
@@ -66,7 +66,7 @@ class TcpTransceiver {
 
             // The error callback can be triggered from the socket write(). We don't want it to be dispatched right
             // away from within the write() so we delay the call with setImmediate. We do the same for close as a
-            // precaution. See also issue #6226.
+            // precaution.
             this._fd.on("close", hadError => Timer.setImmediate(() => this.socketClosed(hadError)));
             this._fd.on("error", err => Timer.setImmediate(() => this.socketError(err)));
 

--- a/js/packages/slice2js/scripts/prepack.js
+++ b/js/packages/slice2js/scripts/prepack.js
@@ -78,7 +78,6 @@ let binDestDir = path.resolve(__dirname, "../bin");
 
 // Copy hand-written type declarations for unplugin adapters.
 // These replace the auto-generated ones to avoid leaking all bundler dependencies via unplugin's barrel types.
-// See https://github.com/zeroc-ice/ice/issues/5067
 const typesSourceDir = path.resolve(__dirname, "../types/unplugin");
 const typesDestDir = path.resolve(__dirname, "../dist/unplugin");
 

--- a/js/packages/test/Ice/optional/Test.ice
+++ b/js/packages/test/Ice/optional/Test.ice
@@ -185,8 +185,8 @@ module Test
 
         optional(1) byte opByte(optional(2) byte p1, out optional(3) byte p3);
 
-        // Regression test for issue #5480: slice2js must not emit a '?' suffix for an optional parameter
-        // that is followed by a required parameter (this would generate invalid TypeScript, TS1016).
+        // slice2js must not emit a '?' suffix for an optional parameter that is followed by a required
+        // parameter (this would generate invalid TypeScript, TS1016).
         int opOptionalFirstParam(optional(1) int p1, int p2);
 
         // slice2js must not consider 'out' parameters when deciding if the remaining 'in' parameters are

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -137,8 +137,8 @@ IcePHP::ResultCallback::ResultCallback() { ZVAL_UNDEF(&zv); }
 IcePHP::ResultCallback::~ResultCallback()
 {
 #ifdef NDEBUG
-    // BUGFIX releasing this object triggers an assert in zend_weakrefs_notify
-    // see https://github.com/zeroc-ice/ice/issues/1439
+    // Release-build only: with a debug build of PHP, releasing this object triggers an assert in
+    // zend_weakrefs_notify.
     zval_ptr_dtor(&zv);
 #endif
 }

--- a/php/test/Ice/info/Client.php
+++ b/php/test/Ice/info/Client.php
@@ -117,14 +117,14 @@ function allTests($helper)
         $connection = $testIntf->ice_getConnection();
         $connection->setBufferSize(1024, 2048);
 
-        // setBufferSize must reject non-integer arguments instead of applying a garbage size (see #5534).
+        // setBufferSize must reject non-integer arguments instead of applying a garbage size.
         try {
             $connection->setBufferSize("not an int", 2048);
             test(false);
         } catch (TypeError $ex) {
         }
 
-        // It must also reject values outside the C++ int range instead of silently truncating them (see #5534).
+        // It must also reject values outside the C++ int range instead of silently truncating them.
         try {
             $connection->setBufferSize(2 ** 40, 2048);
             test(false);
@@ -179,7 +179,7 @@ function allTests($helper)
         }
 
         // rcvSize and sndSize must be declared properties on Ice\UDPConnectionInfo, not deprecated dynamic
-        // properties created only at runtime (see #5536).
+        // properties created only at runtime.
         $udpInfo = $testIntf->ice_datagram()->ice_getConnection()->getInfo();
         test($udpInfo instanceof Ice\UDPConnectionInfo);
         $udpInfoClass = new ReflectionClass(Ice\UDPConnectionInfo::class);

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -13,8 +13,7 @@ function allTests($helper)
 
     echo "testing class stringification... ";
     flush(); {
-        // Stringifying a class must print each required member once and include the optional members. Before #5535
-        // ClassInfo::printMembers iterated the required members twice, so 'requiredA' printed twice and 'ma' never.
+        // Stringifying a class must print each required member once and include the optional members.
         $a = new Test\A();
         $a->requiredA = 11;
         $a->ma = 22;

--- a/php/test/Ice/registeredCommunicator/Client.php
+++ b/php/test/Ice/registeredCommunicator/Client.php
@@ -61,14 +61,13 @@ class Client extends TestHelper
         test(Ice\find('Hello8') == null);
 
         // A registered communicator must not be reaped before its expiration time. The reap task runs every
-        // expires/2; intermediate ticks must not destroy a communicator that has not yet expired (see #5533).
+        // expires/2; intermediate ticks must not destroy a communicator that has not yet expired.
         $communicator = Ice\initialize();
         Ice\register($communicator, "Reap", 0.1); // Expires after ~6s; the reap task ticks every ~3s.
         sleep(4); // Past the first reap tick (~3s) but well before expiration (~6s).
         $reapCommunicator = Ice\find("Reap");
         test($reapCommunicator != null);
-        // The communicator has not expired, so it must still be usable. Before #5533 it was destroyed on the
-        // first reap tick and this call raised CommunicatorDestroyedException.
+        // The communicator has not expired, so it must still be usable.
         $reapCommunicator->stringToProxy("test");
         $reapCommunicator->destroy();
         test(Ice\find("Reap") == null);

--- a/scripts/IceStormUtil.py
+++ b/scripts/IceStormUtil.py
@@ -239,8 +239,6 @@ class IceStormAdmin(ProcessFromBinDir, ProcessIsReleaseOnly, IceStormProcess, Cl
         IceStormProcess.__init__(self, instanceName, instance)
 
     def getExe(self, current: Driver.Current) -> str:
-        # This used to skip the "_32" suffix when testing against a binary distribution, but binary
-        # distribution testing (ICE_BIN_DIST) was removed in #3442.
         assert self.exe is not None
         return self.exe + "_32" if current.config.buildPlatform == "ppc" else self.exe
 

--- a/scripts/tests/Ice/adapterDeactivation.py
+++ b/scripts/tests/Ice/adapterDeactivation.py
@@ -3,8 +3,7 @@
 from Util import CSharpMapping, Darwin, Mapping, TestSuite, platform
 
 options = {}
-# Disable IPv6 for .NET on macOS until https://github.com/dotnet/runtime/pull/108334 is merged in .NET 8
-# See https://github.com/zeroc-ice/ice/issues/2061
+# Disable IPv6 for .NET on macOS. TODO: probably obsolete, see #6436.
 if isinstance(Mapping.getByPath(__name__), CSharpMapping) and isinstance(platform, Darwin):
     options = {"ipv6": [False]}
 

--- a/swift/test/Ice/location/AllTests.swift
+++ b/swift/test/Ice/location/AllTests.swift
@@ -537,7 +537,8 @@ func allTests(_ helper: TestHelper) async throws {
         try await helloPrx.ice_ping()
         try test(false)
     } catch is Ice.NotRegisteredException {
-        // Calls on the well-known proxy are not collocated because of issue #507
+        // Calls on a well-known proxy are never collocated in Swift: collocation for well-known proxies relies
+        // on the C++ object adapter's active servant map, and Swift maintains its own.
     }
 
     // Ensure that calls on the indirect proxy (with adapter ID) are collocated

--- a/swift/test/Ice/operations/Twoways.swift
+++ b/swift/test/Ice/operations/Twoways.swift
@@ -3,7 +3,6 @@
 import Ice
 import TestCommon
 
-// temporary work-around for issue #816
 func twoways(_ helper: TestHelper, _ p: MyInterfacePrx) async throws {
     func test(_ value: Bool, file: String = #file, line: Int = #line) throws {
         try helper.test(value, file: file, line: line)


### PR DESCRIPTION
## Summary

Comment-only cleanup: removes references to closed issues and PRs from code comments, keeping only references to still-open issues.

- **Bare "See #N / See \<URL\>" with no remaining value** — removed: the clang-pragma note in `OutgoingAsync.h`, the timeout-test note, the `prepack.js` and `Parser.cpp` trailers (the surrounding text already explains the why), the `Timer.cpp` trailer, and the `certs/makecerts.sh` trailer.
- **References that were doing the explaining** — replaced with the actual rationale: why the PHP mapping restricts dictionary key types (`slice2php`), the Schannel global-initialization mutex, why `ResultCallback`'s zval release is release-build-only (IcePHP), why `sd_journal_send` takes a trailing NULL (the old text cited EL7, a platform we no longer support), and why well-known-proxy calls are never collocated in Swift (closed as not-planned, so now stated as a fact).
- **"Regression test for #N" tags and pre-fix behavior descriptions** — dropped, keeping the behavioral statements the tests assert.
- **Dead references** — the `bug #6070`/`#7558` numbers in the IceStorm `test.py` headers (pre-GitHub tracker), the js `TcpTransceiver` reference to a number since reused by an unrelated issue, and the `ICE_BIN_DIST` history note in `IceStormUtil.py`.
- **Vanished workaround** — `Twoways.swift`'s "temporary work-around" comment referred to an `@_optimize(none)` attribute that the async/await port removed in 2024; the comment had outlived the workaround.
- **Kept** — the `#5209` and `#3940` references (open issues), the external dotnet/runtime links, and the historical entries in the deb/rpm packaging changelogs. The obsolete IPv6-on-macOS condition in `adapterDeactivation.py` now reads "TODO: probably obsolete, see #6436" (the referenced dotnet fix shipped in .NET 8 servicing releases in early 2025; #6436 tracks re-enabling IPv6 there).

No behavior change; no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
