### PR TITLE
Remove redundant IPv6 override for csharp Ice/adapterDeactivation

### DIFF
--- a/scripts/tests/Ice/adapterDeactivation.py
+++ b/scripts/tests/Ice/adapterDeactivation.py
@@ -1,10 +1,5 @@
 # Copyright (c) ZeroC, Inc.
 
-from Util import CSharpMapping, Darwin, Mapping, TestSuite, platform
+from Util import TestSuite
 
-options = {}
-# Disable IPv6 for .NET on macOS. TODO: probably obsolete, see #6436.
-if isinstance(Mapping.getByPath(__name__), CSharpMapping) and isinstance(platform, Darwin):
-    options = {"ipv6": [False]}
-
-TestSuite(__name__, multihost=False, options=options)
+TestSuite(__name__, multihost=False)


### PR DESCRIPTION
This removes the per-test C#/macOS IPv6 override from `scripts/tests/Ice/adapterDeactivation.py`, keeping only `multihost=False`.

Fixes #6436.

Note this is just a cleanup of a redundant disabling — it does not actually re-enable IPv6 for this test. Since #4870, IPv6 testing is disabled for the entire C# mapping on macOS in `CSharpMapping.getOptions` (`scripts/Util.py`), so this per-test override has no effect. Actually re-enabling IPv6 is not possible yet: the crash that motivated the override still reproduces with both the latest .NET 8 runtime (8.0.29) and the .NET 10 runtime (10.0.5), so the guard from dotnet/runtime#108334 is not sufficient. Re-enabling IPv6 for .NET on macOS is now tracked by #6504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
