### PR TITLE
Don't defer reads when Serialize is enabled on a single-threaded pool

### DIFF
--- a/changelog.d/cpp/6279.md
+++ b/changelog.d/cpp/6279.md
@@ -1,0 +1,2 @@
+- Improved performance on Windows when thread pool serialization (`Serialize=1`) is enabled on a thread pool with a
+  single thread.

--- a/changelog.d/csharp/6279.md
+++ b/changelog.d/csharp/6279.md
@@ -1,0 +1,2 @@
+- Improved performance when thread pool serialization (`Serialize=1`) is enabled on a thread pool with a single
+  thread.

--- a/cpp/src/Ice/ThreadPool.cpp
+++ b/cpp/src/Ice/ThreadPool.cpp
@@ -799,7 +799,7 @@ IceInternal::ThreadPool::ioCompleted(ThreadPoolCurrent& current)
         }
     }
 
-    return _serialize && current._handler.get() != _workQueue.get();
+    return _sizeMax > 1 && _serialize && current._handler.get() != _workQueue.get();
 }
 
 #if defined(ICE_USE_IOCP)

--- a/csharp/src/Ice/Internal/ThreadPool.cs
+++ b/csharp/src/Ice/Internal/ThreadPool.cs
@@ -550,7 +550,7 @@ public sealed class ThreadPool : System.Threading.Tasks.TaskScheduler
                 }
             }
         }
-        return _serialize;
+        return _sizeMax > 1 && _serialize;
     }
 
     public bool startMessage(ThreadPoolCurrent current)


### PR DESCRIPTION
Fixes #6279.

On Windows, `ThreadPool::ioCompleted` returned `_serialize && current._handler.get() != _workQueue.get()` regardless of the pool size, and the IOCP `IOScope` uses this return value to defer `finishMessage` — which posts the next `WSARecv` — until after the dispatch. A single-threaded pool cannot dispatch two messages concurrently, so serialization buys no ordering there; deferring the read only costs the connection its read/dispatch overlap. On POSIX the entire serialize path already sits inside the `_sizeMax > 1` guard (and the return value is discarded), so this change adds the same guard to the return value, aligning the two platforms.

The C# thread pool copied the async-model design and had the same behavior — on all platforms, since C# always uses the async model. Same one-line fix there. Java follows the POSIX selector model and already guards its serialize path with `_sizeMax > 1`, and JS has no thread pool.

This is not a regression: the behavior is identical in 3.7.10 and at the tip of the 3.7 branch, in both C++ and C#.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
