### PR TITLE
Ship the CMake package configuration in the RPM devel package

### DIFF
--- a/changelog.d/packaging/6440.md
+++ b/changelog.d/packaging/6440.md
@@ -1,2 +1,3 @@
-- The Ice CMake package configuration files moved from the `libice3.9-c++` RPM to `libice-c++-devel`, so
-  `find_package(Ice)` on a runtime-only host now reports that no Ice package was found.
+- The Ice CMake package configuration files are now in the `libice-c++-devel` RPM instead of the C++ runtime
+  RPM. Building an Ice application on a host missing the devel RPM now fails with CMake's standard
+  "package not found" error, instead of a confusing error from inside the Ice package configuration.

--- a/changelog.d/packaging/6440.md
+++ b/changelog.d/packaging/6440.md
@@ -1,0 +1,2 @@
+- The Ice CMake package configuration files moved from the `libice3.9-c++` RPM to `libice-c++-devel`, so
+  `find_package(Ice)` on a runtime-only host now reports that no Ice package was found.

--- a/packaging/rpm/ice.spec
+++ b/packaging/rpm/ice.spec
@@ -427,7 +427,6 @@ cp -p java/lib/icegridgui.jar %{buildroot}%{_javadir}/icegridgui.jar
 %{_libdir}/libIceGrid.so.*
 %{_libdir}/libIceLocatorDiscovery.so.*
 %{_libdir}/libIceStorm.so.*
-%{_libdir}/cmake/*/*.cmake
 %post -n lib%{?nameprefix}ice%{mmversion}-c++ -p /sbin/ldconfig
 %postun -n lib%{?nameprefix}ice%{mmversion}-c++
 /sbin/ldconfig
@@ -460,6 +459,7 @@ exit 0
 %{_libdir}/libIceGrid.so
 %{_libdir}/libIceLocatorDiscovery.so
 %{_libdir}/libIceStorm.so
+%{_libdir}/cmake/*/*.cmake
 %{_includedir}/DataStorm
 %{_includedir}/Glacier2
 %{_includedir}/Ice


### PR DESCRIPTION
Fixes #6440.

The Ice CMake package configuration files were packaged in the `libice3.9-c++` runtime RPM, so a runtime-only host advertised a CMake package it could not satisfy: `find_package(Ice)` found `IceConfig.cmake` and then failed inside it, reading as a broken Ice installation rather than a missing `libice-c++-devel`.

This moves `%{_libdir}/cmake/*/*.cmake` into `libice-c++-devel`, alongside the headers and `slice2cpp`, matching the Debian packaging. A runtime-only host now has no configuration file, and CMake reports its own "Could not find a package configuration file provided by Ice".

The stray `;` in `set(Ice_NOT_FOUND_MESSAGE ...)`, also mentioned in the report, was already fixed by #6420.

Verified with a local RPM build using the `ghcr.io/zeroc-ice/ice-rpm-builder-el10:3.9` CI image: the cmake files land in `libice-c++-devel`, `find_package(Ice CONFIG REQUIRED)` finds no package on a runtime-only container, and succeeds once the devel package is installed.
