### PR TITLE
Fix several latent bugs in the Make build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ define make-global-rule
 $1::
 	+@for subdir in $2; \
 	do \
-		echo "making all in $$$$subdir"; \
+		echo "making $1 in $$$$subdir"; \
 		( cd $$$$subdir && $(MAKE) $1 ) || exit 1; \
 	done
 endef
@@ -28,5 +28,5 @@ install:: install-doc install-slice
 $(eval $(call install-data-files,$(wildcard $(top_srcdir)/*LICENSE),$(top_srcdir),$(install_docdir),\
          install-doc,"Installing documentation files"))
 
-$(eval $(call install-data-files,$(filter-out Lookup.ice,$(wildcard $(slicedir)/*/*.ice)),$(slicedir),$(install_slicedir),\
+$(eval $(call install-data-files,$(filter-out %/Lookup.ice,$(wildcard $(slicedir)/*/*.ice)),$(slicedir),$(install_slicedir),\
          install-slice,"Installing slice files"))

--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -123,7 +123,6 @@ endif
 ifneq ($(filter %.ice $2/%.$7,$4),)
 # Rules to build generated sources from <srcdir>/generated
 $3/%.o: $2/%.$7
-$3/%.o: $2/%.$7
 	$(E) "Compiling [$8-$9] $$<"
 	$(Q)$(or $($8_cxx),$(platform_cxx)) $(CXXFLAGS) $(call depend-cppflags,$3/$$*.Td,$$@)\
 	$(strip $6) $(CPPFLAGS) -c $$< -o $$@
@@ -132,7 +131,6 @@ endif
 
 ifneq ($(filter %.cpp,$4),)
 # Rules to build C++ sources from <srcdir>
-$3/%.o: $1/%.cpp
 $3/%.o: $1/%.cpp
 	$(E) "Compiling [$8-$9] $$<"
 	$(Q)$(or $($8_cxx),$(platform_cxx)) $(CXXFLAGS) $(call depend-cppflags,$3/$$*.Td,$$@)\
@@ -143,7 +141,6 @@ endif
 ifneq ($(filter %.mm,$4),)
 # Rules to build Objective-C++ sources from <srcdir>
 $3/%.o: $1/%.mm
-$3/%.o: $1/%.mm
 	$(E) "Compiling [$8-$9] $$<"
 	$(Q)$(or $($8_cxx),$(platform_cxx)) $(CXXFLAGS) $(call depend-cppflags,$3/$$*.Td,$$@)\
 	$(strip $6) $(CPPFLAGS) -c $$< -o $$@
@@ -152,7 +149,6 @@ endif
 
 ifneq ($(filter %.m,$4),)
 # Rules to build Objective-C sources from <srcdir>
-$3/%.o: $1/%.m
 $3/%.o: $1/%.m
 	$(E) "Compiling [$8-$9] $$<"
 	$(Q)$(or $($8_cxx),$(platform_cxx)) $(CXXFLAGS) $(call depend-cppflags,$3/$$*.Td,$$@)\
@@ -189,7 +185,7 @@ endef
 #
 define make-bison
 $1/%.h $1/%.cpp: $1/%.y
-	@$(RM) $$*.h $$*.cpp
+	@$(RM) $1/$$*.h $1/$$*.cpp
 	bison -tv $2 --header=$1/$$*.h -o $1/$$*.cpp $$<
 	@$(RM) $1/$$*.output
 endef
@@ -213,6 +209,7 @@ define make-static-library
 $2/$(call mklibname,$1,$3,$4): $5
 	$(E) "Linking [$8-$9] $$@"
 	$(Q)$(MKDIR) -p $2
+	@$(RM) $$@
 	$(Q)$(call mklib,$2/$(call mklibname,$1,$3,$4),$(strip $5),$1,$3,$4,$(LDFLAGS) $(strip $7),$8)
 endef
 
@@ -224,7 +221,7 @@ $(DESTDIR)$5/$(call mklibname,$1,$3,$4): $2/$(call mklibname,$1,$3,$4) | $(DESTD
 endef
 
 # $(call get-static-library-targets,$1=libname,$2=libdir,$3=version,$4=soversion,$5=devinstall)
-get-static-library-targets = $(if $2,$2/$(call mklibname,$1))
+get-static-library-targets = $(if $2,$2/$(call mklibname,$1,$3,$4))
 
 #
 # $(call make-shared-library,$1=libname,$2=libdir,$3=version,$4=soversion,$5=objects,$6=dependencies,$7=ldflags,
@@ -678,7 +675,7 @@ $2_distclean::
 #
 ifeq ($$($2_devinstall),yes)
 ifneq ($$(and $$($2_components),$(filter library,$3),$$(filter $(includedir)/%,$$($2_includedir))),)
-$$(eval $$(call install-data-files,$$(wildcard $$($2_includedir)/*.h) $$(wildcard $$($2_includedir)/**/*.h),$(includedir),$(install_includedir),$2_install))
+$$(eval $$(call install-data-files,$$(wildcard $$($2_includedir)/*.h) $$(wildcard $$($2_includedir)/*/*.h),$(includedir),$(install_includedir),$2_install))
 ifeq ($$($2_install_generated_headers),yes)
 ifneq ($$($2_generated_headers),)
 $$(eval $$(call install-data-files,$$($2_generated_headers),$(includedir)/generated,$(install_includedir),$2_install))
@@ -949,7 +946,7 @@ is-system-install       ?= $(filter $(system-install-dir),$1)
 # Helper functions
 #
 dirname         = $(patsubst %/,%,$(if $(findstring /,$1),$(dir $1)))
-currentdir      = $(call dirname,$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST)))
+currentdir      = $(call dirname,$(lastword $(MAKEFILE_LIST)))
 unique          = $(strip $(if $1,$(firstword $1) $(call unique,$(filter-out $(firstword $1),$1))))
 runique         = $(strip $(if $1,$(lastword $1) $(call runique,$(filter-out $(lastword $1),$1))))
 files-to-dirs   = $(call unique,$(call dirname,$(filter $(if $2,$(addprefix %.,$2),%),$1)))
@@ -1181,5 +1178,6 @@ install::
 #
 # Rule to view the value of a variable (e.g.: make debug V=Ice_sources to print out the variable Ice_sources).
 #
+.PHONY: print
 print:
 	$(foreach v,$(filter $(V),$(.VARIABLES)),$(warning $v = $($v)))

--- a/config/Make.rules
+++ b/config/Make.rules
@@ -101,8 +101,6 @@ compatversion           = $(version)
 ice_cpp_cppflags        = -I$(top_srcdir)/cpp/include -I$(top_srcdir)/cpp/include/generated
 
 bindir                  = $(call mappingdir,$(or $1,$(currentdir)),bin)
-
-bindir                  = $(call mappingdir,$(or $1,$(currentdir)),bin)
 libdir                  = $(call mappingdir,$(or $1,$(currentdir)),lib)
 includedir              = $(call mappingdir,$(or $1,$(currentdir)),include)
 slicedir                = $(top_srcdir)/slice

--- a/cpp/config/Make.artifactbundle.rules
+++ b/cpp/config/Make.artifactbundle.rules
@@ -21,6 +21,6 @@ $(slice2swift_artifactbundle): bin/slice2swift
 
 srcs all:: $(slice2swift_artifactbundle)
 
-clean::
+clean distclean::
 	$(E) Cleaning slice2swift artifact bundles
 	$(Q)$(RM) -r $(slice2swift_artifactbundle) $(slice2swift_artifactbundle_dir)

--- a/cpp/config/Make.rules
+++ b/cpp/config/Make.rules
@@ -105,7 +105,7 @@ $(create-test-project)
 endef
 
 #
-# Create top-level include/config dir
+# Create the config dir where templates.xml is installed.
 #
-$(DESTDIR)$(install_includedir) $(DESTDIR)$(install_configdir):
-	$(Q)$(MKDIR) $@
+$(DESTDIR)$(install_configdir):
+	$(Q)$(MKDIR) -p $@

--- a/cpp/config/Make.xcframework.rules
+++ b/cpp/config/Make.xcframework.rules
@@ -40,14 +40,14 @@ $(DESTDIR)$(prefix)/lib/XCFrameworks/$1.xcframework: lib/XCFrameworks/$1.xcframe
 	$(Q)$(MKDIR) -p $(DESTDIR)$(prefix)/lib/XCFrameworks
 	$(Q)cp -pR lib/XCFrameworks/$1.xcframework $(DESTDIR)$(prefix)/lib/XCFrameworks
 
-clean::
+clean distclean::
 	$(E) Cleaning lib/XCFrameworks/$1.xcframework
 	$(Q)$(RM) -r lib/XCFrameworks/$1.xcframework
 endef
 
-ifeq ($(filter $(config),static),)
+# The xcframeworks are built from the static libraries, so the static configuration is always
+# enabled for these components, even when it's not in CONFIGS.
 $(foreach f, $(xcframeworks), $(eval $f_always_enable_configs := static))
-endif
 
 define make-xcframeworks
 $(foreach f, $(xcframeworks),\

--- a/js/Makefile
+++ b/js/Makefile
@@ -7,6 +7,9 @@ endif
 all: npminstall
 	$(NPM) run build
 
+# The JavaScript tests are built together with the rest of the packages.
+tests: all
+
 srcs: npminstall
 	$(NPM) run dist
 

--- a/matlab/Makefile
+++ b/matlab/Makefile
@@ -65,7 +65,7 @@ $(icethunk_proto): $(icethunk_builddir)/icethunk.c
 $(icethunk_target): $(lang_srcdir)/src/build/icethunk.c $(icethunk_proto)
 	$(CC) $(lang_srcdir)/src/build/icethunk.c $(icethunk_cflags) -o $(icethunk_target)
 
-clean::
+clean distclean::
 	rm -rf $(lang_srcdir)/lib/x86_64-linux-gnu
 	rm -rf $(icethunk_builddir)
 
@@ -115,7 +115,7 @@ else
 	cd $(lang_srcdir)/toolbox && $(MATLAB_HOME)/bin/matlab -nodisplay -r "removeFolderFromPath '`realpath build`'"
 endif
 
-clean::
+clean distclean::
 	rm -rf $(icetoolbox_file)
 	rm -rf $(lang_srcdir)/toolbox/build
 	rm -rf $(lang_srcdir)/toolbox/toolbox.prj

--- a/php/config/Make.rules
+++ b/php/config/Make.rules
@@ -29,7 +29,7 @@ endif
 $1/%.php: $1/%.ice $1/.depend/%.ice.d $(slice2php_path)
 	$(E) "Compiling $$<"
 	$(Q)$(slice2php_path) $(slice2php_flags) -I$(slicedir) -I$1 --output-dir $1 $$($1_sliceflags) --depend $$< | \
-		sed 's/\(.*: \\\)/$(subst /,\/,$2)\/$3\/\1/' > $1/.depend/$$(*F).ice.d
+		sed 's/\(.*: \\\)/$(subst /,\/,$1)\/\1/' > $1/.depend/$$(*F).ice.d
 	$(Q)$(slice2php_path) $(slice2php_flags) -I$(slicedir) -I$1 --output-dir $1 $$($1_sliceflags) $$<
 
 distclean clean::

--- a/python/Makefile
+++ b/python/Makefile
@@ -38,3 +38,9 @@ all generate-srcs clean distclean install::
 	+$(Q)$(MAKE) -C test $@
 
 srcs:: generate-srcs
+
+#
+# The Python test suite only needs the Slice files from the test directories to be translated.
+#
+tests::
+	+$(Q)$(MAKE) -C test generate-srcs

--- a/python/config/Make.rules
+++ b/python/config/Make.rules
@@ -21,7 +21,7 @@ ifeq ($(os),Linux)
 endif
 
 python_cppflags         := $(or $(PYTHON_CPPFLAGS),$(shell $(python-config) --includes))
-python_ldflags          := $(PYTHON_LDLFLAGS)
+python_ldflags          := $(PYTHON_LDFLAGS)
 
 # Use .so as default value --extension-suffix is not supported by python-config in all platforms
 python_extsuffix        := $(or $(shell $(python-config) --extension-suffix 2> /dev/null),.so)
@@ -88,7 +88,7 @@ generate-srcs all:: $$(STAMPS_$1)
 srcs:: generate-srcs
 
 # Clean rule
-clean::
+clean distclean::
 	@echo "Cleaning generated Python files for $1..."
 	@if [ -d $1/.depend ]; then \
 	  find $1/.depend -name '*.depend' -exec cat {} + 2>/dev/null | xargs rm -f; \
@@ -111,7 +111,7 @@ generate-srcs all:: $1/__init__.py
 
 srcs:: generate-srcs
 
-clean::
+clean distclean::
 	$(E) "Cleaning Python package $1..."
 	$(Q)$(RM) -f $1/__init__.py
 
@@ -139,6 +139,11 @@ $1/.depend: $$($1_slices) $(slice2py_path)
 	$(Q)touch $1/.depend
 
 generate-srcs all:: $1/.depend
+
+distclean clean::
+	$(E) "Cleaning $1"
+	$(Q)$(RM) -r $1/generated
+	$(Q)$(RM) $1/.depend
 endif
 
 endef

--- a/python/modules/IcePy/Makefile.mk
+++ b/python/modules/IcePy/Makefile.mk
@@ -8,6 +8,7 @@ IcePy_targetdir         := $(lang_srcdir)/python
 IcePy_installdir        := $(install_pythondir)
 IcePy_cppflags          := $(ice_cpp_cppflags) -I$(top_srcdir)/cpp/src $(python_cppflags)
 IcePy_dependencies      := IceDiscovery IceLocatorDiscovery Ice
+IcePy_system_libs       := $(python_ldflags)
 IcePy_libs              := mcpp
 IcePy_extra_sources     := $(wildcard $(top_srcdir)/cpp/src/Slice/*.cpp) \
                            $(top_srcdir)/cpp/src/slice2py/PythonUtil.cpp \

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -39,3 +39,8 @@ $(eval $(call make-ruby-package,$(slicedir),$(lang_srcdir)/ruby,IceGrid))
 $(eval $(call make-ruby-package,$(slicedir),$(lang_srcdir)/ruby,IceStorm))
 
 all:: srcs
+
+#
+# The Ruby test suite loads its Slice files at runtime, so there is nothing to build.
+#
+tests::

--- a/ruby/config/Make.rules
+++ b/ruby/config/Make.rules
@@ -25,7 +25,7 @@ endif
 
 ifeq ($(os),Linux)
    cppflags			:= $(filter-out -Wredundant-decls -Wshadow,$(cppflags))
-   ruby_cppflags 	+= $(ruby_cppflags) -Wno-missing-field-initializers
+   ruby_cppflags 	+= -Wno-missing-field-initializers
 endif
 
 # Ruby linker flags


### PR DESCRIPTION
A review pass over the Make build system. Each item was reproduced before it was changed and the fix verified after, on macOS and in the `ice-deb-builder-ubuntu24.04` CI image.

### Correctness

- **PHP test dependencies were written with an unusable target.** `make-php-test-project` takes a single argument but used the `$2`/`$3` sed prefix copied from `make-php-package`, so every `.ice.d` under `php/test` started with `//Test.php:` and matched no target. Before: `touch php/test/Ice/optional/Test.ice && make tests` regenerated only `Test.php`, leaving `ClientPrivate.php` stale. After: both are regenerated.
- **`make install` could fail with `mkdir: No such file or directory`.** The config directory rule was the only `mkdir` without `-p`. `make install prefix=$P install_configdir=$P/share/ice` failed outright. This is how RPM invokes the install (`install_configdir=%{_datadir}/ice`); it works there only because the man page rules happen to create `$(DESTDIR)/usr/share` first, which `-j` does not guarantee. The `$(install_includedir)` half of that rule had no dependents and is removed.
- **Top-level `make tests` failed for js, python and ruby**, which have no such target: `make tests LANGUAGES=python` → ``No rule to make target `tests'``. Python now translates the test Slice files, Ruby is a no-op (it loads Slice at runtime) and JavaScript builds the packages.
- **`make distclean` was less thorough than `make clean`.** Several cleanup rules hooked only `clean::`, so a `distclean` left behind the xcframeworks and `slice2swift.artifactbundle.zip` (~90 MB on macOS), the generated Python modules and packages, the generated Slice files of the Python tests, and the MATLAB toolbox and thunk library.
- **The Lookup.ice install exclusion never matched.** `filter-out Lookup.ice` is compared against full paths. This regressed in b95343c441, which rewrote the working `%Discovery.ice` pattern without the `%` when the files were renamed.
- **`make-bison` removed the wrong files.** `$*` is the stem, so the recipe expanded to `rm -f Grammar.h Grammar.cpp` relative to `cpp/`, and the outputs were never removed before running bison.
- **`PYTHON_LDFLAGS` had no effect, for two independent reasons.** It was read as `PYTHON_LDLFLAGS`, *and* nothing consumed the resulting `python_ldflags`. The assignment that fed it to the IcePy link was lost in #1747: the temporary `++11` link flags removed there had been appended to the same `IcePy_system_libs :=` line, so `$(python_ldflags)` went with them. IceRuby survived only because its `++11` flags were on a separate `+=` line. Restored in the form IceRuby still uses, which also makes the Debian filter that strips `-lpython%` meaningful again. PHP, Ruby and MATLAB were checked for the same defect and are correctly wired.
- **`ruby_cppflags` appended its own value to itself** on Linux, duplicating every include directory.
- **Static libraries kept stale members.** `ar cr` replaces and inserts but never removes, and the rule did not delete the archive first, so the object of a deleted or renamed source stayed linked in. macOS was unaffected (`libtool -static` rewrites the archive). Note this makes a relink authoritative; it does not by itself force a relink when a source is *merely deleted*, since the archive remains newer than every remaining object — that case still needs a `distclean`, as it does for shared libraries and programs.

### Cleanups

- Duplicate `bindir` definition, and the duplicated recipe-less pattern rules in `make-objects` — an identical pattern rule without a recipe cancels the preceding one, so those lines were dead in every ordering.
- `get-static-library-targets` now passes version/soversion to `mklibname`, like the build and install rules. No behavior change today, since neither platform's `mklibname` uses them.
- `ifeq ($(filter $(config),static),)` tested an undefined variable with reversed arguments and was always true. Removed, with a comment stating why the static configuration is always enabled for the xcframework components.
- `$(lastword ...)` in `currentdir`; `*/*.h` instead of `**/*.h`, which make does not expand recursively; `print` declared phony; and the recursive make message now names the goal instead of always saying "making all in ...".

### Verification

**macOS:** `make -j10 srcs` and `make -j10 tests` from a clean tree, both succeeding and idempotent on a second run; `make install` into a fresh prefix; `make distclean` restoring a pristine `git status`; `make -n BISON_FLEX=yes src/Slice/Grammar.cpp`.

**Linux** (`ghcr.io/zeroc-ice/ice-deb-builder-ubuntu24.04`, the multiarch path): full `CONFIGS="shared static"` C++ build and incremental no-op; IcePy, IceRuby and IcePHP; `make tests` for python and ruby; the PHP dependency regeneration before/after; `make -j12 V=1 prefix=/usr DESTDIR=... install` exactly as `debian/rules` invokes it, with `usr/share/ice/templates.xml`, the multiarch `lib/aarch64-linux-gnu` (both `.a` and `.so`), `usr/include/Ice/SSL`, and the two Lookup.ice files correctly absent from the installed slice directory; and `PYTHON_LDFLAGS=-lmypythonlib` now reaching `IcePy[arm64-shared]_system_libs`.