### PR TITLE
Remove obsolete Ruby compatibility shims

### DIFF
--- a/ruby/config/Make.rules
+++ b/ruby/config/Make.rules
@@ -30,7 +30,7 @@ endif
 
 # Ruby linker flags
 ruby_ldflags    := $(call ruby-call,$$(LIBRUBYARG))
-ruby_libdir     := $(call ruby-call,$(if $(findstring MINGW,$(shell uname)),$$(bindir),$$(libdir)))
+ruby_libdir     := $(call ruby-call,$$(libdir))
 ifneq ($(ruby_libdir),)
     ruby_ldflags := -L$(call ruby-call,$$(libdir)) $(ruby_ldflags)
 endif

--- a/ruby/config/Make.rules
+++ b/ruby/config/Make.rules
@@ -32,7 +32,7 @@ endif
 ruby_ldflags    := $(call ruby-call,$$(LIBRUBYARG))
 ruby_libdir     := $(call ruby-call,$$(libdir))
 ifneq ($(ruby_libdir),)
-    ruby_ldflags := -L$(call ruby-call,$$(libdir)) $(ruby_ldflags)
+    ruby_ldflags := -L$(ruby_libdir) $(ruby_ldflags)
 endif
 
 #

--- a/ruby/src/IceRuby/Config.h
+++ b/ruby/src/IceRuby/Config.h
@@ -55,18 +55,6 @@
 #    pragma GCC diagnostic pop
 #endif
 
-//
-// The Ruby header file win32/win32.h defines a number of macros for
-// functions like shutdown() and close() that wreak havoc.
-//
-#ifdef _WIN32
-#    undef shutdown
-#    undef close
-#    undef read
-#    undef write
-#    undef sleep
-#endif
-
 extern "C"
 {
     typedef VALUE (*ICE_RUBY_ENTRY_POINT)(...);

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -12,18 +12,6 @@
 #include <list>
 #include <math.h>
 
-//
-// Required for RHASH_SIZE to work properly with Ruby 1.8.x.
-// T_ZOMBIE is only defined in Ruby 1.9.
-//
-#ifndef T_ZOMBIE
-#    include "st.h"
-#endif
-
-#ifndef RHASH_SIZE
-#    define RHASH_SIZE(v) RHASH(v)->tbl->num_entries
-#endif
-
 using namespace std;
 using namespace IceRuby;
 using namespace Ice;

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -279,11 +279,7 @@ IceRuby::contextToHash(const Ice::Context& ctx)
 }
 
 extern "C" VALUE
-#ifdef RUBY_BLOCK_CALL_FUNC_TAKES_BLOCKARG // Defined Ruby >= 2.1
 IceRuby_Util_hash_foreach_callback(VALUE val, VALUE arg, int, const VALUE*, VALUE)
-#else
-IceRuby_Util_hash_foreach_callback(VALUE val, VALUE arg, int, VALUE*)
-#endif
 {
     VALUE key = rb_ary_entry(val, 0);
     VALUE value = rb_ary_entry(val, 1);
@@ -300,16 +296,6 @@ IceRuby_Util_hash_foreach_callback(VALUE val, VALUE arg, int, VALUE*)
     return val;
 }
 
-extern "C"
-{
-// Defined Ruby >= 2.1. Ruby 2.7 enables RB_BLOCK_CALL_FUNC_STRICT by default
-#ifdef RB_BLOCK_CALL_FUNC_STRICT
-    typedef rb_block_call_func_t ICE_RUBY_HASH_FOREACH_CALLBACK;
-#else
-    typedef VALUE (*ICE_RUBY_HASH_FOREACH_CALLBACK)(...);
-#endif
-}
-
 void
 IceRuby::hashIterate(VALUE h, HashIterator& iter)
 {
@@ -321,7 +307,7 @@ IceRuby::hashIterate(VALUE h, HashIterator& iter)
         rb_intern("each"),
         0,
         static_cast<VALUE*>(0),
-        reinterpret_cast<ICE_RUBY_HASH_FOREACH_CALLBACK>(IceRuby_Util_hash_foreach_callback),
+        IceRuby_Util_hash_foreach_callback,
         reinterpret_cast<VALUE>(&iter));
 }
 


### PR DESCRIPTION
Ice for Ruby requires Ruby >= 3.4 and builds only on Linux and macOS, so several old compatibility shims are dead code:

- `Types.cpp`: the `T_ZOMBIE`/`RHASH_SIZE` fallback for Ruby 1.8/1.9 — both are unconditionally defined by the headers of all supported Ruby versions.
- `Util.cpp`: the pre-2.1 arms of the `RUBY_BLOCK_CALL_FUNC_TAKES_BLOCKARG` and `RB_BLOCK_CALL_FUNC_STRICT` conditionals. The hash-foreach callback now matches `rb_block_call_func_t` exactly, so the `ICE_RUBY_HASH_FOREACH_CALLBACK` typedef and the cast at the call site are gone as well.
- `Config.h`: the `_WIN32` macro-undef block (`extconf.rb` rejects MinGW builds).
- `config/Make.rules`: the MinGW branch in the `ruby_libdir` computation.

Fixes #6447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
