### PR TITLE
Remove dead code in Ice for MATLAB and fix an async-connection doc comment

### DIFF
--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -627,7 +627,7 @@ namespace Ice
         /// Gets the connection for this proxy. If the proxy does not yet have an established connection or its
         /// connection is closed or being closed, it first attempts to create a new connection. For a fixed proxy,
         /// this function returns the connection this proxy is bound to, even when this connection is closed.
-        /// @return A future that becomes available when the invocation completes. This future holds:
+        /// @return A future that becomes available when the connection is established. This future holds:
         /// - The connection for this proxy.
         /// @remark When this proxy reaches its target object through collocation optimization (see
         /// #ice_collocationOptimized), the future holds a null connection: collocated invocations don't use a

--- a/matlab/Makefile
+++ b/matlab/Makefile
@@ -21,16 +21,7 @@ include $(shell find $(lang_srcdir) -name Makefile.mk)
 $(call make-projects,$(projects))
 srcs:: $(projects)
 
-$(eval $(call make-matlab-package,$(slicedir),lib/generated,Ice,%F.ice \
-    %/FacetMap.ice \
-    %/ImplicitContext.ice \
-    %/Instrumentation.ice \
-    %/Logger.ice \
-    %/ObjectAdapter.ice \
-    %/ObjectFactory.ice \
-    %/Plugin.ice \
-    %/Properties.ice \
-    %/ServantLocator.ice))
+$(eval $(call make-matlab-package,$(slicedir),lib/generated,Ice))
 $(eval $(call make-matlab-package,$(slicedir),lib/generated,Glacier2))
 $(eval $(call make-matlab-package,$(slicedir),lib/generated,IceGrid))
 $(eval $(call make-matlab-package,$(slicedir),lib/generated,IceBox))

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -1068,7 +1068,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %   connection this proxy is bound to, even when this connection is closed.
             %
             %   Output Arguments
-            %     r - A future that will be completed when the invocation completes.
+            %     r - A future that will be completed with the connection for this proxy.
             %       Ice.Future scalar
 
             arguments

--- a/matlab/msbuild/ice.toolbox.targets
+++ b/matlab/msbuild/ice.toolbox.targets
@@ -23,7 +23,6 @@
     <Slices Include="$(RootDir)..\slice\**\*.ice"
             Exclude="$(RootDir)..\slice\IceDiscovery\*.ice;
                      $(RootDir)..\slice\IceLocatorDiscovery\*.ice" />
-    <Doc Include="$(MSBuildThisFileDirectory)doc\*.html;$(MSBuildThisFileDirectory)doc\*.xml;$(MSBuildThisFileDirectory)doc\**\*.css" />
   </ItemGroup>
 
   <!-- Copy required files to the package specific directories -->
@@ -33,6 +32,5 @@
     <Copy SourceFiles="@(Headers)" DestinationFolder="$(MSBuildThisFileDirectory)..\toolbox\build\" />
     <Copy SourceFiles="@(Tools)" DestinationFolder="$(MSBuildThisFileDirectory)..\toolbox\build" />
     <Copy SourceFiles="@(Slices)" DestinationFolder="$(MSBuildThisFileDirectory)..\toolbox\build\slice\%(Slices.RecursiveDir)" />
-    <Copy SourceFiles="@(Doc)" DestinationFolder="$(MSBuildThisFileDirectory)..\toolbox\build\doc\%(Doc.RecursiveDir)" />
   </Target>
 </Project>

--- a/matlab/src/ObjectPrx.cpp
+++ b/matlab/src/ObjectPrx.cpp
@@ -18,11 +18,7 @@ namespace
         virtual void exception(exception_ptr);
         virtual void sent();
 
-        void finished(
-            const std::shared_ptr<Ice::Communicator>&,
-            const Ice::EncodingVersion&,
-            bool,
-            std::pair<const byte*, const byte*>);
+        void finished(bool, std::pair<const byte*, const byte*>);
         void getResults(bool&, pair<const byte*, const byte*>&);
 
     protected:
@@ -61,11 +57,7 @@ namespace
         _cond.notify_all();
     }
 
-    void InvocationFuture::finished(
-        const std::shared_ptr<Ice::Communicator>& /*communicator*/,
-        const Ice::EncodingVersion& /*encoding*/,
-        bool b,
-        pair<const byte*, const byte*> p)
+    void InvocationFuture::finished(bool b, pair<const byte*, const byte*> p)
     {
         lock_guard<mutex> lock(_mutex);
         _ok = b;
@@ -296,8 +288,7 @@ extern "C"
                 op,
                 mode,
                 params,
-                [proxy, f](bool ok, pair<const byte*, const byte*> outParams)
-                { f->finished(proxy->ice_getCommunicator(), proxy->ice_getEncodingVersion(), ok, outParams); },
+                [f](bool ok, pair<const byte*, const byte*> outParams) { f->finished(ok, outParams); },
                 [f](exception_ptr e) { f->exception(e); },
                 [f](bool /*sentSynchronously*/) { f->sent(); },
                 *ctxPtr);
@@ -912,12 +903,6 @@ extern "C"
         return createEmptyArray();
     }
 
-    mxArray* Ice_InvocationFuture_id(void* self, unsigned long long* id)
-    {
-        *id = reinterpret_cast<unsigned long long>(self);
-        return createEmptyArray();
-    }
-
     mxArray* Ice_InvocationFuture_wait(void* self)
     {
         bool b = deref<InvocationFuture>(self)->waitForState(Future::State::Finished, -1);
@@ -1000,12 +985,6 @@ extern "C"
     mxArray* Ice_GetConnectionFuture_unref(void* self)
     {
         delete reinterpret_cast<shared_ptr<GetConnectionFuture>*>(self);
-        return createEmptyArray();
-    }
-
-    mxArray* Ice_GetConnectionFuture_id(void* self, unsigned long long* id)
-    {
-        *id = reinterpret_cast<unsigned long long>(self);
         return createEmptyArray();
     }
 

--- a/matlab/src/ice.rc
+++ b/matlab/src/ice.rc
@@ -1,12 +1,7 @@
 #include "../../cpp/src/Ice/ResourceConfig.h"
 
-#ifdef _DEBUG
-#   define ICE_INTERNALNAME "ice\0"
-#   define ICE_ORIGINALFILENAME "ice.mexw64\0"
-#else
-#   define ICE_INTERNALNAME "ice\0"
-#   define ICE_ORIGINALFILENAME "ice.mexw64\0"
-#endif
+#define ICE_INTERNALNAME "ice\0"
+#define ICE_ORIGINALFILENAME "ice.mexw64\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION ICE_VERSION


### PR DESCRIPTION
Clears four MATLAB dead-code findings and one doc-comment slip, each from a separate `ai-audit` issue.

### #6459 — Makefile filter-out list is entirely dead

`make-matlab-package` for the Ice package passed a ten-entry `filter-out` (`%F.ice %/FacetMap.ice %/ImplicitContext.ice …`). All ten are Ice 3.7-era file names that no longer exist under `slice/Ice/`, so the list excluded nothing. Dropped it; the build now globs `slice/Ice/*.ice` with no exclusions, matching what `matlab/lib/msbuild/ice.proj` already does.

### #6460 — two unreachable `extern "C"` exports

`Ice_InvocationFuture_id` and `Ice_GetConnectionFuture_id` are absent from `matlab/src/ice.h`, the sole input to the thunk/`iceproto.m` generator, so `calllib` can never resolve them; no `.m` code calls them either (`Ice.Future` mints its own id). Deleted.

### #6462 — per-reply work thrown away

`InvocationFuture::finished` took a `Communicator` and an `EncodingVersion` it immediately discarded (`/*communicator*/`, `/*encoding*/`), and its only caller evaluated `ice_getCommunicator()` and `ice_getEncodingVersion()` to supply them on every async reply. Dropped both parameters and both calls.

### #6463 — two dead build branches

- `ice.rc`: the `#ifdef _DEBUG` and `#else` arms were byte-identical; collapsed to the two `#define`s.
- `ice.toolbox.targets`: the `<Doc>` glob resolved to `matlab/msbuild/doc`, which does not exist, so `@(Doc)` was always empty and its `Copy` a no-op. Docs are staged by `ice.proj`. Removed both.

### #6439 — `ice_getConnectionAsync` doc comment

`ice_getConnectionAsync` sends no request, so its future does not complete "when the invocation completes" — a phrase copied from the genuine invocation methods. Reworded in both C++ (`Proxy.h`) and MATLAB (`ObjectPrx.m`) to describe it as completing with the connection.

No changelog fragment: dead-code removal and a doc-comment fix, nothing a user observes.

### Testing

MEX rebuilt; full MATLAB suite 16/16. The `Makefile` change is Linux-only (not exercised by the Windows build) and the `ice.toolbox.targets` change affects only the `.mltbx` `Package` target, which was not run — both are removals of provably-dead config.

Fixes #6459.
Fixes #6460.
Fixes #6462.
Fixes #6463.
Fixes #6439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
