### PR TITLE
Give each sample-filtered DataStorm reader a node-unique session facet

### DIFF
--- a/changelog.d/datastorm/6347.md
+++ b/changelog.d/datastorm/6347.md
@@ -1,0 +1,3 @@
+- Fixed a bug affecting nodes that create two or more `Topic` instances with the same name. A reader with a sample
+  filter on one of these topics also received the samples another such reader's filter matched, and its own filter
+  no longer excluded anything.

--- a/changelog.d/datastorm/6347.md
+++ b/changelog.d/datastorm/6347.md
@@ -1,3 +1,3 @@
-- Fixed a bug affecting nodes that create two or more `Topic` instances with the same name. A reader with a sample
-  filter on one of these topics also received the samples another such reader's filter matched, and its own filter
-  no longer excluded anything.
+- Fixed a bug affecting nodes that create two or more `Topic` instances with the same name. A reader with a
+  sample filter on one of these topics received every sample that matched any such reader's filter, instead of
+  only the samples its own filter matched.

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -727,6 +727,15 @@ DataReaderI::DataReaderI(
     {
         _config->sampleFilter =
             FilterInfo{.name = std::move(sampleFilterName), .criteria = std::move(sampleFilterCriteria)};
+
+        // Sample filtering is evaluated on the writer, which groups the subscribers of a session by facet and
+        // forwards a sample to a facet as soon as one of its subscribers matches. A sample-filtered reader
+        // therefore needs a facet of its own, or it also receives the samples another reader's filter matched.
+        // Element ids restart at 1 in every topic and a node can hold several same-name topics, so the facet is
+        // qualified with the topic id, which the topic factory allocates per node.
+        ostringstream os;
+        os << "fa" << topic->getId() << '-' << _id;
+        _config->facet = os.str();
     }
 }
 
@@ -1320,14 +1329,6 @@ KeyDataReaderI::KeyDataReaderI(
         Trace out(_traceLevels->logger, _traceLevels->dataCat);
         out << this << ": created key reader";
     }
-
-    // If sample filtering is enabled, ensure the updates are received using a session facet specific to this reader.
-    if (_config->sampleFilter)
-    {
-        ostringstream os;
-        os << "fa" << _id;
-        _config->facet = os.str();
-    }
 }
 
 void
@@ -1686,14 +1687,6 @@ FilteredDataReaderI::FilteredDataReaderI(
     {
         Trace out(_traceLevels->logger, _traceLevels->dataCat);
         out << this << ": created filtered reader";
-    }
-
-    // If sample filtering is enabled, ensure the updates are received using a session facet specific to this reader.
-    if (_config->sampleFilter)
-    {
-        ostringstream os;
-        os << "fa" << _id;
-        _config->facet = os.str();
     }
 }
 

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -759,6 +759,26 @@ void ::Reader::run(int argc, char* argv[])
         doneWriter.waitForReaders();
         doneWriter.update(0);
     }
+
+    // Two same-name topics on this node, each with a sample-filtered reader on the one writer's key. Each reader is
+    // the first element of its own topic, so the two topics number them identically. Each reader must receive only
+    // the samples its own filter matches: the writer publishes "a", "b" and "ab", and the reader filtering on "a"
+    // must see "a" and "ab" while the reader filtering on "b" must see "b" and "ab".
+    {
+        Topic<string, string> topicA(node, "sameNameSampleFilter");
+        Topic<string, string> topicB(node, "sameNameSampleFilter");
+
+        auto readerA = makeSingleKeyReader(topicA, "elem", Filter<string>("contains", "a"), "", config);
+        auto readerB = makeSingleKeyReader(topicB, "elem", Filter<string>("contains", "b"), "", config);
+
+        test(readerA.getNextUnread().getValue() == "a");
+        test(readerA.getNextUnread().getValue() == "ab");
+        test(!readerA.hasUnread());
+
+        test(readerB.getNextUnread().getValue() == "b");
+        test(readerB.getNextUnread().getValue() == "ab");
+        test(!readerB.hasUnread());
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -605,6 +605,29 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // Two same-name reader topics on the peer node, each with a sample-filtered reader on this writer's key. Each
+    // reader is the first element of its own topic, so per-topic element numbering gives the two readers the same
+    // element id. Each reader must still receive only the samples its own filter matches.
+    cout << "testing sample filtering across same-name reader topics... " << flush;
+    {
+        Topic<string, string> topic(node, "sameNameSampleFilter");
+        topic.setSampleFilter<string>(
+            "contains",
+            [](const string& substring)
+            {
+                return [substring](const Sample<string, string>& sample)
+                { return sample.getValue().find(substring) != string::npos; };
+            });
+
+        auto writer = makeSingleKeyWriter(topic, "elem", "", config);
+        writer.waitForReaders(2); // the sample-filtered reader of each same-name topic
+        writer.update("a");       // matches only the reader filtering on "a"
+        writer.update("b");       // matches only the reader filtering on "b"
+        writer.update("ab");      // matches both readers
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
     cout << "testing topic collocated key reader and writer... " << flush;
     {
         Topic<string, string> topic(node, "collocated");


### PR DESCRIPTION
Fixes #6347.

A reader that declares a sample filter is isolated from the other readers of its session by a facet the writer
addresses it under. The facet was built from the reader's element id alone, and element ids restart at 1 in every
topic object — so two same-name topic objects in one node produced two sample-filtered readers with the facet
`fa1`. They collapsed into a single writer-side listener, which forwards a sample as soon as *any* of its
subscribers matches, and the only reader-side gate is the facet compare. Each reader received the union of the
two filters' matches rather than only its own.

The facet is now qualified with the topic id, which the topic factory allocates from a per-node counter, so it
identifies exactly one reader element of the node. The construction also moves into the `DataReaderI` constructor,
where the sample filter it depends on is recorded; the two subclasses were running identical copies of it.

New test in `cpp/test/DataStorm/events`: two same-name topics, each with a sample-filtered reader on the writer's
key, one filtering on `"a"` and the other on `"b"`, against a writer publishing `a`, `b` and `ab`. Without the fix
reader A's second sample is `b` rather than `ab`. All 108 C++ suites pass.

## Not in this PR

This makes the facet unique within a node; it does not make it survive a relay hop. A relay node forwards session
invocations without the facet, so a sample-filtered reader behind a relay receives nothing live — filed separately
as #6467, since it is a different defect in a different place and this fix does not depend on it.

Verifying this fix also turned up #6468: an unfiltered reader sharing a key and session with a sample-filtered
reader receives every matching sample twice, because a reader without a facet accepts an invocation on any facet.
Also left out.
