### PR TITLE
Load a PKCS12 certificate with an empty password on macOS

### DIFF
--- a/changelog.d/cpp/6489.md
+++ b/changelog.d/cpp/6489.md
@@ -1,0 +1,1 @@
+- Fixed the SSL transport on macOS failing to load a PKCS#12 certificate whose password is empty.

--- a/changelog.d/cpp/6489.md
+++ b/changelog.d/cpp/6489.md
@@ -1,1 +1,1 @@
-- Fixed the SSL transport on macOS failing to load a PKCS#12 certificate whose password is empty.
+- The SSL transport on macOS now supports PKCS#12 certificate files with an empty password.

--- a/cpp/src/Ice/SSL/SecureTransportUtil.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportUtil.cpp
@@ -245,18 +245,36 @@ namespace
         memset(&params, 0, sizeof(params));
         params.version = SEC_KEY_IMPORT_EXPORT_PARAMS_VERSION;
         params.flags |= kSecKeyNoAccessControl;
-        UniqueRef<CFStringRef> passphraseHolder;
-        if (!passphrase.empty())
-        {
-            passphraseHolder.reset(toCFString(passphrase));
-            params.passphrase = passphraseHolder.get();
-        }
+        // Always pass a passphrase, even an empty one: SecItemImport rejects a PKCS12 file with
+        // errSecPassphraseRequired when params.passphrase is null, without looking at the file contents.
+        UniqueRef<CFStringRef> passphraseHolder(toCFString(passphrase));
+        params.passphrase = passphraseHolder.get();
 
         UniqueRef<CFArrayRef> items;
         SecExternalItemType importType = type;
         SecExternalFormat format = type == kSecItemTypeUnknown ? kSecFormatPKCS12 : kSecFormatUnknown;
         UniqueRef<CFStringRef> path(toCFString(file));
         OSStatus err = SecItemImport(data.get(), path.get(), &format, &importType, 0, &params, keychain, &items.get());
+
+        if (err == errSecPkcs12VerifyFailure && passphrase.empty())
+        {
+            // There are two encodings of the empty PKCS12 password, and they derive different keys. RFC 7292
+            // appendix B.1 formats every password as a NULL-terminated UTF-16BE string, which makes the empty
+            // password two 0x00 bytes; appendix B.2 step 3 instead notes that an empty password gives an empty
+            // block. openssl and keytool write the first, .NET writes either one depending on whether the
+            // password is "" or null.
+            //
+            // SecItemImport reads a CFString passphrase as the second encoding and a CFData passphrase as the
+            // raw password bytes, so retry with the two bytes appendix B.1 asks for. This mirrors .NET's own
+            // PKCS12 reader, which retries the other encoding when MAC verification fails.
+            const uint8_t emptyPassword[2] = {0, 0};
+            UniqueRef<CFDataRef> dataPassphrase(
+                CFDataCreate(kCFAllocatorDefault, emptyPassword, sizeof(emptyPassword)));
+            params.passphrase = dataPassphrase.get();
+            importType = type;
+            format = type == kSecItemTypeUnknown ? kSecFormatPKCS12 : kSecFormatUnknown;
+            err = SecItemImport(data.get(), path.get(), &format, &importType, 0, &params, keychain, &items.get());
+        }
 
         if (err != noErr)
         {

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -1251,6 +1251,35 @@ testEncryptedKey(const string&, const Ice::PropertiesPtr&)
 }
 #endif
 
+// Load a PKCS12 certificate whose password is empty, with IceSSL.Password left empty too. The fixtures are
+// written by `openssl pkcs12 -export -passout pass:`.
+void
+testPasswordLessCert(const string& factoryRef, const Ice::PropertiesPtr& defaultProps)
+{
+    cout << "testing PKCS12 certificate without a password... " << flush;
+    InitializationData initData;
+    initData.properties = createClientProps(defaultProps, true, "ca1/client_password_less", "ca1/ca1");
+    initData.properties->setProperty("IceSSL.Password", "");
+    CommunicatorPtr comm = initialize(initData);
+    Test::ServerFactoryPrx fact{comm, factoryRef};
+
+    Test::Properties d = createServerProps(defaultProps, true, "ca1/server_password_less", "ca1/ca1");
+    d["IceSSL.Password"] = "";
+    optional<Test::ServerPrx> server = fact->createServer(d);
+    try
+    {
+        server->ice_ping();
+    }
+    catch (const LocalException& ex)
+    {
+        cerr << ex << endl;
+        test(false);
+    }
+    fact->destroyServer(server);
+    comm->destroy();
+    cout << "ok" << endl;
+}
+
 void
 testMutlipleCACerts(const string& factoryRef, const Ice::PropertiesPtr& defaultProps, bool p12)
 {
@@ -2431,6 +2460,10 @@ allTests(Test::TestHelper* helper, const string& defaultDir, bool p12)
     testCertificateChains(factory, defaultDir, defaultProps, p12);
     testCAsDirectory(factory, defaultDir, defaultProps, p12);
     testEncryptedKey(factory, defaultProps);
+    if (p12)
+    {
+        testPasswordLessCert(factory, defaultProps);
+    }
     testMutlipleCACerts(factory, defaultProps, p12);
     testDerCertificates(factory, defaultProps, p12);
     testTrustOnly(factory, defaultProps, p12);


### PR DESCRIPTION
Closes #6489. Supersedes #6503.

## The bug

`SecItemImport` rejects a PKCS#12 file with `errSecPassphraseRequired` (-25260) whenever `params.passphrase` is null, before it looks at the file contents. `loadKeychainItems` left the field unset when `IceSSL.Password` was empty, so a certificate with an empty password could never load on macOS.

## Why an empty CFString is not enough

There are two encodings of the empty PKCS#12 password, and they derive different keys. RFC 7292 appendix B.1 formats every password as a NULL-terminated UTF-16BE string, which makes the empty password two `0x00` bytes; appendix B.2 step 3 instead notes that an empty password gives an empty block. `openssl` and `keytool` write the first, .NET writes either one depending on whether the password is `""` or `null` — `Pkcs12Kdf.cs:117-141` implements both deliberately.

`SecItemImport` derives the key from a `CFString` passphrase using the second encoding, and from a `CFData` passphrase verbatim. Measured on macOS 26 with Ice's exact call:

| `params.passphrase` | `openssl -passout pass:` | .NET `Export(Pkcs12, null)` |
| --- | --- | --- |
| `NULL` (today) | -25260 | -25260 |
| `CFString ""` | -25264 MAC fail | loads |
| `CFData 00 00` | loads | -25264 MAC fail |

An empty `CFString` alone would therefore load only the .NET form and leave the usual `openssl pkcs12 -export -passout pass:` file failing. This passes the empty `CFString` and, on `errSecPkcs12VerifyFailure`, retries with the two bytes appendix B.1 asks for — the way .NET's own PKCS#12 reader retries the other encoding when MAC verification fails (`X509CertificateLoader.Pkcs12.cs:170-185`). Both forms load.

## Tests

`testPasswordLessCert` in the C++ IceSSL configuration suite uses the existing `ca1/*_password_less.p12` fixtures, so no new certificates are added. With the retry disabled and the library rebuilt, it fails with `-25264`. Full C++ suite: 109/109.

The .NET zero-length form is deliberately left uncovered: a fixture for it would be a checked-in binary that `makecerts.sh` cannot regenerate, or `dotnet` added to the certs image. The branch that reads it is the pre-existing call with an empty passphrase.

## Notes for the reviewer

- iOS is unaffected — `SecPKCS12Import` follows appendix B.1, so openssl files already load there. The two Apple platforms accept opposite forms, each rejecting the other with `errSecAuthFailed` (-25293); verified on an iOS 26.5 simulator.
- #6503 approached this by shipping a generator script plus a second fixture in the zero-length form. @externl pointed out that leaves the openssl case — the normal way to produce a password-less PKCS#12 — still broken on macOS, and suggested the `CFDataRef` route used here.
