### PR TITLE
Contain a throwing DataStorm decoder during element attachment

### DIFF
--- a/cpp/msbuild/ice.test.slnx
+++ b/cpp/msbuild/ice.test.slnx
@@ -18,6 +18,10 @@
     <Project Path="../test/DataStorm/config/msbuild/reader/reader.vcxproj" />
     <Project Path="../test/DataStorm/config/msbuild/writer/writer.vcxproj" />
   </Folder>
+  <Folder Name="/DataStorm/decoderFailures/">
+    <Project Path="../test/DataStorm/decoderFailures/msbuild/reader/reader.vcxproj" />
+    <Project Path="../test/DataStorm/decoderFailures/msbuild/writer/writer.vcxproj" />
+  </Folder>
   <Folder Name="/DataStorm/events/">
     <Project Path="../test/DataStorm/events/msbuild/reader/reader.vcxproj" />
     <Project Path="../test/DataStorm/events/msbuild/writer/writer.vcxproj" />

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -116,8 +116,8 @@ DataElementI::attach(
             // The sample filter factory runs the application's decoder. Leave this element unattached rather than
             // attaching it without the filter, which would send the peer the samples its filter meant to exclude.
             // Returning without an ack confines the failure to this element: the caller attaches the other elements
-            // of the request and acks them, so the peer still initializes them. Print the element id rather than the
-            // element, whose keys stream through the application's formatter — application code inside this catch.
+            // of the request and acks them, so the peer still initializes them. The warning prints the element id:
+            // streaming the element itself would run the application's key formatter inside this very catch.
             Warning out(_traceLevels->logger);
             out << "did not attach 'e" << _id << "' to a peer element: its sample filter '" << info->name
                 << "' could not be decoded:\n"
@@ -186,8 +186,8 @@ DataElementI::attach(
             // The sample filter factory runs the application's decoder. Leave this element unattached rather than
             // attaching it without the filter, which would send the peer the samples its filter meant to exclude.
             // Returning no initialization callback confines the failure to this element: the caller attaches and
-            // initializes the other elements of the acknowledgement. Print the element id rather than the element,
-            // whose keys stream through the application's formatter — application code inside this catch.
+            // initializes the other elements of the acknowledgement. The warning prints the element id: streaming
+            // the element itself would run the application's key formatter inside this very catch.
             Warning out(_traceLevels->logger);
             out << "did not attach 'e" << _id << "' to a peer element: its sample filter '" << info->name
                 << "' could not be decoded:\n"

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -107,7 +107,22 @@ DataElementI::attach(
     shared_ptr<Filter> sampleFilter;
     if (auto info = data.config->sampleFilter)
     {
-        sampleFilter = _parent->getSampleFilterFactories()->decode(getCommunicator(), info->name, info->criteria);
+        try
+        {
+            sampleFilter = _parent->getSampleFilterFactories()->decode(getCommunicator(), info->name, info->criteria);
+        }
+        catch (const std::exception& ex)
+        {
+            // The sample filter factory runs the application's decoder. Leave this element unattached rather than
+            // attaching it without the filter, which would send the peer the samples its filter meant to exclude.
+            // Returning without an ack confines the failure to this element: the caller attaches the other elements
+            // of the request and acks them, so the peer still initializes them.
+            Warning out(_traceLevels->logger);
+            out << "did not attach '" << this << "' to a peer element: its sample filter '" << info->name
+                << "' could not be decoded:\n"
+                << ex.what();
+            return;
+        }
     }
 
     string facet = data.config->facet.value_or(string{});
@@ -161,7 +176,22 @@ DataElementI::attach(
     shared_ptr<Filter> sampleFilter;
     if (auto info = data.config->sampleFilter)
     {
-        sampleFilter = _parent->getSampleFilterFactories()->decode(getCommunicator(), info->name, info->criteria);
+        try
+        {
+            sampleFilter = _parent->getSampleFilterFactories()->decode(getCommunicator(), info->name, info->criteria);
+        }
+        catch (const std::exception& ex)
+        {
+            // The sample filter factory runs the application's decoder. Leave this element unattached rather than
+            // attaching it without the filter, which would send the peer the samples its filter meant to exclude.
+            // Returning no initialization callback confines the failure to this element: the caller attaches and
+            // initializes the other elements of the acknowledgement.
+            Warning out(_traceLevels->logger);
+            out << "did not attach '" << this << "' to a peer element: its sample filter '" << info->name
+                << "' could not be decoded:\n"
+                << ex.what();
+            return nullptr;
+        }
     }
 
     string facet = data.config->facet.value_or(string{});

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -116,9 +116,10 @@ DataElementI::attach(
             // The sample filter factory runs the application's decoder. Leave this element unattached rather than
             // attaching it without the filter, which would send the peer the samples its filter meant to exclude.
             // Returning without an ack confines the failure to this element: the caller attaches the other elements
-            // of the request and acks them, so the peer still initializes them.
+            // of the request and acks them, so the peer still initializes them. Print the element id rather than the
+            // element, whose keys stream through the application's formatter — application code inside this catch.
             Warning out(_traceLevels->logger);
-            out << "did not attach '" << this << "' to a peer element: its sample filter '" << info->name
+            out << "did not attach 'e" << _id << "' to a peer element: its sample filter '" << info->name
                 << "' could not be decoded:\n"
                 << ex.what();
             return;
@@ -185,9 +186,10 @@ DataElementI::attach(
             // The sample filter factory runs the application's decoder. Leave this element unattached rather than
             // attaching it without the filter, which would send the peer the samples its filter meant to exclude.
             // Returning no initialization callback confines the failure to this element: the caller attaches and
-            // initializes the other elements of the acknowledgement.
+            // initializes the other elements of the acknowledgement. Print the element id rather than the element,
+            // whose keys stream through the application's formatter — application code inside this catch.
             Warning out(_traceLevels->logger);
-            out << "did not attach '" << this << "' to a peer element: its sample filter '" << info->name
+            out << "did not attach 'e" << _id << "' to a peer element: its sample filter '" << info->name
                 << "' could not be decoded:\n"
                 << ex.what();
             return nullptr;

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -115,9 +115,8 @@ DataElementI::attach(
         {
             // The sample filter factory runs the application's decoder. Leave this element unattached rather than
             // attaching it without the filter, which would send the peer the samples its filter meant to exclude.
-            // Returning without an ack confines the failure to this element: the caller attaches the other elements
-            // of the request and acks them, so the peer still initializes them. The warning prints the element id:
-            // streaming the element itself would run the application's key formatter inside this very catch.
+            // The warning prints the element id: streaming the element itself would run the application's key
+            // formatter inside this very catch.
             Warning out(_traceLevels->logger);
             out << "did not attach 'e" << _id << "' to a peer element: its sample filter '" << info->name
                 << "' could not be decoded:\n"
@@ -185,9 +184,8 @@ DataElementI::attach(
         {
             // The sample filter factory runs the application's decoder. Leave this element unattached rather than
             // attaching it without the filter, which would send the peer the samples its filter meant to exclude.
-            // Returning no initialization callback confines the failure to this element: the caller attaches and
-            // initializes the other elements of the acknowledgement. The warning prints the element id: streaming
-            // the element itself would run the application's key formatter inside this very catch.
+            // The warning prints the element id: streaming the element itself would run the application's key
+            // formatter inside this very catch.
             Warning out(_traceLevels->logger);
             out << "did not attach 'e" << _id << "' to a peer element: its sample filter '" << info->name
                 << "' could not be decoded:\n"

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1773,7 +1773,24 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
                 }
                 else
                 {
-                    key = topic->getKeyFactory()->decode(_instance->getCommunicator(), dataSample.keyValue);
+                    try
+                    {
+                        key = topic->getKeyFactory()->decode(_instance->getCommunicator(), dataSample.keyValue);
+                    }
+                    catch (const std::exception& ex)
+                    {
+                        // The key factory runs the application's decoder. Discard the sample rather than let the
+                        // exception escape: the decoding happens before the subscriber loop below, so an escape
+                        // discards the sample for every reader attached to this writer element and unwinds out of
+                        // runWithTopics, skipping the other local topics subscribed to this remote topic. The
+                        // session protocol is fire-and-forget, so a local warning is the only way to report the
+                        // failure.
+                        Warning out(_traceLevels->logger);
+                        out << _id << ": discarding sample '" << dataSample.id << "' from 'e" << elementId << '@'
+                            << topicId << "': the key could not be decoded:\n"
+                            << ex.what();
+                        return;
+                    }
                 }
                 assert(key);
 

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1780,11 +1780,8 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
                     catch (const std::exception& ex)
                     {
                         // The key factory runs the application's decoder. Discard the sample rather than let the
-                        // exception escape: the decoding happens before the subscriber loop below, so an escape
-                        // discards the sample for every reader attached to this writer element and unwinds out of
-                        // runWithTopics, skipping the other local topics subscribed to this remote topic. The
-                        // session protocol is fire-and-forget, so a local warning is the only way to report the
-                        // failure.
+                        // exception escape: an escape would discard it for every reader attached to this writer
+                        // element and skip the other local topics subscribed to this remote topic.
                         Warning out(_traceLevels->logger);
                         out << _id << ": discarding sample '" << dataSample.id << "' from 'e" << elementId << '@'
                             << topicId << "': the key could not be decoded:\n"

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -198,7 +198,22 @@ TopicI::getElementSpecs(int64_t topicId, const ElementInfoSeq& infos, const shar
     {
         if (info.id > 0)
         {
-            auto key = _keyFactory->decode(_instance->getCommunicator(), info.value);
+            shared_ptr<Key> key;
+            try
+            {
+                key = _keyFactory->decode(_instance->getCommunicator(), info.value);
+            }
+            catch (const std::exception& ex)
+            {
+                // The key factory runs the application's decoder. Skip the peer key it can't decode and keep matching
+                // the remaining ones: the elements the peer announced under the other keys still attach, and a spec
+                // set missing this key is indistinguishable on the wire from one where no local element matched it.
+                Warning out(_traceLevels->logger);
+                out << "skipped a key announced on topic '" << this << "': the key could not be decoded:\n"
+                    << ex.what();
+                continue;
+            }
+
             auto p = _keyElements.find(key);
             if (p != _keyElements.end())
             {
@@ -255,7 +270,23 @@ TopicI::getElementSpecs(int64_t topicId, const ElementInfoSeq& infos, const shar
             }
             else
             {
-                peerFilter = _keyFilterFactories->decode(_instance->getCommunicator(), info.name, info.value);
+                try
+                {
+                    peerFilter = _keyFilterFactories->decode(_instance->getCommunicator(), info.name, info.value);
+                }
+                catch (const std::exception& ex)
+                {
+                    // The key filter factory runs the application's decoder. Skip the peer filter it can't decode
+                    // rather than falling back to alwaysMatchFilter the way a null return does above: a null return
+                    // means no factory is registered under that name, while a throw leaves the filter's criteria
+                    // unknown, and matching everything would attach elements the peer's filter meant to exclude.
+                    Warning out(_traceLevels->logger);
+                    out << "skipped the key filter '" << info.name << "' announced on topic '" << this
+                        << "': the filter could not be decoded:\n"
+                        << ex.what();
+                    continue;
+                }
+
                 if (!peerFilter)
                 {
                     peerFilter = alwaysMatchFilter;
@@ -397,7 +428,24 @@ TopicI::attachElements(
                     }
                     else
                     {
-                        filter = _keyFilterFactories->decode(_instance->getCommunicator(), spec.name, spec.value);
+                        try
+                        {
+                            filter = _keyFilterFactories->decode(_instance->getCommunicator(), spec.name, spec.value);
+                        }
+                        catch (const std::exception& ex)
+                        {
+                            // The key filter factory runs the application's decoder. Skip this spec and keep
+                            // attaching the remaining ones: the elements attached by the earlier specs are already
+                            // registered and their acks must still reach the peer, or it never initializes them.
+                            // Falling back to alwaysMatchFilter the way a null return does would attach elements the
+                            // peer's filter meant to exclude.
+                            Warning out(_traceLevels->logger);
+                            out << "skipped the elements of key filter '" << spec.name << "' on topic '" << this
+                                << "': the filter could not be decoded:\n"
+                                << ex.what();
+                            continue;
+                        }
+
                         if (!filter)
                         {
                             filter = alwaysMatchFilter;
@@ -448,7 +496,21 @@ TopicI::attachElements(
                 shared_ptr<Key> key;
                 if (spec.id > 0) // Key
                 {
-                    key = _keyFactory->decode(_instance->getCommunicator(), spec.value);
+                    try
+                    {
+                        key = _keyFactory->decode(_instance->getCommunicator(), spec.value);
+                    }
+                    catch (const std::exception& ex)
+                    {
+                        // The key factory runs the application's decoder. Skip this spec and keep attaching the
+                        // remaining ones: the elements attached by the earlier specs are already registered and their
+                        // acks must still reach the peer, or it never initializes them.
+                        Warning out(_traceLevels->logger);
+                        out << "skipped the elements announced under a key on topic '" << this
+                            << "': the key could not be decoded:\n"
+                            << ex.what();
+                        continue;
+                    }
                 }
 
                 if (spec.id < 0 || matchKeyFilter(filter, key))
@@ -507,7 +569,24 @@ TopicI::attachElementsAck(
                     }
                     else
                     {
-                        filter = _keyFilterFactories->decode(_instance->getCommunicator(), spec.name, spec.value);
+                        try
+                        {
+                            filter = _keyFilterFactories->decode(_instance->getCommunicator(), spec.name, spec.value);
+                        }
+                        catch (const std::exception& ex)
+                        {
+                            // The key filter factory runs the application's decoder. Skip this spec and keep
+                            // processing the remaining ones: the elements attached by the earlier specs have their
+                            // initialization callbacks queued below, and abandoning the loop would drop those along
+                            // with the ids collected in removedIds. Falling back to alwaysMatchFilter the way a null
+                            // return does would attach elements the peer's filter meant to exclude.
+                            Warning out(_traceLevels->logger);
+                            out << "skipped the acknowledged elements of key filter '" << spec.name << "' on topic '"
+                                << this << "': the filter could not be decoded:\n"
+                                << ex.what();
+                            continue;
+                        }
+
                         if (!filter)
                         {
                             filter = alwaysMatchFilter;
@@ -575,7 +654,22 @@ TopicI::attachElementsAck(
                 shared_ptr<Key> key;
                 if (spec.id > 0) // Key
                 {
-                    key = _keyFactory->decode(_instance->getCommunicator(), spec.value);
+                    try
+                    {
+                        key = _keyFactory->decode(_instance->getCommunicator(), spec.value);
+                    }
+                    catch (const std::exception& ex)
+                    {
+                        // The key factory runs the application's decoder. Skip this spec and keep processing the
+                        // remaining ones: the elements attached by the earlier specs have their initialization
+                        // callbacks queued below, and abandoning the loop would drop those along with the ids
+                        // collected in removedIds.
+                        Warning out(_traceLevels->logger);
+                        out << "skipped the acknowledged elements announced under a key on topic '" << this
+                            << "': the key could not be decoded:\n"
+                            << ex.what();
+                        continue;
+                    }
                 }
 
                 for (const auto& data : spec.elements)

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -206,8 +206,8 @@ TopicI::getElementSpecs(int64_t topicId, const ElementInfoSeq& infos, const shar
             catch (const std::exception& ex)
             {
                 // The key factory runs the application's decoder. Skip the peer key it can't decode and keep matching
-                // the remaining ones: the elements the peer announced under the other keys still attach, and a spec
-                // set missing this key is indistinguishable on the wire from one where no local element matched it.
+                // the remaining ones: the elements the peer announced under the other keys still attach, and the
+                // returned specs are indistinguishable on the wire from ones where no local element matched this key.
                 Warning out(_traceLevels->logger);
                 out << "skipped a key announced on topic '" << this << "': the key could not be decoded:\n"
                     << ex.what();
@@ -277,7 +277,7 @@ TopicI::getElementSpecs(int64_t topicId, const ElementInfoSeq& infos, const shar
                 catch (const std::exception& ex)
                 {
                     // The key filter factory runs the application's decoder. Skip the peer filter it can't decode
-                    // rather than falling back to alwaysMatchFilter the way a null return does above: a null return
+                    // rather than falling back to alwaysMatchFilter the way a null return does below: a null return
                     // means no factory is registered under that name, while a throw leaves the filter's criteria
                     // unknown, and matching everything would attach elements the peer's filter meant to exclude.
                     Warning out(_traceLevels->logger);

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -572,24 +572,22 @@ TopicI::attachElementsAck(
                         try
                         {
                             filter = _keyFilterFactories->decode(_instance->getCommunicator(), spec.name, spec.value);
+                            if (!filter)
+                            {
+                                filter = alwaysMatchFilter;
+                            }
                         }
                         catch (const std::exception& ex)
                         {
-                            // The key filter factory runs the application's decoder. Skip this spec and keep
-                            // processing the remaining ones: the elements attached by the earlier specs have their
-                            // initialization callbacks queued below, and abandoning the loop would drop those along
-                            // with the ids collected in removedIds. Falling back to alwaysMatchFilter the way a null
-                            // return does would attach elements the peer's filter meant to exclude.
+                            // The key filter factory runs the application's decoder. Leave the filter null: the loop
+                            // below then skips attaching these elements — falling back to alwaysMatchFilter the way a
+                            // null return does would attach elements the peer's filter meant to exclude — while still
+                            // recording the ids of the elements this node no longer holds in removedIds. Skipping the
+                            // whole spec would drop that bookkeeping along with the attachments.
                             Warning out(_traceLevels->logger);
                             out << "skipped the acknowledged elements of key filter '" << spec.name << "' on topic '"
                                 << this << "': the filter could not be decoded:\n"
                                 << ex.what();
-                            continue;
-                        }
-
-                        if (!filter)
-                        {
-                            filter = alwaysMatchFilter;
                         }
                     }
                 }
@@ -607,7 +605,7 @@ TopicI::attachElementsAck(
                                 initCb = dataElement
                                              ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);
                             }
-                            else if (matchKeyFilter(filter, key)) // Filter
+                            else if (filter && matchKeyFilter(filter, key)) // Filter
                             {
                                 initCb = dataElement
                                              ->attach(topicId, spec.id, key, filter, session, prx, data, now, batches);
@@ -660,15 +658,14 @@ TopicI::attachElementsAck(
                     }
                     catch (const std::exception& ex)
                     {
-                        // The key factory runs the application's decoder. Skip this spec and keep processing the
-                        // remaining ones: the elements attached by the earlier specs have their initialization
-                        // callbacks queued below, and abandoning the loop would drop those along with the ids
-                        // collected in removedIds.
+                        // The key factory runs the application's decoder. Leave the key null: the loop below then
+                        // skips attaching these elements while still recording the ids of the elements this node no
+                        // longer holds in removedIds. Skipping the whole spec would drop that bookkeeping along with
+                        // the attachments.
                         Warning out(_traceLevels->logger);
                         out << "skipped the acknowledged elements announced under a key on topic '" << this
                             << "': the key could not be decoded:\n"
                             << ex.what();
-                        continue;
                     }
                 }
 
@@ -686,7 +683,7 @@ TopicI::attachElementsAck(
                                     dataElement
                                         ->attach(topicId, spec.id, nullptr, filter, session, prx, data, now, batches);
                             }
-                            else if (matchKeyFilter(filter, key))
+                            else if (key && matchKeyFilter(filter, key))
                             {
                                 initCb = dataElement
                                              ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -206,8 +206,7 @@ TopicI::getElementSpecs(int64_t topicId, const ElementInfoSeq& infos, const shar
             catch (const std::exception& ex)
             {
                 // The key factory runs the application's decoder. Skip the peer key it can't decode and keep matching
-                // the remaining ones: the elements the peer announced under the other keys still attach, and the
-                // returned specs are indistinguishable on the wire from ones where no local element matched this key.
+                // the remaining ones.
                 Warning out(_traceLevels->logger);
                 out << "skipped a key announced on topic '" << this << "': the key could not be decoded:\n"
                     << ex.what();
@@ -435,10 +434,8 @@ TopicI::attachElements(
                         catch (const std::exception& ex)
                         {
                             // The key filter factory runs the application's decoder. Skip this spec and keep
-                            // attaching the remaining ones: the elements attached by the earlier specs are already
-                            // registered and their acks must still reach the peer, or it never initializes them.
-                            // Falling back to alwaysMatchFilter the way a null return does would attach elements the
-                            // peer's filter meant to exclude.
+                            // attaching the remaining ones. Falling back to alwaysMatchFilter the way a null return
+                            // does would attach elements the peer's filter meant to exclude.
                             Warning out(_traceLevels->logger);
                             out << "skipped the elements of key filter '" << spec.name << "' on topic '" << this
                                 << "': the filter could not be decoded:\n"
@@ -503,8 +500,7 @@ TopicI::attachElements(
                     catch (const std::exception& ex)
                     {
                         // The key factory runs the application's decoder. Skip this spec and keep attaching the
-                        // remaining ones: the elements attached by the earlier specs are already registered and their
-                        // acks must still reach the peer, or it never initializes them.
+                        // remaining ones.
                         Warning out(_traceLevels->logger);
                         out << "skipped the elements announced under a key on topic '" << this
                             << "': the key could not be decoded:\n"
@@ -579,11 +575,10 @@ TopicI::attachElementsAck(
                         }
                         catch (const std::exception& ex)
                         {
-                            // The key filter factory runs the application's decoder. Leave the filter null: the loop
-                            // below then skips attaching these elements — falling back to alwaysMatchFilter the way a
-                            // null return does would attach elements the peer's filter meant to exclude — while still
-                            // recording the ids of the elements this node no longer holds in removedIds. Skipping the
-                            // whole spec would drop that bookkeeping along with the attachments.
+                            // The key filter factory runs the application's decoder. Leave the filter null — falling
+                            // back to alwaysMatchFilter the way a null return does would attach elements the peer's
+                            // filter meant to exclude. Skipping the whole spec would drop the removedIds bookkeeping
+                            // along with the attachments.
                             Warning out(_traceLevels->logger);
                             out << "skipped the acknowledged elements of key filter '" << spec.name << "' on topic '"
                                 << this << "': the filter could not be decoded:\n"
@@ -658,10 +653,8 @@ TopicI::attachElementsAck(
                     }
                     catch (const std::exception& ex)
                     {
-                        // The key factory runs the application's decoder. Leave the key null: the loop below then
-                        // skips attaching these elements while still recording the ids of the elements this node no
-                        // longer holds in removedIds. Skipping the whole spec would drop that bookkeeping along with
-                        // the attachments.
+                        // The key factory runs the application's decoder. Leave the key null. Skipping the whole spec
+                        // would drop the removedIds bookkeeping along with the attachments.
                         Warning out(_traceLevels->logger);
                         out << "skipped the acknowledged elements announced under a key on topic '" << this
                             << "': the key could not be decoded:\n"

--- a/cpp/test/DataStorm/decoderFailures/Makefile.mk
+++ b/cpp/test/DataStorm/decoderFailures/Makefile.mk
@@ -1,0 +1,9 @@
+# Copyright (c) ZeroC, Inc.
+
+$(project)_programs        = reader writer
+$(project)_dependencies    = DataStorm Ice TestCommon
+
+$(project)_reader_sources  = Reader.cpp
+$(project)_writer_sources  = Writer.cpp
+
+tests += $(project)

--- a/cpp/test/DataStorm/decoderFailures/Reader.cpp
+++ b/cpp/test/DataStorm/decoderFailures/Reader.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+#include "TestKey.h"
+
+using namespace DataStorm;
+using namespace std;
+
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Reader::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    ReaderConfig config;
+    config.sampleCount = -1;
+    config.clearHistory = ClearHistoryPolicy::Never;
+
+    {
+        // An any-key reader matches every key of the writer, so the writer answers with one element spec per key and
+        // each spec carries its key inline. Decoding them here rejects "poison", and the spec for "good" must still
+        // attach.
+        Topic<TestKey, string> topic(node, "announcedKeys");
+        auto reader = makeAnyKeyReader(topic, "", config);
+
+        auto sample = reader.getNextUnread();
+        test(sample.getKey() == TestKey{"good"});
+        test(sample.getValue() == "announced");
+    }
+
+    {
+        // Both readers travel to the any-key writer in the same request, each carrying its key inline. The writer
+        // cannot decode "poison", and the reader on "good" must attach regardless.
+        Topic<TestKey, string> topic(node, "anyKey");
+        auto poisonReader = makeSingleKeyReader(topic, TestKey{"poison"}, "", config);
+        auto reader = makeSingleKeyReader(topic, TestKey{"good"}, "", config);
+
+        auto sample = reader.getNextUnread();
+        test(sample.getKey() == TestKey{"good"});
+        test(sample.getValue() == "spec");
+        test(!poisonReader.hasUnread());
+    }
+
+    {
+        // The key-filtered reader's criteria is a key the writer cannot decode. Matching that filter against the
+        // writer's keys must not cost the plain reader announced in the same request its attachment.
+        Topic<TestKey, string> topic(node, "keyFilter");
+        // The reader resolves the filter locally from the criteria object; only the writer decodes it off the wire.
+        topic.setKeyFilter<TestKey>(
+            "named",
+            [](const TestKey& criteria) { return [criteria](const TestKey& key) { return key == criteria; }; });
+
+        auto filteredReader = makeFilteredKeyReader(topic, Filter<TestKey>("named", TestKey{"poison"}), "", config);
+        auto reader = makeSingleKeyReader(topic, TestKey{"good"}, "", config);
+
+        auto sample = reader.getNextUnread();
+        test(sample.getValue() == "keyFiltered");
+        test(!filteredReader.hasUnread());
+    }
+
+    {
+        // The filtered reader's criteria is a key the writer cannot decode. The writer has to leave that reader
+        // unattached without dropping the unfiltered reader attached in the same request.
+        Topic<TestKey, string> topic(node, "sampleFilter");
+        auto filteredReader =
+            makeSingleKeyReader(topic, TestKey{"good"}, Filter<TestKey>("named", TestKey{"poison"}), "", config);
+        auto reader = makeSingleKeyReader(topic, TestKey{"good"}, "", config);
+
+        auto sample = reader.getNextUnread();
+        test(sample.getValue() == "filtered");
+        test(!filteredReader.hasUnread());
+    }
+}
+
+DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/decoderFailures/TestKey.h
+++ b/cpp/test/DataStorm/decoderFailures/TestKey.h
@@ -1,0 +1,59 @@
+// Copyright (c) ZeroC, Inc.
+
+#ifndef TEST_KEY_H
+#define TEST_KEY_H
+
+#include "DataStorm/DataStorm.h"
+
+#include <stdexcept>
+#include <string>
+
+// A key type whose Decoder rejects one of the values. The writer encodes "poison" without complaint, so the value
+// reaches the peer and only fails when the peer decodes it. The same type doubles as a sample filter criteria, so a
+// filter can carry a criteria the writer cannot decode.
+struct TestKey
+{
+    std::string name;
+
+    bool operator<(const TestKey& other) const { return name < other.name; }
+
+    bool operator==(const TestKey& other) const { return name == other.name; }
+};
+
+namespace DataStorm
+{
+    template<> struct Encoder<TestKey>
+    {
+        static Ice::ByteSeq encode(const Ice::CommunicatorPtr&, const TestKey& key)
+        {
+            Ice::ByteSeq bytes;
+            bytes.reserve(key.name.size());
+            for (char c : key.name)
+            {
+                bytes.push_back(static_cast<std::byte>(c));
+            }
+            return bytes;
+        }
+    };
+
+    template<> struct Decoder<TestKey>
+    {
+        static TestKey decode(const Ice::CommunicatorPtr&, const Ice::ByteSeq& data)
+        {
+            std::string name;
+            name.reserve(data.size());
+            for (std::byte b : data)
+            {
+                name += static_cast<char>(b);
+            }
+
+            if (name == "poison")
+            {
+                throw std::runtime_error("undecodable key");
+            }
+            return TestKey{name};
+        }
+    };
+}
+
+#endif

--- a/cpp/test/DataStorm/decoderFailures/Writer.cpp
+++ b/cpp/test/DataStorm/decoderFailures/Writer.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+#include "TestKey.h"
+
+using namespace DataStorm;
+using namespace std;
+
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Writer::run(int argc, char* argv[])
+{
+    Node node(argc, argv);
+
+    WriterConfig config;
+    config.sampleCount = -1;
+    config.clearHistory = ClearHistoryPolicy::Never;
+
+    cout << "testing an undecodable key in an element spec sent to a reader... " << flush;
+    {
+        // One element carries both keys, so the any-key reader is answered with a spec for a key it can decode and a
+        // spec for a key it cannot.
+        Topic<TestKey, string> topic(node, "announcedKeys");
+        auto writer = makeMultiKeyWriter(topic, {TestKey{"good"}, TestKey{"poison"}}, "", config);
+
+        writer.waitForReaders(1);
+        writer.add(TestKey{"good"}, "announced");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    cout << "testing an undecodable key in an element spec... " << flush;
+    {
+        // An any-key writer publishes the key with each sample rather than announcing it, so the reader's keys travel
+        // to this writer inline in the element specs and are decoded here.
+        Topic<TestKey, string> topic(node, "anyKey");
+        auto writer = makeAnyKeyWriter(topic, "", config);
+
+        writer.waitForReaders(1);
+        writer.add(TestKey{"good"}, "spec");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    cout << "testing an undecodable key filter criteria... " << flush;
+    {
+        Topic<TestKey, string> topic(node, "keyFilter");
+        topic.setKeyFilter<TestKey>(
+            "named",
+            [](const TestKey& criteria) { return [criteria](const TestKey& key) { return key == criteria; }; });
+
+        auto writer = makeSingleKeyWriter(topic, TestKey{"good"}, "", config);
+
+        writer.waitForReaders(1);
+        writer.update("keyFiltered");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    cout << "testing an undecodable sample filter criteria... " << flush;
+    {
+        Topic<TestKey, string> topic(node, "sampleFilter");
+        topic.setSampleFilter<TestKey>(
+            "named",
+            [](const TestKey& criteria)
+            { return [criteria](const Sample<TestKey, string>& sample) { return sample.getKey() == criteria; }; });
+
+        auto writer = makeSingleKeyWriter(topic, TestKey{"good"}, "", config);
+
+        writer.waitForReaders(1);
+        writer.update("filtered");
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+}
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/decoderFailures/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/decoderFailures/msbuild/reader/reader.vcxproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\TestKey.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3F1A6B4C-9D2E-4A87-B5C1-7E60D2A4F118}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/decoderFailures/msbuild/reader/reader.vcxproj.filters
+++ b/cpp/test/DataStorm/decoderFailures/msbuild/reader/reader.vcxproj.filters
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Reader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\TestKey.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/decoderFailures/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/decoderFailures/msbuild/writer/writer.vcxproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\TestKey.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7C48D25A-1B93-4E6F-A0D8-52B7913C6EA4}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/decoderFailures/msbuild/writer/writer.vcxproj.filters
+++ b/cpp/test/DataStorm/decoderFailures/msbuild/writer/writer.vcxproj.filters
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\TestKey.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/decoderFailures/test.py
+++ b/cpp/test/DataStorm/decoderFailures/test.py
@@ -1,0 +1,24 @@
+# Copyright (c) ZeroC, Inc.
+
+#
+# A key, a key filter or a sample filter criteria is decoded by the application's Decoder, which can throw. These
+# decodings run while a session attaches its elements, so a Decoder that rejects one value used to abandon the whole
+# request and leave the elements around it unattached: the peer never acknowledged them, so readers that had nothing
+# to do with the rejected value silently received nothing.
+#
+
+from DataStormUtil import Reader, Writer
+from Util import ClientServerTestCase, TestSuite
+
+traceProps = {
+    "DataStorm.Trace.Topic": 1,
+    "DataStorm.Trace.Session": 3,
+    "DataStorm.Trace.Data": 2,
+}
+
+TestSuite(
+    __file__,
+    [
+        ClientServerTestCase(name="Writer/Reader", client=Writer(), server=Reader(), traceProps=traceProps),
+    ],
+)


### PR DESCRIPTION
Refs #6389.

#6522 guarded the two key decodings on the initialization paths. This guards the nine that remain on the element
attachment paths, where the failure is worse than a missing diagnostic: the throw abandons the whole request, so
the elements around the rejected value are left unattached and unacknowledged and the peer never initializes them.
Readers that had nothing to do with the rejected value silently receive nothing.

A key, a key filter and a sample filter criteria all run the application's `Decoder`. The nine sites:

| Site | Decodes | Now |
| --- | --- | --- |
| `TopicI::getElementSpecs` ×2 | a peer key, a peer key filter | skip that announcement entry, keep matching the rest |
| `TopicI::attachElements` ×2 | an inline key, a peer key filter | skip that spec, keep attaching and acking the rest |
| `TopicI::attachElementsAck` ×2 | an inline key, a peer key filter | skip that spec, keep the `initCb`s and `removedIds` |
| `DataElementI::attach` ×2 | a sample filter criteria | leave that element unattached, ack nothing for it |
| `SubscriberSessionI::s` | an inline key | discard that sample |

`SessionI.cpp:225` is left alone — that one is #6507.

## Why per-item skip rather than all-or-nothing

`getElementSpecs` is pure, but the other five `TopicI` sites mutate as they iterate: each spec's
`DataElementI::attach` runs `attachKey`, which inserts into `_listeners`, populates `subscriber->keyIds`/`keys` and
queues the `onConnectedElements` callbacks. None of that unwinds. Returning an empty result would therefore leave
this node believing it is attached to peer elements the peer never hears about — a half-open attach that survives
until the session drops. In `attachElementsAck` the same throw also discards the `initCb`s accumulated so far (they
run only after the loop) and the `removedIds` that drive `detachElementsAsync`.

A partial spec set is indistinguishable on the wire from one where no local element matched, so skipping is not
observable to the peer as an error — it is the same shape as a normal partial match.

## Why a throw is not a null return

`getElementSpecs`, `attachElements` and `attachElementsAck` already fall back to `alwaysMatchFilter` when a key
filter factory returns **null**. That is fail-open for "no factory registered under that name". A throw is
different — the codec exists and failed — and failing open there would attach elements the peer's filter meant to
exclude, delivering samples it never subscribed to. The guards skip instead, with a comment at each site since it
reads as inconsistent with the line above it.

## Logging

Each site logs a `Warning` naming the topic or element, matching #6522 and the `attachTags` guard from #6343. The
session protocol is fire-and-forget, so a local warning is the only way to report the failure — the oneway dispatch
means no exception reaches the peer, and before this the only trace was a generic `Ice.Warn.Dispatch` naming
neither the topic nor the element:

```
-! warning: failed to dispatch attachElementsAck to p/1 over 127.0.0.1:50926<->127.0.0.1:12020:
   undecodable key
```

`SubscriberSessionI::s` is on the live path, so a persistently throwing decoder warns once per sample. That is
already the precedent one frame down the same call path — `DataReaderI::queue`'s `matchKey` guard warns per sample
too.

## Tests

New `cpp/test/DataStorm/decoderFailures` suite. `Decoder<TestKey>` throws on one value, and the type doubles as a
key filter and sample filter criteria. Four scenarios, each **verified red on `origin/main` and green with this
change** — every one hangs before the fix, because the reader it is asserting on never attaches:

1. **any-key reader, multi-key writer** — the writer answers with one spec per key, each carrying its key inline;
   the spec for the good key must still attach → `TopicI::attachElements` key decode
2. **any-key writer, keyed readers** — the readers' keys travel to the writer inline in the element specs →
   `TopicI::getElementSpecs` key decode
3. **key-filtered reader** whose criteria the writer cannot decode → `TopicI::getElementSpecs` filter decode
4. **sample-filtered reader** whose criteria the writer cannot decode → `DataElementI::attach`

Confirmed by the warnings the run emits, those four scenarios drive four of the nine guards. **Not covered by a
test**: the `attachElements` filter decode, both `attachElementsAck` decodes, and `SubscriberSessionI::s`. The
first three need a topology I could not construct without contorting the suite; the `s()` one is not observable —
every same-name topic in the loop rejects the same sample, so the sample is dropped with or without the guard and
only the warning differs.

No changelog fragment: a throwing `Decoder` is an application bug, so a working application never observes this,
same disposition as #6522.

Verified on macOS: `make -C cpp srcs` and `tests` clean, all 20 `cpp/DataStorm` suites pass, and the new suite ran
6× with no flake. clang-format-19 and ruff clean.
