### PR TITLE
Publish the MATLAB API reference outside of MATLAB

### DIFF
--- a/.github/actions/matlab-documentation/action.yml
+++ b/.github/actions/matlab-documentation/action.yml
@@ -1,0 +1,48 @@
+name: MATLAB API Reference
+description: Generate the API reference for Ice for MATLAB
+inputs:
+  aws-access-key-id:
+    description: "AWS access key ID"
+    required: true
+  aws-secret-access-key:
+    description: "AWS secret access key"
+    required: true
+  aws-s3-code-bucket:
+    description: "AWS S3 bucket for storing the API reference"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    # MATLAB_COMMAND is exported by the setup-matlab action; the MATLAB build must have run before so that
+    # lib/generated is populated.
+    - name: Extract the MATLAB API into matlab-api.json
+      working-directory: ./matlab/docs
+      run: $MATLAB_COMMAND "extractapi"
+      shell: bash
+
+    - name: Render the MATLAB API reference
+      working-directory: ./matlab/docs
+      run: |
+        ice_version=$(sed -n 's/#define ICE_STRING_VERSION "\([^"]*\)".*/\1/p' ../../cpp/include/Ice/Config.h)
+        python3 renderapi.py --input matlab-api.json --output site \
+          --ice-version "$ice_version" \
+          --base-url https://code.zeroc.com/ice/main/api/matlab/
+      shell: bash
+
+    - name: Upload the MATLAB API reference as a workflow artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: matlab-api-reference
+        path: matlab/docs/site
+
+    # See the sync rationale in .github/actions/documentation/action.yml.
+    - name: Sync the MATLAB API reference to S3
+      run: aws s3 sync ./matlab/docs/site s3://${AWS_S3_CODE_BUCKET}/ice/main/api/matlab --delete
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
+        AWS_S3_CODE_BUCKET: ${{ inputs.aws-s3-code-bucket }}
+        AWS_DEFAULT_REGION: us-east-1
+      shell: bash
+      if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.repository == 'zeroc-ice/ice'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         if: matrix.config == 'release' && runner.os == 'macOS'
 
+      # The MATLAB API reference is generated separately because the MATLAB mapping does not build on macOS.
+      - name: Generate MATLAB API Reference
+        uses: ./.github/actions/matlab-documentation
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-s3-code-bucket: ${{ secrets.AWS_S3_CODE_BUCKET }}
+        if: matrix.config == 'matlab' && runner.os == 'Linux'
+
       - name: Upload test logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -37,6 +37,8 @@ exclude = [
     "^https?://dotnet\\.microsoft\\.com",
     # Symbol server
     "^https?://symbols\\.zeroc\\.com",
+    # Not published yet: goes live with the first main-branch CI run after the PR that adds it merges
+    "^https?://code\\.zeroc\\.com/ice/main/api/matlab",
 ]
 
 # Exclude paths from being checked

--- a/changelog.d/matlab/6274.md
+++ b/changelog.d/matlab/6274.md
@@ -1,0 +1,2 @@
+- The MATLAB API reference is now published at https://code.zeroc.com/ice/main/api/matlab/, like the API reference of
+  the other language mappings. The help available inside MATLAB is unchanged.

--- a/matlab/.gitignore
+++ b/matlab/.gitignore
@@ -6,3 +6,5 @@ toolbox/build
 toolbox/toolbox.prj
 toolbox/info.xml
 config/result.json
+docs/matlab-api.json
+docs/site/

--- a/matlab/Makefile
+++ b/matlab/Makefile
@@ -123,6 +123,21 @@ clean::
 
 toolbox:: $(icetoolbox_file)
 
+# Static API reference, published at https://code.zeroc.com/ice/main/api/matlab/
+doc:: generate-srcs
+ifneq (,$(MATLAB_COMMAND))
+	cd $(lang_srcdir)/docs && $(MATLAB_COMMAND) "extractapi"
+else
+	cd $(lang_srcdir)/docs && $(MATLAB_HOME)/bin/matlab -batch "extractapi"
+endif
+	python3 $(lang_srcdir)/docs/renderapi.py --input $(lang_srcdir)/docs/matlab-api.json \
+	    --output $(lang_srcdir)/docs/site \
+	    --ice-version $(shell sed -n 's/#define ICE_STRING_VERSION "\([^"]*\)".*/\1/p' $(top_srcdir)/cpp/include/Ice/Config.h) \
+	    --base-url https://code.zeroc.com/ice/main/api/matlab/
+
+clean::
+	rm -rf $(lang_srcdir)/docs/matlab-api.json $(lang_srcdir)/docs/site
+
 #
 # Translate the Slice files from test directories
 #

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -1,6 +1,6 @@
 # Ice for MATLAB
 
-[Examples] | [Documentation] | [Building from source]
+[Examples] | [Documentation] | [API Reference] | [Building from source]
 
 The [Ice framework] provides everything you need to build networked applications,
 including RPC, pub/sub, server deployment, and more.
@@ -52,5 +52,6 @@ end
 
 [Examples]: https://github.com/zeroc-ice/ice-demos/tree/main/matlab
 [Documentation]: https://docs.zeroc.com/ice/latest/matlab
+[API Reference]: https://code.zeroc.com/ice/main/api/matlab/index.html
 [Building from source]: ./BUILDING.md
 [Ice framework]: https://github.com/zeroc-ice/ice

--- a/matlab/docs/assets/style.css
+++ b/matlab/docs/assets/style.css
@@ -1,0 +1,209 @@
+/* Copyright (c) ZeroC, Inc. */
+
+:root {
+    --text: #1f2328;
+    --muted: #59636e;
+    --link: #0b5cad;
+    --border: #d1d9e0;
+    --surface: #f6f8fa;
+    --header-bg: #24292f;
+    --header-text: #ffffff;
+    --deprecated-bg: #fff8e5;
+    --deprecated-border: #d4a72c;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--text);
+    background: #ffffff;
+}
+
+header {
+    background: var(--header-bg);
+    padding: 0.75rem 1.5rem;
+}
+
+header a {
+    color: var(--header-text);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+main {
+    max-width: 56rem;
+    margin: 0 auto;
+    padding: 1rem 1.5rem 3rem;
+}
+
+footer {
+    max-width: 56rem;
+    margin: 0 auto;
+    padding: 1rem 1.5rem 2rem;
+    color: var(--muted);
+    font-size: 0.85rem;
+    border-top: 1px solid var(--border);
+}
+
+h1 {
+    font-size: 1.7rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.4rem;
+}
+
+h2 {
+    font-size: 1.35rem;
+    margin-top: 2rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.3rem;
+}
+
+h3 {
+    font-size: 1.1rem;
+    margin-top: 1.5rem;
+}
+
+h4,
+h5,
+h6 {
+    font-size: 0.95rem;
+    margin: 1rem 0 0.4rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+a {
+    color: var(--link);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+code,
+pre {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 0.9em;
+}
+
+pre {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    overflow-x: auto;
+}
+
+.badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--muted);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.05rem 0.5rem;
+    vertical-align: middle;
+}
+
+.superclasses,
+.inherited {
+    color: var(--muted);
+}
+
+.member {
+    border-top: 1px solid var(--border);
+    margin-top: 1.25rem;
+}
+
+.member h3 {
+    margin-top: 1rem;
+}
+
+ul.members {
+    padding-left: 1.25rem;
+}
+
+ul.members li {
+    margin: 0.2rem 0;
+}
+
+dl.arguments {
+    margin: 0.5rem 0;
+}
+
+dl.arguments dt {
+    font-weight: 600;
+    margin-top: 0.5rem;
+}
+
+dl.arguments dd {
+    margin: 0 0 0.4rem 1.25rem;
+}
+
+.type {
+    display: block;
+    color: var(--muted);
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 0.85em;
+}
+
+table.enum {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0.75rem 0;
+}
+
+table.enum th,
+table.enum td {
+    border: 1px solid var(--border);
+    padding: 0.4rem 0.6rem;
+    text-align: left;
+    vertical-align: top;
+}
+
+table.enum th {
+    background: var(--surface);
+}
+
+table.enum td p {
+    margin: 0;
+}
+
+.deprecated {
+    background: var(--deprecated-bg);
+    border-left: 4px solid var(--deprecated-border);
+    border-radius: 4px;
+    padding: 0.5rem 1rem;
+    margin: 0.75rem 0;
+}
+
+.deprecated .admonition-title {
+    font-weight: 700;
+    margin: 0 0 0.25rem;
+}
+
+.seealso {
+    color: var(--muted);
+}
+
+@media (max-width: 40rem) {
+    body {
+        font-size: 15px;
+    }
+
+    main,
+    footer {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+}

--- a/matlab/docs/extractapi.m
+++ b/matlab/docs/extractapi.m
@@ -115,8 +115,13 @@ function cls = extractClass(mc)
             continue;
         end
         entry = extractMethod(mc, m);
+        own = strcmp(m.DefiningClass.Name, mc.Name);
         if strcmp(m.Name, shortName)
             constructor = entry;
+        elseif own && ~helpConforms(entry.help, m.Name)
+            % Undocumented methods (MATLAB-synthesized enumeration methods, marshaling helpers, ...) get generic
+            % or implementation text from help(); they are not part of the documented API.
+            continue;
         else
             methodList{end + 1} = entry; %#ok<AGROW>
         end
@@ -128,6 +133,9 @@ function cls = extractClass(mc)
         % help() falls back to the class help when the constructor has no help block of its own.
         constructor.help = '';
     end
+    if ~isempty(constructor) && ~helpConforms(constructor.help, shortName)
+        constructor.help = '';
+    end
     cls.constructor = constructor;
     cls.methods = methodList;
 
@@ -137,18 +145,24 @@ function cls = extractClass(mc)
         if p.Hidden || ~strcmp(accessName(p.GetAccess), 'public') || isForeignClass(p.DefiningClass.Name)
             continue;
         end
-        propertyList{end + 1} = extractProperty(mc, p); %#ok<AGROW>
+        entry = extractProperty(mc, p);
+        if strcmp(p.DefiningClass.Name, mc.Name) && ~helpConforms(entry.help, p.Name)
+            continue;
+        end
+        propertyList{end + 1} = entry; %#ok<AGROW>
     end
     cls.properties = propertyList;
 
     members = {};
     for i = 1:numel(mc.EnumerationMemberList)
         em = mc.EnumerationMemberList(i);
-        entry.name = em.Name;
-        entry.help = getHelp([mc.Name, '.', em.Name]);
+        memberHelp = getHelp([mc.Name, '.', em.Name]);
+        if ~helpConforms(memberHelp, em.Name)
+            memberHelp = '';
+        end
         % Ice enumerations subclass int32 or uint8, so evaluating a member executes no user code.
-        entry.value = double(eval([mc.Name, '.', em.Name]));
-        members{end + 1} = entry; %#ok<AGROW>
+        members{end + 1} = struct('name', em.Name, 'help', memberHelp, ...
+                                  'value', double(eval([mc.Name, '.', em.Name]))); %#ok<AGROW>
     end
     cls.enumerationMembers = members;
 end
@@ -186,6 +200,10 @@ end
 function f = extractFunction(name)
     f.name = name;
     f.help = getHelp(name);
+    [~, shortName] = splitName(name);
+    if ~helpConforms(f.help, shortName)
+        f.help = '';
+    end
     f.declaration = readDeclaration(name);
 end
 
@@ -246,8 +264,10 @@ function text = getHelp(name)
     % Strip the footer lines that the help command appends after the help comment itself, for example:
     %   Documentation for Ice.Communicator
     %      doc Ice.Communicator
+    %   Help for Ice.Communicator/destroy is inherited from superclass ...
     lines = splitlines(text);
-    footers = ["Documentation for ", "doc ", "Folders named ", "Other uses of ", "Other functions named "];
+    footers = ["Documentation for ", "doc ", "Folders named ", "Other uses of ", "Other functions named ", ...
+               "Help for "];
     for i = 1:numel(lines)
         if startsWith(strip(eraseAnchors(lines{i})), footers)
             lines = lines(1:i - 1);
@@ -262,7 +282,25 @@ function text = getHelp(name)
             lines{i} = line(2:end);
         end
     end
+    if ~isempty(lines)
+        % Property help gets one more level of indentation than class and method help.
+        lines{1} = strip(lines{1}, 'left');
+    end
     text = char(strip(strjoin(lines, newline), 'right'));
+end
+
+function r = helpConforms(text, name)
+    % The help of every documented Ice symbol starts with the symbol name in upper case. Anything else is
+    % fallback text that the help command found elsewhere: generic MATLAB documentation, implementation
+    % comments, or an "is a function" placeholder.
+    r = false;
+    if isempty(text)
+        return;
+    end
+    firstLine = strip(eraseAnchors(extractBefore([text, newline], newline)));
+    token = extractBefore([firstLine, ' '], ' ');
+    % The comparison is deliberately case sensitive: the convention requires the upper-case name.
+    r = strcmp(token, upper(name)); %#ok<STCI>
 end
 
 function text = eraseAnchors(text)

--- a/matlab/docs/extractapi.m
+++ b/matlab/docs/extractapi.m
@@ -1,0 +1,270 @@
+function extractapi(outputFile)
+    %EXTRACTAPI Extract the public API of Ice for MATLAB into a JSON file.
+    %   Walks the public packages with the metaclass API and captures the help text of each documented symbol into
+    %   matlab-api.json. The companion script renderapi.py renders this file into a static HTML API reference; nothing
+    %   in the rendered output requires MATLAB.
+    %
+    %   Both lib and lib/generated must be on the MATLAB path (this function adds them), and lib/generated must be
+    %   populated by a prior build.
+
+    % Copyright (c) ZeroC, Inc.
+
+    if nargin < 1
+        outputFile = fullfile(fileparts(mfilename('fullpath')), 'matlab-api.json');
+    end
+
+    % Keep the <a href="matlab:help ..."> anchors emitted by slice2matlab in the captured help text.
+    feature('hotlinks', 1);
+
+    rootDir = fileparts(fileparts(mfilename('fullpath')));
+    addpath(fullfile(rootDir, 'lib'));
+    addpath(fullfile(rootDir, 'lib', 'generated'));
+
+    api.schemaVersion = 1;
+    api.matlabRelease = ['R', version('-release')];
+    api.functions = {extractFunction('slice2matlab')};
+
+    packageNames = {'Ice', 'Ice.SSL', 'Glacier2', 'IceBox', 'IceGrid', 'IceMX', 'IceStorm'};
+    packages = cell(1, numel(packageNames));
+    for i = 1:numel(packageNames)
+        packages{i} = extractPackage(packageNames{i});
+    end
+    api.packages = packages;
+
+    checkPackage(api, 'Ice', 50);
+    checkPackage(api, 'Glacier2', 1);
+    checkPackage(api, 'IceBox', 1);
+    checkPackage(api, 'IceGrid', 1);
+    checkPackage(api, 'IceMX', 1);
+    checkPackage(api, 'IceStorm', 1);
+
+    text = jsonencode(api, PrettyPrint = true);
+    fid = fopen(outputFile, 'w', 'n', 'UTF-8');
+    if fid == -1
+        error('extractapi:cannotOpen', 'Cannot open %s for writing.', outputFile);
+    end
+    fprintf(fid, '%s\n', text);
+    fclose(fid);
+    fprintf('Wrote %s\n', outputFile);
+end
+
+function checkPackage(api, name, minClasses)
+    % A package with fewer classes than expected means the generated code is missing; fail instead of publishing a
+    % gutted reference.
+    for i = 1:numel(api.packages)
+        if strcmp(api.packages{i}.name, name)
+            if numel(api.packages{i}.classes) < minClasses
+                error('extractapi:incompletePackage', ...
+                      'Package %s has %d classes, expected at least %d. Is lib/generated populated?', ...
+                      name, numel(api.packages{i}.classes), minClasses);
+            end
+            return;
+        end
+    end
+    error('extractapi:missingPackage', 'Package %s was not extracted.', name);
+end
+
+function pkg = extractPackage(name)
+    mp = meta.package.fromName(name);
+    if isempty(mp)
+        error('extractapi:missingPackage', 'Package %s not found on the MATLAB path.', name);
+    end
+
+    pkg.name = name;
+
+    classes = {};
+    for i = 1:numel(mp.ClassList)
+        mc = mp.ClassList(i);
+        if mc.Hidden
+            continue;
+        end
+        classes{end + 1} = extractClass(mc); %#ok<AGROW>
+    end
+    pkg.classes = classes;
+
+    functions = {};
+    for i = 1:numel(mp.FunctionList)
+        functions{end + 1} = extractFunction([name, '.', mp.FunctionList(i).Name]); %#ok<AGROW>
+    end
+    pkg.functions = functions;
+end
+
+function cls = extractClass(mc)
+    cls.name = mc.Name;
+    if mc.Enumeration
+        cls.kind = 'enum';
+    else
+        cls.kind = 'class';
+    end
+    cls.abstract = mc.Abstract;
+
+    superclasses = {};
+    for i = 1:numel(mc.SuperclassList)
+        superclasses{end + 1} = mc.SuperclassList(i).Name; %#ok<AGROW>
+    end
+    cls.superclasses = superclasses;
+    cls.help = getHelp(mc.Name);
+
+    [~, shortName] = splitName(mc.Name);
+
+    constructor = [];
+    methodList = {};
+    for i = 1:numel(mc.MethodList)
+        m = mc.MethodList(i);
+        if m.Hidden || ~strcmp(accessName(m.Access), 'public') || isForeignClass(m.DefiningClass.Name)
+            continue;
+        end
+        entry = extractMethod(mc, m);
+        if strcmp(m.Name, shortName)
+            constructor = entry;
+        else
+            methodList{end + 1} = entry; %#ok<AGROW>
+        end
+    end
+    if mc.Enumeration
+        % Enumerations are not constructed by users; their synthesized constructor is not part of the API.
+        constructor = [];
+    elseif ~isempty(constructor) && strcmp(constructor.help, cls.help)
+        % help() falls back to the class help when the constructor has no help block of its own.
+        constructor.help = '';
+    end
+    cls.constructor = constructor;
+    cls.methods = methodList;
+
+    propertyList = {};
+    for i = 1:numel(mc.PropertyList)
+        p = mc.PropertyList(i);
+        if p.Hidden || ~strcmp(accessName(p.GetAccess), 'public') || isForeignClass(p.DefiningClass.Name)
+            continue;
+        end
+        propertyList{end + 1} = extractProperty(mc, p); %#ok<AGROW>
+    end
+    cls.properties = propertyList;
+
+    members = {};
+    for i = 1:numel(mc.EnumerationMemberList)
+        em = mc.EnumerationMemberList(i);
+        entry.name = em.Name;
+        entry.help = getHelp([mc.Name, '.', em.Name]);
+        % Ice enumerations subclass int32 or uint8, so evaluating a member executes no user code.
+        entry.value = double(eval([mc.Name, '.', em.Name]));
+        members{end + 1} = entry; %#ok<AGROW>
+    end
+    cls.enumerationMembers = members;
+end
+
+function entry = extractMethod(mc, m)
+    entry.name = m.Name;
+    entry.definingClass = m.DefiningClass.Name;
+    entry.static = m.Static;
+    entry.abstract = m.Abstract;
+    entry.inputs = cellstr(m.InputNames);
+    entry.outputs = cellstr(m.OutputNames);
+    if strcmp(m.DefiningClass.Name, mc.Name)
+        % Inherited methods get no help text; the renderer links to the defining class instead.
+        entry.help = getHelp([mc.Name, '/', m.Name]);
+    else
+        entry.help = '';
+    end
+end
+
+function entry = extractProperty(mc, p)
+    % Deliberately never reads p.DefaultValue: querying it evaluates the initializer expression. The type and default
+    % are already described by the help comment's type line.
+    entry.name = p.Name;
+    entry.definingClass = p.DefiningClass.Name;
+    entry.constant = p.Constant;
+    entry.dependent = p.Dependent;
+    entry.setAccess = accessName(p.SetAccess);
+    if strcmp(p.DefiningClass.Name, mc.Name)
+        entry.help = getHelp([mc.Name, '/', p.Name]);
+    else
+        entry.help = '';
+    end
+end
+
+function f = extractFunction(name)
+    f.name = name;
+    f.help = getHelp(name);
+    f.declaration = readDeclaration(name);
+end
+
+function declaration = readDeclaration(name)
+    % The function metadata does not reliably expose signatures, so read the declaration from the source file.
+    declaration = '';
+    file = which(name);
+    if isempty(file) || ~isfile(file)
+        return;
+    end
+    lines = readlines(file);
+    for i = 1:numel(lines)
+        line = strtrim(lines(i));
+        if startsWith(line, 'function')
+            % Strip a trailing comment or line continuation from the declaration.
+            declaration = char(strip(regexprep(line, '\s*(%|\.\.\.).*$', '')));
+            return;
+        end
+    end
+end
+
+function name = accessName(access)
+    % Access is a char vector, or a cell array of metaclasses for access lists; the latter is not public.
+    if ischar(access) || isstring(access)
+        name = char(access);
+    else
+        name = 'restricted';
+    end
+end
+
+function r = isForeignClass(name)
+    % Members defined by MATLAB base classes are boilerplate (addlistener, eq, ...) and get no page in the reference.
+    [packageName, ~] = splitName(name);
+    r = isempty(packageName) || strcmp(packageName, 'matlab') || startsWith(name, 'matlab.');
+end
+
+function [packageName, shortName] = splitName(name)
+    pos = find(name == '.', 1, 'last');
+    if isempty(pos)
+        packageName = '';
+        shortName = name;
+    else
+        packageName = name(1:pos - 1);
+        shortName = name(pos + 1:end);
+    end
+end
+
+function text = getHelp(name)
+    try
+        text = help(name);
+    catch
+        text = '';
+    end
+    if isempty(text)
+        return;
+    end
+
+    % Strip the footer lines that the help command appends after the help comment itself, for example:
+    %   Documentation for Ice.Communicator
+    %      doc Ice.Communicator
+    lines = splitlines(text);
+    footers = ["Documentation for ", "doc ", "Folders named ", "Other uses of ", "Other functions named "];
+    for i = 1:numel(lines)
+        if startsWith(strip(eraseAnchors(lines{i})), footers)
+            lines = lines(1:i - 1);
+            break;
+        end
+    end
+
+    % Remove one level of indentation: help() indents every line of the comment block.
+    for i = 1:numel(lines)
+        line = lines{i};
+        if startsWith(line, ' ')
+            lines{i} = line(2:end);
+        end
+    end
+    text = char(strip(strjoin(lines, newline), 'right'));
+end
+
+function text = eraseAnchors(text)
+    text = regexprep(text, '<a\s+href="[^"]*">|</a>', '');
+end

--- a/matlab/docs/renderapi.py
+++ b/matlab/docs/renderapi.py
@@ -17,8 +17,12 @@ import re
 import shutil
 import sys
 from pathlib import Path
+from typing import Any
 
 BODY_INDENT = 3
+
+# A parsed help block: kind, header line, and content lines.
+Block = tuple[str, str | None, list[str]]
 
 # Sections recognized in a help block, at the base indentation of the body text.
 HEADER_RE = re.compile(
@@ -61,21 +65,21 @@ PAGE_TEMPLATE = """<!DOCTYPE html>
 """
 
 
-def esc(text):
+def esc(text: str) -> str:
     return html.escape(text, quote=False)
 
 
-def indent_of(line):
+def indent_of(line: str) -> int:
     return len(line) - len(line.lstrip(" "))
 
 
 class Model:
     """The API model: symbol tables built from matlab-api.json."""
 
-    def __init__(self, api):
+    def __init__(self, api: dict[str, Any]) -> None:
         self.api = api
-        self.classes = {}  # fully qualified name -> class dict
-        self.functions = {}  # fully qualified name -> function dict
+        self.classes: dict[str, dict[str, Any]] = {}
+        self.functions: dict[str, dict[str, Any]] = {}
         for function in api["functions"]:
             self.functions[function["name"]] = function
         for package in api["packages"]:
@@ -84,12 +88,12 @@ class Model:
             for function in package["functions"]:
                 self.functions[function["name"]] = function
 
-    def page(self, name):
+    def page(self, name: str) -> str | None:
         if name in self.classes or name in self.functions:
             return name + ".html"
         return None
 
-    def member_url(self, class_name, member_name):
+    def member_url(self, class_name: str, member_name: str) -> str | None:
         """URL of a class member, following inheritance to the page that documents it."""
         cls = self.classes.get(class_name)
         if cls is None:
@@ -111,7 +115,7 @@ class Model:
             return f"{class_name}.html#{member_name}"
         return None
 
-    def resolve(self, name, context_class=None):
+    def resolve(self, name: str, context_class: str | None = None) -> str | None:
         """Resolve a symbol reference from a See also list or a matlab:help anchor to a URL."""
         name = name.strip().rstrip(".,")
         if not name:
@@ -137,8 +141,8 @@ class Model:
                     return page
         return None
 
-    def derives_from(self, cls, ancestor_name):
-        seen = set()
+    def derives_from(self, cls: dict[str, Any], ancestor_name: str) -> bool:
+        seen: set[str] = set()
         names = list(cls["superclasses"])
         while names:
             name = names.pop()
@@ -150,7 +154,7 @@ class Model:
             names.extend(self.classes[name]["superclasses"])
         return False
 
-    def category(self, cls):
+    def category(self, cls: dict[str, Any]) -> str:
         if cls["kind"] == "enum":
             return "Enumerations"
         name = cls["name"]
@@ -164,12 +168,12 @@ class Model:
 class HelpRenderer:
     """Renders one help comment block into HTML."""
 
-    def __init__(self, model, context_class=None):
+    def __init__(self, model: Model, context_class: str | None = None) -> None:
         self.model = model
         self.context_class = context_class
-        self.links = []
+        self.links: list[tuple[str, str]] = []
 
-    def render(self, text, symbol_name, heading_level):
+    def render(self, text: str, symbol_name: str, heading_level: int) -> str:
         """Render the help text of symbol_name; sections become <h{heading_level}> headings."""
         if not text:
             return ""
@@ -179,7 +183,7 @@ class HelpRenderer:
         blocks = parse_blocks(lines, BODY_INDENT)
         return self._render_blocks(blocks, BODY_INDENT, heading_level)
 
-    def summary(self, text, symbol_name):
+    def summary(self, text: str, symbol_name: str) -> str:
         """The first sentence of the help text, as inline HTML."""
         if not text:
             return ""
@@ -188,19 +192,37 @@ class HelpRenderer:
         first = self._strip_name_prefix(first, symbol_name)
         return self._inline(first)
 
-    def _protect_anchor(self, match):
+    def argument_lists(self, text: str) -> tuple[list[str], bool, list[str]]:
+        """The argument names documented in the help text: input names, whether name-value arguments are
+        documented, and output names."""
+        inputs: list[str] = []
+        outputs: list[str] = []
+        name_value = False
+        for kind, header, lines in parse_blocks(text.split("\n"), BODY_INDENT):
+            if kind != "args":
+                continue
+            names = [name for name, _ in self._parse_entries(lines, BODY_INDENT + 2)]
+            if header == "Input Arguments":
+                inputs = names
+            elif header == "Input Name-Value Arguments":
+                name_value = True
+            elif header == "Output Arguments":
+                outputs = names
+        return inputs, name_value, outputs
+
+    def _protect_anchor(self, match: re.Match[str]) -> str:
         self.links.append((match.group(1), match.group(2)))
         return f"\x01{len(self.links) - 1}\x02"
 
     @staticmethod
-    def _strip_name_prefix(line, symbol_name):
+    def _strip_name_prefix(line: str, symbol_name: str) -> str:
         short = symbol_name.rpartition(".")[2]
         token, _, rest = line.lstrip().partition(" ")
         if token == short.upper():
             return rest
         return line
 
-    def _restore_anchor(self, match):
+    def _restore_anchor(self, match: re.Match[str]) -> str:
         target, label = self.links[int(match.group(1))]
         # The target is a MATLAB command such as "help Ice.Future -displayBanner".
         words = [word for word in target.split() if not word.startswith("-")]
@@ -210,7 +232,7 @@ class HelpRenderer:
             return f'<a href="{url}">{esc(label)}</a>'
         return esc(label)
 
-    def _inline(self, text, type_line=False):
+    def _inline(self, text: str, type_line: bool = False) -> str:
         text = esc(text)
         text = PLACEHOLDER_RE.sub(self._restore_anchor, text)
         if type_line:
@@ -220,16 +242,17 @@ class HelpRenderer:
             text = re.sub(r"\|([^|\n]+)\|", r"<code>\1</code>", text)
         return text
 
-    def _autolink_name(self, match):
+    def _autolink_name(self, match: re.Match[str]) -> str:
         page = self.model.page(match.group(0))
         if page:
             return f'<a href="{page}">{match.group(0)}</a>'
         return match.group(0)
 
-    def _render_blocks(self, blocks, base_indent, heading_level):
-        parts = []
+    def _render_blocks(self, blocks: list[Block], base_indent: int, heading_level: int) -> str:
+        parts: list[str] = []
         h = f"h{heading_level}"
         for kind, header, lines in blocks:
+            header = header or ""
             if kind == "para":
                 parts.append(self._render_paragraphs(lines))
             elif kind == "memberlist":
@@ -259,13 +282,13 @@ class HelpRenderer:
                 parts.append(self._render_deprecated(header, lines))
         return "\n".join(part for part in parts if part)
 
-    def _render_paragraphs(self, lines):
+    def _render_paragraphs(self, lines: list[str]) -> str:
         # Group the lines into paragraphs and "- item" bullet lists.
-        parts = []
-        paragraph = []
-        items = []
+        parts: list[str] = []
+        paragraph: list[str] = []
+        items: list[str] = []
 
-        def flush():
+        def flush() -> None:
             if paragraph:
                 parts.append(f"<p>{self._inline(' '.join(paragraph))}</p>")
                 paragraph.clear()
@@ -289,9 +312,9 @@ class HelpRenderer:
         flush()
         return "\n".join(parts)
 
-    def _parse_entries(self, lines, entry_indent):
+    def _parse_entries(self, lines: list[str], entry_indent: int) -> list[tuple[str, list[str]]]:
         """Parse "name - description" entries with indented continuation lines."""
-        entries = []
+        entries: list[tuple[str, list[str]]] = []
         for line in lines:
             stripped = line.strip()
             if not stripped:
@@ -303,16 +326,16 @@ class HelpRenderer:
                 entries[-1][1].append(stripped)
         return entries
 
-    def _render_member_list(self, lines, entry_indent):
-        items = []
+    def _render_member_list(self, lines: list[str], entry_indent: int) -> str:
+        items: list[str] = []
         for name, description in self._parse_entries(lines, entry_indent):
             url = self.model.member_url(self.context_class, name) if self.context_class else None
             label = f'<a href="{url}">{esc(name)}</a>' if url else f"<code>{esc(name)}</code>"
             items.append(f"<li>{label} &mdash; {self._inline(' '.join(description))}</li>")
         return f'<ul class="members">{"".join(items)}</ul>' if items else ""
 
-    def _render_arguments(self, lines, entry_indent, typed):
-        parts = []
+    def _render_arguments(self, lines: list[str], entry_indent: int, typed: bool) -> str:
+        parts: list[str] = []
         for name, description in self._parse_entries(lines, entry_indent):
             if typed and len(description) > 1 and not description[-1].rstrip().endswith("."):
                 # The last line of an argument entry is its type line — unless it ends a wrapped sentence, as in
@@ -330,7 +353,7 @@ class HelpRenderer:
             parts.append(f"<dd>{self._inline(' '.join(description))}{type_line}</dd>")
         return f'<dl class="arguments">{"".join(parts)}</dl>' if parts else ""
 
-    def _render_pre(self, lines, css_class=None):
+    def _render_pre(self, lines: list[str], css_class: str | None = None) -> str:
         while lines and not lines[0].strip():
             lines = lines[1:]
         while lines and not lines[-1].strip():
@@ -343,9 +366,9 @@ class HelpRenderer:
         css = f' class="{css_class}"' if css_class else ""
         return f"<pre{css}>{body}</pre>"
 
-    def _render_see_also(self, header, lines):
-        text = " ".join([header[len("See also"):]] + [line.strip() for line in lines if line.strip()])
-        rendered = []
+    def _render_see_also(self, header: str, lines: list[str]) -> str:
+        text = " ".join([header[len("See also") :]] + [line.strip() for line in lines if line.strip()])
+        rendered: list[str] = []
         for name in text.split(","):
             name = name.strip().rstrip(".")
             if not name:
@@ -354,22 +377,22 @@ class HelpRenderer:
             rendered.append(f'<a href="{url}">{esc(name)}</a>' if url else esc(name))
         return f'<p class="seealso">See also: {", ".join(rendered)}</p>' if rendered else ""
 
-    def _render_deprecated(self, header, lines):
-        text = header[len("Deprecated"):].lstrip(": ")
+    def _render_deprecated(self, header: str, lines: list[str]) -> str:
+        text = header[len("Deprecated") :].lstrip(": ")
         paragraphs = self._render_paragraphs(([text] if text else []) + lines)
         return f'<div class="deprecated"><p class="admonition-title">Deprecated</p>{paragraphs}</div>'
 
 
-def parse_blocks(lines, base_indent):
+def parse_blocks(lines: list[str], base_indent: int) -> list[Block]:
     """Split help-comment lines into an ordered list of (kind, header, content lines) blocks.
 
     A line at the base indentation that matches HEADER_RE starts a section; its content is every following line
     indented deeper than the base. Everything else is paragraph text.
     """
-    blocks = []
-    paragraph = []
+    blocks: list[Block] = []
+    paragraph: list[str] = []
 
-    def flush():
+    def flush() -> None:
         if paragraph:
             blocks.append(("para", None, paragraph[:]))
             paragraph.clear()
@@ -388,7 +411,7 @@ def parse_blocks(lines, base_indent):
             i += 1
             continue
         flush()
-        content = []
+        content: list[str] = []
         i += 1
         while i < len(lines):
             next_line = lines[i]
@@ -396,26 +419,26 @@ def parse_blocks(lines, base_indent):
                 break
             content.append(next_line)
             i += 1
-        blocks.append((match.lastgroup, stripped, content))
+        blocks.append((match.lastgroup or "para", stripped, content))
     flush()
     return blocks
 
 
 class SiteRenderer:
-    def __init__(self, model, output_dir, ice_version, base_url):
+    def __init__(self, model: Model, output_dir: Path, ice_version: str, base_url: str) -> None:
         self.model = model
         self.output_dir = output_dir
         self.ice_version = ice_version
         self.base_url = base_url
-        self.pages = []
+        self.pages: list[str] = []
 
-    def write_page(self, file_name, title, main):
+    def write_page(self, file_name: str, title: str, main: str) -> None:
         canonical = f'<link rel="canonical" href="{self.base_url}{file_name}">\n' if self.base_url else ""
         text = PAGE_TEMPLATE.format(title=esc(title), canonical=canonical, version=esc(self.ice_version), main=main)
         (self.output_dir / file_name).write_text(text, encoding="utf-8")
         self.pages.append(file_name)
 
-    def render_site(self):
+    def render_site(self) -> None:
         self.output_dir.mkdir(parents=True, exist_ok=True)
         for cls in self.model.classes.values():
             self.render_class(cls)
@@ -424,7 +447,7 @@ class SiteRenderer:
         self.render_index()
         self.render_sitemap()
 
-    def render_class(self, cls):
+    def render_class(self, cls: dict[str, Any]) -> None:
         name = cls["name"]
         renderer = HelpRenderer(self.model, context_class=name)
         parts = [f"<h1>{esc(name)}{self._badges(cls)}</h1>"]
@@ -434,23 +457,23 @@ class SiteRenderer:
         parts.append(renderer.render(cls["help"], name, heading_level=2))
 
         if cls["enumerationMembers"]:
-            rows = []
+            rows: list[str] = []
             for member in cls["enumerationMembers"]:
                 description = renderer.render(member["help"], member["name"], heading_level=6)
                 rows.append(
                     f'<tr id="{member["name"]}"><td><code>{esc(member["name"])}</code></td>'
-                    f'<td>{member["value"]:g}</td><td>{description}</td></tr>'
+                    f"<td>{member['value']:g}</td><td>{description}</td></tr>"
                 )
             parts.append("<h2>Enumeration Members</h2>")
             parts.append(
                 '<table class="enum"><thead><tr><th>Member</th><th>Value</th><th>Description</th></tr></thead>'
-                f'<tbody>{"".join(rows)}</tbody></table>'
+                f"<tbody>{''.join(rows)}</tbody></table>"
             )
 
         constructor = cls.get("constructor")
         if constructor and constructor["help"]:
             parts.append("<h2>Constructor</h2>")
-            parts.append(self._render_member(renderer, constructor, static=False))
+            parts.append(self._render_member(renderer, constructor, name, static=False, is_constructor=True))
 
         own_properties = [p for p in cls["properties"] if p["definingClass"] == name]
         if own_properties:
@@ -462,32 +485,70 @@ class SiteRenderer:
         if own_methods:
             parts.append("<h2>Method Details</h2>")
             for method in sorted(own_methods, key=lambda m: m["name"].lower()):
-                parts.append(self._render_member(renderer, method, static=method["static"]))
+                parts.append(self._render_member(renderer, method, name, static=method["static"]))
 
         parts.append(self._render_inherited(cls, "methods", "Methods"))
         parts.append(self._render_inherited(cls, "properties", "Properties"))
 
         self.write_page(f"{name}.html", f"{name} - Ice for MATLAB API Reference", "\n".join(p for p in parts if p))
 
-    def _badges(self, cls):
-        badges = []
+    def _badges(self, cls: dict[str, Any]) -> str:
+        badges: list[str] = []
         if cls["kind"] == "enum":
             badges.append("Enumeration")
         if cls["abstract"]:
             badges.append("Abstract")
         return "".join(f' <span class="badge">{badge}</span>' for badge in badges)
 
-    def _class_link(self, name):
+    def _class_link(self, name: str) -> str:
         page = self.model.page(name)
         return f'<a href="{page}">{esc(name)}</a>' if page else f"<code>{esc(name)}</code>"
 
-    def _render_member(self, renderer, member, static):
-        badge = ' <span class="badge">Static</span>' if static else ""
-        body = renderer.render(member["help"], member["name"], heading_level=4)
-        return f'<section class="member" id="{member["name"]}"><h3>{esc(member["name"])}{badge}</h3>{body}</section>'
+    def _signature(self, renderer: HelpRenderer, member: dict[str, Any], class_name: str, is_constructor: bool) -> str:
+        """The calling syntax of a method, reconstructed from its documented arguments.
 
-    def _render_property(self, renderer, prop):
-        badges = []
+        The metaclass argument names are unusable here: any method with an arguments block reports a single
+        "varargin" input. The documented Input Arguments and Output Arguments entries are authoritative.
+        """
+        inputs, name_value, outputs = renderer.argument_lists(member["help"])
+        if is_constructor:
+            callee = class_name
+            outputs = ["obj"]
+        elif member["static"]:
+            callee = f"{class_name}.{member['name']}"
+        else:
+            callee = member["name"]
+            inputs = ["obj"] + inputs
+        if name_value:
+            inputs = inputs + ["Name=Value"]
+        if not outputs:
+            outputs = [name for name in member.get("outputs", []) if name != "varargout"]
+        if not outputs:
+            left = ""
+        elif len(outputs) == 1:
+            left = f"{outputs[0]} = "
+        else:
+            left = f"[{', '.join(outputs)}] = "
+        return f'<pre class="syntax">{esc(f"{left}{callee}({', '.join(inputs)})")}</pre>'
+
+    def _render_member(
+        self,
+        renderer: HelpRenderer,
+        member: dict[str, Any],
+        class_name: str,
+        static: bool,
+        is_constructor: bool = False,
+    ) -> str:
+        badge = ' <span class="badge">Static</span>' if static else ""
+        signature = self._signature(renderer, member, class_name, is_constructor)
+        body = renderer.render(member["help"], member["name"], heading_level=4)
+        return (
+            f'<section class="member" id="{member["name"]}">'
+            f"<h3>{esc(member['name'])}{badge}</h3>{signature}{body}</section>"
+        )
+
+    def _render_property(self, renderer: HelpRenderer, prop: dict[str, Any]) -> str:
+        badges: list[str] = []
         if prop["constant"]:
             badges.append("Constant")
         if prop["dependent"]:
@@ -498,8 +559,8 @@ class SiteRenderer:
         body = renderer.render(prop["help"], prop["name"], heading_level=4)
         return f'<section class="member" id="{prop["name"]}"><h3>{esc(prop["name"])}{rendered}</h3>{body}</section>'
 
-    def _render_inherited(self, cls, group, label):
-        by_class = {}
+    def _render_inherited(self, cls: dict[str, Any], group: str, label: str) -> str:
+        by_class: dict[str, list[str]] = {}
         for member in cls[group]:
             defining = member["definingClass"]
             if defining != cls["name"] and defining in self.model.classes:
@@ -515,7 +576,7 @@ class SiteRenderer:
             parts.append(f'<p class="inherited">From {self._class_link(defining)}: {links}</p>')
         return "\n".join(parts)
 
-    def render_function(self, function):
+    def render_function(self, function: dict[str, Any]) -> None:
         name = function["name"]
         renderer = HelpRenderer(self.model, context_class=name)
         parts = [f"<h1>{esc(name)}</h1>"]
@@ -524,19 +585,19 @@ class SiteRenderer:
         parts.append(renderer.render(function["help"], name, heading_level=2))
         self.write_page(f"{name}.html", f"{name} - Ice for MATLAB API Reference", "\n".join(parts))
 
-    def render_index(self):
+    def render_index(self) -> None:
         renderer = HelpRenderer(self.model)
-        parts = [f"<h1>Ice for MATLAB API Reference</h1>"]
+        parts = ["<h1>Ice for MATLAB API Reference</h1>"]
         for package in self.model.api["packages"]:
-            parts.append(f'<h2>{esc(package["name"])}</h2>')
-            groups = {}
+            parts.append(f"<h2>{esc(package['name'])}</h2>")
+            groups: dict[str, list[dict[str, Any]]] = {}
             for cls in package["classes"]:
                 groups.setdefault(self.model.category(cls), []).append(cls)
             for group_name in ("Classes", "Proxies", "Exceptions", "Enumerations"):
                 if group_name not in groups:
                     continue
                 parts.append(f"<h3>{group_name}</h3>")
-                items = []
+                items: list[str] = []
                 for cls in sorted(groups[group_name], key=lambda c: c["name"]):
                     summary = renderer.summary(cls["help"], cls["name"])
                     items.append(f'<li><a href="{cls["name"]}.html">{esc(cls["name"])}</a> &mdash; {summary}</li>')
@@ -555,11 +616,13 @@ class SiteRenderer:
             items = []
             for function in sorted(self.model.api["functions"], key=lambda f: f["name"]):
                 summary = renderer.summary(function["help"], function["name"])
-                items.append(f'<li><a href="{function["name"]}.html">{esc(function["name"])}</a> &mdash; {summary}</li>')
+                items.append(
+                    f'<li><a href="{function["name"]}.html">{esc(function["name"])}</a> &mdash; {summary}</li>'
+                )
             parts.append(f'<ul class="members">{"".join(items)}</ul>')
         self.write_page("index.html", "Ice for MATLAB API Reference", "\n".join(parts))
 
-    def render_sitemap(self):
+    def render_sitemap(self) -> None:
         if not self.base_url:
             return
         urls = "\n".join(f"  <url><loc>{self.base_url}{page}</loc></url>" for page in sorted(self.pages))
@@ -571,8 +634,10 @@ class SiteRenderer:
         (self.output_dir / "sitemap.xml").write_text(text, encoding="utf-8")
 
 
-def main():
-    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Render matlab-api.json (produced by extractapi.m) into a static HTML API reference."
+    )
     parser.add_argument("--input", required=True, type=Path, help="path to matlab-api.json")
     parser.add_argument("--output", required=True, type=Path, help="output directory for the static site")
     parser.add_argument("--ice-version", required=True, help="Ice version displayed in the page header")

--- a/matlab/docs/renderapi.py
+++ b/matlab/docs/renderapi.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+# Copyright (c) ZeroC, Inc.
+
+"""Render matlab-api.json (produced by extractapi.m) into a static HTML API reference.
+
+The help text captured by extractapi.m is the raw MATLAB help comment block: a summary line followed by
+3-space-indented body text, with the section conventions used by both the hand-written classes and the code that
+slice2matlab generates (Input Arguments, Output Arguments, Exceptions, Examples, See also, ...). This script parses
+those conventions and emits one page per class, enumeration, and function, plus an index and a sitemap. It only uses
+the Python standard library.
+"""
+
+import argparse
+import html
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+BODY_INDENT = 3
+
+# Sections recognized in a help block, at the base indentation of the body text.
+HEADER_RE = re.compile(
+    r"(?P<memberlist>\S+ (?:Static )?(?:Methods|Properties):)$"
+    r"|(?P<args>Input Arguments|Input Name-Value Arguments|Output Arguments)$"
+    r"|(?P<exceptions>Exceptions)$"
+    r"|(?P<remarks>Remarks)$"
+    r"|(?P<examples>Examples?)$"
+    r"|(?P<creation>Creation)$"
+    r"|(?P<syntax>Syntax)$"
+    r"|(?P<seealso>See also\s.*)$"
+    r"|(?P<deprecated>Deprecated\b.*)$"
+)
+
+# <a href="matlab:help Ice.Future -displayBanner">Ice.Future</a> anchors emitted by slice2matlab.
+MATLAB_ANCHOR_RE = re.compile(r'<a\s+href="matlab:([^"]*)"[^>]*>(.*?)</a>')
+
+# Placeholders that carry the anchors through HTML escaping.
+PLACEHOLDER_RE = re.compile("\x01(\\d+)\x02")
+
+# A qualified name such as Ice.Communicator or Glacier2.SessionPrx, as it appears in type lines.
+QUALIFIED_NAME_RE = re.compile(r"\b[A-Z]\w*(?:\.[A-Z]\w*)+\b")
+
+PAGE_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+{canonical}<link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header><a href="index.html">Ice for MATLAB {version} API Reference</a></header>
+<main>
+{main}
+</main>
+<footer>Copyright &copy; ZeroC, Inc.</footer>
+</body>
+</html>
+"""
+
+
+def esc(text):
+    return html.escape(text, quote=False)
+
+
+def indent_of(line):
+    return len(line) - len(line.lstrip(" "))
+
+
+class Model:
+    """The API model: symbol tables built from matlab-api.json."""
+
+    def __init__(self, api):
+        self.api = api
+        self.classes = {}  # fully qualified name -> class dict
+        self.functions = {}  # fully qualified name -> function dict
+        for function in api["functions"]:
+            self.functions[function["name"]] = function
+        for package in api["packages"]:
+            for cls in package["classes"]:
+                self.classes[cls["name"]] = cls
+            for function in package["functions"]:
+                self.functions[function["name"]] = function
+
+    def page(self, name):
+        if name in self.classes or name in self.functions:
+            return name + ".html"
+        return None
+
+    def member_url(self, class_name, member_name):
+        """URL of a class member, following inheritance to the page that documents it."""
+        cls = self.classes.get(class_name)
+        if cls is None:
+            return None
+        for group in ("methods", "properties"):
+            for member in cls[group]:
+                if member["name"] == member_name:
+                    defining = member["definingClass"]
+                    if defining == class_name:
+                        return f"{class_name}.html#{member_name}"
+                    if defining in self.classes:
+                        return f"{defining}.html#{member_name}"
+                    return None
+        for member in cls["enumerationMembers"]:
+            if member["name"] == member_name:
+                return f"{class_name}.html#{member_name}"
+        constructor = cls.get("constructor")
+        if constructor and constructor["name"] == member_name:
+            return f"{class_name}.html#{member_name}"
+        return None
+
+    def resolve(self, name, context_class=None):
+        """Resolve a symbol reference from a See also list or a matlab:help anchor to a URL."""
+        name = name.strip().rstrip(".,")
+        if not name:
+            return None
+        if "/" in name:
+            class_name, _, member_name = name.partition("/")
+            return self.member_url(class_name, member_name)
+        page = self.page(name)
+        if page:
+            return page
+        # Class.Member (property, method, or enumeration member).
+        parent, _, member_name = name.rpartition(".")
+        if parent in self.classes:
+            return self.member_url(parent, member_name)
+        if context_class:
+            url = self.member_url(context_class, name)
+            if url:
+                return url
+            package = context_class.rpartition(".")[0]
+            for prefix in (package, "Ice"):
+                page = self.page(f"{prefix}.{name}")
+                if page:
+                    return page
+        return None
+
+    def derives_from(self, cls, ancestor_name):
+        seen = set()
+        names = list(cls["superclasses"])
+        while names:
+            name = names.pop()
+            if name == ancestor_name:
+                return True
+            if name in seen or name not in self.classes:
+                continue
+            seen.add(name)
+            names.extend(self.classes[name]["superclasses"])
+        return False
+
+    def category(self, cls):
+        if cls["kind"] == "enum":
+            return "Enumerations"
+        name = cls["name"]
+        if name == "Ice.ObjectPrx" or self.derives_from(cls, "Ice.ObjectPrx"):
+            return "Proxies"
+        if name == "Ice.Exception" or self.derives_from(cls, "Ice.Exception"):
+            return "Exceptions"
+        return "Classes"
+
+
+class HelpRenderer:
+    """Renders one help comment block into HTML."""
+
+    def __init__(self, model, context_class=None):
+        self.model = model
+        self.context_class = context_class
+        self.links = []
+
+    def render(self, text, symbol_name, heading_level):
+        """Render the help text of symbol_name; sections become <h{heading_level}> headings."""
+        if not text:
+            return ""
+        text = MATLAB_ANCHOR_RE.sub(self._protect_anchor, text)
+        lines = text.split("\n")
+        lines[0] = self._strip_name_prefix(lines[0], symbol_name)
+        blocks = parse_blocks(lines, BODY_INDENT)
+        return self._render_blocks(blocks, BODY_INDENT, heading_level)
+
+    def summary(self, text, symbol_name):
+        """The first sentence of the help text, as inline HTML."""
+        if not text:
+            return ""
+        first = text.split("\n", 1)[0]
+        first = MATLAB_ANCHOR_RE.sub(self._protect_anchor, first)
+        first = self._strip_name_prefix(first, symbol_name)
+        return self._inline(first)
+
+    def _protect_anchor(self, match):
+        self.links.append((match.group(1), match.group(2)))
+        return f"\x01{len(self.links) - 1}\x02"
+
+    @staticmethod
+    def _strip_name_prefix(line, symbol_name):
+        short = symbol_name.rpartition(".")[2]
+        token, _, rest = line.partition(" ")
+        if token == short.upper():
+            return rest
+        return line
+
+    def _restore_anchor(self, match):
+        target, label = self.links[int(match.group(1))]
+        # The target is a MATLAB command such as "help Ice.Future -displayBanner".
+        words = [word for word in target.split() if not word.startswith("-")]
+        symbol = words[1] if len(words) > 1 and words[0] in ("help", "doc") else words[0] if words else ""
+        url = self.model.resolve(symbol, self.context_class)
+        if url:
+            return f'<a href="{url}">{esc(label)}</a>'
+        return esc(label)
+
+    def _inline(self, text, type_line=False):
+        text = esc(text)
+        text = PLACEHOLDER_RE.sub(self._restore_anchor, text)
+        if type_line:
+            # In a type line, "|" separates alternatives; it never delimits a |code| span.
+            text = QUALIFIED_NAME_RE.sub(self._autolink_name, text)
+        else:
+            text = re.sub(r"\|([^|\n]+)\|", r"<code>\1</code>", text)
+        return text
+
+    def _autolink_name(self, match):
+        page = self.model.page(match.group(0))
+        if page:
+            return f'<a href="{page}">{match.group(0)}</a>'
+        return match.group(0)
+
+    def _render_blocks(self, blocks, base_indent, heading_level):
+        parts = []
+        h = f"h{heading_level}"
+        for kind, header, lines in blocks:
+            if kind == "para":
+                parts.append(self._render_paragraphs(lines))
+            elif kind == "memberlist":
+                parts.append(f"<{h}>{esc(header.rstrip(':'))}</{h}>")
+                parts.append(self._render_member_list(lines, base_indent + 2))
+            elif kind == "args":
+                parts.append(f"<{h}>{esc(header)}</{h}>")
+                parts.append(self._render_arguments(lines, base_indent + 2, typed=True))
+            elif kind == "exceptions":
+                parts.append(f"<{h}>Exceptions</{h}>")
+                parts.append(self._render_arguments(lines, base_indent + 2, typed=False))
+            elif kind == "remarks":
+                parts.append(f"<{h}>Remarks</{h}>")
+                parts.append(self._render_paragraphs(lines))
+            elif kind == "examples":
+                parts.append(f"<{h}>{esc(header)}</{h}>")
+                parts.append(self._render_pre(lines))
+            elif kind == "syntax":
+                parts.append(self._render_pre(lines, css_class="syntax"))
+            elif kind == "creation":
+                parts.append(f"<{h}>Creation</{h}>")
+                inner = parse_blocks(lines, base_indent + 2)
+                parts.append(self._render_blocks(inner, base_indent + 2, min(heading_level + 1, 6)))
+            elif kind == "seealso":
+                parts.append(self._render_see_also(header, lines))
+            elif kind == "deprecated":
+                parts.append(self._render_deprecated(header, lines))
+        return "\n".join(part for part in parts if part)
+
+    def _render_paragraphs(self, lines):
+        # Group the lines into paragraphs and "- item" bullet lists.
+        parts = []
+        paragraph = []
+        items = []
+
+        def flush():
+            if paragraph:
+                parts.append(f"<p>{self._inline(' '.join(paragraph))}</p>")
+                paragraph.clear()
+            if items:
+                rendered = "".join(f"<li>{self._inline(item)}</li>" for item in items)
+                parts.append(f"<ul>{rendered}</ul>")
+                items.clear()
+
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                flush()
+            elif stripped.startswith("- "):
+                if paragraph:
+                    flush()
+                items.append(stripped[2:])
+            elif items:
+                items[-1] += " " + stripped
+            else:
+                paragraph.append(stripped)
+        flush()
+        return "\n".join(parts)
+
+    def _parse_entries(self, lines, entry_indent):
+        """Parse "name - description" entries with indented continuation lines."""
+        entries = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            match = re.match(r"([\w.]+) - (.*)$", stripped)
+            if match and indent_of(line) == entry_indent:
+                entries.append((match.group(1), [match.group(2)]))
+            elif entries:
+                entries[-1][1].append(stripped)
+        return entries
+
+    def _render_member_list(self, lines, entry_indent):
+        items = []
+        for name, description in self._parse_entries(lines, entry_indent):
+            url = self.model.member_url(self.context_class, name) if self.context_class else None
+            label = f'<a href="{url}">{esc(name)}</a>' if url else f"<code>{esc(name)}</code>"
+            items.append(f"<li>{label} &mdash; {self._inline(' '.join(description))}</li>")
+        return f'<ul class="members">{"".join(items)}</ul>' if items else ""
+
+    def _render_arguments(self, lines, entry_indent, typed):
+        parts = []
+        for name, description in self._parse_entries(lines, entry_indent):
+            if typed and len(description) > 1:
+                # The last line of an argument entry is its type line.
+                type_line = f'<span class="type">{self._inline(description[-1], type_line=True)}</span>'
+                description = description[:-1]
+            else:
+                type_line = ""
+            if typed:
+                title = f"<code>{esc(name)}</code>"
+            else:
+                page = self.model.page(name)
+                title = f'<a href="{page}">{esc(name)}</a>' if page else f"<code>{esc(name)}</code>"
+            parts.append(f"<dt>{title}</dt>")
+            parts.append(f"<dd>{self._inline(' '.join(description))}{type_line}</dd>")
+        return f'<dl class="arguments">{"".join(parts)}</dl>' if parts else ""
+
+    def _render_pre(self, lines, css_class=None):
+        while lines and not lines[0].strip():
+            lines = lines[1:]
+        while lines and not lines[-1].strip():
+            lines = lines[:-1]
+        if not lines:
+            return ""
+        dedent = min(indent_of(line) for line in lines if line.strip())
+        body = "\n".join(line[dedent:] if line.strip() else "" for line in lines)
+        body = PLACEHOLDER_RE.sub(self._restore_anchor, esc(body))
+        css = f' class="{css_class}"' if css_class else ""
+        return f"<pre{css}>{body}</pre>"
+
+    def _render_see_also(self, header, lines):
+        text = " ".join([header[len("See also"):]] + [line.strip() for line in lines if line.strip()])
+        rendered = []
+        for name in text.split(","):
+            name = name.strip().rstrip(".")
+            if not name:
+                continue
+            url = self.model.resolve(name, self.context_class)
+            rendered.append(f'<a href="{url}">{esc(name)}</a>' if url else esc(name))
+        return f'<p class="seealso">See also: {", ".join(rendered)}</p>' if rendered else ""
+
+    def _render_deprecated(self, header, lines):
+        text = header[len("Deprecated"):].lstrip(": ")
+        paragraphs = self._render_paragraphs(([text] if text else []) + lines)
+        return f'<div class="deprecated"><p class="admonition-title">Deprecated</p>{paragraphs}</div>'
+
+
+def parse_blocks(lines, base_indent):
+    """Split help-comment lines into an ordered list of (kind, header, content lines) blocks.
+
+    A line at the base indentation that matches HEADER_RE starts a section; its content is every following line
+    indented deeper than the base. Everything else is paragraph text.
+    """
+    blocks = []
+    paragraph = []
+
+    def flush():
+        if paragraph:
+            blocks.append(("para", None, paragraph[:]))
+            paragraph.clear()
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if not stripped:
+            paragraph.append("")
+            i += 1
+            continue
+        match = HEADER_RE.fullmatch(stripped) if indent_of(line) <= base_indent else None
+        if match is None:
+            paragraph.append(line)
+            i += 1
+            continue
+        flush()
+        content = []
+        i += 1
+        while i < len(lines):
+            next_line = lines[i]
+            if next_line.strip() and indent_of(next_line) <= base_indent:
+                break
+            content.append(next_line)
+            i += 1
+        blocks.append((match.lastgroup, stripped, content))
+    flush()
+    return blocks
+
+
+class SiteRenderer:
+    def __init__(self, model, output_dir, ice_version, base_url):
+        self.model = model
+        self.output_dir = output_dir
+        self.ice_version = ice_version
+        self.base_url = base_url
+        self.pages = []
+
+    def write_page(self, file_name, title, main):
+        canonical = f'<link rel="canonical" href="{self.base_url}{file_name}">\n' if self.base_url else ""
+        text = PAGE_TEMPLATE.format(title=esc(title), canonical=canonical, version=esc(self.ice_version), main=main)
+        (self.output_dir / file_name).write_text(text, encoding="utf-8")
+        self.pages.append(file_name)
+
+    def render_site(self):
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        for cls in self.model.classes.values():
+            self.render_class(cls)
+        for function in self.model.functions.values():
+            self.render_function(function)
+        self.render_index()
+        self.render_sitemap()
+
+    def render_class(self, cls):
+        name = cls["name"]
+        renderer = HelpRenderer(self.model, context_class=name)
+        parts = [f"<h1>{esc(name)}{self._badges(cls)}</h1>"]
+        if cls["superclasses"]:
+            supers = ", ".join(self._class_link(super_name) for super_name in cls["superclasses"])
+            parts.append(f'<p class="superclasses">Superclasses: {supers}</p>')
+        parts.append(renderer.render(cls["help"], name, heading_level=2))
+
+        if cls["enumerationMembers"]:
+            rows = []
+            for member in cls["enumerationMembers"]:
+                description = renderer.render(member["help"], member["name"], heading_level=6)
+                rows.append(
+                    f'<tr id="{member["name"]}"><td><code>{esc(member["name"])}</code></td>'
+                    f'<td>{member["value"]:g}</td><td>{description}</td></tr>'
+                )
+            parts.append("<h2>Enumeration Members</h2>")
+            parts.append(
+                '<table class="enum"><thead><tr><th>Member</th><th>Value</th><th>Description</th></tr></thead>'
+                f'<tbody>{"".join(rows)}</tbody></table>'
+            )
+
+        constructor = cls.get("constructor")
+        if constructor and constructor["help"]:
+            parts.append("<h2>Constructor</h2>")
+            parts.append(self._render_member(renderer, constructor, static=False))
+
+        own_properties = [p for p in cls["properties"] if p["definingClass"] == name]
+        if own_properties:
+            parts.append("<h2>Property Details</h2>")
+            for prop in sorted(own_properties, key=lambda p: p["name"].lower()):
+                parts.append(self._render_property(renderer, prop))
+
+        own_methods = [m for m in cls["methods"] if m["definingClass"] == name]
+        if own_methods:
+            parts.append("<h2>Method Details</h2>")
+            for method in sorted(own_methods, key=lambda m: m["name"].lower()):
+                parts.append(self._render_member(renderer, method, static=method["static"]))
+
+        parts.append(self._render_inherited(cls, "methods", "Methods"))
+        parts.append(self._render_inherited(cls, "properties", "Properties"))
+
+        self.write_page(f"{name}.html", f"{name} - Ice for MATLAB API Reference", "\n".join(p for p in parts if p))
+
+    def _badges(self, cls):
+        badges = []
+        if cls["kind"] == "enum":
+            badges.append("Enumeration")
+        if cls["abstract"]:
+            badges.append("Abstract")
+        return "".join(f' <span class="badge">{badge}</span>' for badge in badges)
+
+    def _class_link(self, name):
+        page = self.model.page(name)
+        return f'<a href="{page}">{esc(name)}</a>' if page else f"<code>{esc(name)}</code>"
+
+    def _render_member(self, renderer, member, static):
+        badge = ' <span class="badge">Static</span>' if static else ""
+        body = renderer.render(member["help"], member["name"], heading_level=4)
+        return f'<section class="member" id="{member["name"]}"><h3>{esc(member["name"])}{badge}</h3>{body}</section>'
+
+    def _render_property(self, renderer, prop):
+        badges = []
+        if prop["constant"]:
+            badges.append("Constant")
+        if prop["dependent"]:
+            badges.append("Dependent")
+        if prop["setAccess"] != "public" and not prop["constant"]:
+            badges.append("Read-only")
+        rendered = "".join(f' <span class="badge">{badge}</span>' for badge in badges)
+        body = renderer.render(prop["help"], prop["name"], heading_level=4)
+        return f'<section class="member" id="{prop["name"]}"><h3>{esc(prop["name"])}{rendered}</h3>{body}</section>'
+
+    def _render_inherited(self, cls, group, label):
+        by_class = {}
+        for member in cls[group]:
+            defining = member["definingClass"]
+            if defining != cls["name"] and defining in self.model.classes:
+                by_class.setdefault(defining, []).append(member["name"])
+        if not by_class:
+            return ""
+        parts = [f"<h2>Inherited {label}</h2>"]
+        for defining in sorted(by_class):
+            links = ", ".join(
+                f'<a href="{defining}.html#{member_name}">{esc(member_name)}</a>'
+                for member_name in sorted(by_class[defining], key=str.lower)
+            )
+            parts.append(f'<p class="inherited">From {self._class_link(defining)}: {links}</p>')
+        return "\n".join(parts)
+
+    def render_function(self, function):
+        name = function["name"]
+        renderer = HelpRenderer(self.model, context_class=name)
+        parts = [f"<h1>{esc(name)}</h1>"]
+        if function["declaration"]:
+            parts.append(f'<pre class="syntax">{esc(function["declaration"])}</pre>')
+        parts.append(renderer.render(function["help"], name, heading_level=2))
+        self.write_page(f"{name}.html", f"{name} - Ice for MATLAB API Reference", "\n".join(parts))
+
+    def render_index(self):
+        renderer = HelpRenderer(self.model)
+        parts = [f"<h1>Ice for MATLAB API Reference</h1>"]
+        for package in self.model.api["packages"]:
+            parts.append(f'<h2>{esc(package["name"])}</h2>')
+            groups = {}
+            for cls in package["classes"]:
+                groups.setdefault(self.model.category(cls), []).append(cls)
+            for group_name in ("Classes", "Proxies", "Exceptions", "Enumerations"):
+                if group_name not in groups:
+                    continue
+                parts.append(f"<h3>{group_name}</h3>")
+                items = []
+                for cls in sorted(groups[group_name], key=lambda c: c["name"]):
+                    summary = renderer.summary(cls["help"], cls["name"])
+                    items.append(f'<li><a href="{cls["name"]}.html">{esc(cls["name"])}</a> &mdash; {summary}</li>')
+                parts.append(f'<ul class="members">{"".join(items)}</ul>')
+            if package["functions"]:
+                parts.append("<h3>Functions</h3>")
+                items = []
+                for function in sorted(package["functions"], key=lambda f: f["name"]):
+                    summary = renderer.summary(function["help"], function["name"])
+                    items.append(
+                        f'<li><a href="{function["name"]}.html">{esc(function["name"])}</a> &mdash; {summary}</li>'
+                    )
+                parts.append(f'<ul class="members">{"".join(items)}</ul>')
+        if self.model.api["functions"]:
+            parts.append("<h2>Functions</h2>")
+            items = []
+            for function in sorted(self.model.api["functions"], key=lambda f: f["name"]):
+                summary = renderer.summary(function["help"], function["name"])
+                items.append(f'<li><a href="{function["name"]}.html">{esc(function["name"])}</a> &mdash; {summary}</li>')
+            parts.append(f'<ul class="members">{"".join(items)}</ul>')
+        self.write_page("index.html", "Ice for MATLAB API Reference", "\n".join(parts))
+
+    def render_sitemap(self):
+        if not self.base_url:
+            return
+        urls = "\n".join(f"  <url><loc>{self.base_url}{page}</loc></url>" for page in sorted(self.pages))
+        text = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+            f"{urls}\n</urlset>\n"
+        )
+        (self.output_dir / "sitemap.xml").write_text(text, encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--input", required=True, type=Path, help="path to matlab-api.json")
+    parser.add_argument("--output", required=True, type=Path, help="output directory for the static site")
+    parser.add_argument("--ice-version", required=True, help="Ice version displayed in the page header")
+    parser.add_argument("--base-url", default="", help="canonical URL prefix, for example https://.../api/matlab/")
+    args = parser.parse_args()
+
+    if args.base_url and not args.base_url.endswith("/"):
+        args.base_url += "/"
+
+    api = json.loads(args.input.read_text(encoding="utf-8"))
+    if api["schemaVersion"] != 1:
+        sys.exit(f"unsupported schema version {api['schemaVersion']}")
+
+    model = Model(api)
+    site = SiteRenderer(model, args.output, args.ice_version, args.base_url)
+    site.render_site()
+
+    assets_dir = Path(__file__).parent / "assets"
+    (args.output / "css").mkdir(exist_ok=True)
+    shutil.copyfile(assets_dir / "style.css", args.output / "css" / "style.css")
+    shutil.copyfile(args.input, args.output / "matlab-api.json")
+
+    print(f"Rendered {len(site.pages)} pages into {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/matlab/docs/renderapi.py
+++ b/matlab/docs/renderapi.py
@@ -195,7 +195,7 @@ class HelpRenderer:
     @staticmethod
     def _strip_name_prefix(line, symbol_name):
         short = symbol_name.rpartition(".")[2]
-        token, _, rest = line.partition(" ")
+        token, _, rest = line.lstrip().partition(" ")
         if token == short.upper():
             return rest
         return line
@@ -314,8 +314,9 @@ class HelpRenderer:
     def _render_arguments(self, lines, entry_indent, typed):
         parts = []
         for name, description in self._parse_entries(lines, entry_indent):
-            if typed and len(description) > 1:
-                # The last line of an argument entry is its type line.
+            if typed and len(description) > 1 and not description[-1].rstrip().endswith("."):
+                # The last line of an argument entry is its type line — unless it ends a wrapped sentence, as in
+                # the checkedCast output descriptions, which have no type line.
                 type_line = f'<span class="type">{self._inline(description[-1], type_line=True)}</span>'
                 description = description[:-1]
             else:
@@ -586,6 +587,9 @@ def main():
         sys.exit(f"unsupported schema version {api['schemaVersion']}")
 
     model = Model(api)
+    if args.output.exists():
+        # Remove pages left behind by a previous run for symbols that no longer exist.
+        shutil.rmtree(args.output)
     site = SiteRenderer(model, args.output, args.ice_version, args.base_url)
     site.render_site()
 


### PR DESCRIPTION
This PR publishes the MATLAB API reference at https://code.zeroc.com/ice/main/api/matlab/, like the API reference of the other language mappings. The help available inside MATLAB and the packaged toolbox are unchanged.

The pipeline follows the approach proposed in the issue:

- `matlab/docs/extractapi.m` runs MATLAB once in CI and exports the public API — classes, superclasses, properties, methods, enumeration members, and help text — into a neutral `matlab-api.json`. It walks the `Ice`, `Ice.SSL`, `Glacier2`, `IceBox`, `IceGrid`, `IceMX`, and `IceStorm` packages with the metaclass API and fails loudly when `lib/generated` is not populated.
- `matlab/docs/renderapi.py` (Python stdlib only) renders `matlab-api.json` into a static site: one page per class, enumeration, and function, plus an index and a sitemap. It parses the help-comment conventions used by the hand-written classes and by `slice2matlab` (argument blocks with type lines, exceptions, examples, `See also`), and converts the `matlab:help` hyperlinks into relative links. `matlab-api.json` is published inside the synced directory so the documentation site can later render the same data with its own components. The published site does not depend on a live MATLAB.
- A new `matlab-documentation` composite action runs both steps from the existing `matlab` CI job on Linux (the MATLAB mapping does not build on macOS, so it cannot join the `documentation` action). On PRs the generation acts as a validation gate and uploads the site as a workflow artifact; the S3 sync uses the same gating as the `documentation` action.
- `make -C matlab doc` builds the same site locally on Linux.

Locally, the rendered site has no broken internal links (5,590 references across 235 pages).

Fixes #6274.