### PR TITLE
Fix the Stringification of Non-nil Proxies in Ruby

### DIFF
--- a/changelog.d/ruby/6490.md
+++ b/changelog.d/ruby/6490.md
@@ -1,0 +1,1 @@
+- Fixed the stringification of non-nil proxy data members. Now proxies print correctly, instead of raising `TypeError`.

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -2385,7 +2385,7 @@ IceRuby::ProxyInfo::print(VALUE value, IceInternal::Output& out, PrintObjectHist
     }
     else
     {
-        out << getString(value);
+        out << getProxy(value)->ice_toString();
     }
 }
 

--- a/ruby/test/Ice/objects/AllTests.rb
+++ b/ruby/test/Ice/objects/AllTests.rb
@@ -331,6 +331,15 @@ def allTests(helper, communicator)
     end
     puts "ok"
 
+    print "testing stringification of proxy members... "
+    STDOUT.flush
+    f3 = Test::F3.new(nil, Test::F2Prx.new(communicator, "F21:#{helper.getTestEndpoint()}"))
+    s = f3.inspect
+    test(s.include?("::Test::F3"))
+    test(s.include?("f1 = <nil>"))
+    test(s.include?("f2 = #{f3.f2.ice_toString()}"))
+    puts "ok"
+
     print "testing GC compaction during stringification... "
     STDOUT.flush
     if compactionSupported


### PR DESCRIPTION
This PR fixes #6490. Ended up being simpler than expected.