### PR TITLE
Clean up the C++ MSBuild build system

### DIFF
--- a/config/ice.common.targets
+++ b/config/ice.common.targets
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <!-- Custom task to download files -->
     <!-- Nuget executable -->
     <PropertyGroup>
-        <NugetExe>$(MSBuildThisFileDirectory)NuGet-7.0.1.exe</NugetExe>
-        <NugetURL>https://dist.nuget.org/win-x86-commandline/v7.0.1/nuget.exe</NugetURL>
+        <NuGetExe>$(MSBuildThisFileDirectory)NuGet-7.0.1.exe</NuGetExe>
+        <NuGetURL>https://dist.nuget.org/win-x86-commandline/v7.0.1/nuget.exe</NuGetURL>
     </PropertyGroup>
 
     <!-- Download nuget.exe if not present -->
-    <Target Name="GetNuget" Condition="!Exists('$(NugetExe)')">
-      <Exec Command="powershell -ExecutionPolicy ByPass -Command &quot;[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;(New-Object Net.WebClient).DownloadFile('$(NugetURL)', '$(NugetExe)')&quot;"/>
+    <Target Name="GetNuGet" Condition="!Exists('$(NuGetExe)')">
+      <Exec Command="powershell -ExecutionPolicy ByPass -Command &quot;[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;(New-Object Net.WebClient).DownloadFile('$(NuGetURL)', '$(NuGetExe)')&quot;"/>
     </Target>
 </Project>

--- a/cpp/msbuild/ZeroC.Ice.Cpp.nuspec
+++ b/cpp/msbuild/ZeroC.Ice.Cpp.nuspec
@@ -3,7 +3,8 @@
   <metadata>
     <id>ZeroC.Ice.Cpp</id>
     <title>Ice for C++ Windows developer kit.</title>
-    <version>3.9.0-alpha0</version>
+    <!-- Placeholder, the actual version is set with "nuget pack -Version". -->
+    <version>0.0.0</version>
     <authors>ZeroC</authors>
     <copyright>Copyright (c) ZeroC, Inc.</copyright>
     <license type="expression">GPL-2.0-only</license>

--- a/cpp/msbuild/ZeroC.Ice.Cpp.targets
+++ b/cpp/msbuild/ZeroC.Ice.Cpp.targets
@@ -7,7 +7,7 @@
         <IceConfiguration Condition="'$(UseDebugLibraries)' != 'true'">Release</IceConfiguration>
 
         <!-- Set the debugger environment PATH to include the package bin directory for the selected configuration. -->
-        <LocalDebuggerEnvironment Condition="'$(LocalDebuggerEnvironment)' == ''">PATH=$(MSBuildThisFileDirectory)bin\$(Platform)\$(IceConfiguration)</LocalDebuggerEnvironment>
+        <LocalDebuggerEnvironment Condition="'$(LocalDebuggerEnvironment)' == ''">PATH=$(MSBuildThisFileDirectory)bin\$(Platform)\$(IceConfiguration);%PATH%</LocalDebuggerEnvironment>
     </PropertyGroup>
 
     <!-- Import Slice Tools targets file -->

--- a/cpp/msbuild/ice.cpp.props
+++ b/cpp/msbuild/ice.cpp.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <IceLanguageMapping Condition="'$(IceLanguageMapping)' == ''">cpp</IceLanguageMapping>
     <IceBuildingSrc Condition="'$(IceBuildingSrc)' == ''">yes</IceBuildingSrc>
@@ -39,12 +39,10 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <PreprocessorDefinitions>_CONSOLE;_WIN32_WINNT=0x0A00;WIN32_LEAN_AND_MEAN</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WIN32_WINNT=0x0A00;WIN32_LEAN_AND_MEAN</PreprocessorDefinitions>
       <DisableSpecificWarnings>4121;4250;4251;4275;4324</DisableSpecificWarnings>
       <AdditionalOptions>/utf-8 /bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <MinimalRebuild>false</MinimalRebuild>
       <PrecompiledHeaderOutputFile />
       <OmitFramePointers>false</OmitFramePointers>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -123,20 +121,9 @@
   </ItemDefinitionGroup>
 
   <!-- Base target names. -->
-  <PropertyGroup Condition="'$(Configuration)|$(ConfigurationType)' == 'Debug|DynamicLibrary'">
-    <TargetName>$(ProjectName)$(IceSoVersion)d</TargetName>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(ConfigurationType)' == 'Release|DynamicLibrary'">
-    <TargetName>$(ProjectName)$(IceSoVersion)</TargetName>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(ConfigurationType)' == 'Debug|StaticLibrary'">
-    <TargetName>$(ProjectName)$(IceSoVersion)d</TargetName>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(ConfigurationType)' == 'Release|StaticLibrary'">
-    <TargetName>$(ProjectName)$(IceSoVersion)</TargetName>
+  <PropertyGroup Condition="'$(ConfigurationType)' == 'DynamicLibrary' or '$(ConfigurationType)' == 'StaticLibrary'">
+    <TargetName Condition="'$(Configuration)' == 'Debug'">$(ProjectName)$(IceSoVersion)d</TargetName>
+    <TargetName Condition="'$(Configuration)' == 'Release'">$(ProjectName)$(IceSoVersion)</TargetName>
   </PropertyGroup>
 
   <!-- See https://github.com/ccache/ccache/wiki/MS-Visual-Studio -->

--- a/cpp/msbuild/ice.proj
+++ b/cpp/msbuild/ice.proj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildThisFileDirectory)\..\..\config\ice.version.props" />
+    <Import Project="$(MSBuildThisFileDirectory)..\..\config\ice.version.props" />
     <PropertyGroup>
         <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
         <Platform Condition="'$(Platform)' == ''">x64</Platform>
@@ -12,11 +12,9 @@
         <PackageVersion>$(IcePackageVersion)</PackageVersion>
         <IceTestSolution>ice.test.slnx</IceTestSolution>
         <IceDoxygenExamplesSolution>ice.doxygen.examples.slnx</IceDoxygenExamplesSolution>
-        <SymbolServer Condition="'$(SymbolServer)' == ''">SRV*%TEMP%\SymbolCache*https://symbols.zeroc.com</SymbolServer>
     </PropertyGroup>
 
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-    <Import Project="$(MSBuildThisFileDirectory)\..\..\config\Ice.common.targets" />
+    <Import Project="$(MSBuildThisFileDirectory)..\..\config\ice.common.targets" />
 
     <!-- Restore NuGet packages. -->
     <Target Name="NuGetRestore" DependsOnTargets="GetNuGet">
@@ -24,11 +22,11 @@
             Projects="$(MSBuildThisFileDirectory)..\tools\ZeroC.Ice.Slice.Tools.Cpp\ZeroC.Ice.Slice.Tools.Cpp.slnx"
             Properties="Platform=Any CPU"
             Targets="Restore" />
-        <Exec Command="$(NuGetExe) restore $(MSBuildThisFileDirectory)ice.slnx"/>
+        <Exec Command="&quot;$(NuGetExe)&quot; restore &quot;$(MSBuildThisFileDirectory)ice.slnx&quot;"/>
     </Target>
 
     <Target Name="RemovePackages">
-        <Exec Command="rmdir /s /q $(MSBuildThisFileDirectory)packages" Condition="Exists('$(MSBuildThisFileDirectory)packages')" />
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)packages" />
     </Target>
 
     <!-- Ice for C++ builds. -->
@@ -83,7 +81,7 @@
                     <Properties>Configuration=$(Configuration);Platform=$(Platform)</Properties>
                 </TestSolution>
 
-                 <DoxygenExamplesSolution Include="$(IceDoxygenExamplesSolution)">
+                <DoxygenExamplesSolution Include="$(IceDoxygenExamplesSolution)">
                     <Properties>Configuration=$(Configuration);Platform=$(Platform)</Properties>
                 </DoxygenExamplesSolution>
             </ItemGroup>
@@ -98,6 +96,7 @@
 
     <!-- Clean distribution targets -->
     <Target Name="CleanDist">
+        <MSBuild Projects="@(ToolsSolution)" Properties="%(Properties)" Targets="Clean" />
         <MSBuild Projects="@(DistSolution)" BuildInParallel="true" Properties="%(Properties)" Targets="Clean" />
     </Target>
 
@@ -115,68 +114,68 @@
 
     <!-- Create nuget packages -->
     <Target Name="Pack" DependsOnTargets="GetNuGet">
-        <RemoveDir Directories="ZeroC.Ice.Cpp" />
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp" />
 
         <MSBuild Projects="ice.nuget.targets"
-                 Properties="Configuration=Debug;Platform=Win32;PackageDirectory=ZeroC.Ice.Cpp;DefaultBuild=$(DefaultBuild)"
+                 Properties="Configuration=Debug;Platform=Win32;PackageDirectory=$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp;DefaultBuild=$(DefaultBuild)"
                  Condition="'$(Platform)|$(Configuration)' == 'Win32|Debug' or '$(BuildAllConfigurations)' == 'yes'" />
         <MSBuild Projects="ice.nuget.targets"
-                 Properties="Configuration=Debug;Platform=x64;PackageDirectory=ZeroC.Ice.Cpp;DefaultBuild=$(DefaultBuild)"
+                 Properties="Configuration=Debug;Platform=x64;PackageDirectory=$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp;DefaultBuild=$(DefaultBuild)"
                  Condition="'$(Platform)|$(Configuration)' == 'x64|Debug' or '$(BuildAllConfigurations)' == 'yes'"/>
         <MSBuild Projects="ice.nuget.targets"
-                 Properties="Configuration=Release;Platform=Win32;PackageDirectory=ZeroC.Ice.Cpp;DefaultBuild=$(DefaultBuild)"
+                 Properties="Configuration=Release;Platform=Win32;PackageDirectory=$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp;DefaultBuild=$(DefaultBuild)"
                  Condition="'$(Platform)|$(Configuration)' == 'Win32|Release' or '$(BuildAllConfigurations)' == 'yes'"/>
         <MSBuild Projects="ice.nuget.targets"
-                 Properties="Configuration=Release;Platform=x64;PackageDirectory=ZeroC.Ice.Cpp;DefaultBuild=$(DefaultBuild)"
+                 Properties="Configuration=Release;Platform=x64;PackageDirectory=$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp;DefaultBuild=$(DefaultBuild)"
                  Condition="'$(Platform)|$(Configuration)' == 'x64|Release' or '$(BuildAllConfigurations)' == 'yes'"/>
 
         <Copy SourceFiles="$(MSBuildThisFileDirectory)..\README.md"
-              DestinationFiles="ZeroC.Ice.Cpp\README.md" />
+              DestinationFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\README.md" />
 
         <Copy SourceFiles="$(MSBuildThisFileDirectory)THIRD_PARTY_LICENSE.txt"
-              DestinationFiles="ZeroC.Ice.Cpp\THIRD_PARTY_LICENSE.txt" />
+              DestinationFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\THIRD_PARTY_LICENSE.txt" />
         <Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\ICE_LICENSE"
-              DestinationFiles="ZeroC.Ice.Cpp\ICE_LICENSE.txt" />
+              DestinationFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\ICE_LICENSE.txt" />
         <Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\LICENSE"
-              DestinationFiles="ZeroC.Ice.Cpp\LICENSE.txt" />
+              DestinationFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\LICENSE.txt" />
         <Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\assets\logo-128x128.png"
-              DestinationFiles="ZeroC.Ice.Cpp\logo-128x128.png" />
-        <Copy SourceFiles="ZeroC.Ice.Cpp.nuspec"
-              DestinationFolder="ZeroC.Ice.Cpp" />
-        <Copy SourceFiles="ZeroC.Ice.Cpp.props"
-              DestinationFiles="ZeroC.Ice.Cpp\build\native\ZeroC.Ice.Cpp.props" />
-        <Copy SourceFiles="ZeroC.Ice.Cpp.targets"
-              DestinationFiles="ZeroC.Ice.Cpp\build\native\ZeroC.Ice.Cpp.targets" />
+              DestinationFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\logo-128x128.png" />
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp.nuspec"
+              DestinationFolder="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp" />
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp.props"
+              DestinationFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\build\native\ZeroC.Ice.Cpp.props" />
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp.targets"
+              DestinationFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\build\native\ZeroC.Ice.Cpp.targets" />
 
         <!-- Copy Ice Tools files to the NuGet package -->
         <Copy SourceFiles="$(MSBuildThisFileDirectory)..\tools\ZeroC.Ice.Slice.Tools.Cpp\bin\$(Configuration)\netstandard2.0\ZeroC.Ice.Slice.Tools.Cpp.dll"
-              DestinationFiles="ZeroC.Ice.Cpp\tasks\netstandard2.0\ZeroC.Ice.Slice.Tools.Cpp.dll" />
+              DestinationFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\tasks\netstandard2.0\ZeroC.Ice.Slice.Tools.Cpp.dll" />
         <Copy SourceFiles="$(MSBuildThisFileDirectory)..\tools\ZeroC.Ice.Slice.Tools.Cpp\ZeroC.Ice.Slice.Tools.Cpp.props"
-              DestinationFiles="ZeroC.Ice.Cpp\build\ZeroC.Ice.Slice.Tools.Cpp.props" />
+              DestinationFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\build\ZeroC.Ice.Slice.Tools.Cpp.props" />
         <Copy SourceFiles="$(MSBuildThisFileDirectory)..\tools\ZeroC.Ice.Slice.Tools.Cpp\ZeroC.Ice.Slice.Tools.Cpp.targets"
-              DestinationFiles="ZeroC.Ice.Cpp\build\ZeroC.Ice.Slice.Tools.Cpp.targets" />
+              DestinationFiles="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\build\ZeroC.Ice.Slice.Tools.Cpp.targets" />
         <Copy SourceFiles="$(MSBuildThisFileDirectory)..\tools\ZeroC.Ice.Slice.Tools.Cpp\ProjectItemsSchema.xaml"
-              DestinationFolder="ZeroC.Ice.Cpp\build\" />
+              DestinationFolder="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\build\" />
         <Copy SourceFiles="$(MSBuildThisFileDirectory)..\tools\ZeroC.Ice.Slice.Tools.Cpp\SliceCompile.Cpp.File.xaml"
-              DestinationFolder="ZeroC.Ice.Cpp\build\" />
+              DestinationFolder="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\build\" />
         <Copy SourceFiles="$(MSBuildThisFileDirectory)..\tools\ZeroC.Ice.Slice.Tools.Cpp\SliceCompile.Cpp.xaml"
-              DestinationFolder="ZeroC.Ice.Cpp\build\" />
+              DestinationFolder="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\build\" />
 
-        <Exec Command="$(NuGetExe) pack -NoPackageAnalysis -NonInteractive -Version $(PackageVersion)"
-              WorkingDirectory="ZeroC.Ice.Cpp"/>
+        <Exec Command="&quot;$(NuGetExe)&quot; pack -NoPackageAnalysis -NonInteractive -Version $(PackageVersion)"
+              WorkingDirectory="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp"/>
     </Target>
 
     <Target Name="Publish" DependsOnTargets="Pack">
-        <Exec Command="$(NuGetExe) locals global-packages -list" ConsoleToMSBuild="true" EchoOff="yes">
+        <Exec Command="&quot;$(NuGetExe)&quot; locals global-packages -list" ConsoleToMSBuild="true" EchoOff="yes">
             <Output TaskParameter="ConsoleOutput" PropertyName="NuGetGlobalPackages" />
         </Exec>
         <PropertyGroup>
-            <NuGetGlobalPackages>$(NuGetGlobalPackages.TrimStart('info : '))</NuGetGlobalPackages>
-            <NuGetGlobalPackages>$(NuGetGlobalPackages.TrimStart('global-packages: '))</NuGetGlobalPackages>
+            <!-- The output is "global-packages: <path>", possibly prefixed with "info : ". -->
+            <NuGetGlobalPackages>$([System.Text.RegularExpressions.Regex]::Replace('$(NuGetGlobalPackages)', '^.*?global-packages:\s*', ''))</NuGetGlobalPackages>
         </PropertyGroup>
 
         <RemoveDir Directories="$(NuGetGlobalPackages)\ZeroC.Ice.Cpp\$(PackageVersion)"
             Condition="Exists('$(NuGetGlobalPackages)\ZeroC.Ice.Cpp\$(PackageVersion)')"/>
-        <Exec Command="$(NuGetExe) push $(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\ZeroC.Ice.Cpp.$(PackageVersion).nupkg -source $(NuGetGlobalPackages)" />
+        <Exec Command="&quot;$(NuGetExe)&quot; push &quot;$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\ZeroC.Ice.Cpp.$(PackageVersion).nupkg&quot; -source &quot;$(NuGetGlobalPackages)&quot;" />
     </Target>
 </Project>

--- a/cpp/msbuild/ice.proj
+++ b/cpp/msbuild/ice.proj
@@ -164,18 +164,4 @@
         <Exec Command="&quot;$(NuGetExe)&quot; pack -NoPackageAnalysis -NonInteractive -Version $(PackageVersion)"
               WorkingDirectory="$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp"/>
     </Target>
-
-    <Target Name="Publish" DependsOnTargets="Pack">
-        <Exec Command="&quot;$(NuGetExe)&quot; locals global-packages -list" ConsoleToMSBuild="true" EchoOff="yes">
-            <Output TaskParameter="ConsoleOutput" PropertyName="NuGetGlobalPackages" />
-        </Exec>
-        <PropertyGroup>
-            <!-- The output is "global-packages: <path>", possibly prefixed with "info : ". -->
-            <NuGetGlobalPackages>$([System.Text.RegularExpressions.Regex]::Replace('$(NuGetGlobalPackages)', '^.*?global-packages:\s*', ''))</NuGetGlobalPackages>
-        </PropertyGroup>
-
-        <RemoveDir Directories="$(NuGetGlobalPackages)\ZeroC.Ice.Cpp\$(PackageVersion)"
-            Condition="Exists('$(NuGetGlobalPackages)\ZeroC.Ice.Cpp\$(PackageVersion)')"/>
-        <Exec Command="&quot;$(NuGetExe)&quot; push &quot;$(MSBuildThisFileDirectory)ZeroC.Ice.Cpp\ZeroC.Ice.Cpp.$(PackageVersion).nupkg&quot; -source &quot;$(NuGetGlobalPackages)&quot;" />
-    </Target>
 </Project>

--- a/cpp/msbuild/ice.slnx
+++ b/cpp/msbuild/ice.slnx
@@ -107,29 +107,13 @@
   <Project Path="../src/Slice/msbuild/slice.vcxproj">
     <BuildDependency Project="../src/IceUtil/msbuild/iceutil/iceutil.vcxproj" />
   </Project>
-  <Project Path="../src/slice2cpp/msbuild/slice2cpp.vcxproj">
-    <BuildDependency Project="../src/Slice/msbuild/slice.vcxproj" />
-  </Project>
-  <Project Path="../src/slice2cs/msbuild/slice2cs.vcxproj">
-    <BuildDependency Project="../src/Slice/msbuild/slice.vcxproj" />
-  </Project>
-  <Project Path="../src/slice2java/msbuild/slice2java.vcxproj">
-    <BuildDependency Project="../src/Slice/msbuild/slice.vcxproj" />
-  </Project>
-  <Project Path="../src/slice2js/msbuild/slice2js.vcxproj">
-    <BuildDependency Project="../src/Slice/msbuild/slice.vcxproj" />
-  </Project>
-  <Project Path="../src/slice2matlab/msbuild/slice2matlab.vcxproj">
-    <BuildDependency Project="../src/Slice/msbuild/slice.vcxproj" />
-  </Project>
-  <Project Path="../src/slice2php/msbuild/slice2php.vcxproj">
-    <BuildDependency Project="../src/Slice/msbuild/slice.vcxproj" />
-  </Project>
-  <Project Path="../src/slice2py/msbuild/slice2py.vcxproj">
-    <BuildDependency Project="../src/Slice/msbuild/slice.vcxproj" />
-  </Project>
+  <Project Path="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
+  <Project Path="../src/slice2cs/msbuild/slice2cs.vcxproj" />
+  <Project Path="../src/slice2java/msbuild/slice2java.vcxproj" />
+  <Project Path="../src/slice2js/msbuild/slice2js.vcxproj" />
+  <Project Path="../src/slice2matlab/msbuild/slice2matlab.vcxproj" />
+  <Project Path="../src/slice2php/msbuild/slice2php.vcxproj" />
+  <Project Path="../src/slice2py/msbuild/slice2py.vcxproj" />
   <Project Path="../src/slice2rb/msbuild/slice2rb.vcxproj" />
-  <Project Path="../src/slice2swift/msbuild/slice2swift.vcxproj">
-    <BuildDependency Project="../src/Slice/msbuild/slice.vcxproj" />
-  </Project>
+  <Project Path="../src/slice2swift/msbuild/slice2swift.vcxproj" />
 </Solution>

--- a/cpp/msbuild/ice.test.props
+++ b/cpp/msbuild/ice.test.props
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <IceBuildingSrc>no</IceBuildingSrc>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)\ice.cpp.props"/>
+  <Import Project="$(MSBuildThisFileDirectory)ice.cpp.props"/>
 
   <ItemDefinitionGroup>
     <Link>
@@ -26,14 +26,6 @@
       <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)..\test\Common\msbuild\$(Platform)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(ConfigurationType)' == 'Debug|DynamicLibrary'">
-    <TargetName>$(ProjectName)$(IceSoVersion)d</TargetName>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(ConfigurationType)' == 'Release|DynamicLibrary'">
-    <TargetName>$(ProjectName)$(IceSoVersion)</TargetName>
-  </PropertyGroup>
 
   <ItemDefinitionGroup Condition="'$(ConfigurationType)' == 'DynamicLibrary'">
     <Link>

--- a/cpp/msbuild/ice.test.slnx
+++ b/cpp/msbuild/ice.test.slnx
@@ -694,7 +694,7 @@
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
     </Project>
     <Project Path="../test/IceGrid/session/msbuild/verifier/verifier.vcxproj">
-      <BuildDependency Project="../test/IceGrid/allocation/msbuild/verifier/verifier.vcxproj" />
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
     </Project>
   </Folder>
   <Folder Name="/IceGrid/simple/">

--- a/cpp/src/Ice/msbuild/ice/ice.vcxproj
+++ b/cpp/src/Ice/msbuild/ice/ice.vcxproj
@@ -145,22 +145,9 @@
   <ItemGroup>
     <CustomBuild Include="..\..\EventLoggerMsg.mc">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">mc -r $(Platform)\$(Configuration)\ ..\..\EventLoggerMsg.mc &amp;&amp; move EventLoggerMsg.h $(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice\EventLoggerMsg.h</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-      </AdditionalInputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">mc -r $(Platform)\$(Configuration)\ ..\..\EventLoggerMsg.mc &amp;&amp; move EventLoggerMsg.h $(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice\EventLoggerMsg.h</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-      </AdditionalInputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">mc -r $(Platform)\$(Configuration)\ ..\..\EventLoggerMsg.mc &amp;&amp; move EventLoggerMsg.h $(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice\EventLoggerMsg.h</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-      </AdditionalInputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">mc -r $(Platform)\$(Configuration)\ ..\..\EventLoggerMsg.mc &amp;&amp; move EventLoggerMsg.h $(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice\EventLoggerMsg.h</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-      </AdditionalInputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice\EventLoggerMsg.h;$(Platform)\$(Configuration)\EventLoggerMsg.rc</Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice\EventLoggerMsg.h;$(Platform)\$(Configuration)\EventLoggerMsg.rc</Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice\EventLoggerMsg.h;$(Platform)\$(Configuration)\EventLoggerMsg.rc</Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice\EventLoggerMsg.h;$(Platform)\$(Configuration)\EventLoggerMsg.rc</Outputs>
+      <Command>if not exist "$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice\" mkdir "$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice"
+mc -h "$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice" -r $(Platform)\$(Configuration)\ ..\..\EventLoggerMsg.mc</Command>
+      <Outputs>$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice\EventLoggerMsg.h;$(Platform)\$(Configuration)\EventLoggerMsg.rc</Outputs>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>

--- a/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.targets
+++ b/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.targets
@@ -160,7 +160,11 @@
 
     <Target Name="SliceCompileClean" BeforeTargets="Clean">
         <Delete Files="@(SliceCompile->'%(OutputDir)\%(Filename).%(SourceExt)')"/>
-        <Delete Files="@(SliceCompile->'%(OutputDir)\%(Filename).%(HeaderExt)')"/>
+        <!-- Generated headers go to HeaderOutputDir when set, and to OutputDir otherwise. -->
+        <Delete Files="@(SliceCompile->'%(OutputDir)\%(Filename).%(HeaderExt)')"
+                Condition="'%(SliceCompile.HeaderOutputDir)' == ''"/>
+        <Delete Files="@(SliceCompile->'%(HeaderOutputDir)\%(Filename).%(HeaderExt)')"
+                Condition="'%(SliceCompile.HeaderOutputDir)' != ''"/>
         <Delete Files="@(SliceCompile->'%(OutputDir)\SliceCompile.%(Filename).d')"/>
     </Target>
 </Project>


### PR DESCRIPTION
Cleanup and fixes for the C++ MSBuild build system, following a review of `cpp\msbuild`.

## Fixes

- **`EventLoggerMsg.h` generation raced across parallel configurations**: `mc` wrote the header into the shared project directory and then `move`d it into the per-config generated include directory, so concurrent configurations (`/p:BuildAllConfigurations=yes`) could collide. The command now uses `mc -h` to write the header directly to its destination (and creates the directory first, removing the ordering dependency on the Slice compilation target). This also collapses the four identical per-config `Command`/`Outputs` blocks into one.
- **`SliceCompileClean` left generated headers behind**: it deleted headers from `OutputDir`, but the library projects emit them to `HeaderOutputDir` (`include\generated\...`). Clean now deletes from `HeaderOutputDir` when it is set.
- **Wrong build dependency in `ice.test.slnx`**: `IceGrid/session/verifier` depended on `IceGrid/allocation/verifier` (an unrelated test project) instead of `testcommon`.
- **`Clean` never cleaned the Slice tools solution**: `CleanDist` now cleans `ToolsSolution` since `BuildDist` builds it.
- **Paths with spaces broke `Exec` commands**: the nuget.exe invocations are now quoted, and `Pack`'s bare relative paths (which resolve against the process working directory) are anchored to `$(MSBuildThisFileDirectory)`.
- **The NuGet package's debugger environment replaced `PATH`**: `ZeroC.Ice.Cpp.targets` now appends `;%PATH%` instead of discarding the inherited value.

## Cleanup

- Removed the `Publish` target: it pushed the package to the local NuGet global-packages folder to support running the demos against a local build, which is no longer a supported configuration; it is not documented in any BUILDING instructions and nothing invokes it. (It was also subtly broken: `TrimStart('global-packages: ')` trims a *character set*, not a prefix, corrupting global-packages paths such as `e:\nuget\packages\`.)
- Removed the dead `SymbolServer` property (leftover from the removed `DownloadSymbols` target) and the unused `Microsoft.Cpp.Default.props` import from `ice.proj`.
- Removed the redundant `BuildDependency` entries on `slice.vcxproj` from the `slice2*` projects in `ice.slnx`; their `ProjectReference`s already enforce the build order (`slice2rb` has relied on this all along).
- Removed the duplicated `TargetName` property groups from `ice.test.props` (identical to the ones `ice.cpp.props` already sets) and collapsed the four `TargetName` groups in `ice.cpp.props` into one.
- Removed no-op compiler settings: `MinimalRebuild` (the underlying `/Gm` option no longer exists), `RuntimeTypeInfo=true` (the default), and the `_CONSOLE` define (unused, and meaningless for the DLL/static-library builds it was applied to).
- `RemovePackages` uses the `RemoveDir` task instead of shelling out to `rmdir`.
- Replaced the hard-coded version in `ZeroC.Ice.Cpp.nuspec` with a `0.0.0` placeholder; the actual version is always set via `nuget pack -Version`.
- Unified the `NuGetExe`/`GetNuGet` spelling in `config/ice.common.targets` and fixed the import to use the file's actual name (`ice.common.targets`), which only worked thanks to case-insensitive file systems.
- Dropped the obsolete `ToolsVersion` attribute and a stray `\` in import paths.

## Testing

On Windows (VS 2026), from a clean worktree:
- `msbuild /m ice.proj /t:BuildDist /p:Platform=x64 /p:Configuration=Release` — clean build, 0 warnings/errors; verified the generated `EventLoggerMsg.h` and the `39a0` target names.
- `msbuild ice.proj /t:Pack` — package builds with the correct version and layout (`build/native`, `tasks`, `tools`, `slice`, `cmake`).
- `msbuild /m ice.proj /t:Clean` — `bin` fully cleaned and no generated headers left under `include\generated` (previously they survived).
