### PR TITLE
Deliver a sample once to a DataStorm reader that has no sample filter

### DIFF
--- a/changelog.d/datastorm/6468.md
+++ b/changelog.d/datastorm/6468.md
@@ -1,0 +1,3 @@
+- Fixed a bug where a reader without a sample filter received a duplicate of every sample that a sample-filtered
+  reader of the same key and writer matched. The duplicate was indistinguishable from a real sample and, for a
+  partial update, applied the update to the reader's value twice.

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -996,8 +996,7 @@ DataReaderI::queue(
 {
     // The writer forwards a sample once per destination facet, and this reader is attached to exactly one of them:
     // the facet it configured for its sample filter, or the unfaceted destination when it has no sample filter.
-    // Both sides are compared, so a reader without a facet accepts only an unfaceted sample: testing the facet
-    // only when this reader has one would also give it the copy addressed to a sample-filtered reader of the key.
+    // Accept only the copy addressed to this reader's destination.
     if (_config->facet ? *_config->facet != facet : !facet.empty())
     {
         if (_traceLevels->data > 2)

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -994,7 +994,11 @@ DataReaderI::queue(
     const chrono::time_point<chrono::system_clock>& now,
     bool checkKey)
 {
-    if (_config->facet && *_config->facet != facet)
+    // The writer forwards a sample once per destination facet, and this reader is attached to exactly one of them:
+    // the facet it configured for its sample filter, or the unfaceted destination when it has no sample filter.
+    // Both sides are compared, so a reader without a facet accepts only an unfaceted sample: testing the facet
+    // only when this reader has one would also give it the copy addressed to a sample-filtered reader of the key.
+    if (_config->facet ? *_config->facet != facet : !facet.empty())
     {
         if (_traceLevels->data > 2)
         {

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -405,6 +405,23 @@ void ::Reader::run(int argc, char* argv[])
         }
     }
 
+    // An unfiltered reader and a sample-filtered reader on the same key of the same writer. The writer forwards a
+    // matching sample to the filtered reader's facet as well as to the unfaceted destination, and the unfiltered
+    // reader must receive it once: the writer publishes "a" and then "b", so this reader reads "a" then "b".
+    {
+        Topic<string, string> topic(node, "unfilteredWithSampleFilter");
+
+        auto plain = makeSingleKeyReader(topic, "elem", "", config);
+        auto filtered = makeSingleKeyReader(topic, "elem", Filter<string>("contains", "a"), "", config);
+
+        test(plain.getNextUnread().getValue() == "a");
+        test(plain.getNextUnread().getValue() == "b");
+        test(!plain.hasUnread());
+
+        test(filtered.getNextUnread().getValue() == "a");
+        test(!filtered.hasUnread());
+    }
+
     // Coexisting any-key and filtered readers on the same topic: each keeps its own subscription. Both receive a
     // sample matching the filter, and destroying the filtered reader leaves the any-key reader subscribed.
     {

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -374,6 +374,28 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // A sample-filtered reader is addressed under a session facet of its own, so this writer forwards a matching
+    // sample to two destinations: the facet of the filtered reader and the unfaceted destination of the reader
+    // that has no sample filter. The unfiltered reader must receive each sample once, not once per destination.
+    cout << "testing an unfiltered reader coexisting with a sample-filtered reader... " << flush;
+    {
+        Topic<string, string> topic(node, "unfilteredWithSampleFilter");
+        topic.setSampleFilter<string>(
+            "contains",
+            [](const string& substring)
+            {
+                return [substring](const Sample<string, string>& sample)
+                { return sample.getValue().find(substring) != string::npos; };
+            });
+
+        auto writer = makeSingleKeyWriter(topic, "elem", "", config);
+        writer.waitForReaders(2); // the unfiltered reader and the sample-filtered one
+        writer.update("a");       // matches the sample filter, so it goes to both destinations
+        writer.update("b");       // does not match, so it goes to the unfaceted destination only
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
     // An any-key reader and a filtered reader coexisting on the same topic must each keep their own subscription:
     // both receive matching samples, and destroying one must not detach the other.
     cout << "testing coexisting any-key and filtered readers... " << flush;


### PR DESCRIPTION
Fixes #6468.

A sample-filtered reader is addressed under a session facet of its own, so a writer that has both an unfiltered
and a sample-filtered reader on one key forwards a matching sample to two destinations: the unfaceted one and the
facet. The receiving session hands each copy to every element subscribed to that writer element, and the
reader-side gate rejected a sample only when the reader *itself* had a facet — so a reader without one accepted
both copies.

The gate now compares both sides, so a reader with no facet accepts only an unfaceted sample. Every reader is
attached to exactly one destination — its own facet, or the unfaceted one — so this rejects only the copies
addressed elsewhere.

Measured before the fix, on the same key of one writer:

- full values: the unfiltered reader read `a,a` where the writer published `a` then `b`;
- a partial update: with an `add` updater and `add(10)` then `partialUpdate("add")(5)`, it read `10 10 15 20`
  instead of `10 15` — the delta resolved twice, against the base the first copy had already installed, leaving
  the reader on a value the writer never published.

New test in `cpp/test/DataStorm/events`, next to the other sample-filter cases: an unfiltered and a
sample-filtered reader on one key, against a writer publishing `a` (matches) then `b` (does not). Without the fix
the unfiltered reader's second read is the duplicate `a` rather than `b`. All 108 C++ suites pass.

## Notes

Independent of #6466 — that one changes the facet's format and where it is built, this one changes how the facet
is compared on receipt. Neither depends on the other and the hunks do not overlap.

Behind a relay node the duplicate survives this fix, because #6467 strips the facet in transit and both copies
arrive unfaceted. That path behaves identically before and after this change; it is fixed by #6467, not here.

The writer still puts both copies on the wire — the duplicate is discarded on receipt rather than never sent.
Suppressing the send would mean teaching `matchOne` about subscribers that another listener already serves, which
is a larger change than the defect warrants.