### PR TITLE
Ignore an incoming Bluetooth connection delivered after the acceptor is closed

### DIFF
--- a/changelog.d/cpp/6441.md
+++ b/changelog.d/cpp/6441.md
@@ -1,0 +1,2 @@
+- Fixed a crash in the IceBT transport. An incoming Bluetooth connection delivered while its object adapter was
+  being deactivated — or the communicator destroyed — could crash the program.

--- a/cpp/src/IceBT/AcceptorI.cpp
+++ b/cpp/src/IceBT/AcceptorI.cpp
@@ -40,6 +40,22 @@ IceBT::AcceptorI::getNativeInfo()
 void
 IceBT::AcceptorI::close()
 {
+    stack<IceInternal::TransceiverPtr> transceivers;
+    {
+        lock_guard lock(_mutex);
+        _closed = true;
+        _transceivers.swap(transceivers);
+    }
+
+    //
+    // Close queued transceivers that were never accepted, otherwise their sockets would leak.
+    //
+    while (!transceivers.empty())
+    {
+        transceivers.top()->close();
+        transceivers.pop();
+    }
+
     if (!_path.empty())
     {
         try
@@ -154,6 +170,15 @@ void
 IceBT::AcceptorI::newConnection(int fd)
 {
     lock_guard lock(_mutex);
+
+    if (_closed)
+    {
+        //
+        // The acceptor was closed: nothing will ever accept this connection, so close the socket here.
+        //
+        IceInternal::closeSocketNoThrow(fd);
+        return;
+    }
 
     _transceivers.push(
         make_shared<TransceiverI>(_instance, make_shared<StreamSocket>(_instance, fd, _bufSize), nullptr, _uuid));

--- a/cpp/src/IceBT/AcceptorI.cpp
+++ b/cpp/src/IceBT/AcceptorI.cpp
@@ -52,7 +52,13 @@ IceBT::AcceptorI::close()
     //
     while (!transceivers.empty())
     {
-        transceivers.top()->close();
+        try
+        {
+            transceivers.top()->close();
+        }
+        catch (...)
+        {
+        }
         transceivers.pop();
     }
 

--- a/cpp/src/IceBT/AcceptorI.h
+++ b/cpp/src/IceBT/AcceptorI.h
@@ -47,6 +47,7 @@ namespace IceBT
         std::string _path;
 
         std::mutex _mutex;
+        bool _closed{false};
         std::stack<IceInternal::TransceiverPtr> _transceivers;
     };
 }


### PR DESCRIPTION
Fixes #6441.

`IceBT::AcceptorI::close()` only unregistered the D-Bus profile, and `DBus::Connection::handleMessage` dispatches outside the lock, so a `NewConnection` invocation already in flight can still reach `AcceptorI::newConnection` after the acceptor is closed. Once the thread-pool work item queued during `IncomingConnectionFactory` shutdown has cleared the ready callback, the late `newConnection` called `ready()` with no callback installed: `assert(_readyCallback)` in debug builds, a call through a null `shared_ptr` in release builds.

This PR adds a `_closed` flag to `AcceptorI`, mirroring the `TransceiverI` guard from #6387:

- `newConnection` now checks `_closed` under `_mutex`; when the acceptor is closed, it closes the delivered fd and returns instead of queuing a transceiver and calling `ready()`. The ordering is sound because `close()` runs inline from `setState(StateClosed)` under the factory mutex (on Linux, `Selector::finish` returns `closeNow` unchanged), while the ready callback is cleared afterwards by a work item whose `finished()` must first acquire that same factory mutex: a `newConnection` that acquires the acceptor's `_mutex` before `close()` completes its `ready()` call while the callback is still installed, and one that acquires it after sees `_closed`.
- `close()` also drains the queued transceivers and closes them. A transceiver queued but never accepted was previously destroyed with a live fd — `assert(_fd == INVALID_SOCKET)` in `~StreamSocket` in debug builds, a leaked fd in release builds. Acceptor-side transceivers have no Bluetooth `Connection` object, so closing them just closes the socket and cannot block.

Unlike #6387, there is no residual `Ice.Executor` window here: the acceptor close is never executor-deferred, so the `_closed` guard covers the whole shutdown path. The startup-side window (a `NewConnection` dispatched between `listen()` and ready-callback installation) is tracked separately in #6550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)