### PR TITLE
Replace hand-maintained BuildDependency edges with ProjectReference items

### DIFF
--- a/cpp/msbuild/ice.slnx
+++ b/cpp/msbuild/ice.slnx
@@ -3,110 +3,29 @@
     <Platform Name="Win32" />
     <Platform Name="x64" />
   </Configurations>
-  <Project Path="../src/DataStorm/msbuild/datastorm/datastorm.vcxproj">
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/dsnode/msbuild/dsnode.vcxproj">
-    <BuildDependency Project="../src/DataStorm/msbuild/datastorm/datastorm.vcxproj" />
-  </Project>
-  <Project Path="../src/Glacier2/msbuild/glacier2router.vcxproj">
-    <BuildDependency Project="../src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj" />
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-  </Project>
-  <Project Path="../src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj">
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/Ice/msbuild/ice/ice.vcxproj">
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/IceBox/msbuild/icebox/icebox.vcxproj">
-    <BuildDependency Project="../src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj" />
-  </Project>
-  <Project Path="../src/IceBox/msbuild/iceboxadmin/iceboxadmin.vcxproj">
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-    <BuildDependency Project="../src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj" />
-  </Project>
-  <Project Path="../src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj">
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/IceBridge/msbuild/icebridge.vcxproj">
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-  </Project>
-  <Project Path="../src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj">
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj">
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-    <BuildDependency Project="../src/IceBox/msbuild/icebox/icebox.vcxproj" />
-    <BuildDependency Project="../src/IceGridLib/msbuild/icegrid/icegrid.vcxproj" />
-    <BuildDependency Project="../src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj">
-    <BuildDependency Project="../src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj" />
-    <BuildDependency Project="../src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj" />
-    <BuildDependency Project="../src/IceGridLib/msbuild/icegrid/icegrid.vcxproj" />
-    <BuildDependency Project="../src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj" />
-    <BuildDependency Project="../src/IceStormLib/msbuild/icestorm/icestorm.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj">
-    <BuildDependency Project="../src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj" />
-    <BuildDependency Project="../src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj" />
-    <BuildDependency Project="../src/IceGridLib/msbuild/icegrid/icegrid.vcxproj" />
-    <BuildDependency Project="../src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj" />
-    <BuildDependency Project="../src/IceStormLib/msbuild/icestorm/icestorm.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/icegriddb/msbuild/icegriddb.vcxproj">
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-    <BuildDependency Project="../src/IceGridLib/msbuild/icegrid/icegrid.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/IceGridLib/msbuild/icegrid/icegrid.vcxproj">
-    <BuildDependency Project="../src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj" />
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj">
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-  </Project>
-  <Project Path="../src/iceserviceinstall/msbuild/iceserviceinstall.vcxproj">
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-  </Project>
-  <Project Path="../src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj">
-    <BuildDependency Project="../src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj" />
-    <BuildDependency Project="../src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj" />
-    <BuildDependency Project="../src/IceGridLib/msbuild/icegrid/icegrid.vcxproj" />
-    <BuildDependency Project="../src/IceStormLib/msbuild/icestorm/icestorm.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj">
-    <BuildDependency Project="../src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj" />
-    <BuildDependency Project="../src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj" />
-    <BuildDependency Project="../src/IceGridLib/msbuild/icegrid/icegrid.vcxproj" />
-    <BuildDependency Project="../src/IceStormLib/msbuild/icestorm/icestorm.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj">
-    <BuildDependency Project="../src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj" />
-    <BuildDependency Project="../src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj" />
-    <BuildDependency Project="../src/IceGridLib/msbuild/icegrid/icegrid.vcxproj" />
-    <BuildDependency Project="../src/IceStormLib/msbuild/icestorm/icestorm.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
-  <Project Path="../src/IceStormLib/msbuild/icestorm/icestorm.vcxproj">
-    <BuildDependency Project="../src/Ice/msbuild/ice/ice.vcxproj" />
-    <BuildDependency Project="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
-  </Project>
+  <Project Path="../src/DataStorm/msbuild/datastorm/datastorm.vcxproj" />
+  <Project Path="../src/dsnode/msbuild/dsnode.vcxproj" />
+  <Project Path="../src/Glacier2/msbuild/glacier2router.vcxproj" />
+  <Project Path="../src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj" />
+  <Project Path="../src/Ice/msbuild/ice/ice.vcxproj" />
+  <Project Path="../src/IceBox/msbuild/icebox/icebox.vcxproj" />
+  <Project Path="../src/IceBox/msbuild/iceboxadmin/iceboxadmin.vcxproj" />
+  <Project Path="../src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj" />
+  <Project Path="../src/IceBridge/msbuild/icebridge.vcxproj" />
+  <Project Path="../src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj" />
+  <Project Path="../src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj" />
+  <Project Path="../src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj" />
+  <Project Path="../src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj" />
+  <Project Path="../src/icegriddb/msbuild/icegriddb.vcxproj" />
+  <Project Path="../src/IceGridLib/msbuild/icegrid/icegrid.vcxproj" />
+  <Project Path="../src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj" />
+  <Project Path="../src/iceserviceinstall/msbuild/iceserviceinstall.vcxproj" />
+  <Project Path="../src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj" />
+  <Project Path="../src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj" />
+  <Project Path="../src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj" />
+  <Project Path="../src/IceStormLib/msbuild/icestorm/icestorm.vcxproj" />
   <Project Path="../src/IceUtil/msbuild/iceutil/iceutil.vcxproj" />
-  <Project Path="../src/Slice/msbuild/slice.vcxproj">
-    <BuildDependency Project="../src/IceUtil/msbuild/iceutil/iceutil.vcxproj" />
-  </Project>
+  <Project Path="../src/Slice/msbuild/slice.vcxproj" />
   <Project Path="../src/slice2cpp/msbuild/slice2cpp.vcxproj" />
   <Project Path="../src/slice2cs/msbuild/slice2cs.vcxproj" />
   <Project Path="../src/slice2java/msbuild/slice2java.vcxproj" />

--- a/cpp/msbuild/ice.test.slnx
+++ b/cpp/msbuild/ice.test.slnx
@@ -8,863 +8,432 @@
   </Folder>
   <Folder Name="/DataStorm/" />
   <Folder Name="/DataStorm/api/">
-    <Project Path="../test/DataStorm/api/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/api/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/DataStorm/callbacks/">
-    <Project Path="../test/DataStorm/callbacks/msbuild/reader/reader.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/DataStorm/callbacks/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/callbacks/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/callbacks/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/DataStorm/config/">
-    <Project Path="../test/DataStorm/config/msbuild/reader/reader.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/DataStorm/config/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/config/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/config/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/DataStorm/events/">
-    <Project Path="../test/DataStorm/events/msbuild/reader/reader.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/DataStorm/events/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/events/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/events/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/DataStorm/fanInRelay/">
-    <Project Path="../test/DataStorm/fanInRelay/msbuild/reader/reader.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/DataStorm/fanInRelay/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/fanInRelay/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/fanInRelay/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/DataStorm/partial/">
-    <Project Path="../test/DataStorm/partial/msbuild/reader/reader.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/DataStorm/partial/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/partial/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/partial/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/DataStorm/partialReconnect/">
-    <Project Path="../test/DataStorm/partialReconnect/msbuild/reader/reader.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/DataStorm/partialReconnect/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/partialReconnect/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/partialReconnect/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/DataStorm/relayReconnect/">
-    <Project Path="../test/DataStorm/relayReconnect/msbuild/reader/reader.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/DataStorm/relayReconnect/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/relayReconnect/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/relayReconnect/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/DataStorm/relaySampleFilter/">
-    <Project Path="../test/DataStorm/relaySampleFilter/msbuild/reader/reader.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/DataStorm/relaySampleFilter/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/relaySampleFilter/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/relaySampleFilter/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/DataStorm/reliability/">
-    <Project Path="../test/DataStorm/reliability/msbuild/reader/reader.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/DataStorm/reliability/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/reliability/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/reliability/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/DataStorm/topicDestroy/">
-    <Project Path="../test/DataStorm/topicDestroy/msbuild/reader/reader.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/DataStorm/topicDestroy/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/topicDestroy/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/topicDestroy/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/DataStorm/types/">
-    <Project Path="../test/DataStorm/types/msbuild/reader/reader.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/DataStorm/types/msbuild/writer/writer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/DataStorm/types/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/types/msbuild/writer/writer.vcxproj" />
   </Folder>
   <Folder Name="/Glacier2/" />
   <Folder Name="/Glacier2/attack/">
-    <Project Path="../test/Glacier2/attack/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Glacier2/attack/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Glacier2/attack/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Glacier2/attack/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Glacier2/dynamicFiltering/">
-    <Project Path="../test/Glacier2/dynamicFiltering/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Glacier2/dynamicFiltering/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Glacier2/dynamicFiltering/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Glacier2/dynamicFiltering/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Glacier2/router/">
-    <Project Path="../test/Glacier2/router/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Glacier2/router/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Glacier2/router/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Glacier2/router/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Glacier2/sessionControl/">
-    <Project Path="../test/Glacier2/sessionControl/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Glacier2/sessionControl/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Glacier2/sessionControl/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Glacier2/sessionControl/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Glacier2/ssl/">
-    <Project Path="../test/Glacier2/ssl/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Glacier2/ssl/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Glacier2/ssl/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Glacier2/ssl/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Glacier2/staticFiltering/">
-    <Project Path="../test/Glacier2/staticFiltering/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Glacier2/staticFiltering/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Glacier2/staticFiltering/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Glacier2/staticFiltering/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/" />
   <Folder Name="/Ice/adapterDeactivation/">
-    <Project Path="../test/Ice/adapterDeactivation/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/adapterDeactivation/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/adapterDeactivation/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/adapterDeactivation/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/adapterDeactivation/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/adapterDeactivation/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/admin/">
-    <Project Path="../test/Ice/admin/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/admin/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/admin/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/admin/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/ami/">
-    <Project Path="../test/Ice/ami/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/ami/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/ami/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/ami/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/ami/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/ami/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/background/">
-    <Project Path="../test/Ice/background/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-      <BuildDependency Project="../test/Ice/background/msbuild/testtransport/testtransport.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/background/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-      <BuildDependency Project="../test/Ice/background/msbuild/testtransport/testtransport.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/background/msbuild/testtransport/testtransport.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/background/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/background/msbuild/server/server.vcxproj" />
+    <Project Path="../test/Ice/background/msbuild/testtransport/testtransport.vcxproj" />
   </Folder>
   <Folder Name="/Ice/binding/">
-    <Project Path="../test/Ice/binding/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/binding/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/binding/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/binding/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/custom/">
-    <Project Path="../test/Ice/custom/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/custom/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/custom/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/custom/msbuild/serveramd/serveramd.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/custom/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/custom/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/custom/msbuild/server/server.vcxproj" />
+    <Project Path="../test/Ice/custom/msbuild/serveramd/serveramd.vcxproj" />
   </Folder>
   <Folder Name="/Ice/defaultServant/">
-    <Project Path="../test/Ice/defaultServant/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/defaultServant/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Ice/defaultValue/">
-    <Project Path="../test/Ice/defaultValue/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/defaultValue/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Ice/echo/">
-    <Project Path="../test/Ice/echo/msbuild/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/echo/msbuild/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/enums/">
-    <Project Path="../test/Ice/enums/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/enums/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/enums/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/enums/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/exceptions/">
-    <Project Path="../test/Ice/exceptions/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/exceptions/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/exceptions/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/exceptions/msbuild/serveramd/serveramd.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/exceptions/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/exceptions/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/exceptions/msbuild/server/server.vcxproj" />
+    <Project Path="../test/Ice/exceptions/msbuild/serveramd/serveramd.vcxproj" />
   </Folder>
   <Folder Name="/Ice/executor/">
-    <Project Path="../test/Ice/executor/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/executor/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/executor/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/executor/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/executor/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/executor/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/facets/">
-    <Project Path="../test/Ice/facets/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/facets/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/facets/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/facets/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/facets/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/facets/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/faultTolerance/">
-    <Project Path="../test/Ice/faultTolerance/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/faultTolerance/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/faultTolerance/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/faultTolerance/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/hash/">
-    <Project Path="../test/Ice/hash/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/hash/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Ice/hold/">
-    <Project Path="../test/Ice/hold/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/hold/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/hold/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/hold/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/idleTimeout/">
-    <Project Path="../test/Ice/idleTimeout/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/idleTimeout/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/idleTimeout/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/idleTimeout/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/inactivityTimeout/">
-    <Project Path="../test/Ice/inactivityTimeout/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/inactivityTimeout/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/inactivityTimeout/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/inactivityTimeout/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/info/">
-    <Project Path="../test/Ice/info/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/info/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/info/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/info/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/inheritance/">
-    <Project Path="../test/Ice/inheritance/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/inheritance/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/inheritance/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/inheritance/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/inheritance/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/inheritance/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/invoke/">
-    <Project Path="../test/Ice/invoke/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/invoke/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/invoke/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/invoke/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/library/">
-    <Project Path="../test/Ice/library/msbuild/alltests/alltests.vcxproj">
-      <BuildDependency Project="../test/Ice/library/msbuild/consumer/consumer.vcxproj" />
-      <BuildDependency Project="../test/Ice/library/msbuild/gencode/gencode.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/library/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-      <BuildDependency Project="../test/Ice/library/msbuild/alltests/alltests.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/library/msbuild/consumer/consumer.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-      <BuildDependency Project="../test/Ice/library/msbuild/gencode/gencode.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/library/msbuild/alltests/alltests.vcxproj" />
+    <Project Path="../test/Ice/library/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/library/msbuild/consumer/consumer.vcxproj" />
     <Project Path="../test/Ice/library/msbuild/gencode/gencode.vcxproj" />
   </Folder>
   <Folder Name="/Ice/location/">
-    <Project Path="../test/Ice/location/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/location/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/location/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/location/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/logger/">
-    <Project Path="../test/Ice/logger/msbuild/client1/client1.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/logger/msbuild/client2/client2.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/logger/msbuild/client3/client3.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/logger/msbuild/client4/client4.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/logger/msbuild/client5/client5.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/logger/msbuild/client1/client1.vcxproj" />
+    <Project Path="../test/Ice/logger/msbuild/client2/client2.vcxproj" />
+    <Project Path="../test/Ice/logger/msbuild/client3/client3.vcxproj" />
+    <Project Path="../test/Ice/logger/msbuild/client4/client4.vcxproj" />
+    <Project Path="../test/Ice/logger/msbuild/client5/client5.vcxproj" />
   </Folder>
   <Folder Name="/Ice/maxConnections/">
-    <Project Path="../test/Ice/maxConnections/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/maxConnections/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/maxConnections/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/maxConnections/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/maxDispatches/">
-    <Project Path="../test/Ice/maxDispatches/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/maxDispatches/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/maxDispatches/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/maxDispatches/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/metrics/">
-    <Project Path="../test/Ice/metrics/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/metrics/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/metrics/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/metrics/msbuild/serveramd/serveramd.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/metrics/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/metrics/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/metrics/msbuild/server/server.vcxproj" />
+    <Project Path="../test/Ice/metrics/msbuild/serveramd/serveramd.vcxproj" />
   </Folder>
   <Folder Name="/Ice/middleware/">
-    <Project Path="../test/Ice/middleware/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/middleware/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Ice/networkProxy/">
-    <Project Path="../test/Ice/networkProxy/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/networkProxy/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/networkProxy/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/networkProxy/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/objects/">
-    <Project Path="../test/Ice/objects/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/objects/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/objects/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/objects/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/objects/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/objects/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/operations/">
-    <Project Path="../test/Ice/operations/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/operations/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/operations/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/operations/msbuild/serveramd/serveramd.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/operations/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/operations/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/operations/msbuild/server/server.vcxproj" />
+    <Project Path="../test/Ice/operations/msbuild/serveramd/serveramd.vcxproj" />
   </Folder>
   <Folder Name="/Ice/optional/">
-    <Project Path="../test/Ice/optional/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/optional/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/optional/msbuild/serveramd/serveramd.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/optional/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/optional/msbuild/server/server.vcxproj" />
+    <Project Path="../test/Ice/optional/msbuild/serveramd/serveramd.vcxproj" />
   </Folder>
   <Folder Name="/Ice/plugin/">
-    <Project Path="../test/Ice/plugin/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/plugin/msbuild/testplugin/testplugin.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/plugin/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/plugin/msbuild/testplugin/testplugin.vcxproj" />
   </Folder>
   <Folder Name="/Ice/properties/">
-    <Project Path="../test/Ice/properties/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/properties/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Ice/proxy/">
-    <Project Path="../test/Ice/proxy/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/proxy/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/proxy/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/proxy/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/proxy/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/proxy/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/retry/">
-    <Project Path="../test/Ice/retry/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/retry/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/retry/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/retry/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/retry/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/retry/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/scope/">
-    <Project Path="../test/Ice/scope/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/scope/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/scope/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/scope/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/servantLocator/">
-    <Project Path="../test/Ice/servantLocator/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/servantLocator/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/servantLocator/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/servantLocator/msbuild/serveramd/serveramd.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/servantLocator/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/servantLocator/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/servantLocator/msbuild/server/server.vcxproj" />
+    <Project Path="../test/Ice/servantLocator/msbuild/serveramd/serveramd.vcxproj" />
   </Folder>
   <Folder Name="/Ice/services/">
-    <Project Path="../test/Ice/services/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/services/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Ice/slicing/" />
   <Folder Name="/Ice/slicing/exceptions/">
-    <Project Path="../test/Ice/slicing/exceptions/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/slicing/exceptions/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/slicing/exceptions/msbuild/serveramd/serveramd.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/slicing/exceptions/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/slicing/exceptions/msbuild/server/server.vcxproj" />
+    <Project Path="../test/Ice/slicing/exceptions/msbuild/serveramd/serveramd.vcxproj" />
   </Folder>
   <Folder Name="/Ice/slicing/objects/">
-    <Project Path="../test/Ice/slicing/objects/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/slicing/objects/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/slicing/objects/msbuild/serveramd/serveramd.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/slicing/objects/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/slicing/objects/msbuild/server/server.vcxproj" />
+    <Project Path="../test/Ice/slicing/objects/msbuild/serveramd/serveramd.vcxproj" />
   </Folder>
   <Folder Name="/Ice/span/">
-    <Project Path="../test/Ice/span/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/span/msbuild/collocated/collocated.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/span/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/span/msbuild/serveramd/serveramd.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/span/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/span/msbuild/collocated/collocated.vcxproj" />
+    <Project Path="../test/Ice/span/msbuild/server/server.vcxproj" />
+    <Project Path="../test/Ice/span/msbuild/serveramd/serveramd.vcxproj" />
   </Folder>
   <Folder Name="/Ice/stream/">
-    <Project Path="../test/Ice/stream/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/stream/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Ice/stringConverter/">
-    <Project Path="../test/Ice/stringConverter/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/stringConverter/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/stringConverter/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/stringConverter/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/timeout/">
-    <Project Path="../test/Ice/timeout/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/timeout/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/timeout/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/timeout/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/udp/">
-    <Project Path="../test/Ice/udp/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/Ice/udp/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/udp/msbuild/client/client.vcxproj" />
+    <Project Path="../test/Ice/udp/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/Ice/wsAllowedOrigins/">
-    <Project Path="../test/Ice/wsAllowedOrigins/msbuild/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Ice/wsAllowedOrigins/msbuild/server.vcxproj" />
   </Folder>
   <Folder Name="/IceBox/" />
   <Folder Name="/IceBox/admin/">
-    <Project Path="../test/IceBox/admin/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceBox/admin/msbuild/testservice/testservice.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceBox/admin/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceBox/admin/msbuild/testservice/testservice.vcxproj" />
   </Folder>
   <Folder Name="/IceBox/configuration/">
-    <Project Path="../test/IceBox/configuration/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceBox/configuration/msbuild/testservice/testservice.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceBox/configuration/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceBox/configuration/msbuild/testservice/testservice.vcxproj" />
   </Folder>
   <Folder Name="/IceBridge/" />
   <Folder Name="/IceBridge/simple/">
-    <Project Path="../test/IceBridge/simple/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceBridge/simple/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceBridge/simple/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceBridge/simple/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/IceDiscovery/" />
   <Folder Name="/IceDiscovery/simple/">
-    <Project Path="../test/IceDiscovery/simple/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceDiscovery/simple/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceDiscovery/simple/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceDiscovery/simple/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/IceGrid/" />
   <Folder Name="/IceGrid/activation/">
-    <Project Path="../test/IceGrid/activation/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/activation/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceGrid/activation/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceGrid/activation/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/IceGrid/admin/">
-    <Project Path="../test/IceGrid/admin/msbuild/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceGrid/admin/msbuild/server.vcxproj" />
   </Folder>
   <Folder Name="/IceGrid/allocation/">
-    <Project Path="../test/IceGrid/allocation/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/allocation/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/allocation/msbuild/verifier/verifier.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceGrid/allocation/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceGrid/allocation/msbuild/server/server.vcxproj" />
+    <Project Path="../test/IceGrid/allocation/msbuild/verifier/verifier.vcxproj" />
   </Folder>
   <Folder Name="/IceGrid/deployer/">
-    <Project Path="../test/IceGrid/deployer/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/deployer/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/deployer/msbuild/testservice/testservice.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceGrid/deployer/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceGrid/deployer/msbuild/server/server.vcxproj" />
+    <Project Path="../test/IceGrid/deployer/msbuild/testservice/testservice.vcxproj" />
   </Folder>
   <Folder Name="/IceGrid/noRestartUpdate/">
-    <Project Path="../test/IceGrid/noRestartUpdate/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/noRestartUpdate/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/noRestartUpdate/msbuild/testservice/testservice.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceGrid/noRestartUpdate/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceGrid/noRestartUpdate/msbuild/server/server.vcxproj" />
+    <Project Path="../test/IceGrid/noRestartUpdate/msbuild/testservice/testservice.vcxproj" />
   </Folder>
   <Folder Name="/IceGrid/replicaGroup/">
-    <Project Path="../test/IceGrid/replicaGroup/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/replicaGroup/msbuild/registryplugin/registryplugin.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/replicaGroup/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/replicaGroup/msbuild/testservice/testservice.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceGrid/replicaGroup/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceGrid/replicaGroup/msbuild/registryplugin/registryplugin.vcxproj" />
+    <Project Path="../test/IceGrid/replicaGroup/msbuild/server/server.vcxproj" />
+    <Project Path="../test/IceGrid/replicaGroup/msbuild/testservice/testservice.vcxproj" />
   </Folder>
   <Folder Name="/IceGrid/replication/">
-    <Project Path="../test/IceGrid/replication/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/replication/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceGrid/replication/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceGrid/replication/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/IceGrid/session/">
-    <Project Path="../test/IceGrid/session/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/session/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/session/msbuild/verifier/verifier.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceGrid/session/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceGrid/session/msbuild/server/server.vcxproj" />
+    <Project Path="../test/IceGrid/session/msbuild/verifier/verifier.vcxproj" />
   </Folder>
   <Folder Name="/IceGrid/simple/">
-    <Project Path="../test/IceGrid/simple/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/simple/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceGrid/simple/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceGrid/simple/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/IceGrid/update/">
-    <Project Path="../test/IceGrid/update/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceGrid/update/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceGrid/update/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceGrid/update/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/IceSSL/" />
   <Folder Name="/IceSSL/configuration/">
-    <Project Path="../test/IceSSL/configuration/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceSSL/configuration/msbuild/server/server.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceSSL/configuration/msbuild/client/client.vcxproj" />
+    <Project Path="../test/IceSSL/configuration/msbuild/server/server.vcxproj" />
   </Folder>
   <Folder Name="/IceStorm/" />
   <Folder Name="/IceStorm/createOrRetrieve/">
-    <Project Path="../test/IceStorm/createOrRetrieve/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceStorm/createOrRetrieve/msbuild/client/client.vcxproj" />
   </Folder>
   <Folder Name="/IceStorm/federation/">
-    <Project Path="../test/IceStorm/federation/msbuild/publisher/publisher.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceStorm/federation/msbuild/subscriber/subscriber.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceStorm/federation/msbuild/publisher/publisher.vcxproj" />
+    <Project Path="../test/IceStorm/federation/msbuild/subscriber/subscriber.vcxproj" />
   </Folder>
   <Folder Name="/IceStorm/federation2/">
-    <Project Path="../test/IceStorm/federation2/msbuild/publisher/publisher.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceStorm/federation2/msbuild/subscriber/subscriber.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceStorm/federation2/msbuild/publisher/publisher.vcxproj" />
+    <Project Path="../test/IceStorm/federation2/msbuild/subscriber/subscriber.vcxproj" />
   </Folder>
   <Folder Name="/IceStorm/persistent/">
-    <Project Path="../test/IceStorm/persistent/msbuild/client/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceStorm/persistent/msbuild/client/client.vcxproj" />
   </Folder>
   <Folder Name="/IceStorm/rep1/">
-    <Project Path="../test/IceStorm/rep1/msbuild/publisher/publisher.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceStorm/rep1/msbuild/sub/sub.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceStorm/rep1/msbuild/subscriber/subscriber.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceStorm/rep1/msbuild/publisher/publisher.vcxproj" />
+    <Project Path="../test/IceStorm/rep1/msbuild/sub/sub.vcxproj" />
+    <Project Path="../test/IceStorm/rep1/msbuild/subscriber/subscriber.vcxproj" />
   </Folder>
   <Folder Name="/IceStorm/repgrid/">
-    <Project Path="../test/IceStorm/repgrid/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceStorm/repgrid/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/IceStorm/repstress/">
-    <Project Path="../test/IceStorm/repstress/msbuild/control/control.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceStorm/repstress/msbuild/publisher/publisher.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceStorm/repstress/msbuild/subscriber/subscriber.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceStorm/repstress/msbuild/control/control.vcxproj" />
+    <Project Path="../test/IceStorm/repstress/msbuild/publisher/publisher.vcxproj" />
+    <Project Path="../test/IceStorm/repstress/msbuild/subscriber/subscriber.vcxproj" />
   </Folder>
   <Folder Name="/IceStorm/single/">
-    <Project Path="../test/IceStorm/single/msbuild/publisher/publisher.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceStorm/single/msbuild/subscriber/subscriber.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceStorm/single/msbuild/publisher/publisher.vcxproj" />
+    <Project Path="../test/IceStorm/single/msbuild/subscriber/subscriber.vcxproj" />
   </Folder>
   <Folder Name="/IceStorm/stress/">
-    <Project Path="../test/IceStorm/stress/msbuild/publisher/publisher.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
-    <Project Path="../test/IceStorm/stress/msbuild/subscriber/subscriber.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceStorm/stress/msbuild/publisher/publisher.vcxproj" />
+    <Project Path="../test/IceStorm/stress/msbuild/subscriber/subscriber.vcxproj" />
   </Folder>
   <Folder Name="/IceUtil/" />
   <Folder Name="/IceUtil/ctrlHandler/">
-    <Project Path="../test/IceUtil/ctrlCHandler/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceUtil/ctrlCHandler/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/IceUtil/inputUtil/">
-    <Project Path="../test/IceUtil/inputUtil/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceUtil/inputUtil/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/IceUtil/sha1/">
-    <Project Path="../test/IceUtil/sha1/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceUtil/sha1/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/IceUtil/stackTrace/">
-    <Project Path="../test/IceUtil/stacktrace/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceUtil/stacktrace/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/IceUtil/timer/">
-    <Project Path="../test/IceUtil/timer/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceUtil/timer/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/IceUtil/unicode/">
-    <Project Path="../test/IceUtil/unicode/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceUtil/unicode/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/IceUtil/uuid/">
-    <Project Path="../test/IceUtil/uuid/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/IceUtil/uuid/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Slice/" />
   <Folder Name="/Slice/deprecated/">
-    <Project Path="../test/Slice/deprecated/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Slice/deprecated/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Slice/escape/">
-    <Project Path="../test/Slice/escape/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Slice/escape/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Slice/macros/">
-    <Project Path="../test/Slice/macros/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Slice/macros/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Slice/parser/">
-    <Project Path="../test/Slice/parser/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Slice/parser/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Slice/print/">
-    <Project Path="../test/Slice/print/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Slice/print/msbuild/client.vcxproj" />
   </Folder>
   <Folder Name="/Slice/structure/">
-    <Project Path="../test/Slice/structure/msbuild/client.vcxproj">
-      <BuildDependency Project="../test/Common/msbuild/testcommon.vcxproj" />
-    </Project>
+    <Project Path="../test/Slice/structure/msbuild/client.vcxproj" />
   </Folder>
 </Solution>

--- a/cpp/src/DataStorm/msbuild/datastorm/datastorm.vcxproj
+++ b/cpp/src/DataStorm/msbuild/datastorm/datastorm.vcxproj
@@ -248,5 +248,12 @@
       <HeaderOutputDir>$(Platform)\$(Configuration)\DataStorm</HeaderOutputDir>
     </SliceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Ice\msbuild\ice\ice.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/src/Glacier2/msbuild/glacier2router.vcxproj
+++ b/cpp/src/Glacier2/msbuild/glacier2router.vcxproj
@@ -133,5 +133,9 @@
     <ClInclude Include="..\ServerBlobject.h" />
     <ClInclude Include="..\SessionRouterI.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Glacier2Lib\msbuild\glacier2\glacier2.vcxproj" />
+    <ProjectReference Include="..\..\Ice\msbuild\ice\ice.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj
+++ b/cpp/src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj
@@ -345,6 +345,13 @@
   <ItemGroup>
     <ResourceCompile Include="..\..\Glacier2.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Ice\msbuild\ice\ice.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/cpp/src/Ice/msbuild/ice/ice.vcxproj
+++ b/cpp/src/Ice/msbuild/ice/ice.vcxproj
@@ -1029,6 +1029,12 @@ mc -h "$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice" -r $
     <SliceCompile Include="..\..\..\..\..\slice\Ice\PropertyDict.ice" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\msbuild\packages\ZeroC.Bzip2.1.0.6\build\native\ZeroC.Bzip2.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.Bzip2.1.0.6\build\native\ZeroC.Bzip2.targets')" />

--- a/cpp/src/IceBox/msbuild/icebox/icebox.vcxproj
+++ b/cpp/src/IceBox/msbuild/icebox/icebox.vcxproj
@@ -76,6 +76,9 @@
   <ItemGroup>
     <ResourceCompile Include="..\..\IceBoxExe.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\iceboxlib\iceboxlib.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/cpp/src/IceBox/msbuild/iceboxadmin/iceboxadmin.vcxproj
+++ b/cpp/src/IceBox/msbuild/iceboxadmin/iceboxadmin.vcxproj
@@ -73,6 +73,10 @@
   <ItemGroup>
     <ClCompile Include="..\..\Admin.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Ice\msbuild\ice\ice.vcxproj" />
+    <ProjectReference Include="..\iceboxlib\iceboxlib.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/cpp/src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj
+++ b/cpp/src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj
@@ -160,6 +160,13 @@
   <ItemGroup>
     <SliceCompile Include="..\..\..\..\..\slice\IceBox\ServiceManager.ice" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Ice\msbuild\ice\ice.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/cpp/src/IceBridge/msbuild/icebridge.vcxproj
+++ b/cpp/src/IceBridge/msbuild/icebridge.vcxproj
@@ -83,5 +83,8 @@
   <ItemGroup>
     <ClCompile Include="..\IceBridge.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Ice\msbuild\ice\ice.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj
+++ b/cpp/src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj
@@ -153,6 +153,13 @@
       <SliceCompileSource>..\..\..\..\..\slice\IceDiscovery\Lookup.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Ice\msbuild\ice\ice.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj
@@ -157,6 +157,16 @@
       <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Ice\msbuild\ice\ice.vcxproj" />
+    <ProjectReference Include="..\..\..\IceBox\msbuild\iceboxlib\iceboxlib.vcxproj" />
+    <ProjectReference Include="..\..\..\IceGridLib\msbuild\icegrid\icegrid.vcxproj" />
+    <ProjectReference Include="..\..\..\IceLocatorDiscovery\msbuild\icelocatordiscovery\icelocatordiscovery.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets')" />

--- a/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj
@@ -255,6 +255,17 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Glacier2Lib\msbuild\glacier2\glacier2.vcxproj" />
+    <ProjectReference Include="..\..\..\IceBox\msbuild\iceboxlib\iceboxlib.vcxproj" />
+    <ProjectReference Include="..\..\..\IceGridLib\msbuild\icegrid\icegrid.vcxproj" />
+    <ProjectReference Include="..\..\..\IceStorm\msbuild\icestormservice\icestormservice.vcxproj" />
+    <ProjectReference Include="..\..\..\IceStormLib\msbuild\icestorm\icestorm.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" />

--- a/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj
@@ -249,6 +249,17 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Glacier2Lib\msbuild\glacier2\glacier2.vcxproj" />
+    <ProjectReference Include="..\..\..\IceBox\msbuild\iceboxlib\iceboxlib.vcxproj" />
+    <ProjectReference Include="..\..\..\IceGridLib\msbuild\icegrid\icegrid.vcxproj" />
+    <ProjectReference Include="..\..\..\IceStorm\msbuild\icestormservice\icestormservice.vcxproj" />
+    <ProjectReference Include="..\..\..\IceStormLib\msbuild\icestorm\icestorm.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" />

--- a/cpp/src/IceGridLib/msbuild/icegrid/icegrid.vcxproj
+++ b/cpp/src/IceGridLib/msbuild/icegrid/icegrid.vcxproj
@@ -448,6 +448,14 @@
     <ClInclude Include="..\..\..\..\include\IceGrid\IceGrid.h" />
     <ClInclude Include="..\..\..\..\include\IceGrid\ReplicaGroupFilter.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Glacier2Lib\msbuild\glacier2\glacier2.vcxproj" />
+    <ProjectReference Include="..\..\..\Ice\msbuild\ice\ice.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj
+++ b/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj
@@ -149,6 +149,9 @@
       <BaseDirectoryForGeneratedInclude>IceLocatorDiscovery</BaseDirectoryForGeneratedInclude>
     </SliceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Ice\msbuild\ice\ice.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/cpp/src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj
@@ -339,6 +339,16 @@
   <ItemGroup>
     <ResourceCompile Include="..\..\IceStormAdmin.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Glacier2Lib\msbuild\glacier2\glacier2.vcxproj" />
+    <ProjectReference Include="..\..\..\IceBox\msbuild\iceboxlib\iceboxlib.vcxproj" />
+    <ProjectReference Include="..\..\..\IceGridLib\msbuild\icegrid\icegrid.vcxproj" />
+    <ProjectReference Include="..\..\..\IceStormLib\msbuild\icestorm\icestorm.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
@@ -255,6 +255,16 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Glacier2Lib\msbuild\glacier2\glacier2.vcxproj" />
+    <ProjectReference Include="..\..\..\IceBox\msbuild\iceboxlib\iceboxlib.vcxproj" />
+    <ProjectReference Include="..\..\..\IceGridLib\msbuild\icegrid\icegrid.vcxproj" />
+    <ProjectReference Include="..\..\..\IceStormLib\msbuild\icestorm\icestorm.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" />

--- a/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
@@ -383,6 +383,16 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Glacier2Lib\msbuild\glacier2\glacier2.vcxproj" />
+    <ProjectReference Include="..\..\..\IceBox\msbuild\iceboxlib\iceboxlib.vcxproj" />
+    <ProjectReference Include="..\..\..\IceGridLib\msbuild\icegrid\icegrid.vcxproj" />
+    <ProjectReference Include="..\..\..\IceStormLib\msbuild\icestorm\icestorm.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" />

--- a/cpp/src/IceStormLib/msbuild/icestorm/icestorm.vcxproj
+++ b/cpp/src/IceStormLib/msbuild/icestorm/icestorm.vcxproj
@@ -194,6 +194,13 @@
       <SliceCompileSource>..\..\..\..\..\slice\IceStorm\Metrics.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Ice\msbuild\ice\ice.vcxproj" />
+    <ProjectReference Include="..\..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/cpp/src/Slice/msbuild/slice.vcxproj
+++ b/cpp/src/Slice/msbuild/slice.vcxproj
@@ -114,6 +114,9 @@
     <ClInclude Include="..\Preprocessor.h" />
     <ClInclude Include="..\Util.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/cpp/src/dsnode/msbuild/dsnode.vcxproj
+++ b/cpp/src/dsnode/msbuild/dsnode.vcxproj
@@ -95,6 +95,9 @@
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\DataStorm\msbuild\datastorm\datastorm.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
+++ b/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
@@ -161,6 +161,14 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Ice\msbuild\ice\ice.vcxproj" />
+    <ProjectReference Include="..\..\IceGridLib\msbuild\icegrid\icegrid.vcxproj" />
+    <ProjectReference Include="..\..\slice2cpp\msbuild\slice2cpp.vcxproj">
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" />

--- a/cpp/src/iceserviceinstall/msbuild/iceserviceinstall.vcxproj
+++ b/cpp/src/iceserviceinstall/msbuild/iceserviceinstall.vcxproj
@@ -106,6 +106,9 @@
   <ItemGroup>
     <ResourceCompile Include="..\IceServiceInstall.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Ice\msbuild\ice\ice.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/cpp/src/slice2cpp/msbuild/slice2cpp.vcxproj
+++ b/cpp/src/slice2cpp/msbuild/slice2cpp.vcxproj
@@ -116,12 +116,8 @@
     <ClInclude Include="..\Gen.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj">
-      <Project>{4d1a5110-3176-44ba-8bbb-57bf56519b9f}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj">
-      <Project>{57cd6ac2-0c9d-4648-9e9d-5df60c90f18a}</Project>
-    </ProjectReference>
+    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj" />
+    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/cpp/src/slice2cs/msbuild/slice2cs.vcxproj
+++ b/cpp/src/slice2cs/msbuild/slice2cs.vcxproj
@@ -128,12 +128,8 @@
     <ClInclude Include="..\IceVisitors.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj">
-      <Project>{4d1a5110-3176-44ba-8bbb-57bf56519b9f}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj">
-      <Project>{57cd6ac2-0c9d-4648-9e9d-5df60c90f18a}</Project>
-    </ProjectReference>
+    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj" />
+    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/cpp/src/slice2java/msbuild/slice2java.vcxproj
+++ b/cpp/src/slice2java/msbuild/slice2java.vcxproj
@@ -116,12 +116,8 @@
     <ClInclude Include="..\JavaUtil.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj">
-      <Project>{4d1a5110-3176-44ba-8bbb-57bf56519b9f}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj">
-      <Project>{57cd6ac2-0c9d-4648-9e9d-5df60c90f18a}</Project>
-    </ProjectReference>
+    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj" />
+    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/cpp/src/slice2js/msbuild/slice2js.vcxproj
+++ b/cpp/src/slice2js/msbuild/slice2js.vcxproj
@@ -119,12 +119,8 @@
     <ClInclude Include="..\JsUtil.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj">
-      <Project>{4d1a5110-3176-44ba-8bbb-57bf56519b9f}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj">
-      <Project>{57cd6ac2-0c9d-4648-9e9d-5df60c90f18a}</Project>
-    </ProjectReference>
+    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj" />
+    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/cpp/src/slice2matlab/msbuild/slice2matlab.vcxproj
+++ b/cpp/src/slice2matlab/msbuild/slice2matlab.vcxproj
@@ -107,12 +107,8 @@
     <ResourceCompile Include="..\Slice2Matlab.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj">
-      <Project>{4d1a5110-3176-44ba-8bbb-57bf56519b9f}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj">
-      <Project>{57cd6ac2-0c9d-4648-9e9d-5df60c90f18a}</Project>
-    </ProjectReference>
+    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj" />
+    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/cpp/src/slice2php/msbuild/slice2php.vcxproj
+++ b/cpp/src/slice2php/msbuild/slice2php.vcxproj
@@ -110,12 +110,8 @@
     <ResourceCompile Include="..\Slice2PHP.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj">
-      <Project>{4d1a5110-3176-44ba-8bbb-57bf56519b9f}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj">
-      <Project>{57cd6ac2-0c9d-4648-9e9d-5df60c90f18a}</Project>
-    </ProjectReference>
+    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj" />
+    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/cpp/src/slice2py/msbuild/slice2py.vcxproj
+++ b/cpp/src/slice2py/msbuild/slice2py.vcxproj
@@ -111,12 +111,8 @@
     <ResourceCompile Include="..\Slice2Py.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj">
-      <Project>{4d1a5110-3176-44ba-8bbb-57bf56519b9f}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj">
-      <Project>{57cd6ac2-0c9d-4648-9e9d-5df60c90f18a}</Project>
-    </ProjectReference>
+    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj" />
+    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/cpp/src/slice2rb/msbuild/slice2rb.vcxproj
+++ b/cpp/src/slice2rb/msbuild/slice2rb.vcxproj
@@ -108,12 +108,8 @@
     <ClCompile Include="..\RubyUtil.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj">
-      <Project>{4d1a5110-3176-44ba-8bbb-57bf56519b9f}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj">
-      <Project>{57cd6ac2-0c9d-4648-9e9d-5df60c90f18a}</Project>
-    </ProjectReference>
+    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj" />
+    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\Slice2Rb.rc" />

--- a/cpp/src/slice2swift/msbuild/slice2swift.vcxproj
+++ b/cpp/src/slice2swift/msbuild/slice2swift.vcxproj
@@ -116,12 +116,8 @@
     <ClInclude Include="..\SwiftUtil.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj">
-      <Project>{4d1a5110-3176-44ba-8bbb-57bf56519b9f}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj">
-      <Project>{57cd6ac2-0c9d-4648-9e9d-5df60c90f18a}</Project>
-    </ProjectReference>
+    <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj" />
+    <ProjectReference Include="..\..\Slice\msbuild\slice.vcxproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/cpp/test/DataStorm/api/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/api/msbuild/writer/writer.vcxproj
@@ -139,5 +139,8 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/callbacks/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/callbacks/msbuild/reader/reader.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/callbacks/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/callbacks/msbuild/writer/writer.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/config/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/config/msbuild/reader/reader.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/config/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/config/msbuild/writer/writer.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/events/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/events/msbuild/reader/reader.vcxproj
@@ -139,5 +139,8 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/events/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/events/msbuild/writer/writer.vcxproj
@@ -139,5 +139,8 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/fanInRelay/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/fanInRelay/msbuild/reader/reader.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/fanInRelay/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/fanInRelay/msbuild/writer/writer.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/partial/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/partial/msbuild/reader/reader.vcxproj
@@ -139,5 +139,8 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/partial/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/partial/msbuild/writer/writer.vcxproj
@@ -139,5 +139,8 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/partialReconnect/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/partialReconnect/msbuild/reader/reader.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/partialReconnect/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/partialReconnect/msbuild/writer/writer.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/relayReconnect/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/relayReconnect/msbuild/reader/reader.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/relayReconnect/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/relayReconnect/msbuild/writer/writer.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/relaySampleFilter/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/relaySampleFilter/msbuild/reader/reader.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/relaySampleFilter/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/relaySampleFilter/msbuild/writer/writer.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/reliability/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/reliability/msbuild/reader/reader.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/reliability/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/reliability/msbuild/writer/writer.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/topicDestroy/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/topicDestroy/msbuild/reader/reader.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/topicDestroy/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/topicDestroy/msbuild/writer/writer.vcxproj
@@ -85,6 +85,9 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/DataStorm/types/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/types/msbuild/reader/reader.vcxproj
@@ -139,5 +139,8 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/types/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/types/msbuild/writer/writer.vcxproj
@@ -139,5 +139,8 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/attack/msbuild/client/client.vcxproj
+++ b/cpp/test/Glacier2/attack/msbuild/client/client.vcxproj
@@ -115,5 +115,8 @@
   <ItemGroup>
     <SliceCompile Include="..\..\Backend.ice" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/attack/msbuild/server/server.vcxproj
+++ b/cpp/test/Glacier2/attack/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/dynamicFiltering/msbuild/client/client.vcxproj
+++ b/cpp/test/Glacier2/dynamicFiltering/msbuild/client/client.vcxproj
@@ -114,5 +114,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/dynamicFiltering/msbuild/server/server.vcxproj
+++ b/cpp/test/Glacier2/dynamicFiltering/msbuild/server/server.vcxproj
@@ -120,5 +120,8 @@
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/router/msbuild/client/client.vcxproj
+++ b/cpp/test/Glacier2/router/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/router/msbuild/server/server.vcxproj
+++ b/cpp/test/Glacier2/router/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/sessionControl/msbuild/client/client.vcxproj
+++ b/cpp/test/Glacier2/sessionControl/msbuild/client/client.vcxproj
@@ -115,5 +115,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/sessionControl/msbuild/server/server.vcxproj
+++ b/cpp/test/Glacier2/sessionControl/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/ssl/msbuild/client/client.vcxproj
+++ b/cpp/test/Glacier2/ssl/msbuild/client/client.vcxproj
@@ -61,6 +61,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Glacier2/ssl/msbuild/server/server.vcxproj
+++ b/cpp/test/Glacier2/ssl/msbuild/server/server.vcxproj
@@ -61,6 +61,9 @@
     <ClCompile Include="..\..\Server.cpp" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Glacier2/staticFiltering/msbuild/client/client.vcxproj
+++ b/cpp/test/Glacier2/staticFiltering/msbuild/client/client.vcxproj
@@ -116,5 +116,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/staticFiltering/msbuild/server/server.vcxproj
+++ b/cpp/test/Glacier2/staticFiltering/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/adapterDeactivation/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/adapterDeactivation/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/adapterDeactivation/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/adapterDeactivation/msbuild/collocated/collocated.vcxproj
@@ -121,5 +121,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/adapterDeactivation/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/adapterDeactivation/msbuild/server/server.vcxproj
@@ -120,5 +120,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/admin/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/admin/msbuild/client/client.vcxproj
@@ -118,5 +118,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/admin/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/admin/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/ami/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/ami/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/ami/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/ami/msbuild/collocated/collocated.vcxproj
@@ -119,5 +119,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/ami/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/ami/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/background/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/background/msbuild/client/client.vcxproj
@@ -99,6 +99,10 @@
   <ItemGroup>
     <ClInclude Include="..\..\Configuration.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+    <ProjectReference Include="..\testtransport\testtransport.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/background/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/background/msbuild/server/server.vcxproj
@@ -100,6 +100,10 @@
     <ClInclude Include="..\..\Configuration.h" />
     <ClInclude Include="..\..\TestI.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+    <ProjectReference Include="..\testtransport\testtransport.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/background/msbuild/testtransport/testtransport.vcxproj
+++ b/cpp/test/Ice/background/msbuild/testtransport/testtransport.vcxproj
@@ -153,5 +153,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/binding/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/binding/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/binding/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/binding/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/custom/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/custom/msbuild/client/client.vcxproj
@@ -194,5 +194,8 @@
       <SliceCompileSource>..\..\Wstring.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/custom/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/custom/msbuild/collocated/collocated.vcxproj
@@ -198,5 +198,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/custom/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/custom/msbuild/server/server.vcxproj
@@ -197,5 +197,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/custom/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/custom/msbuild/serveramd/serveramd.vcxproj
@@ -197,5 +197,8 @@
     <SliceCompile Include="..\..\Wstring.ice" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/defaultServant/msbuild/client.vcxproj
+++ b/cpp/test/Ice/defaultServant/msbuild/client.vcxproj
@@ -138,5 +138,8 @@
       <SliceCompileSource>..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/defaultValue/msbuild/client.vcxproj
+++ b/cpp/test/Ice/defaultValue/msbuild/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/echo/msbuild/server.vcxproj
+++ b/cpp/test/Ice/echo/msbuild/server.vcxproj
@@ -138,5 +138,8 @@
       <SliceCompileSource>..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/enums/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/enums/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/enums/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/enums/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/exceptions/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/exceptions/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/exceptions/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/exceptions/msbuild/collocated/collocated.vcxproj
@@ -119,5 +119,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/exceptions/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/exceptions/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/exceptions/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/exceptions/msbuild/serveramd/serveramd.vcxproj
@@ -118,5 +118,8 @@
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/executor/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/executor/msbuild/client/client.vcxproj
@@ -119,5 +119,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/executor/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/executor/msbuild/collocated/collocated.vcxproj
@@ -121,5 +121,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/executor/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/executor/msbuild/server/server.vcxproj
@@ -120,5 +120,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/facets/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/facets/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/facets/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/facets/msbuild/collocated/collocated.vcxproj
@@ -119,5 +119,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/facets/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/facets/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/faultTolerance/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/faultTolerance/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/faultTolerance/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/faultTolerance/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/hash/msbuild/client.vcxproj
+++ b/cpp/test/Ice/hash/msbuild/client.vcxproj
@@ -63,5 +63,8 @@
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/hold/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/hold/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/hold/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/hold/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/idleTimeout/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/idleTimeout/msbuild/client/client.vcxproj
@@ -118,5 +118,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/idleTimeout/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/idleTimeout/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/inactivityTimeout/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/inactivityTimeout/msbuild/client/client.vcxproj
@@ -118,5 +118,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/inactivityTimeout/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/inactivityTimeout/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/info/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/info/msbuild/client/client.vcxproj
@@ -119,5 +119,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/info/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/info/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/inheritance/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/inheritance/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/inheritance/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/inheritance/msbuild/collocated/collocated.vcxproj
@@ -119,5 +119,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/inheritance/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/inheritance/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/invoke/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/invoke/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/invoke/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/invoke/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/library/msbuild/alltests/alltests.vcxproj
+++ b/cpp/test/Ice/library/msbuild/alltests/alltests.vcxproj
@@ -99,6 +99,10 @@
   <ItemGroup>
     <ClCompile Include="..\..\AllTests.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\consumer\consumer.vcxproj" />
+    <ProjectReference Include="..\gencode\gencode.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/library/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/library/msbuild/client/client.vcxproj
@@ -83,6 +83,10 @@
   <ItemGroup>
     <ClCompile Include="..\..\Client.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+    <ProjectReference Include="..\alltests\alltests.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/library/msbuild/consumer/consumer.vcxproj
+++ b/cpp/test/Ice/library/msbuild/consumer/consumer.vcxproj
@@ -99,6 +99,10 @@
   <ItemGroup>
     <ClCompile Include="..\..\Consumer.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+    <ProjectReference Include="..\gencode\gencode.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/location/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/location/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/location/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/location/msbuild/server/server.vcxproj
@@ -120,5 +120,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/logger/msbuild/client1/client1.vcxproj
+++ b/cpp/test/Ice/logger/msbuild/client1/client1.vcxproj
@@ -63,6 +63,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/logger/msbuild/client2/client2.vcxproj
+++ b/cpp/test/Ice/logger/msbuild/client2/client2.vcxproj
@@ -63,6 +63,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/logger/msbuild/client3/client3.vcxproj
+++ b/cpp/test/Ice/logger/msbuild/client3/client3.vcxproj
@@ -63,6 +63,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/logger/msbuild/client4/client4.vcxproj
+++ b/cpp/test/Ice/logger/msbuild/client4/client4.vcxproj
@@ -63,6 +63,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/logger/msbuild/client5/client5.vcxproj
+++ b/cpp/test/Ice/logger/msbuild/client5/client5.vcxproj
@@ -63,6 +63,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/maxConnections/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/maxConnections/msbuild/client/client.vcxproj
@@ -118,5 +118,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/maxConnections/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/maxConnections/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/maxDispatches/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/maxDispatches/msbuild/client/client.vcxproj
@@ -118,5 +118,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/maxDispatches/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/maxDispatches/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/metrics/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/metrics/msbuild/client/client.vcxproj
@@ -118,5 +118,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/metrics/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/metrics/msbuild/collocated/collocated.vcxproj
@@ -120,5 +120,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/metrics/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/metrics/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/metrics/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/metrics/msbuild/serveramd/serveramd.vcxproj
@@ -118,5 +118,8 @@
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/middleware/msbuild/client.vcxproj
+++ b/cpp/test/Ice/middleware/msbuild/client.vcxproj
@@ -138,5 +138,8 @@
       <SliceCompileSource>..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/networkProxy/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/networkProxy/msbuild/client/client.vcxproj
@@ -138,5 +138,8 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/networkProxy/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/networkProxy/msbuild/server/server.vcxproj
@@ -137,5 +137,8 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/objects/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/objects/msbuild/client/client.vcxproj
@@ -303,5 +303,8 @@
     <SliceCompile Include="..\..\Forward.ice" />
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/objects/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/objects/msbuild/collocated/collocated.vcxproj
@@ -267,5 +267,8 @@
     <SliceCompile Include="..\..\Forward.ice" />
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/objects/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/objects/msbuild/server/server.vcxproj
@@ -266,5 +266,8 @@
     <SliceCompile Include="..\..\Forward.ice" />
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/operations/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/operations/msbuild/client/client.vcxproj
@@ -143,5 +143,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/operations/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/operations/msbuild/collocated/collocated.vcxproj
@@ -145,5 +145,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/operations/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/operations/msbuild/server/server.vcxproj
@@ -138,5 +138,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/operations/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/operations/msbuild/serveramd/serveramd.vcxproj
@@ -138,5 +138,8 @@
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/optional/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/optional/msbuild/client/client.vcxproj
@@ -138,5 +138,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/optional/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/optional/msbuild/server/server.vcxproj
@@ -138,5 +138,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/optional/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/optional/msbuild/serveramd/serveramd.vcxproj
@@ -138,5 +138,8 @@
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/plugin/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/plugin/msbuild/client/client.vcxproj
@@ -68,6 +68,9 @@
       <AdditionalIncludeDirectories>generated;..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/plugin/msbuild/testplugin/testplugin.vcxproj
+++ b/cpp/test/Ice/plugin/msbuild/testplugin/testplugin.vcxproj
@@ -63,6 +63,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/properties/msbuild/client.vcxproj
+++ b/cpp/test/Ice/properties/msbuild/client.vcxproj
@@ -63,6 +63,9 @@
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Ice/proxy/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/proxy/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/proxy/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/proxy/msbuild/collocated/collocated.vcxproj
@@ -119,5 +119,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/proxy/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/proxy/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/retry/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/retry/msbuild/client/client.vcxproj
@@ -139,5 +139,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/retry/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/retry/msbuild/collocated/collocated.vcxproj
@@ -121,5 +121,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/retry/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/retry/msbuild/server/server.vcxproj
@@ -120,5 +120,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/scope/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/scope/msbuild/client/client.vcxproj
@@ -137,5 +137,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/scope/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/scope/msbuild/server/server.vcxproj
@@ -137,5 +137,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/servantLocator/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/servantLocator/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/servantLocator/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/servantLocator/msbuild/collocated/collocated.vcxproj
@@ -121,5 +121,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/servantLocator/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/servantLocator/msbuild/server/server.vcxproj
@@ -120,5 +120,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/servantLocator/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/servantLocator/msbuild/serveramd/serveramd.vcxproj
@@ -120,5 +120,8 @@
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/services/msbuild/client.vcxproj
+++ b/cpp/test/Ice/services/msbuild/client.vcxproj
@@ -137,5 +137,8 @@
       <SliceCompileSource>..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/slicing/exceptions/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/slicing/exceptions/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/slicing/exceptions/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/slicing/exceptions/msbuild/server/server.vcxproj
@@ -167,5 +167,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/slicing/exceptions/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/slicing/exceptions/msbuild/serveramd/serveramd.vcxproj
@@ -167,5 +167,8 @@
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/slicing/objects/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/slicing/objects/msbuild/client/client.vcxproj
@@ -166,5 +166,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/slicing/objects/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/slicing/objects/msbuild/server/server.vcxproj
@@ -167,5 +167,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/slicing/objects/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/slicing/objects/msbuild/serveramd/serveramd.vcxproj
@@ -167,5 +167,8 @@
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/span/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/span/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/span/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/span/msbuild/collocated/collocated.vcxproj
@@ -119,5 +119,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/span/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/span/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/span/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/span/msbuild/serveramd/serveramd.vcxproj
@@ -118,5 +118,8 @@
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/stream/msbuild/client.vcxproj
+++ b/cpp/test/Ice/stream/msbuild/client.vcxproj
@@ -128,5 +128,8 @@
       <SliceCompileSource>..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/stringConverter/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/stringConverter/msbuild/client/client.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/stringConverter/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/stringConverter/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/timeout/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/timeout/msbuild/client/client.vcxproj
@@ -119,5 +119,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/timeout/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/timeout/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/udp/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/udp/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/udp/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/udp/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/wsAllowedOrigins/msbuild/server.vcxproj
+++ b/cpp/test/Ice/wsAllowedOrigins/msbuild/server.vcxproj
@@ -83,5 +83,8 @@
   <ItemGroup>
     <ClCompile Include="..\Server.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceBox/admin/msbuild/client/client.vcxproj
+++ b/cpp/test/IceBox/admin/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceBox/admin/msbuild/testservice/testservice.vcxproj
+++ b/cpp/test/IceBox/admin/msbuild/testservice/testservice.vcxproj
@@ -130,5 +130,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceBox/configuration/msbuild/client/client.vcxproj
+++ b/cpp/test/IceBox/configuration/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceBox/configuration/msbuild/testservice/testservice.vcxproj
+++ b/cpp/test/IceBox/configuration/msbuild/testservice/testservice.vcxproj
@@ -130,5 +130,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceBridge/simple/msbuild/client/client.vcxproj
+++ b/cpp/test/IceBridge/simple/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceBridge/simple/msbuild/server/server.vcxproj
+++ b/cpp/test/IceBridge/simple/msbuild/server/server.vcxproj
@@ -117,5 +117,8 @@
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceDiscovery/simple/msbuild/client/client.vcxproj
+++ b/cpp/test/IceDiscovery/simple/msbuild/client/client.vcxproj
@@ -117,5 +117,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceDiscovery/simple/msbuild/server/server.vcxproj
+++ b/cpp/test/IceDiscovery/simple/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/activation/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/activation/msbuild/client/client.vcxproj
@@ -115,5 +115,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/activation/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/activation/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/admin/msbuild/server.vcxproj
+++ b/cpp/test/IceGrid/admin/msbuild/server.vcxproj
@@ -61,6 +61,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/IceGrid/allocation/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/allocation/msbuild/client/client.vcxproj
@@ -115,5 +115,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/allocation/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/allocation/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/allocation/msbuild/verifier/verifier.vcxproj
+++ b/cpp/test/IceGrid/allocation/msbuild/verifier/verifier.vcxproj
@@ -61,6 +61,9 @@
   <ItemGroup>
     <ClCompile Include="..\..\PermissionsVerifier.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/IceGrid/deployer/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/deployer/msbuild/client/client.vcxproj
@@ -115,5 +115,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/deployer/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/deployer/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/deployer/msbuild/testservice/testservice.vcxproj
+++ b/cpp/test/IceGrid/deployer/msbuild/testservice/testservice.vcxproj
@@ -128,5 +128,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/noRestartUpdate/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/noRestartUpdate/msbuild/client/client.vcxproj
@@ -115,5 +115,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/noRestartUpdate/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/noRestartUpdate/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/noRestartUpdate/msbuild/testservice/testservice.vcxproj
+++ b/cpp/test/IceGrid/noRestartUpdate/msbuild/testservice/testservice.vcxproj
@@ -128,5 +128,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/replicaGroup/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/replicaGroup/msbuild/client/client.vcxproj
@@ -115,5 +115,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/replicaGroup/msbuild/registryplugin/registryplugin.vcxproj
+++ b/cpp/test/IceGrid/replicaGroup/msbuild/registryplugin/registryplugin.vcxproj
@@ -61,6 +61,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/IceGrid/replicaGroup/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/replicaGroup/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/replicaGroup/msbuild/testservice/testservice.vcxproj
+++ b/cpp/test/IceGrid/replicaGroup/msbuild/testservice/testservice.vcxproj
@@ -128,5 +128,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/replication/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/replication/msbuild/client/client.vcxproj
@@ -115,5 +115,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/replication/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/replication/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/session/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/session/msbuild/client/client.vcxproj
@@ -62,5 +62,8 @@
     <ClCompile Include="..\..\AllTests.cpp" />
     <ClCompile Include="..\..\Client.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/session/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/session/msbuild/server/server.vcxproj
@@ -61,5 +61,8 @@
   <ItemGroup>
     <ClCompile Include="..\..\Server.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/session/msbuild/verifier/verifier.vcxproj
+++ b/cpp/test/IceGrid/session/msbuild/verifier/verifier.vcxproj
@@ -61,5 +61,8 @@
   <ItemGroup>
     <ClCompile Include="..\..\PermissionsVerifier.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/simple/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/simple/msbuild/client/client.vcxproj
@@ -135,5 +135,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/simple/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/simple/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/update/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/update/msbuild/client/client.vcxproj
@@ -115,5 +115,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceGrid/update/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/update/msbuild/server/server.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceSSL/configuration/msbuild/client/client.vcxproj
+++ b/cpp/test/IceSSL/configuration/msbuild/client/client.vcxproj
@@ -139,5 +139,8 @@
       <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceSSL/configuration/msbuild/server/server.vcxproj
+++ b/cpp/test/IceSSL/configuration/msbuild/server/server.vcxproj
@@ -118,5 +118,8 @@
     </ClInclude>
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/createOrRetrieve/msbuild/client/client.vcxproj
+++ b/cpp/test/IceStorm/createOrRetrieve/msbuild/client/client.vcxproj
@@ -64,5 +64,8 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/federation/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/federation/msbuild/publisher/publisher.vcxproj
@@ -115,5 +115,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/federation/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/federation/msbuild/subscriber/subscriber.vcxproj
@@ -114,5 +114,8 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/federation2/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/federation2/msbuild/publisher/publisher.vcxproj
@@ -115,5 +115,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/federation2/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/federation2/msbuild/subscriber/subscriber.vcxproj
@@ -114,5 +114,8 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/persistent/msbuild/client/client.vcxproj
+++ b/cpp/test/IceStorm/persistent/msbuild/client/client.vcxproj
@@ -62,5 +62,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/rep1/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/rep1/msbuild/publisher/publisher.vcxproj
@@ -115,5 +115,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/rep1/msbuild/sub/sub.vcxproj
+++ b/cpp/test/IceStorm/rep1/msbuild/sub/sub.vcxproj
@@ -114,5 +114,8 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/rep1/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/rep1/msbuild/subscriber/subscriber.vcxproj
@@ -114,5 +114,8 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/repgrid/msbuild/client.vcxproj
+++ b/cpp/test/IceStorm/repgrid/msbuild/client.vcxproj
@@ -115,5 +115,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/repstress/msbuild/control/control.vcxproj
+++ b/cpp/test/IceStorm/repstress/msbuild/control/control.vcxproj
@@ -163,5 +163,8 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/repstress/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/repstress/msbuild/publisher/publisher.vcxproj
@@ -164,5 +164,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/repstress/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/repstress/msbuild/subscriber/subscriber.vcxproj
@@ -163,5 +163,8 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/single/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/single/msbuild/publisher/publisher.vcxproj
@@ -115,5 +115,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/single/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/single/msbuild/subscriber/subscriber.vcxproj
@@ -114,5 +114,8 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/stress/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/stress/msbuild/publisher/publisher.vcxproj
@@ -115,5 +115,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/stress/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/stress/msbuild/subscriber/subscriber.vcxproj
@@ -114,5 +114,8 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceUtil/ctrlCHandler/msbuild/client.vcxproj
+++ b/cpp/test/IceUtil/ctrlCHandler/msbuild/client.vcxproj
@@ -63,6 +63,9 @@
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/IceUtil/inputUtil/msbuild/client.vcxproj
+++ b/cpp/test/IceUtil/inputUtil/msbuild/client.vcxproj
@@ -63,6 +63,9 @@
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/IceUtil/sha1/msbuild/client.vcxproj
+++ b/cpp/test/IceUtil/sha1/msbuild/client.vcxproj
@@ -63,6 +63,9 @@
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/IceUtil/stacktrace/msbuild/client.vcxproj
+++ b/cpp/test/IceUtil/stacktrace/msbuild/client.vcxproj
@@ -95,6 +95,9 @@
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/IceUtil/timer/msbuild/client.vcxproj
+++ b/cpp/test/IceUtil/timer/msbuild/client.vcxproj
@@ -63,6 +63,9 @@
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/IceUtil/unicode/msbuild/client.vcxproj
+++ b/cpp/test/IceUtil/unicode/msbuild/client.vcxproj
@@ -63,6 +63,9 @@
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/IceUtil/uuid/msbuild/client.vcxproj
+++ b/cpp/test/IceUtil/uuid/msbuild/client.vcxproj
@@ -63,6 +63,9 @@
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/cpp/test/Slice/deprecated/msbuild/client.vcxproj
+++ b/cpp/test/Slice/deprecated/msbuild/client.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Slice/escape/msbuild/client.vcxproj
+++ b/cpp/test/Slice/escape/msbuild/client.vcxproj
@@ -165,5 +165,8 @@
       <SliceCompileSource>..\Key.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Slice/macros/msbuild/client.vcxproj
+++ b/cpp/test/Slice/macros/msbuild/client.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Slice/parser/msbuild/client.vcxproj
+++ b/cpp/test/Slice/parser/msbuild/client.vcxproj
@@ -166,5 +166,8 @@
       <IncludeDirectories>..\;%(IncludeDirectories)</IncludeDirectories>
     </SliceCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Slice/print/msbuild/client.vcxproj
+++ b/cpp/test/Slice/print/msbuild/client.vcxproj
@@ -137,5 +137,8 @@
       <SliceCompileSource>..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Slice/structure/msbuild/client.vcxproj
+++ b/cpp/test/Slice/structure/msbuild/client.vcxproj
@@ -116,5 +116,8 @@
       <SliceCompileSource>..\Test.ice</SliceCompileSource>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>


### PR DESCRIPTION
Fixes #6500.

Converts all 59 `BuildDependency` edges in `cpp/msbuild/ice.slnx` and all 218 in `cpp/msbuild/ice.test.slnx` into GUID-free `ProjectReference` items declared by each `.vcxproj`, so a project carries its own build dependencies instead of relying on solution edges nothing verifies. The solution files now contain only plain project listings.

- The 14 edges to `slice2cpp.vcxproj` (an Application) order Slice compilation rather than linking, so those references set `LinkLibraryDependencies=false` and `ReferenceOutputAssembly=false`.
- `icegridadmin` declared a dependency on `icebox.vcxproj`, an executable it cannot link. It now references `iceboxlib.vcxproj`, matching the `IceBox/IceBox.h` include in `IceGrid/Parser.cpp` whose auto-link pragma pulls in `IceBox[D].lib`.
- Every converted test edge was checked against the sources before conversion: they are all genuine link dependencies established by auto-link pragmas (`test/include/TestHelper.h` for `testcommon`, plus the `Ice/library` `alltests`/`consumer`/`gencode` chain and the `Ice/background` `testtransport` plugin, which the clients link directly).
- The existing `slice2*` references drop their redundant `<Project>` GUID metadata; references resolve by path.

Verified on Windows with cold-tree parallel builds of both solutions (`msbuild /m ice.proj /t:BuildDist` and `msbuild /m ice.test.slnx`, x64 Release) from a fresh checkout — the failure mode this guards against only shows up when the tree is cold and the graph is walked in parallel. Both builds completed with zero warnings.