### PR TITLE
Fix MATLAB Failing to Cache Empty `implicitContext`s

### DIFF
--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -248,7 +248,7 @@ classdef Communicator < IceInternal.WrapperObject
             arguments
                 obj (1, 1) Ice.Communicator
             end
-            if isempty(obj.implicitContext)
+            if ismissing(obj.implicitContext)
                 impl = libpointer('voidPtr');
                 obj.iceCall('getImplicitContext', impl);
                 if isNull(impl)
@@ -463,7 +463,7 @@ classdef Communicator < IceInternal.WrapperObject
         SliceLoader
         encoding
         format
-        implicitContext
+        implicitContext = missing % Set lazily by 'getImplicitContext'.
         Properties
         logger
     end


### PR DESCRIPTION
This PR fixes #6401, but I think adding another property, and all the other ideas my Claude proposed are lame.
MATLAB has a dedicated `missing` keyword, and this feels like the obvious and simple fix here.

Searching through the code, we literally never use `missing` once, despite it being around since 2017.
I suspect there are other places in our code which could be improved or simplified with `missing`...

----

No changelog or test, since this isn't observable from outside. We always returned the right value, we just weren't caching it properly before in some cases.