### PR TITLE
Remove Various Dead Code from IceRuby

### DIFF
--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -423,17 +423,15 @@ IceRuby_ObjectPrx_ice_getEncodingVersion(VALUE self)
 extern "C" VALUE
 IceRuby_ObjectPrx_ice_encodingVersion(VALUE self, VALUE v)
 {
-    Ice::EncodingVersion val;
-    if (getEncodingVersion(v, val))
+    ICE_RUBY_TRY
     {
-        ICE_RUBY_TRY
-        {
-            Ice::ObjectPrx p = getProxy(self);
-            return createProxy(p->ice_encodingVersion(val), rb_class_of(self));
-        }
-        ICE_RUBY_CATCH
-    }
+        Ice::EncodingVersion val;
+        getEncodingVersion(v, val);
 
+        Ice::ObjectPrx p = getProxy(self);
+        return createProxy(p->ice_encodingVersion(val), rb_class_of(self));
+    }
+    ICE_RUBY_CATCH
     return Qnil;
 }
 

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -428,8 +428,6 @@ IceRuby::TypeInfo::destroy()
 //
 // PrimitiveInfo implementation.
 //
-IceRuby::PrimitiveInfo::PrimitiveInfo() = default;
-
 IceRuby::PrimitiveInfo::PrimitiveInfo(Kind k) : kind(k) {}
 
 string
@@ -2244,10 +2242,9 @@ IceRuby::ProxyInfo::create(VALUE ident)
     return proxyInfo;
 }
 
-IceRuby::ProxyInfo::ProxyInfo(VALUE ident) : isBase(false), rubyClass(Qnil), typeObj(Qnil)
+IceRuby::ProxyInfo::ProxyInfo(VALUE ident) : rubyClass(Qnil), typeObj(Qnil)
 {
     const_cast<string&>(id) = getString(ident);
-    const_cast<bool&>(isBase) = id == Ice::Object::ice_staticId();
 }
 
 void
@@ -2375,38 +2372,6 @@ IceRuby::ProxyInfo::print(VALUE value, IceInternal::Output& out, PrintObjectHist
     {
         out << getProxy(value)->ice_toString();
     }
-}
-
-bool
-IceRuby::ProxyInfo::isA(const ProxyInfoPtr& info)
-{
-    //
-    // Return true if this class has an is-a relationship with info.
-    //
-    if (info->isBase)
-    {
-        return true;
-    }
-    else if (this == info.get())
-    {
-        return true;
-    }
-    else if (base && base->isA(info))
-    {
-        return true;
-    }
-    else if (!interfaces.empty())
-    {
-        for (ProxyInfoList::const_iterator p = interfaces.begin(); p != interfaces.end(); ++p)
-        {
-            if ((*p)->isA(info))
-            {
-                return true;
-            }
-        }
-    }
-
-    return false;
 }
 
 void

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -440,8 +440,6 @@ IceRuby::TypeInfo::destroy()
 //
 // PrimitiveInfo implementation.
 //
-IceRuby::PrimitiveInfo::PrimitiveInfo() = default;
-
 IceRuby::PrimitiveInfo::PrimitiveInfo(Kind k) : kind(k) {}
 
 string
@@ -2256,10 +2254,9 @@ IceRuby::ProxyInfo::create(VALUE ident)
     return proxyInfo;
 }
 
-IceRuby::ProxyInfo::ProxyInfo(VALUE ident) : isBase(false), rubyClass(Qnil), typeObj(Qnil)
+IceRuby::ProxyInfo::ProxyInfo(VALUE ident) : rubyClass(Qnil), typeObj(Qnil)
 {
     const_cast<string&>(id) = getString(ident);
-    const_cast<bool&>(isBase) = id == Ice::Object::ice_staticId();
 }
 
 void
@@ -2387,38 +2384,6 @@ IceRuby::ProxyInfo::print(VALUE value, IceInternal::Output& out, PrintObjectHist
     {
         out << getString(value);
     }
-}
-
-bool
-IceRuby::ProxyInfo::isA(const ProxyInfoPtr& info)
-{
-    //
-    // Return true if this class has an is-a relationship with info.
-    //
-    if (info->isBase)
-    {
-        return true;
-    }
-    else if (this == info.get())
-    {
-        return true;
-    }
-    else if (base && base->isA(info))
-    {
-        return true;
-    }
-    else if (!interfaces.empty())
-    {
-        for (ProxyInfoList::const_iterator p = interfaces.begin(); p != interfaces.end(); ++p)
-        {
-            if ((*p)->isA(info))
-            {
-                return true;
-            }
-        }
-    }
-
-    return false;
 }
 
 void

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -2252,17 +2252,14 @@ IceRuby::ProxyInfo::define(VALUE t, VALUE b, VALUE i)
 {
     if (!NIL_P(b))
     {
-        const_cast<ProxyInfoPtr&>(base) = dynamic_pointer_cast<ProxyInfo>(getType(b));
-        assert(base);
+        assert(dynamic_pointer_cast<ProxyInfo>(getType(b)));
     }
 
     volatile VALUE arr = callRuby(rb_check_array_type, i);
     assert(!NIL_P(arr));
     for (int n = 0; n < RARRAY_LEN(arr); ++n)
     {
-        ProxyInfoPtr iface = dynamic_pointer_cast<ProxyInfo>(getType(RARRAY_AREF(arr, n)));
-        assert(iface);
-        const_cast<ProxyInfoList&>(interfaces).push_back(iface);
+        assert(dynamic_pointer_cast<ProxyInfo>(getType(RARRAY_AREF(arr, n))));
     }
 
     const_cast<VALUE&>(rubyClass) = t;
@@ -2372,13 +2369,6 @@ IceRuby::ProxyInfo::print(VALUE value, IceInternal::Output& out, PrintObjectHist
     {
         out << getProxy(value)->ice_toString();
     }
-}
-
-void
-IceRuby::ProxyInfo::destroy()
-{
-    const_cast<ProxyInfoPtr&>(base) = 0;
-    const_cast<ProxyInfoList&>(interfaces).clear();
 }
 
 //

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -21,7 +21,6 @@ namespace IceRuby
 
     class ProxyInfo;
     using ProxyInfoPtr = std::shared_ptr<ProxyInfo>;
-    using ProxyInfoList = std::vector<ProxyInfoPtr>;
 
     //
     // This class is raised as an exception when object marshaling needs to be aborted.
@@ -423,6 +422,8 @@ namespace IceRuby
     public:
         static ProxyInfoPtr create(VALUE);
 
+        // TODO: the 2nd and 3rd parameters are dead code, and should be removed in 3.9.
+        // They cannot be removed yet because slice2rb generated code which passes them in.
         void define(VALUE, VALUE, VALUE);
 
         std::string getId() const final;
@@ -438,11 +439,7 @@ namespace IceRuby
 
         void print(VALUE, IceInternal::Output&, PrintObjectHistory*) final;
 
-        void destroy() final;
-
         const std::string id;
-        const ProxyInfoPtr base;
-        const ProxyInfoList interfaces; // TODO this field is also dead but affects public API.
         const VALUE rubyClass;
         const VALUE typeObj;
 

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -194,7 +194,6 @@ namespace IceRuby
             KindString
         };
 
-        PrimitiveInfo();
         PrimitiveInfo(Kind);
 
         std::string getId() const final;
@@ -441,12 +440,9 @@ namespace IceRuby
 
         void destroy() final;
 
-        bool isA(const ProxyInfoPtr&);
-
         const std::string id;
-        const bool isBase; // Is this the ClassInfo for Ice::ObjectPrx?
         const ProxyInfoPtr base;
-        const ProxyInfoList interfaces;
+        const ProxyInfoList interfaces; // TODO this field is also dead but affects public API.
         const VALUE rubyClass;
         const VALUE typeObj;
 

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -9,17 +9,15 @@ using namespace IceRuby;
 
 namespace
 {
-    template<typename T> bool setVersion(VALUE p, const T& version)
+    template<typename T> void setVersion(VALUE p, const T& version)
     {
         volatile VALUE major = callRuby(rb_int2inum, version.major);
         volatile VALUE minor = callRuby(rb_int2inum, version.minor);
         rb_ivar_set(p, rb_intern("@major"), major);
         rb_ivar_set(p, rb_intern("@minor"), minor);
-
-        return true;
     }
 
-    template<typename T> bool getVersion(VALUE p, T& v)
+    template<typename T> void getVersion(VALUE p, T& v)
     {
         volatile VALUE major = callRuby(rb_ivar_get, p, rb_intern("@major"));
         volatile VALUE minor = callRuby(rb_ivar_get, p, rb_intern("@minor"));
@@ -30,7 +28,6 @@ namespace
         if (m < 0 || m > 255)
         {
             throw RubyException(rb_eTypeError, "version major must be a value between 0 and 255");
-            return false;
         }
         v.major = m;
 
@@ -38,11 +35,8 @@ namespace
         if (m < 0 || m > 255)
         {
             throw RubyException(rb_eTypeError, "version minor must be a value between 0 and 255");
-            return false;
         }
         v.minor = m;
-
-        return true;
     }
 
     template<typename T> VALUE createVersion(const T& version, const char* type)
@@ -51,11 +45,7 @@ namespace
         assert(!NIL_P(rbType));
 
         volatile VALUE obj = callRuby(rb_class_new_instance, 0, static_cast<VALUE*>(0), rbType);
-
-        if (!setVersion<T>(obj, version))
-        {
-            return Qnil;
-        }
+        setVersion<T>(obj, version);
 
         return obj;
     }
@@ -378,7 +368,7 @@ IceRuby::createEncodingVersion(const Ice::EncodingVersion& v)
     return createVersion<Ice::EncodingVersion>(v, Ice_EncodingVersion);
 }
 
-bool
+void
 IceRuby::getEncodingVersion(VALUE p, Ice::EncodingVersion& v)
 {
     volatile VALUE cls = callRuby(rb_path2class, Ice_EncodingVersion);
@@ -389,12 +379,7 @@ IceRuby::getEncodingVersion(VALUE p, Ice::EncodingVersion& v)
         throw RubyException(rb_eTypeError, "value is not an Ice::EncodingVersion");
     }
 
-    if (!getVersion<Ice::EncodingVersion>(p, v))
-    {
-        return false;
-    }
-
-    return true;
+    getVersion<Ice::EncodingVersion>(p, v);
 }
 
 VALUE

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -9,17 +9,15 @@ using namespace IceRuby;
 
 namespace
 {
-    template<typename T> bool setVersion(VALUE p, const T& version)
+    template<typename T> void setVersion(VALUE p, const T& version)
     {
         volatile VALUE major = callRuby(rb_int2inum, version.major);
         volatile VALUE minor = callRuby(rb_int2inum, version.minor);
         rb_ivar_set(p, rb_intern("@major"), major);
         rb_ivar_set(p, rb_intern("@minor"), minor);
-
-        return true;
     }
 
-    template<typename T> bool getVersion(VALUE p, T& v)
+    template<typename T> void getVersion(VALUE p, T& v)
     {
         volatile VALUE major = callRuby(rb_ivar_get, p, rb_intern("@major"));
         volatile VALUE minor = callRuby(rb_ivar_get, p, rb_intern("@minor"));
@@ -30,7 +28,6 @@ namespace
         if (m < 0 || m > 255)
         {
             throw RubyException(rb_eTypeError, "version major must be a value between 0 and 255");
-            return false;
         }
         v.major = m;
 
@@ -38,11 +35,8 @@ namespace
         if (m < 0 || m > 255)
         {
             throw RubyException(rb_eTypeError, "version minor must be a value between 0 and 255");
-            return false;
         }
         v.minor = m;
-
-        return true;
     }
 
     template<typename T> VALUE createVersion(const T& version, const char* type)
@@ -51,11 +45,7 @@ namespace
         assert(!NIL_P(rbType));
 
         volatile VALUE obj = callRuby(rb_class_new_instance, 0, static_cast<VALUE*>(0), rbType);
-
-        if (!setVersion<T>(obj, version))
-        {
-            return Qnil;
-        }
+        setVersion<T>(obj, version);
 
         return obj;
     }
@@ -364,7 +354,7 @@ IceRuby::createEncodingVersion(const Ice::EncodingVersion& v)
     return createVersion<Ice::EncodingVersion>(v, Ice_EncodingVersion);
 }
 
-bool
+void
 IceRuby::getEncodingVersion(VALUE p, Ice::EncodingVersion& v)
 {
     volatile VALUE cls = callRuby(rb_path2class, Ice_EncodingVersion);
@@ -375,12 +365,7 @@ IceRuby::getEncodingVersion(VALUE p, Ice::EncodingVersion& v)
         throw RubyException(rb_eTypeError, "value is not an Ice::EncodingVersion");
     }
 
-    if (!getVersion<Ice::EncodingVersion>(p, v))
-    {
-        return false;
-    }
-
-    return true;
+    getVersion<Ice::EncodingVersion>(p, v);
 }
 
 VALUE

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -207,21 +207,6 @@ IceRuby::stringSeqToArray(const vector<string>& seq)
     return result;
 }
 
-VALUE
-IceRuby::createNumSeq(const vector<byte>& v)
-{
-    volatile VALUE result = createArray(v.size());
-    long i = 0;
-    if (v.size() > 0)
-    {
-        for (vector<byte>::const_iterator p = v.begin(); p != v.end(); ++p, ++i)
-        {
-            RARRAY_ASET(result, i, INT2FIX(std::to_integer<int>(*p)));
-        }
-    }
-    return result;
-}
-
 namespace
 {
     struct HashToContextIterator : public IceRuby::HashIterator

--- a/ruby/src/IceRuby/Util.h
+++ b/ruby/src/IceRuby/Util.h
@@ -136,9 +136,9 @@ namespace IceRuby
     VALUE createEncodingVersion(const Ice::EncodingVersion&);
 
     //
-    // Extracts the members of an encoding version.
+    // Extracts the members of an encoding version. May raise RubyException.
     //
-    bool getEncodingVersion(VALUE, Ice::EncodingVersion&);
+    void getEncodingVersion(VALUE, Ice::EncodingVersion&);
 
     //
     // The callRuby functions are used to invoke Ruby C API functions

--- a/ruby/src/IceRuby/Util.h
+++ b/ruby/src/IceRuby/Util.h
@@ -86,12 +86,6 @@ namespace IceRuby
     VALUE stringSeqToArray(const std::vector<std::string>&);
 
     //
-    // Convert a vector of std::byte into a Ruby array of numbers.
-    // May raise RubyException.
-    //
-    VALUE createNumSeq(const std::vector<std::byte>&);
-
-    //
     // Convert a Ruby hash to Ice::Context. Returns true on success
     // and false if the value is not a hash. May raise RubyException.
     //


### PR DESCRIPTION
This PR implements #6448, changing IceRuby to take advantage of the fact the functions in it always return `true` or throw.
They never return `false`, which allows for some simplification.

It also removes most of the dead code found in #6446.
While working on it, I identified an additional dead field `ProxyInfo::interfaces`, but removing it affects public APIs and even the code-generator. Instead, I'll open another issue to remove this code for 3.9.0.

This PR also fixes a small bug caught along the way: `getEncodingVersion` could throw, but was not called within an `ICE_RUBY_TRY` section.