### PR TITLE
Remove Dead Java Code

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -130,6 +130,8 @@ rewrite {
         'java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowLogFileDialog.java',
         // This file is never effectively fixed by OpenRewrite, yet OpenRewrite continually attempts to reformat it.
         'java/test/src/main/java/test/Ice/operations/Twoways.java',
+        // This file intentionally declares unused local variables to check the compilation of escaped identifiers.
+        'java/test/src/main/java/test/Slice/escape/Client.java',
     )
 }
 

--- a/java/config/checkstyle/checkstyle.xml
+++ b/java/config/checkstyle/checkstyle.xml
@@ -98,6 +98,7 @@
       <property name="allowNonPrintableEscapes" value="true"/>
     </module>
 
+    <module name="UnusedLocalVariable"/>
     <module name="UnusedImports"/>
     <module name="AvoidStarImport"/>
     <module name="OneTopLevelClass"/>

--- a/java/rewrite.yml
+++ b/java/rewrite.yml
@@ -14,6 +14,9 @@ recipeList:
   - org.openrewrite.staticanalysis.NeedBraces
   - org.openrewrite.staticanalysis.OperatorWrap
   - org.openrewrite.staticanalysis.RemoveCallsToObjectFinalize
+  - org.openrewrite.staticanalysis.RemoveUnusedLocalVariables
+  - org.openrewrite.staticanalysis.RemoveUnusedPrivateFields
+  - org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods
   - org.openrewrite.staticanalysis.ReplaceStringBuilderWithString
   - org.openrewrite.staticanalysis.ReplaceThreadRunWithThreadStart
   - org.openrewrite.staticanalysis.TypecastParenPad

--- a/java/src/IceGridGUI/icegridgui.pro
+++ b/java/src/IceGridGUI/icegridgui.pro
@@ -48,8 +48,8 @@
 -dontnote com.zeroc.Ice.MetricsMap
 -dontnote com.zeroc.Ice.ObjectPrx
 -dontnote com.zeroc.Ice.PluginManagerI
--dontnote com.zeroc.Ice.IceMX.Observer
--dontnote com.zeroc.Ice.IceMX.ObserverFactory
+-dontnote com.zeroc.IceMX.Observer
+-dontnote com.zeroc.IceMX.ObserverFactory
 
 -dontnote com.zeroc.IceBox.ServiceManagerI
 -dontnote com.zeroc.IceGridGUI.Coordinator
@@ -89,9 +89,7 @@
 -keep public class com.zeroc.IceGrid.** {
   public *;
 }
--keep public class com.zeroc.IceSSL.** {
-  public *;
-}
+
 -keep interface com.zeroc.IceGrid.**
 -keep class com.zeroc.IceMX.**
 -keep interface com.zeroc.IceMX.**

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/AdapterEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/AdapterEditor.java
@@ -551,9 +551,6 @@ class AdapterEditor extends CommunicatorChildEditor {
     private JComboBox _publishedEndpoints = new JComboBox(new Object[]{PUBLISH_ACTUAL});
     private JTextField _proxyOptions = new JTextField(20);
 
-    private JTextField _currentStatus = new JTextField(20);
-    private JTextField _currentEndpoints = new JTextField(20);
-
     private JCheckBox _serverLifetime;
 
     private ArrayMapField _objects;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/CommunicatorChildEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/CommunicatorChildEditor.java
@@ -27,7 +27,6 @@ abstract class CommunicatorChildEditor extends Editor {
                 _target.destroy(); // just removes the child
 
                 try {
-                    // @SuppressWarnings("unchecked")
                     childList.tryAdd(descriptor);
                 } catch (UpdateFailedException e) {
                     // Restore ephemeral
@@ -48,7 +47,6 @@ abstract class CommunicatorChildEditor extends Editor {
                 }
 
                 // Success
-                // @SuppressWarnings("unchecked")
                 _target = childList.findChildWithDescriptor(descriptor);
                 root.updated();
                 if (refresh) {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertySetParent.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertySetParent.java
@@ -7,7 +7,7 @@ import com.zeroc.IceGrid.PropertySetDescriptor;
 interface PropertySetParent {
     void tryAdd(String id, PropertySetDescriptor descriptor) throws UpdateFailedException;
 
-    void tryRename(String oldId, String oldUnresolveId, String newUnresolvedId)
+    void tryRename(String oldId, String oldUnresolvedId, String newUnresolvedId)
         throws UpdateFailedException;
 
     void insertPropertySet(PropertySet nps, boolean fireEvent) throws UpdateFailedException;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsViewEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsViewEditor.java
@@ -1179,7 +1179,6 @@ public class MetricsViewEditor extends Editor implements MetricsFieldContext {
         }
 
         private double _scaleFactor = 1.0d;
-        private String _columnName;
         private TableCellRenderer _cellRenderer;
         private final Map<String, Metrics> _deltas = new HashMap<>();
     }
@@ -1535,12 +1534,6 @@ public class MetricsViewEditor extends Editor implements MetricsFieldContext {
                                                     .getCellRenderer());
                                     }
                                 }
-
-                                int idColumn =
-                                    table.getColumnModel()
-                                        .getColumnIndex(
-                                            _properties.getProperty(
-                                                prefix + ".id.columnName"));
 
                                 for (Metrics m : objects) {
                                     model.addMetrics(m, timestamp);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CollocatedRequestHandler.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CollocatedRequestHandler.java
@@ -169,7 +169,7 @@ final class CollocatedRequestHandler implements RequestHandler {
                 try {
                     _adapter.incDirectCount();
                 } catch (ObjectAdapterDestroyedException ex) {
-                    handleException(ex, requestId, false);
+                    handleException(ex, requestId);
                     break;
                 }
 
@@ -197,7 +197,7 @@ final class CollocatedRequestHandler implements RequestHandler {
             }
             is.clear();
         } catch (LocalException ex) {
-            dispatchException(ex, requestId, false); // Fatal dispatch exception
+            dispatchException(ex, requestId); // Fatal dispatch exception
         } catch (RuntimeException | Error ex) {
             // A runtime exception or an error was thrown outside of servant code (i.e., by Ice code).
             // Note that this code does NOT send a response to the client.
@@ -208,7 +208,7 @@ final class CollocatedRequestHandler implements RequestHandler {
             pw.flush();
 
             _logger.error(sw.toString());
-            dispatchException(uex, requestId, false);
+            dispatchException(uex, requestId);
         } finally {
             _adapter.decDirectCount();
         }
@@ -256,12 +256,12 @@ final class CollocatedRequestHandler implements RequestHandler {
         _adapter.decDirectCount();
     }
 
-    private void dispatchException(LocalException ex, int requestId, boolean amd) {
-        handleException(ex, requestId, amd);
+    private void dispatchException(LocalException ex, int requestId) {
+        handleException(ex, requestId);
         _adapter.decDirectCount();
     }
 
-    private void handleException(LocalException ex, int requestId, boolean amd) {
+    private void handleException(LocalException ex, int requestId) {
         if (requestId == 0) {
             return; // Ignore exception for oneway messages.
         }
@@ -275,13 +275,7 @@ final class CollocatedRequestHandler implements RequestHandler {
         }
 
         if (outAsync != null) {
-            // If called from an AMD dispatch, invoke asynchronously the completion callback since
-            // this might be called from the user code.
-            if (amd) {
-                outAsync.invokeCompletedAsync();
-            } else {
-                outAsync.invokeCompleted();
-            }
+            outAsync.invokeCompleted();
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -354,39 +354,6 @@ public final class Util {
         return (InvocationFuture<T>) f;
     }
 
-    /**
-     * Translates a Slice type id to a Java class name.
-     *
-     * @param id The Slice type id, such as {@code ::Module::Type}.
-     * @return The equivalent Java class name, or null if the type id is malformed.
-     */
-    public static String typeIdToClass(String id) {
-        if (!id.startsWith("::")) {
-            return null;
-        }
-
-        StringBuilder buf = new StringBuilder(id.length());
-        int start = 2;
-        boolean done = false;
-        while (!done) {
-            int end = id.indexOf(':', start);
-            String s;
-            if (end != -1) {
-                s = id.substring(start, end);
-                start = end + 2;
-            } else {
-                s = id.substring(start);
-                done = true;
-            }
-            if (buf.length() > 0) {
-                buf.append('.');
-            }
-            buf.append(s);
-        }
-
-        return buf.toString();
-    }
-
     static String createThreadName(final Properties properties, final String name) {
         String threadName = properties.getIceProperty("Ice.ProgramName");
         if (!threadName.isEmpty()) {

--- a/java/test/src/main/java/test/Slice/escape/Client.java
+++ b/java/test/src/main/java/test/Slice/escape/Client.java
@@ -78,6 +78,7 @@ public class Client extends TestHelper {
     // This section of the test is present to ensure that the C++ types are named correctly. It is
     // not expected to run.
     @SuppressWarnings({"unused", "null"})
+    //CHECKSTYLE:OFF: UnusedLocalVariable
     private static void testtypes() {
         _assert v = _assert.escaped_boolean;
         _break b = new _break();
@@ -104,6 +105,7 @@ public class Client extends TestHelper {
         _finalize k = new finalizeServantI();
         assert escaped_synchronized.value == 0;
     }
+    //CHECKSTYLE:ON: UnusedLocalVariable
 
     public void run(String[] args) {
         var initData = new InitializationData();


### PR DESCRIPTION
This PR fixes #6494: it just removes various dead things from our Java code.

It also adds a couple extra rules to our linting setup, that helped catch even more dead code than what the issue flagged.