### PR TITLE
Remove dead code from test scripts and build config

### DIFF
--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -950,7 +950,6 @@ currentdir      = $(call dirname,$(lastword $(MAKEFILE_LIST)))
 unique          = $(strip $(if $1,$(firstword $1) $(call unique,$(filter-out $(firstword $1),$1))))
 runique         = $(strip $(if $1,$(lastword $1) $(call runique,$(filter-out $(lastword $1),$1))))
 files-to-dirs   = $(call unique,$(call dirname,$(filter $(if $2,$(addprefix %.,$2),%),$1)))
-join-with       = $(subst $(space),$1,$(strip $2))
 
 empty           :=
 space           := $(empty) $(empty)

--- a/config/makeprops.py
+++ b/config/makeprops.py
@@ -107,9 +107,6 @@ class PropertyHandler(ContentHandler):
     def generatedPropertyArrays(self) -> list[str]:
         return [name for name, propertyArray in self.propertyArrayDict.items() if not propertyArray.isClass]
 
-    def reservedPropertyPrefixes(self) -> list[str]:
-        return [name for name, array in self.propertyArrayDict.items() if not array.isClass]
-
     def parseProperty(self, attrs: AttributesImpl) -> str:
         name = attrs.get("name")
         assert name is not None, "property element is missing its name attribute"

--- a/scripts/Glacier2Util.py
+++ b/scripts/Glacier2Util.py
@@ -13,7 +13,6 @@ from Util import (
     Mapping,
     Process,
     ProcessFromBinDir,
-    ProcessIsReleaseOnly,
     Props,
     Server,
     TestCase,
@@ -23,7 +22,7 @@ from Util import (
 )
 
 
-class Glacier2Router(ProcessFromBinDir, ProcessIsReleaseOnly, Server):
+class Glacier2Router(ProcessFromBinDir, Server):
     # icehashpassword.py only emits sha512-crypt (Linux) and PBKDF2-sha256 (macOS/Windows), so schemes like
     # bcrypt need pre-hashed entries. This is a known-answer bcrypt hash of "abc123" (cost 4); the
     # Glacier2/router test authenticates against it where the native crypt library supports bcrypt.

--- a/scripts/IceBoxUtil.py
+++ b/scripts/IceBoxUtil.py
@@ -15,7 +15,6 @@ from Util import (
     Linux,
     Mapping,
     ProcessFromBinDir,
-    ProcessIsReleaseOnly,
     Server,
     platform,
 )
@@ -55,7 +54,7 @@ class IceBox(ProcessFromBinDir, Server):
         return args
 
 
-class IceBoxAdmin(ProcessFromBinDir, ProcessIsReleaseOnly, Client):
+class IceBoxAdmin(ProcessFromBinDir, Client):
     def getMapping(self, current: Driver.Current) -> Mapping:
         # IceBox admin is only provided with the C++/Java, not C#
         mapping = Client.getMapping(self, current)

--- a/scripts/IceBridgeUtil.py
+++ b/scripts/IceBridgeUtil.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from Util import Driver, Mapping, ProcessFromBinDir, ProcessIsReleaseOnly, Props, Server
+from Util import Driver, Mapping, ProcessFromBinDir, Props, Server
 
 
-class IceBridge(ProcessFromBinDir, ProcessIsReleaseOnly, Server):
+class IceBridge(ProcessFromBinDir, Server):
     def __init__(self, *args: Any, **kargs: Any):
         Server.__init__(
             self,

--- a/scripts/IceGridUtil.py
+++ b/scripts/IceGridUtil.py
@@ -18,7 +18,6 @@ from Util import (
     Mapping,
     Process,
     ProcessFromBinDir,
-    ProcessIsReleaseOnly,
     Props,
     Server,
     TestCase,
@@ -77,7 +76,7 @@ class IceGridClient(IceGridProcess, Client):
         return Client.getProps(self, current)
 
 
-class IceGridAdmin(ProcessFromBinDir, ProcessIsReleaseOnly, IceGridClient):
+class IceGridAdmin(ProcessFromBinDir, IceGridClient):
     def __init__(
         self,
         replica: IceGridRegistry | str | None = None,

--- a/scripts/IceStormUtil.py
+++ b/scripts/IceStormUtil.py
@@ -14,7 +14,6 @@ from Util import (
     Mapping,
     Process,
     ProcessFromBinDir,
-    ProcessIsReleaseOnly,
     Props,
     Server,
     TestCase,
@@ -221,7 +220,7 @@ class IceStormProcess(_IceStormProcessBase):
         return props
 
 
-class IceStormAdmin(ProcessFromBinDir, ProcessIsReleaseOnly, IceStormProcess, Client):
+class IceStormAdmin(ProcessFromBinDir, IceStormProcess, Client):
     def __init__(
         self,
         instanceName: str | None = None,

--- a/scripts/NetworkProxy.py
+++ b/scripts/NetworkProxy.py
@@ -7,7 +7,7 @@ import socket
 import threading
 import time
 
-# The remote address a connection proxies to, and the peer address accept() reports.
+# The remote address a connection proxies to, as read from the connect request.
 Address = tuple[str, int]
 
 
@@ -16,10 +16,9 @@ class InvalidRequest(Exception):
 
 
 class BaseConnection(threading.Thread):
-    def __init__(self, sock: socket.socket, remote: Address):
+    def __init__(self, sock: socket.socket):
         threading.Thread.__init__(self)
         self.socket: socket.socket | None = sock
-        self.remote = remote
         self.remoteSocket: socket.socket | None = None
         self.closed = False
 
@@ -102,7 +101,7 @@ class BaseProxy(threading.Thread):
         if self.failed:
             raise self.failed
 
-    def createConnection(self, sock: socket.socket, peer: Address) -> BaseConnection:
+    def createConnection(self, sock: socket.socket) -> BaseConnection:
         # Overridden to build the protocol specific connection.
         raise NotImplementedError()
 
@@ -133,8 +132,8 @@ class BaseProxy(threading.Thread):
         try:
             assert self.socket is not None
             while not self.closed:
-                incoming, peer = self.socket.accept()
-                connection = self.createConnection(incoming, peer)
+                incoming, _ = self.socket.accept()
+                connection = self.createConnection(incoming)
                 connection.start()
                 with self.cond:
                     self.connections.append(connection)
@@ -200,8 +199,8 @@ class SocksConnection(BaseConnection):
 
 
 class SocksProxy(BaseProxy):
-    def createConnection(self, sock: socket.socket, peer: Address) -> BaseConnection:
-        return SocksConnection(sock, peer)
+    def createConnection(self, sock: socket.socket) -> BaseConnection:
+        return SocksConnection(sock)
 
 
 class HttpConnection(BaseConnection):
@@ -253,5 +252,5 @@ class HttpConnection(BaseConnection):
 
 
 class HttpProxy(BaseProxy):
-    def createConnection(self, sock: socket.socket, peer: Address) -> BaseConnection:
-        return HttpConnection(sock, peer)
+    def createConnection(self, sock: socket.socket) -> BaseConnection:
+        return HttpConnection(sock)

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -700,7 +700,6 @@ class Mapping(object):
             self.worker = False
             self.coverage = False
             self.dotnet = False
-            self.framework = ""
             self.android = False
             self.jacoco = ""
             self.device = ""
@@ -961,17 +960,6 @@ class Mapping(object):
             cls.mappings[name] = m
         else:
             cls.disabled[name] = m
-
-    @classmethod
-    def disable(cls, name: str) -> None:
-        m = cls.mappings[name]
-        if m:
-            cls.disabled[name] = m
-            del cls.mappings[name]
-
-    @classmethod
-    def remove(cls, name: str) -> None:
-        del cls.mappings[name]
 
     @classmethod
     def getAll(cls, driver: Driver | None = None, includeDisabled: bool = False) -> list[Mapping]:
@@ -1564,9 +1552,6 @@ class Process(Runnable):
     def isFromBinDir(self) -> bool:
         return False
 
-    def isReleaseOnly(self) -> bool:
-        return False
-
     def getArgs(self, current: Driver.Current) -> Args:
         return []
 
@@ -1709,18 +1694,7 @@ class ProcessFromBinDir:
         return True
 
 
-#
-# Executables for processes inheriting this marker class are only provided
-# as a Release executable on Windows
-#
-
-
-class ProcessIsReleaseOnly:
-    def isReleaseOnly(self) -> bool:
-        return True
-
-
-class SliceTranslator(ProcessFromBinDir, ProcessIsReleaseOnly, SimpleClient):
+class SliceTranslator(ProcessFromBinDir, SimpleClient):
     def __init__(self, translator: str, quiet: bool = False):
         SimpleClient.__init__(self, exe=translator, quiet=quiet, mapping=Mapping.getByName("cpp"))
 
@@ -3585,8 +3559,6 @@ class iOSSimulatorProcessController(RemoteProcessController):
 
 
 class iOSDeviceProcessController(RemoteProcessController):
-    appPath = "cpp/test/ios/controller/build"
-
     def __init__(self, current: Driver.Current):
         RemoteProcessController.__init__(self, current, None)
 
@@ -3896,7 +3868,6 @@ class Driver:
         languages = ",".join(os.environ.get("LANGUAGES", "").split(" "))
         self.languages = [languages] if languages else []
         self.rlanguages: list[str] = []
-        self.failures: list[Any] = []
         self.keepLogs = False
         self.interface = ""
         self.configs: dict[Mapping, Mapping.Config]


### PR DESCRIPTION
Removes the dead code identified in #6496:

- **`ProcessIsReleaseOnly` mixin and `isReleaseOnly()`** — no call sites remained after the `ICE_BIN_DIST` removal (#3442). Removed from `Util.py` and its usages in `Glacier2Util.py`, `IceBoxUtil.py`, `IceBridgeUtil.py`, `IceGridUtil.py`, and `IceStormUtil.py`.
- **`Mapping.disable` / `Mapping.remove`** — uncalled classmethods in `Util.py` (`Mapping.disabled` itself remains live).
- **Write-only attributes** — `self.framework` in the config initializer, `iOSDeviceProcessController.appPath`, `Driver.failures`, and the unused `remote`/`peer` parameter chain in `NetworkProxy.py` (each connection derives the remote address from the connect request instead).
- **`makeprops.py`** — `reservedPropertyPrefixes()`, an uncalled verbatim duplicate of `generatedPropertyArrays()`.
- **`Make.project.rules`** — the unused `join-with` macro.

The duplicate `bindir` assignment in `Make.rules` mentioned in the issue was already removed by #6487.

Validation: `ruff check` and `ruff format --check` pass on all edited Python files, all test-driver modules import cleanly, `allTests.py --help` works, and `make -n` parses without errors.

Fixes #6496