### PR TITLE
Remove the unread ServantManager.adapterName

### DIFF
--- a/swift/src/Ice/ObjectAdapterI.swift
+++ b/swift/src/Ice/ObjectAdapterI.swift
@@ -28,7 +28,7 @@ final class ObjectAdapterI: LocalObject<ICEObjectAdapter>, ObjectAdapter, ICEDis
 
     init(handle: ICEObjectAdapter, communicator: Communicator) {
         self.communicator = communicator
-        servantManager = ServantManager(adapterName: handle.getName(), communicator: communicator)
+        servantManager = ServantManager(communicator: communicator)
         super.init(handle: handle)
         handle.registerDispatchAdapter(self)
     }

--- a/swift/src/Ice/ServantManager.swift
+++ b/swift/src/Ice/ServantManager.swift
@@ -12,12 +12,10 @@ final class ServantManager: Dispatcher {
         var adminId: Identity?
     }
 
-    private let adapterName: String
     private let communicator: Communicator
     private let state = Mutex<State>(State())
 
-    init(adapterName: String, communicator: Communicator) {
-        self.adapterName = adapterName
+    init(communicator: Communicator) {
         self.communicator = communicator
     }
 


### PR DESCRIPTION
`ServantManager.adapterName` was assigned in `init` and never read. Closes #6456.

- Removes the field and the `adapterName:` initializer parameter.
- `ObjectAdapterI` called `handle.getName()` only to supply it, so that call goes too.