### PR TITLE
Fix typos

### DIFF
--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -1067,7 +1067,7 @@ $1_ldflags      ?= -l$1
 endef
 
 #
-# $(call repathfromdir,path)
+# $(call relpathfromdir,path)
 #
 # Returns reversed relative path for directory (e.g.: test/Ice/operations
 # is transformed to ../../..). This is used for rpath computations.

--- a/cpp/src/Ice/FileUtil.cpp
+++ b/cpp/src/Ice/FileUtil.cpp
@@ -242,19 +242,19 @@ IceInternal::FileLock::FileLock(const std::string& path) : _path(path)
         throw FileLockException(__FILE__, __LINE__, GetLastError(), _path);
     }
 
-    OVERLAPPED overlaped;
-    overlaped.Internal = 0;
-    overlaped.InternalHigh = 0;
-    overlaped.Offset = 0;
-    overlaped.OffsetHigh = 0;
+    OVERLAPPED overlapped;
+    overlapped.Internal = 0;
+    overlapped.InternalHigh = 0;
+    overlapped.Offset = 0;
+    overlapped.OffsetHigh = 0;
 
 #    if defined(_MSC_VER)
-    overlaped.hEvent = nullptr;
+    overlapped.hEvent = nullptr;
 #    else
-    overlaped.hEvent = 0;
+    overlapped.hEvent = 0;
 #    endif
 
-    if (::LockFileEx(_fd, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, 0, 0, &overlaped) == 0)
+    if (::LockFileEx(_fd, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, 0, 0, &overlapped) == 0)
     {
         ::CloseHandle(_fd);
         throw FileLockException(__FILE__, __LINE__, GetLastError(), _path);

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -1409,7 +1409,7 @@ IceInternal::RoutableReference::createConnectionAsync(
     OutgoingConnectionFactoryPtr factory = getInstance()->outgoingConnectionFactory();
     auto self = static_pointer_cast<RoutableReference>(const_cast<RoutableReference*>(this)->shared_from_this());
 
-    auto createConnectionSucceded =
+    auto createConnectionSucceeded =
         [routerInfo = _routerInfo, response = std::move(response)](Ice::ConnectionIPtr connection, bool compress)
     {
         // If we have a router, set the object adapter for this router (if any) to the new connection, so that
@@ -1424,7 +1424,7 @@ IceInternal::RoutableReference::createConnectionAsync(
     if (getCacheConnection() || endpoints.size() == 1)
     {
         // Get an existing connection or create one if there's no existing connection to one of the given endpoints.
-        factory->createAsync(std::move(endpoints), false, std::move(createConnectionSucceded), std::move(exception));
+        factory->createAsync(std::move(endpoints), false, std::move(createConnectionSucceeded), std::move(exception));
     }
     else
     {
@@ -1438,11 +1438,11 @@ IceInternal::RoutableReference::createConnectionAsync(
             CreateConnectionState(
                 vector<EndpointIPtr> endpoints,
                 OutgoingConnectionFactoryPtr factory,
-                function<void(Ice::ConnectionIPtr, bool)> createConnectionSucceded,
+                function<void(Ice::ConnectionIPtr, bool)> createConnectionSucceeded,
                 function<void(exception_ptr)> exception)
                 : _endpoints(std::move(endpoints)),
                   _factory(std::move(factory)),
-                  _createConnectionSucceded(std::move(createConnectionSucceded)),
+                  _createConnectionSucceeded(std::move(createConnectionSucceeded)),
                   _createConnectionFailed(std::move(exception))
             {
             }
@@ -1452,7 +1452,7 @@ IceInternal::RoutableReference::createConnectionAsync(
                 _factory->createAsync(
                     {_endpoints[_endpointIndex]},
                     true,
-                    _createConnectionSucceded,
+                    _createConnectionSucceeded,
                     [self = shared_from_this()](exception_ptr e) { self->handleException(e); });
             }
 
@@ -1473,7 +1473,7 @@ IceInternal::RoutableReference::createConnectionAsync(
                 _factory->createAsync(
                     {_endpoints[_endpointIndex]},
                     more,
-                    _createConnectionSucceded,
+                    _createConnectionSucceeded,
                     [self = shared_from_this()](exception_ptr e) { self->handleException(e); });
             }
 
@@ -1482,14 +1482,14 @@ IceInternal::RoutableReference::createConnectionAsync(
             size_t _endpointIndex = 0;
             vector<EndpointIPtr> _endpoints;
             OutgoingConnectionFactoryPtr _factory;
-            std::function<void(Ice::ConnectionIPtr, bool)> _createConnectionSucceded;
+            std::function<void(Ice::ConnectionIPtr, bool)> _createConnectionSucceeded;
             std::function<void(exception_ptr)> _createConnectionFailed;
         };
 
         auto state = make_shared<CreateConnectionState>(
             std::move(endpoints),
             std::move(factory),
-            std::move(createConnectionSucceded),
+            std::move(createConnectionSucceeded),
             std::move(exception));
         state->createAsync();
     }

--- a/cpp/src/IceGrid/Database.cpp
+++ b/cpp/src/IceGrid/Database.cpp
@@ -2650,11 +2650,11 @@ Database::finishApplicationUpdate(
     {
         try
         {
-            for (const auto& entrie : entries)
+            for (const auto& entry : entries)
             {
                 try
                 {
-                    entrie->waitForSync();
+                    entry->waitForSync();
                 }
                 catch (const NodeUnreachableException&)
                 {

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -1281,7 +1281,7 @@ testPasswordLessCert(const string& factoryRef, const Ice::PropertiesPtr& default
 }
 
 void
-testMutlipleCACerts(const string& factoryRef, const Ice::PropertiesPtr& defaultProps, bool p12)
+testMultipleCACerts(const string& factoryRef, const Ice::PropertiesPtr& defaultProps, bool p12)
 {
     cout << "testing multiple CA certificates... " << flush;
     {
@@ -2464,7 +2464,7 @@ allTests(Test::TestHelper* helper, const string& defaultDir, bool p12)
     {
         testPasswordLessCert(factory, defaultProps);
     }
-    testMutlipleCACerts(factory, defaultProps, p12);
+    testMultipleCACerts(factory, defaultProps, p12);
     testDerCertificates(factory, defaultProps, p12);
     testTrustOnly(factory, defaultProps, p12);
     testCrlRevocation(factory, defaultDir, defaultProps, p12);

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/TreeNode.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/TreeNode.java
@@ -179,7 +179,7 @@ public abstract class TreeNode extends TreeNodeBase {
             amiFailure(
                 prefix,
                 title,
-                "Node '" + nnee.name + " 'was not registered with the IceGrid Registry.");
+                "Node '" + nnee.name + "' was not registered with the IceGrid Registry");
         } else if (e instanceof NodeUnreachableException) {
             NodeUnreachableException nue =
                 (NodeUnreachableException) e;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/RegistryObserverI.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/RegistryObserverI.java
@@ -25,8 +25,8 @@ class RegistryObserverI implements RegistryObserver {
                     names += " " + info.name;
                 }
                 _coordinator.traceObserver(
-                    "registryInit for registr"
-                        + (registryInfos.length == 1 ? "y" : "ies")
+                    "registryInit for "
+                        + (registryInfos.length == 1 ? "registry" : "registries")
                         + names);
             }
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BZip2.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BZip2.java
@@ -114,7 +114,7 @@ public class BZip2 {
             }
             is.close();
         } catch (Exception ex) {
-            throw new ProtocolException("bzip2 uncompression failed", ex);
+            throw new ProtocolException("bzip2 decompression failed", ex);
         }
 
         // Copy the header from the compressed stream to the uncompressed one.

--- a/matlab/test/Ice/objects/LocalTests.m
+++ b/matlab/test/Ice/objects/LocalTests.m
@@ -71,7 +71,7 @@ classdef LocalTests
             % Prior to conversion, the result is a CellArrayHandle
             assert(isa(r, 'IceInternal.CellArrayHandle'));
             r = C1Seq.convert(r);
-            % Now the result should be a cell arary
+            % Now the result should be a cell array
             assert(isa(r, 'cell'));
             assert(length(r) == length(seq));
             for i = 1:10
@@ -284,7 +284,7 @@ classdef LocalTests
             % Prior to conversion, the sequence is a CellArrayHandle
             assert(isa(r.c1seq, 'IceInternal.CellArrayHandle'));
             r = r.ice_convert();
-            % Now the result should be a cell arary
+            % Now the result should be a cell array
             assert(isa(r.c1seq, 'cell'));
             assert(length(r.c1seq) == length(s3.c1seq));
             for i = 1:10
@@ -517,7 +517,7 @@ classdef LocalTests
             % Ending the encapsulation should trigger the conversion and the ice_postUnmarshal callback
             is.endEncapsulation();
             assert(h.value.postUnmarshalInvoked);
-            % Now the member should be a cell arary
+            % Now the member should be a cell array
             assert(isa(h.value.c1seq, 'cell'));
             assert(length(h.value.c1seq) == length(cb.c1seq));
             for i = 1:10

--- a/matlab/toolbox/addFolderToPath.m
+++ b/matlab/toolbox/addFolderToPath.m
@@ -2,7 +2,7 @@
 
 function addFolderToPath(f)
   try
-    fprintf(1, 'Adding toolxbox folder to path... ');
+    fprintf(1, 'Adding toolbox folder to path... ');
     addpath(f);
     savepath();
     fprintf(1, 'ok\n');

--- a/matlab/toolbox/removeFolderFromPath.m
+++ b/matlab/toolbox/removeFolderFromPath.m
@@ -2,7 +2,7 @@
 
 function removeFolderFromPath(p)
   try
-    fprintf(1, 'Removing toolxbox folder from path... ');
+    fprintf(1, 'Removing toolbox folder from path... ');
     rmpath(p);
     savepath();
     fprintf(1, 'ok\n');

--- a/php/src/Proxy.cpp
+++ b/php/src/Proxy.cpp
@@ -1119,7 +1119,7 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getCompress)
 }
 
 ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_invocationTimeout_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
-ZEND_ARG_INFO(0, invocationTiemout)
+ZEND_ARG_INFO(0, invocationTimeout)
 ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_ObjectPrx, ice_invocationTimeout)

--- a/python/python/Ice/UserException.py
+++ b/python/python/Ice/UserException.py
@@ -11,7 +11,7 @@ class UserException(IceException):
     def __str__(self):
         # Types derived from UserException are data classes. We override __str__ to delegate to the generated __repr__,
         # since the built-in __str__ from BaseException only works when all arguments are passed to the constructor,
-        # which is not the case for exceptions unmarshalled from the wire.
+        # which is not the case for exceptions unmarshaled from the wire.
         return self.__repr__()
 
 

--- a/ruby/src/IceRuby/Util.h
+++ b/ruby/src/IceRuby/Util.h
@@ -137,7 +137,7 @@ namespace IceRuby
     //
     // The callRuby functions are used to invoke Ruby C API functions
     // while translating any Ruby exception into RubyException so that
-    // C++ objects are cleaned up properly. Overloadings are provided
+    // C++ objects are cleaned up properly. Overloads are provided
     // to support API functions that accept multiple arguments.
     //
     template<typename Fun> VALUE callRuby(Fun fun);
@@ -296,7 +296,7 @@ namespace IceRuby
     //
     // The callRubyVoid functions are used to invoke Ruby C API functions
     // while translating any Ruby exception into RubyException so that
-    // C++ objects are cleaned up properly. Overloadings are provided
+    // C++ objects are cleaned up properly. Overloads are provided
     // to support API functions that accept multiple arguments.
     //
     template<typename Fun> void callRubyVoid(Fun fun);


### PR DESCRIPTION
Typos found by running cspell over the sources. No tooling is added — just the fixes.

- C++: `overlaped` → `overlapped`, `createConnectionSucceded` → `createConnectionSucceeded`, and a `for (const auto& entrie : entries)` loop variable.
- IceGrid GUI: a `"registryInit for registr" + (n == 1 ? "y" : "ies")` trace message that now picks whole words, and a `"Node ' + name + " 'was not registered"` message whose quote sat on the wrong side of the space, unlike the `Server` and application messages beside it.
- MATLAB: `Adding/Removing toolxbox folder to path` → `toolbox`, in messages the user sees on install, and `cell arary` → `cell array` in test comments.
- Java: the `bzip2 uncompression failed` exception message → `decompression`, matching the C# mapping.
- PHP: the `invocationTiemout` argument name on `ice_invocationTimeout`.
- A `testMutlipleCACerts` test helper, a `repathfromdir` reference in a make comment, `unmarshalled` → `unmarshaled` in a Python comment, and `Overloadings` → `Overloads` in the IceRuby headers.