### PR TITLE
Preserve the session facet when a DataStorm relay forwards an invocation

### DIFF
--- a/changelog.d/datastorm/6467.md
+++ b/changelog.d/datastorm/6467.md
@@ -1,0 +1,2 @@
+- Fixed a bug where a reader with a sample filter received no updates when it read the writer through a relay
+  node. The reader was still initialized correctly, so it appeared to start normally and then never updated.

--- a/cpp/msbuild/ice.test.slnx
+++ b/cpp/msbuild/ice.test.slnx
@@ -68,6 +68,14 @@
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
     </Project>
   </Folder>
+  <Folder Name="/DataStorm/relaySampleFilter/">
+    <Project Path="../test/DataStorm/relaySampleFilter/msbuild/reader/reader.vcxproj">
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
+    </Project>
+    <Project Path="../test/DataStorm/relaySampleFilter/msbuild/writer/writer.vcxproj">
+      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
+    </Project>
+  </Folder>
   <Folder Name="/DataStorm/reliability/">
     <Project Path="../test/DataStorm/reliability/msbuild/reader/reader.vcxproj">
       <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -31,10 +31,13 @@ namespace
                 if (auto session = _nodeSessionManager->getSession(
                         Identity{.name = current.id.name.substr(pos + 1), .category = ""}))
                 {
-                    // Forward the call to the target session, don't need to wait for the result.
+                    // Forward the call to the target session, don't need to wait for the result. The facet is part
+                    // of the addressing and is carried over: a writer addresses a sample-filtered reader under a
+                    // facet of its own, and the reader discards a sample that does not arrive under it.
                     Identity id{.name = current.id.name.substr(0, pos), .category = current.id.category.substr(0, 1)};
                     session->getConnection()
                         ->createProxy(std::move(id))
+                        ->ice_facet(current.facet)
                         ->ice_invokeAsync(
                             current.operation,
                             current.mode,

--- a/cpp/test/DataStorm/relaySampleFilter/Makefile.mk
+++ b/cpp/test/DataStorm/relaySampleFilter/Makefile.mk
@@ -1,0 +1,9 @@
+# Copyright (c) ZeroC, Inc.
+
+$(project)_programs        = reader writer
+$(project)_dependencies    = DataStorm Ice TestCommon
+
+$(project)_reader_sources  = Reader.cpp
+$(project)_writer_sources  = Writer.cpp
+
+tests += $(project)

--- a/cpp/test/DataStorm/relaySampleFilter/Reader.cpp
+++ b/cpp/test/DataStorm/relaySampleFilter/Reader.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+
+using namespace DataStorm;
+using namespace std;
+
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Reader::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    ReaderConfig config;
+    config.clearHistory = ClearHistoryPolicy::Never;
+
+    Topic<string, string> topic(node, "topic");
+    Topic<string, int> barrier(node, "barrier");
+
+    // A sample-filtered reader is addressed under a session facet of its own, which has to survive the relay hop.
+    auto reader = makeSingleKeyReader(topic, "elem", Filter<string>("contains", "a"), "", config);
+    auto barrierReader = makeSingleKeyReader(barrier, "b", "", config);
+
+    // The writer publishes the barrier value last, on the same session and therefore the same connections, and a
+    // node dispatches each connection's requests one at a time — the relay's adapter and these applications'
+    // client thread pool are both serialized. Once the barrier value is here the filtered samples have been
+    // delivered too, if they were delivered at all.
+    [[maybe_unused]] auto _ = barrierReader.getNextUnread();
+
+    // The writer published "a", "b" and "ac"; the filter matches the two that contain "a".
+    vector<string> values;
+    for (const auto& sample : reader.getAllUnread())
+    {
+        values.push_back(sample.getValue());
+    }
+    test(values == vector<string>({"a", "ac"}));
+
+    cout << "reader completed" << endl;
+}
+
+DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/relaySampleFilter/Writer.cpp
+++ b/cpp/test/DataStorm/relaySampleFilter/Writer.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+
+using namespace DataStorm;
+using namespace std;
+
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Writer::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    WriterConfig config;
+    config.clearHistory = ClearHistoryPolicy::Never;
+
+    Topic<string, string> topic(node, "topic");
+    topic.setSampleFilter<string>(
+        "contains",
+        [](const string& substring)
+        {
+            return [substring](const Sample<string, string>& sample)
+            { return sample.getValue().find(substring) != string::npos; };
+        });
+
+    // A second topic with no sample filter. Its value is published last, so the reader can tell "the filtered
+    // samples have not arrived yet" from "they were never delivered".
+    Topic<string, int> barrier(node, "barrier");
+
+    auto writer = makeSingleKeyWriter(topic, "elem", "", config);
+    auto barrierWriter = makeSingleKeyWriter(barrier, "b", "", config);
+
+    writer.waitForReaders(1);
+    barrierWriter.waitForReaders(1);
+
+    // Published after the reader attached, so these travel the live forwarding path across the relay rather than
+    // the reader's initialization batch, which is routed to the reader element rather than to its facet.
+    writer.update("a");  // matches the reader's sample filter
+    writer.update("b");  // does not
+    writer.update("ac"); // matches
+    barrierWriter.update(1);
+    cout << "writer published" << endl;
+
+    writer.waitForNoReaders();
+    cout << "writer completed" << endl;
+}
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/relaySampleFilter/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/relaySampleFilter/msbuild/reader/reader.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{48377520-812D-495D-9DE8-05429D6B397D}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/relaySampleFilter/msbuild/reader/reader.vcxproj.filters
+++ b/cpp/test/DataStorm/relaySampleFilter/msbuild/reader/reader.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/relaySampleFilter/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/relaySampleFilter/msbuild/writer/writer.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{ADA2452D-4750-40C8-9A19-4F440E85B1D6}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/relaySampleFilter/msbuild/writer/writer.vcxproj.filters
+++ b/cpp/test/DataStorm/relaySampleFilter/msbuild/writer/writer.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/relaySampleFilter/test.py
+++ b/cpp/test/DataStorm/relaySampleFilter/test.py
@@ -1,0 +1,91 @@
+# Copyright (c) ZeroC, Inc.
+
+#
+# A sample-filtered reader reads a writer through a relay node.
+#
+#   reader-app --app--> relay <--app-- writer-app   (neither application has a public endpoint)
+#
+# A reader that declares a sample filter is addressed by the writer under a session facet of its own, and the
+# reader accepts a live sample only when it arrives under that facet. The relay has to preserve the facet when it
+# forwards the invocation, or every live sample the filter matched is discarded on arrival and the reader silently
+# stops updating. Initialization is not affected: an initialization batch is routed to the reader element rather
+# than to its facet, so the writer publishes only after the reader attached.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+from DataStormUtil import Node, Reader, Writer
+from Util import ClientServerTestCase, Driver, Process, Props, TestSuite
+
+commonProps = {
+    "DataStorm.Node.Multicast.Enabled": 0,
+}
+
+
+def relay(name: str) -> Props:
+    return dict(
+        commonProps,
+        **{
+            "DataStorm.Node.Server.Endpoints": "tcp -p {port1}",
+            "DataStorm.Node.ConnectTo": "",
+            "DataStorm.Node.Name": name,
+        },
+    )
+
+
+def app(name: str) -> Props:
+    return dict(
+        commonProps,
+        **{
+            "DataStorm.Node.Server.Enabled": 0,
+            "DataStorm.Node.ConnectTo": "tcp -p {port1}",
+            "DataStorm.Node.Name": name,
+        },
+    )
+
+
+class RelaySampleFilterTestCase(ClientServerTestCase):
+    def __init__(self, relayNode: Process, writer: Process, reader: Process, **kwargs: Any):
+        ClientServerTestCase.__init__(self, **kwargs)
+        self.relayNode = relayNode
+        self.writerApp = writer
+        self.readerApp = reader
+
+    # The processes are managed explicitly in runClientSide, so suppress the default client/server.
+    def getClientType(self):
+        return None
+
+    def getServerType(self):
+        return None
+
+    def runClientSide(self, current: Driver.Current) -> None:
+        self.relayNode.start(current)
+        self.writerApp.start(current)
+        self.readerApp.start(current)
+
+        self.writerApp.expect(current, "writer published", timeout=30)
+        self.readerApp.expect(current, "reader completed", timeout=30)
+
+        self.readerApp.stop(current, waitSuccess=True)
+        self.writerApp.expect(current, "writer completed", timeout=30)
+        self.writerApp.stop(current, waitSuccess=True)
+
+    def teardownClientSide(self, current: Driver.Current, success: bool) -> None:
+        for process in [self.readerApp, self.writerApp, self.relayNode]:
+            if process.isStarted(current):
+                process.stop(current)
+
+
+TestSuite(
+    __file__,
+    [
+        RelaySampleFilterTestCase(
+            name="sample-filtered reader through a relay",
+            relayNode=Node(desc="relay", props=relay("relay-node")),
+            writer=Writer(props=app("writer-app")),
+            reader=Reader(props=app("reader-app")),
+        ),
+    ],
+)


### PR DESCRIPTION
Fixes #6467.

A reader that declares a sample filter is addressed by the writer under a session facet of its own, and
`DataReaderI::queue` discards a live sample that does not arrive under that facet. The relay's `SessionForwarder`
rebuilt the target proxy from the request identity with `connection->createProxy(id)` and never carried
`current.facet` over, so every live sample the filter matched arrived unfaceted and was discarded. Sample
filtering delivered nothing whenever the writer and the reader met through a relay node — the documented topology
for nodes with no public endpoint.

Initialization was unaffected, because an initialization batch is routed to the reader element rather than to its
facet. A sample-filtered reader behind a relay therefore appeared to start correctly and then never updated, with
no error and no trace record unless data tracing was enabled.

The fix carries the facet over to the forwarded proxy. It is part of the request's addressing, like the identity,
operation, mode, parameters and context the forwarder already replays; `ice_facet("")` is a no-op, so every
unfaceted invocation — which is all of them except live samples to a sample-filtered reader — is unchanged.

`SessionForwarder` is the only DataStorm forwarder that reconstructs a proxy for an invocation that can carry a
facet. The other forwarders (`NodeI::forwardToSubscribers`/`forwardToPublishers`, `TopicI`'s forwarder,
`NodeSessionManager::forward`, the collocated `ForwarderManager`, `NodeForwarder`) either replay a stored session
proxy or handle operations that never carry one.

## Test

New `cpp/test/DataStorm/relaySampleFilter` suite: a writer application and a reader application, neither with a
public endpoint, meeting through a relay node. The reader declares a sample filter; the writer publishes `a`, `b`
and `ac` **after** the reader attached, so they travel the live path rather than the initialization batch, and the
reader must end up with exactly `a` and `ac`.

A second, unfiltered topic carries a barrier value published last, so the check distinguishes "not delivered yet"
from "never delivered". That is a sound fence: every hop dispatches a connection's requests one at a time — the
relay's adapter gets a per-adapter thread pool because DataStorm sets `DataStorm.Node.Server.ThreadPool.Serialize`
(`ObjectAdapterI` creates one whenever any `<adapter>.ThreadPool.*` property is set), and the endpoint-less
applications dispatch on the client thread pool, which DataStorm serializes too.

Without the fix the reader receives nothing and the assertion fails. All 109 C++ suites pass, and the new suite
was run 20 times without a flake.

## Notes

Independent of #6466 and #6473 — the forwarder treats the facet as an opaque string and neither parses nor builds
it, so the facet format change in #6466 needs nothing here.

This does not introduce the duplicate delivery of #6473 on the relay path: before this fix both copies of a
matching sample arrived unfaceted and an unfiltered reader on the same key already accepted both. Verified by
running the same probe with and without this change — the unfiltered reader reads `a a b ac ac` either way. #6473
is what fixes that, on the relay path as well as directly.