### PR TITLE
Log a warning when a DataStorm key decoder throws during initialization

### DIFF
--- a/changelog.d/datastorm/6389.md
+++ b/changelog.d/datastorm/6389.md
@@ -1,0 +1,3 @@
+- Fixed a bug where a key that the application's `Decoder` rejects during a session's initialization also left the
+  other readers of that session uninitialized. Only the reader the samples are addressed to stays uninitialized now,
+  and DataStorm logs a warning naming that reader instead of letting the failure escape as a generic dispatch error.

--- a/changelog.d/datastorm/6389.md
+++ b/changelog.d/datastorm/6389.md
@@ -1,3 +1,0 @@
-- Fixed a bug where a key that the application's `Decoder` rejects during a session's initialization also left the
-  other readers of that session uninitialized. Only the reader the samples are addressed to stays uninitialized now,
-  and DataStorm logs a warning naming that reader instead of letting the failure escape as a generic dispatch error.

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -614,7 +614,22 @@ SessionI::initSamples(int64_t topicId, int64_t peerTopicId, DataSamplesSeq initi
                     }
                     else
                     {
-                        key = topic->getKeyFactory()->decode(_instance->getCommunicator(), sample.keyValue);
+                        try
+                        {
+                            key = topic->getKeyFactory()->decode(_instance->getCommunicator(), sample.keyValue);
+                        }
+                        catch (const std::exception& ex)
+                        {
+                            // The key factory runs the application's decoder. Abandon the batch and leave the reader
+                            // uninitialized, like the unknown-key case below, so a later redelivery can still
+                            // initialize it. The session protocol is fire-and-forget, so a local warning is the only
+                            // way to report the failure.
+                            Warning out(_traceLevels->logger);
+                            out << "discarded the initialization samples for '" << element
+                                << "': the key could not be decoded:\n"
+                                << ex.what();
+                            return;
+                        }
                     }
 
                     assert(key);
@@ -1493,12 +1508,34 @@ SessionI::subscriberInitialized(
             // key.
             assert(sample.keyId == 0 || key == subscriber.findKey(sample.keyId));
 
+            shared_ptr<Key> sampleKey = key;
+            if (!sampleKey)
+            {
+                try
+                {
+                    sampleKey = keyFactory->decode(_instance->getCommunicator(), sample.keyValue);
+                }
+                catch (const std::exception& ex)
+                {
+                    // The key factory runs the application's decoder. Abandon these samples and keep the subscriber's
+                    // previous state, so the peer still offers them on the next initialization. Returning instead of
+                    // letting the exception escape confines the failure to this element: the other elements in the
+                    // ack are still attached and initialized. The session protocol is fire-and-forget, so a local
+                    // warning is the only way to report the failure.
+                    Warning out(_traceLevels->logger);
+                    out << "discarded the initialization samples for '" << element
+                        << "': the key could not be decoded:\n"
+                        << ex.what();
+                    return {};
+                }
+            }
+
             samplesI.push_back(sampleFactory->create(
                 _id,
                 elementSubscribers->name,
                 sample.id,
                 sample.event,
-                key ? key : keyFactory->decode(_instance->getCommunicator(), sample.keyValue),
+                sampleKey,
                 subscriber.findTag(sample.tag),
                 sample.value,
                 sample.timestamp));


### PR DESCRIPTION
Refs #6389 — left open for the remaining unguarded sites.

DataStorm catches a throwing application decoder and logs a contextual warning on the sample read path
(`DataElementI`) and when decoding update tags (`SessionI::attachTags`, since #6343), but not when decoding a key
during a session's initialization. There the exception escaped a oneway dispatch, so the only diagnostic was a
generic `Ice.Warn.Dispatch` message naming neither the topic nor the element, and the reader then quietly received
nothing from that writer.

`SessionI::initSamples` and `SessionI::subscriberInitialized` now catch around the key decoding and log
`discarded the initialization samples for '<element>': the key could not be decoded:` followed by `what()`. The
element renders through `DataElementI::toString`, which already ends in `@<topicId>:<topicName>`, so one token names
both the element and the topic — `attachTags` spells the topic out separately only because a tag id carries no
topic.

The affected reader stays uninitialized, as #6322 established. What changes is the blast radius: the throw used to
abort the whole dispatch, taking the sibling elements with it.

- In `initSamples`, one undecodable key abandoned the outer `initializationBatches` loop, so the batches addressed
  to the *other* readers in the same request were never applied.
- In `subscriberInitialized`, the throw unwound through `DataElementI::attach` into `TopicI::attachElementsAck`,
  discarding every `initCb` accumulated so far — those run only after the attach loop completes — and skipping the
  `detachElementsAsync` for `removedIds` back in `SessionI::attachElementsAck`.

Each site now abandons only its own element.

## Notes

The inline-key decode is reachable only against an **any-key or filtered writer**: `toSample` marshals the key
inline exactly when the writer element has no keys, so `keyId == 0` implies such a peer.

In `subscriberInitialized` the decode is reached only for a **local reader**. A peer *reader* element acks with
empty `samples` — the base `DataElementI::getSamples` returns `{}` and only `KeyDataWriterI::getSamples` yields
samples — so the early `samples.empty()` return fires first. The starved siblings are therefore the other local
readers in that ack, not the peer's readers.

`initSamples` is guarded by `if (q->second.initialized) return;`, so leaving it there is exactly "still
uninitialized". `subscriberInitialized` has no such guard, so its comment says the subscriber keeps its previous
state.

No test. The logging itself is not assertable, and the containment is only observable through batch/ack ordering,
which follows a `std::map` keyed by `shared_ptr` — a harness built on that would fail before the fix only some of
the time, and by hanging.

Ten sites still run an application decoder unguarded inside a dispatch, and would each need a caller-specific
degradation decision rather than a blanket catch: `SessionI.cpp:225` (#6507), `SessionI.cpp:1776` (the live `s()`
key decode), `TopicI.cpp:167/224/366/417/476/544`, and `DataElementI.cpp:110/164`. #6389 stays open for them. All
four `sample->decode` value sites are already caught.

Verified on macOS: `make -C cpp srcs` and `tests` clean, 12/12 `cpp/DataStorm` suites pass.

