### PR TITLE
Skip an undecodable update tag carried in a DataStorm topic spec

### DIFF
--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -218,12 +218,7 @@ SessionI::attachTopic(TopicSpec spec, const Current&)
                 // If the topic spec has tags, decode them and add them to the subscriber.
                 if (!spec.tags.empty())
                 {
-                    auto& subscriber = _topics.at(spec.id).getSubscriber(topic);
-                    for (const auto& tag : spec.tags)
-                    {
-                        subscriber.tags[tag.id] =
-                            topic->getTagFactory()->decode(_instance->getCommunicator(), tag.value);
-                    }
+                    decodeTags(topic, spec.tags, _topics.at(spec.id).getSubscriber(topic).tags);
                 }
 
                 // Provide the local tags to the remote topic by calling attachTagsAsync.
@@ -318,24 +313,7 @@ SessionI::attachTags(int64_t topicId, ElementInfoSeq tags, bool initialize, cons
             // every tag is decoded; the subscriber keeps its current tags until then. Any other call adds to the tags
             // the subscriber already holds, and decodes into them directly.
             map<int64_t, shared_ptr<Tag>> replacement;
-            auto& decoded = initialize ? replacement : subscriber.tags;
-            for (const auto& tag : tags)
-            {
-                try
-                {
-                    decoded[tag.id] = topic->getTagFactory()->decode(_instance->getCommunicator(), tag.value);
-                }
-                catch (const std::exception& ex)
-                {
-                    // The tag factory runs the application's decoder. Skip a tag it can't decode: the peer resends
-                    // its tags on reconnect; until then a partial update carrying the skipped tag resolves to the
-                    // key's current value.
-                    Warning out(_traceLevels->logger);
-                    out << "skipped update tag " << tag.id << " on topic '" << topic << "': the tag could not be "
-                        << "decoded:\n"
-                        << ex.what();
-                }
-            }
+            decodeTags(topic, tags, initialize ? replacement : subscriber.tags);
 
             if (initialize)
             {
@@ -1635,6 +1613,29 @@ SessionI::runWithTopic(
                 return;
             }
             callback(p->second);
+        }
+    }
+}
+
+void
+SessionI::decodeTags(
+    const shared_ptr<TopicI>& topic,
+    const ElementInfoSeq& tags,
+    map<int64_t, shared_ptr<Tag>>& decoded)
+{
+    for (const auto& tag : tags)
+    {
+        try
+        {
+            decoded[tag.id] = topic->getTagFactory()->decode(_instance->getCommunicator(), tag.value);
+        }
+        catch (const std::exception& ex)
+        {
+            // The tag factory runs the application's decoder. Skip a tag it can't decode rather than let it abandon
+            // the tags around it and the attach that carried them. The peer resends its tags on reconnect.
+            Warning out(_traceLevels->logger);
+            out << "skipped update tag " << tag.id << " on topic '" << topic << "': the tag could not be decoded:\n"
+                << ex.what();
         }
     }
 }

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -463,6 +463,19 @@ namespace DataStormI
             const std::shared_ptr<TopicI>& topic,
             const std::function<void(TopicSubscriber&)>& callback);
 
+        /// Decodes the update tags the peer sent for a topic and adds them to the given tag map.
+        ///
+        /// The tag factory runs the application's decoder, so a tag it rejects is skipped with a warning instead of
+        /// abandoning the tags around it and the attach that carried them. The peer resends its tags on reconnect.
+        ///
+        /// @param topic The topic the tags belong to.
+        /// @param tags The encoded tags received from the peer.
+        /// @param decoded The tag map the decoded tags are added to.
+        void decodeTags(
+            const std::shared_ptr<TopicI>& topic,
+            const DataStormContract::ElementInfoSeq& tags,
+            std::map<std::int64_t, std::shared_ptr<Tag>>& decoded);
+
         /// Returns the topics that match the specified name.
         ///
         /// This method is implemented by the derived classes `PublisherSessionI` and `SubscriberSessionI`:

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -113,6 +113,15 @@ void ::Writer::run(int argc, char* argv[])
 
     topic.setUpdater<float>("price", [](StockPtr& stock, float price) { stock->price = price; });
 
+    // This writer is created here, ahead of the reader topic of the same name, so that the reader attaches to a
+    // writer topic that already holds both update tags: the tags then reach the reader in the topic spec it attaches
+    // to, rather than in a later attachTags call. It publishes at the end of the test.
+    Topic<string, Counter, Op> tagDecodeErrorTopic(node, "tagDecodeErrorTopic");
+    tagDecodeErrorTopic.setWriterDefaultConfig(config);
+    tagDecodeErrorTopic.setUpdater<int>(Op{"undecodable"}, [](Counter& counter, int delta) { counter.value += delta; });
+    tagDecodeErrorTopic.setUpdater<int>(Op{"increment"}, [](Counter& counter, int delta) { counter.value += delta; });
+    auto tagDecodeErrorWriter = makeSingleKeyWriter(tagDecodeErrorTopic, "key");
+
     cout << "testing partial update... " << flush;
     {
         auto writer = makeSingleKeyWriter(topic, "AAPL");
@@ -503,17 +512,12 @@ void ::Writer::run(int argc, char* argv[])
 
     // The writer sends both of its update tags when the reader attaches, and the reader's Decoder rejects one of
     // them. The partial update published with the tag the reader can decode is still applied.
-    Topic<string, Counter, Op> tagDecodeErrorTopic(node, "tagDecodeErrorTopic");
-    tagDecodeErrorTopic.setWriterDefaultConfig(config);
-    tagDecodeErrorTopic.setUpdater<int>(Op{"undecodable"}, [](Counter& counter, int delta) { counter.value += delta; });
-    tagDecodeErrorTopic.setUpdater<int>(Op{"increment"}, [](Counter& counter, int delta) { counter.value += delta; });
     cout << "testing update tag that fails to decode... " << flush;
     {
-        auto writer = makeSingleKeyWriter(tagDecodeErrorTopic, "key");
-        writer.waitForReaders();
-        writer.add(Counter{1});
-        writer.partialUpdate<int>(Op{"increment"})(5);
-        writer.waitForNoReaders();
+        tagDecodeErrorWriter.waitForReaders();
+        tagDecodeErrorWriter.add(Counter{1});
+        tagDecodeErrorWriter.partialUpdate<int>(Op{"increment"})(5);
+        tagDecodeErrorWriter.waitForNoReaders();
     }
     cout << "ok" << endl;
 }


### PR DESCRIPTION
Closes #6507.

`SessionI::attachTopic` decoded the peer's update tags with the application's tag factory without a guard, so a
decoder that threw aborted the whole attach dispatch: no element of the topic was attached, the oneway ack meant the
peer was never told, and both nodes waited forever — the writer in `waitForReaders`, the reader in `getNextUnread`.

The sibling decode in `attachTags` was already guarded, so whether an undecodable tag was skipped or deadlocked the
pair depended only on whether the tag rode the initial topic spec or a later `attachTags` call. This moves the
guarded decode into a `decodeTags` helper and calls it from both sites, so the two cannot diverge again.

The `partial` test now creates the writer topic and its update tags ahead of the reader topic, so the tags reliably
reach the reader in the topic spec instead of racing between the two paths. Against the unpatched library it hangs at
`testing update tag that fails to decode...` with the reported `failed to dispatch attachTopic` warning; with the fix
it passes, as do all 12 DataStorm suites.