### PR TITLE
Use Sphinx cross-reference roles consistently in Python docstrings

### DIFF
--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -100,7 +100,7 @@ Associates an object adapter with this connection.
 
 When a connection receives a request, it dispatches this request using its associated object adapter.
 If the associated object adapter is ``None``, the connection rejects any incoming request with an
-:class:`ObjectNotExistException`.
+:class:`Ice.ObjectNotExistException`.
 
 The default object adapter of an incoming connection is the object adapter that created this connection;
 the default object adapter of an outgoing connection is the communicator's default object adapter.
@@ -229,8 +229,8 @@ sndSize : int
     constexpr const char* connectionThrowException_doc = R"(throwException() -> None
 
 Raises an exception that provides the reason for the closure of this connection. For example,
-this function raises :class:`CloseConnectionException` when the connection was closed gracefully by the peer;
-it raises :class:`ConnectionAbortedException` when the connection is aborted with :func:`abort`.
+this function raises :class:`Ice.CloseConnectionException` when the connection was closed gracefully by the peer;
+it raises :class:`Ice.ConnectionAbortedException` when the connection is aborted with :meth:`~Ice.Connection.abort`.
 This function does nothing if the connection is not yet closing or closed.)";
 }
 

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -228,9 +228,9 @@ sndSize : int
 
     constexpr const char* connectionThrowException_doc = R"(throwException() -> None
 
-Raises an exception that provides the reason for the closure of this connection. For example,
-this function raises :class:`Ice.CloseConnectionException` when the connection was closed gracefully by the peer;
-it raises :class:`Ice.ConnectionAbortedException` when the connection is aborted with :meth:`~Ice.Connection.abort`.
+Raises an exception that provides the reason for the closure of this connection. For example, this function
+raises :class:`Ice.CloseConnectionException` when the connection was closed gracefully by the peer; it raises
+:class:`Ice.ConnectionAbortedException` when the connection is aborted with :meth:`~Ice.Connection.abort`.
 This function does nothing if the connection is not yet closing or closed.)";
 }
 

--- a/python/modules/IcePy/ConnectionInfo.cpp
+++ b/python/modules/IcePy/ConnectionInfo.cpp
@@ -262,8 +262,8 @@ static PyGetSetDef WSConnectionInfoGetters[] = {
     {"headers",
      reinterpret_cast<getter>(wsConnectionInfoGetHeaders),
      nullptr,
-     PyDoc_STR("dict[str, str]: The HTTP headers from the WebSocket upgrade handshake: the request headers for an "
-               "incoming connection, and the response headers for an outgoing connection."),
+     PyDoc_STR("dict[str, str]: The HTTP headers from the WebSocket upgrade handshake, with the request headers for "
+               "an incoming connection and the response headers for an outgoing connection."),
      nullptr},
     {} /* sentinel */
 };

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -132,11 +132,12 @@ This function does not generate any Python source files. Instead, the generated 
 running interpreter.
 
 This function does not generate any code for Slice files included by the Slice files being loaded. It is the caller's
-responsibility to load all necessary Slice definitions. This can be done in a single call to :func:`loadSlice` by
-providing all Slice files (including included files) in the `args` parameter, or by making multiple calls to
-:func:`loadSlice`.
+responsibility to load all necessary Slice definitions. This can be done in a single call to :func:`Ice.loadSlice`
+by providing all Slice files (including included files) in the `args` parameter, or by making multiple calls to
+:func:`Ice.loadSlice`.
 
-When :func:`loadSlice` is called multiple times with the same Slice file, the corresponding Python code is not reloaded.
+When :func:`Ice.loadSlice` is called multiple times with the same Slice file, the corresponding Python code is not
+reloaded.
 
 Parameters
 ----------

--- a/python/python/Ice/Communicator.py
+++ b/python/python/Ice/Communicator.py
@@ -84,7 +84,8 @@ class Communicator:
             created and configured with the communicator. This adapter is responsible for executing coroutines returned
             by Ice asynchronous dispatch methods and for wrapping Ice futures (from Ice Async APIs) into asyncio
             futures. This argument and the `initData` argument are mutually exclusive. If the `initData` argument is
-            provided, the event loop adapter can be set using the :attr:`InitializationData.eventLoopAdapter` attribute.
+            provided, the event loop adapter can be set using the :attr:`Ice.InitializationData.eventLoopAdapter`
+            attribute.
         initData : InitializationData | None, optional
             Options for the new communicator. This argument and the `args` argument are mutually exclusive.
         """
@@ -129,9 +130,10 @@ class Communicator:
 
     def destroy(self) -> None:
         """
-        Destroys this communicator. This function calls :func:`shutdown` implicitly. Calling this function destroys all
-        object adapters, and closes all outgoing connections. This function waits for all outstanding dispatches to
-        complete before returning. This includes "bidirectional dispatches" that execute on outgoing connections.
+        Destroys this communicator. This function calls :meth:`Ice.Communicator.shutdown` implicitly. Calling this
+        function destroys all object adapters, and closes all outgoing connections. This function waits for all
+        outstanding dispatches to complete before returning. This includes "bidirectional dispatches" that execute on
+        outgoing connections.
         """
         self._impl.destroy()
 
@@ -139,7 +141,7 @@ class Communicator:
         """
         Destroys this communicator asynchronously.
 
-        See :func:`destroy`.
+        See :meth:`Ice.Communicator.destroy`.
         """
         future = Future()
 
@@ -155,16 +157,17 @@ class Communicator:
 
     def shutdown(self) -> None:
         """
-        Shuts down this communicator. This function calls :func:`ObjectAdapter.deactivate` on all object adapters
+        Shuts down this communicator. This function calls :meth:`Ice.ObjectAdapter.deactivate` on all object adapters
         created by this communicator. Shutting down a communicator has no effect on outgoing connections.
         """
         self._impl.shutdown()
 
     def waitForShutdown(self) -> None:
         """
-        Waits for shutdown to complete. This function calls :func:`ObjectAdapter.waitForDeactivate` on all object
+        Waits for shutdown to complete. This function calls :meth:`Ice.ObjectAdapter.waitForDeactivate` on all object
         adapters created by this communicator. In a client application that does not accept incoming connections, this
-        function returns as soon as another thread calls :func:`shutdown` or :func:`destroy` on this communicator.
+        function returns as soon as another thread calls :meth:`Ice.Communicator.shutdown` or
+        :meth:`Ice.Communicator.destroy` on this communicator.
         """
         # If invoked by the main thread, waitForShutdown only blocks for the specified timeout in order to give us a
         # chance to handle signals.
@@ -173,13 +176,13 @@ class Communicator:
 
     def shutdownCompleted(self) -> Awaitable[None]:
         """
-        Returns an :class:`Awaitable` that completes when the communicator's shutdown completes.
+        Returns an :class:`~collections.abc.Awaitable` that completes when the communicator's shutdown completes.
         This task always completes successfully.
 
         Notes
         -----
         The shutdown of a communicator completes when all its incoming connections are closed.
-        Awaiting this task is equivalent to calling :func:`waitForShutdown`.
+        Awaiting this task is equivalent to calling :meth:`Ice.Communicator.waitForShutdown`.
 
         Returns
         -------
@@ -190,12 +193,12 @@ class Communicator:
 
     def isShutdown(self) -> bool:
         """
-        Checks whether or not :func:`shutdown` was called on this communicator.
+        Checks whether or not :meth:`Ice.Communicator.shutdown` was called on this communicator.
 
         Returns
         -------
         bool
-            ``True`` if :func:`shutdown` was called on this communicator, ``False`` otherwise
+            ``True`` if :meth:`Ice.Communicator.shutdown` was called on this communicator, ``False`` otherwise
         """
         return self._impl.isShutdown()
 
@@ -326,7 +329,8 @@ class Communicator:
     def createObjectAdapterWithEndpoints(self, name: str, endpoints: str) -> ObjectAdapter:
         """
         Creates a new object adapter with endpoints. This function sets the property ``name.Endpoints``,
-        and then calls :func:`createObjectAdapter`. It is provided as a convenience function. Calling this function
+        and then calls :meth:`Ice.Communicator.createObjectAdapter`. It is provided as a convenience function.
+        Calling this function
         with an empty name will result in a UUID being generated for the name.
 
         Parameters
@@ -378,7 +382,7 @@ class Communicator:
         """
         Gets the object adapter that is associated by default with new outgoing connections created by this
         communicator. This function returns ``None`` unless you set a non-``None`` default object adapter using
-        :func:`setDefaultObjectAdapter`.
+        :meth:`Ice.Communicator.setDefaultObjectAdapter`.
 
         Returns
         -------
@@ -475,7 +479,7 @@ class Communicator:
 
         Notes
         -----
-        You can set a router for an individual proxy by calling :func:`ObjectPrx.ice_router` on the proxy.
+        You can set a router for an individual proxy by calling :meth:`Ice.ObjectPrx.ice_router` on the proxy.
 
         Parameters
         ----------
@@ -512,8 +516,8 @@ class Communicator:
 
         Notes
         -----
-        You can set a locator for an individual proxy by calling :func:`ObjectPrx.ice_locator` on the proxy,
-        or for an object adapter by calling :func:`ObjectAdapter.setLocator` on the object adapter.
+        You can set a locator for an individual proxy by calling :meth:`Ice.ObjectPrx.ice_locator` on the proxy,
+        or for an object adapter by calling :meth:`Ice.ObjectAdapter.setLocator` on the object adapter.
 
         Parameters
         ----------
@@ -559,7 +563,7 @@ class Communicator:
         Returns
         -------
         Awaitable[None]
-            An :class:`Awaitable` that completes when all batch requests have been sent.
+            An :class:`~collections.abc.Awaitable` that completes when all batch requests have been sent.
 
         Raises
         ------
@@ -571,8 +575,8 @@ class Communicator:
     def createAdmin(self, adminAdapter: ObjectAdapter | None, adminId: Identity) -> ObjectPrx:
         """
         Adds the Admin object with all its facets to the provided object adapter.
-        If ``Ice.Admin.ServerId`` is set and the provided object adapter has a :class:`Locator`,
-        this function registers the Admin's Process facet with the :class:`Locator`'s :class:`LocatorRegistry`.
+        If ``Ice.Admin.ServerId`` is set and the provided object adapter has a :class:`Ice.LocatorPrx`,
+        this function registers the Admin's Process facet with the locator's :class:`Ice.LocatorRegistryPrx`.
 
         Parameters
         ----------
@@ -600,10 +604,10 @@ class Communicator:
         """
         Gets a proxy to the main facet of the Admin object.
 
-        ``getAdmin`` also creates the Admin object and creates and activates the ``Ice.Admin`` object adapter to host
-        this Admin object if ``Ice.Admin.Endpoints`` is set. The identity of the Admin object created by ``getAdmin``
+        This function also creates the Admin object and creates and activates the ``Ice.Admin`` object adapter to host
+        this Admin object if ``Ice.Admin.Endpoints`` is set. The identity of the Admin object created by this function
         is ``{value of Ice.Admin.InstanceName}/admin``, or ``{UUID}/admin`` when ``Ice.Admin.InstanceName`` is not set.
-        If ``Ice.Admin.DelayCreation`` is ``0`` or not set, ``getAdmin`` is called by the communicator initialization,
+        If ``Ice.Admin.DelayCreation`` is ``0`` or not set, this function is called by the communicator initialization,
         after initialization of all plugins.
 
         Returns
@@ -651,7 +655,7 @@ class Communicator:
         -------
         Object | None
             The servant associated with this Admin facet, or ``None`` if this facet is implemented by the Ice
-            runtime. See :meth:`findAdminFacet` for the list of such facets.
+            runtime. See :meth:`Ice.Communicator.findAdminFacet` for the list of such facets.
 
         Raises
         ------
@@ -685,7 +689,7 @@ class Communicator:
         Notes
         -----
         Some Admin facets are implemented by the Ice runtime itself rather than by a Python servant. The
-        ``Properties`` facet is returned as an :class:`IcePy.NativePropertiesAdmin`, which is not an :class:`Object`.
+        ``Properties`` facet is returned as an ``IcePy.NativePropertiesAdmin``, which is not an :class:`Ice.Object`.
         The other runtime facets, such as ``Process`` and ``Metrics``, are reported as ``None`` even though they are
         registered and reachable through the Admin object.
         """
@@ -699,7 +703,7 @@ class Communicator:
         -------
         dict[str, Object | IcePy.NativePropertiesAdmin]
             A collection containing all the facet names and servants of the Admin object. Facets implemented by the
-            Ice runtime with no Python servant are omitted; see :meth:`findAdminFacet`.
+            Ice runtime with no Python servant are omitted; see :meth:`Ice.Communicator.findAdminFacet`.
 
         Raises
         ------

--- a/python/python/Ice/Communicator.py
+++ b/python/python/Ice/Communicator.py
@@ -130,7 +130,7 @@ class Communicator:
 
     def destroy(self) -> None:
         """
-        Destroys this communicator. This function calls :meth:`Ice.Communicator.shutdown` implicitly. Calling this
+        Destroys this communicator. This function calls :meth:`~Ice.Communicator.shutdown` implicitly. Calling this
         function destroys all object adapters, and closes all outgoing connections. This function waits for all
         outstanding dispatches to complete before returning. This includes "bidirectional dispatches" that execute on
         outgoing connections.
@@ -141,7 +141,7 @@ class Communicator:
         """
         Destroys this communicator asynchronously.
 
-        See :meth:`Ice.Communicator.destroy`.
+        See :meth:`~Ice.Communicator.destroy`.
         """
         future = Future()
 
@@ -166,8 +166,8 @@ class Communicator:
         """
         Waits for shutdown to complete. This function calls :meth:`Ice.ObjectAdapter.waitForDeactivate` on all object
         adapters created by this communicator. In a client application that does not accept incoming connections, this
-        function returns as soon as another thread calls :meth:`Ice.Communicator.shutdown` or
-        :meth:`Ice.Communicator.destroy` on this communicator.
+        function returns as soon as another thread calls :meth:`~Ice.Communicator.shutdown` or
+        :meth:`~Ice.Communicator.destroy` on this communicator.
         """
         # If invoked by the main thread, waitForShutdown only blocks for the specified timeout in order to give us a
         # chance to handle signals.
@@ -182,7 +182,7 @@ class Communicator:
         Notes
         -----
         The shutdown of a communicator completes when all its incoming connections are closed.
-        Awaiting this task is equivalent to calling :meth:`Ice.Communicator.waitForShutdown`.
+        Awaiting this task is equivalent to calling :meth:`~Ice.Communicator.waitForShutdown`.
 
         Returns
         -------
@@ -193,12 +193,12 @@ class Communicator:
 
     def isShutdown(self) -> bool:
         """
-        Checks whether or not :meth:`Ice.Communicator.shutdown` was called on this communicator.
+        Checks whether or not :meth:`~Ice.Communicator.shutdown` was called on this communicator.
 
         Returns
         -------
         bool
-            ``True`` if :meth:`Ice.Communicator.shutdown` was called on this communicator, ``False`` otherwise
+            ``True`` if :meth:`~Ice.Communicator.shutdown` was called on this communicator, ``False`` otherwise
         """
         return self._impl.isShutdown()
 
@@ -328,10 +328,9 @@ class Communicator:
 
     def createObjectAdapterWithEndpoints(self, name: str, endpoints: str) -> ObjectAdapter:
         """
-        Creates a new object adapter with endpoints. This function sets the property ``name.Endpoints``,
-        and then calls :meth:`Ice.Communicator.createObjectAdapter`. It is provided as a convenience function.
-        Calling this function
-        with an empty name will result in a UUID being generated for the name.
+        Creates a new object adapter with endpoints. This function sets the property ``name.Endpoints``, and then
+        calls :meth:`~Ice.Communicator.createObjectAdapter`. It is provided as a convenience function. Calling this
+        function with an empty name will result in a UUID being generated for the name.
 
         Parameters
         ----------
@@ -382,7 +381,7 @@ class Communicator:
         """
         Gets the object adapter that is associated by default with new outgoing connections created by this
         communicator. This function returns ``None`` unless you set a non-``None`` default object adapter using
-        :meth:`Ice.Communicator.setDefaultObjectAdapter`.
+        :meth:`~Ice.Communicator.setDefaultObjectAdapter`.
 
         Returns
         -------
@@ -655,7 +654,7 @@ class Communicator:
         -------
         Object | None
             The servant associated with this Admin facet, or ``None`` if this facet is implemented by the Ice
-            runtime. See :meth:`Ice.Communicator.findAdminFacet` for the list of such facets.
+            runtime. See :meth:`~Ice.Communicator.findAdminFacet` for the list of such facets.
 
         Raises
         ------
@@ -689,7 +688,7 @@ class Communicator:
         Notes
         -----
         Some Admin facets are implemented by the Ice runtime itself rather than by a Python servant. The
-        ``Properties`` facet is returned as an ``IcePy.NativePropertiesAdmin``, which is not an :class:`Ice.Object`.
+        ``Properties`` facet is returned as an :class:`Ice.NativePropertiesAdmin`, which is not an :class:`Ice.Object`.
         The other runtime facets, such as ``Process`` and ``Metrics``, are reported as ``None`` even though they are
         registered and reachable through the Admin object.
         """
@@ -703,7 +702,7 @@ class Communicator:
         -------
         dict[str, Object | IcePy.NativePropertiesAdmin]
             A collection containing all the facet names and servants of the Admin object. Facets implemented by the
-            Ice runtime with no Python servant are omitted; see :meth:`Ice.Communicator.findAdminFacet`.
+            Ice runtime with no Python servant are omitted; see :meth:`~Ice.Communicator.findAdminFacet`.
 
         Raises
         ------

--- a/python/python/Ice/Exception.py
+++ b/python/python/Ice/Exception.py
@@ -6,7 +6,7 @@ from builtins import Exception as BuiltinsException
 class Exception(BuiltinsException):
     """
     Abstract base class for all Ice exceptions.
-    It has only two derived classes: :class:`LocalException` and :class:`UserException`.
+    It has only two derived classes: :class:`Ice.LocalException` and :class:`Ice.UserException`.
     """
 
     _ice_id: str

--- a/python/python/Ice/ImplicitContext.py
+++ b/python/python/Ice/ImplicitContext.py
@@ -77,7 +77,7 @@ class ImplicitContext:
         -------
         str
             The value associated with the key, or the empty string if no value is associated with the key.
-            :meth:`Ice.ImplicitContext.containsKey` allows you to distinguish between an empty-string value and no
+            :meth:`~Ice.ImplicitContext.containsKey` allows you to distinguish between an empty-string value and no
             value at all.
         """
         return self._impl.get(key)

--- a/python/python/Ice/ImplicitContext.py
+++ b/python/python/Ice/ImplicitContext.py
@@ -77,7 +77,8 @@ class ImplicitContext:
         -------
         str
             The value associated with the key, or the empty string if no value is associated with the key.
-            :func:`containsKey` allows you to distinguish between an empty-string value and no value at all.
+            :meth:`Ice.ImplicitContext.containsKey` allows you to distinguish between an empty-string value and no
+            value at all.
         """
         return self._impl.get(key)
 

--- a/python/python/Ice/InitializationData.py
+++ b/python/python/Ice/InitializationData.py
@@ -25,19 +25,21 @@ class InitializationData:
     ----------
     properties : Ice.Properties | None
         The properties for the communicator.
-        If not ``None``, this corresponds to the object returned by the :func:`Communicator.getProperties` function.
+        If not ``None``, this corresponds to the object returned by the :meth:`Ice.Communicator.getProperties` function.
     logger : Ice.Logger | None
         The logger for the communicator.
     threadStart : Callable[[], None] | None
-        A :class:`Callable` that is invoked whenever the communicator starts a new thread.
+        A :class:`~collections.abc.Callable` that is invoked whenever the communicator starts a new thread.
     threadStop : Callable[[], None] | None
-        A :class:`Callable` that is invoked whenever a thread created by the communicator is about to be destroyed.
+        A :class:`~collections.abc.Callable` that is invoked whenever a thread created by the communicator is about
+        to be destroyed.
     executor : Callable[[Callable[[], None], Connection], None] | None
-        A :class:`Callable` that the communicator invokes to execute dispatches and async invocation callbacks.
+        A :class:`~collections.abc.Callable` that the communicator invokes to execute dispatches and async invocation
+        callbacks.
         The callable receives two arguments: a callable and an Ice.Connection object.
         The executor must eventually invoke the callable with no arguments.
     batchRequestInterceptor : Callable[[Ice.BatchRequest, int, int], None] | None
-        A :class:`Callable` that is invoked by the Ice runtime to enqueue a batch request.
+        A :class:`~collections.abc.Callable` that is invoked by the Ice runtime to enqueue a batch request.
         The callable receives three arguments: a BatchRequest object, an integer representing the number of requests
         currently in the queue, and an integer representing the number of bytes consumed by the requests in the queue.
         The interceptor calls ``enqueue`` on the BatchRequest to confirm queuing of the request; a request that is not
@@ -47,7 +49,7 @@ class InitializationData:
         executing coroutines returned by Ice asynchronous dispatch functions and for wrapping Ice futures (from Ice
         Async APIs) into futures that can be awaited in the application's event loop.
     sliceLoader : Callable[[str], Ice.Value | Ice.UserException | None] | None
-        A :class:`Callable` used to create instances of Slice classes and user exceptions.
+        A :class:`~collections.abc.Callable` used to create instances of Slice classes and user exceptions.
         Applications can supply a custom slice loader that the Ice runtime will use during unmarshaling.
         The callable receives one argument: a type ID or compact type ID (as a string) and returns a new instance of the
         corresponding class or exception, or ``None`` if no such class or exception could be found.

--- a/python/python/Ice/InvocationFuture.py
+++ b/python/python/Ice/InvocationFuture.py
@@ -34,13 +34,13 @@ class InvocationFuture(Future):
         """
         Cancels the invocation.
 
-        This function invokes :func:`Future.cancel` to cancel the underlying future.
+        This function invokes :meth:`Ice.Future.cancel` to cancel the underlying future.
         If the cancellation is successful, the associated invocation is also cancelled.
 
         Cancelling an invocation prevents a queued invocation from being sent.
         If the invocation has already been sent, cancellation ensures that any reply from the server is ignored.
 
-        After cancellation, :func:`done` returns ``True``, and attempting to retrieve the result raises an
+        After cancellation, :meth:`Ice.Future.done` returns ``True``, and attempting to retrieve the result raises an
         :class:`Ice.InvocationCanceledException`.
 
         Notes

--- a/python/python/Ice/LocalExceptions.py
+++ b/python/python/Ice/LocalExceptions.py
@@ -355,7 +355,7 @@ class AlreadyRegisteredException(LocalException):
     @property
     def kindOfObject(self) -> str:
         """
-        Returns the kind of object that is already registered, such as "servant", "facet", "default servant",
+        Returns the kind of object that is already registered, one of "servant", "facet", "default servant",
         "servant locator", "plugin", "object adapter", or "object adapter with router".
 
         Returns

--- a/python/python/Ice/LocalExceptions.py
+++ b/python/python/Ice/LocalExceptions.py
@@ -44,7 +44,7 @@ class DispatchException(LocalException):
     @property
     def replyStatus(self) -> int:
         """
-        Returns the reply status as an int (see :class:`ReplyStatus`).
+        Returns the reply status as an int (see :class:`Ice.ReplyStatus`).
 
         Returns
         -------
@@ -148,8 +148,8 @@ class OperationNotExistException(RequestFailedException):
 
 class UnknownException(DispatchException):
     """
-    The exception that is raised when a dispatch failed with an exception that is not a :class:`LocalException` or a
-    :class:`UserException`.
+    The exception that is raised when a dispatch failed with an exception that is not a :class:`Ice.LocalException`
+    or a :class:`Ice.UserException`.
     """
 
     _ice_id = "::Ice::UnknownException"
@@ -161,8 +161,8 @@ class UnknownException(DispatchException):
 @final
 class UnknownLocalException(UnknownException):
     """
-    The exception that is raised when a dispatch failed with a :class:`LocalException` that is not a
-    :class:`DispatchException`.
+    The exception that is raised when a dispatch failed with a :class:`Ice.LocalException` that is not a
+    :class:`Ice.DispatchException`.
     """
 
     _ice_id = "::Ice::UnknownLocalException"
@@ -174,7 +174,7 @@ class UnknownLocalException(UnknownException):
 @final
 class UnknownUserException(UnknownException):
     """
-    The exception that is raised when a client receives a :class:`UserException` that was not declared in the
+    The exception that is raised when a client receives a :class:`Ice.UserException` that was not declared in the
     operation's exception specification.
     """
 
@@ -355,8 +355,8 @@ class AlreadyRegisteredException(LocalException):
     @property
     def kindOfObject(self) -> str:
         """
-        Returns the kind of object that is already registered: "servant", "facet", "default servant",
-        "servant locator", "plugin", "object adapter", "object adapter with router".
+        Returns the kind of object that is already registered, such as "servant", "facet", "default servant",
+        "servant locator", "plugin", "object adapter", or "object adapter with router".
 
         Returns
         -------
@@ -509,7 +509,7 @@ class NotRegisteredException(LocalException):
 @final
 class ObjectAdapterDeactivatedException(LocalException):
     """
-    The exception that is raised when attempting to use an :class:`ObjectAdapter` that has been deactivated.
+    The exception that is raised when attempting to use an :class:`Ice.ObjectAdapter` that has been deactivated.
     """
 
     _ice_id = "::Ice::ObjectAdapterDeactivatedException"
@@ -518,7 +518,7 @@ class ObjectAdapterDeactivatedException(LocalException):
 @final
 class ObjectAdapterDestroyedException(LocalException):
     """
-    The exception that is raised when attempting to use an :class:`ObjectAdapter` that has been destroyed.
+    The exception that is raised when attempting to use an :class:`Ice.ObjectAdapter` that has been destroyed.
     """
 
     _ice_id = "::Ice::ObjectAdapterDestroyedException"
@@ -527,8 +527,8 @@ class ObjectAdapterDestroyedException(LocalException):
 @final
 class ObjectAdapterIdInUseException(LocalException):
     """
-    The exception that is raised when an :class:`ObjectAdapter` cannot be activated. This can happen when a
-    :class:`Locator` implementation detects another active :class:`ObjectAdapter` with the same adapter ID.
+    The exception that is raised when an :class:`Ice.ObjectAdapter` cannot be activated. This can happen when a
+    :class:`Ice.Locator` implementation detects another active :class:`Ice.ObjectAdapter` with the same adapter ID.
     """
 
     _ice_id = "::Ice::ObjectAdapterIdInUseException"
@@ -555,8 +555,9 @@ class SecurityException(LocalException):
 @final
 class TwowayOnlyException(LocalException):
     """
-    The exception that is raised when attempting to invoke an operation with ``ice_oneway``, ``ice_batchOneway``,
-    ``ice_datagram``, or ``ice_batchDatagram``, and the operation has a return value, an out parameter, or an exception
+    The exception that is raised when attempting to invoke an operation with :meth:`Ice.ObjectPrx.ice_oneway`,
+    :meth:`Ice.ObjectPrx.ice_batchOneway`, :meth:`Ice.ObjectPrx.ice_datagram`, or
+    :meth:`Ice.ObjectPrx.ice_batchDatagram`, and the operation has a return value, an out parameter, or an exception
     specification.
     """
 

--- a/python/python/Ice/ObjectAdapter.py
+++ b/python/python/Ice/ObjectAdapter.py
@@ -23,9 +23,9 @@ class ObjectAdapter:
     An object adapter is the main server-side Ice API. It has two main purposes:
 
     - accept incoming connections from clients and dispatch requests received over these connections
-      (see :meth:`Ice.ObjectAdapter.activate`); and
-    - maintain servants that handle the requests (see :meth:`Ice.ObjectAdapter.add`,
-      :meth:`Ice.ObjectAdapter.addDefaultServant`).
+      (see :meth:`~Ice.ObjectAdapter.activate`); and
+    - maintain servants that handle the requests (see :meth:`~Ice.ObjectAdapter.add`,
+      :meth:`~Ice.ObjectAdapter.addDefaultServant`).
 
     An object adapter can dispatch "bidirectional requests"--requests it receives over an outgoing connection
     instead of a more common incoming connection. It can also dispatch collocated requests (with no connection at all).
@@ -71,7 +71,7 @@ class ObjectAdapter:
     def hold(self) -> None:
         """
         Stops reading requests from incoming connections. Outstanding dispatches are not affected.
-        The object adapter can be reactivated with :meth:`Ice.ObjectAdapter.activate`.
+        The object adapter can be reactivated with :meth:`~Ice.ObjectAdapter.activate`.
 
         Notes
         -----
@@ -82,7 +82,7 @@ class ObjectAdapter:
 
     def waitForHold(self) -> None:
         """
-        Waits until the object adapter is in the holding state (see :meth:`Ice.ObjectAdapter.hold`) and the dispatch of
+        Waits until the object adapter is in the holding state (see :meth:`~Ice.ObjectAdapter.hold`) and the dispatch of
         requests received over incoming connections has completed.
 
         Notes
@@ -100,7 +100,7 @@ class ObjectAdapter:
         Deactivates this object adapter: stops accepting new connections from clients and closes gracefully all
         incoming connections created by this object adapter once all outstanding dispatches have completed.
         If this object adapter is indirect, this function also unregisters the object adapter from the locator
-        (see :meth:`Ice.ObjectAdapter.activate`).
+        (see :meth:`~Ice.ObjectAdapter.activate`).
 
         This function does not cancel outstanding dispatches: it lets them execute until completion.
         A deactivated object adapter cannot be reactivated again; it can only be destroyed.
@@ -109,7 +109,7 @@ class ObjectAdapter:
 
     def waitForDeactivate(self) -> None:
         """
-        Waits until :meth:`Ice.ObjectAdapter.deactivate` is called on this object adapter and all connections accepted
+        Waits until :meth:`~Ice.ObjectAdapter.deactivate` is called on this object adapter and all connections accepted
         by this object adapter are closed. A connection is closed only after all outstanding dispatches on this
         connection have completed.
         """
@@ -120,12 +120,12 @@ class ObjectAdapter:
 
     def isDeactivated(self) -> bool:
         """
-        Checks whether or not :meth:`Ice.ObjectAdapter.deactivate` was called on this object adapter.
+        Checks whether or not :meth:`~Ice.ObjectAdapter.deactivate` was called on this object adapter.
 
         Returns
         -------
         bool
-            ``True`` if :meth:`Ice.ObjectAdapter.deactivate` has been called on this object adapter, ``False``
+            ``True`` if :meth:`~Ice.ObjectAdapter.deactivate` has been called on this object adapter, ``False``
             otherwise.
         """
         return self._impl.isDeactivated()
@@ -144,7 +144,7 @@ class ObjectAdapter:
 
         Notes
         -----
-        This function is equivalent to calling :meth:`Ice.ObjectAdapter.addFacet` with an empty facet.
+        This function is equivalent to calling :meth:`~Ice.ObjectAdapter.addFacet` with an empty facet.
 
         Parameters
         ----------
@@ -417,7 +417,7 @@ class ObjectAdapter:
     def findByProxy(self, proxy: ObjectPrx) -> Object | None:
         """
         Looks up a servant with an identity and a facet. It's equivalent to calling
-        :meth:`Ice.ObjectAdapter.findFacet`.
+        :meth:`~Ice.ObjectAdapter.findFacet`.
 
         Notes
         -----

--- a/python/python/Ice/ObjectAdapter.py
+++ b/python/python/Ice/ObjectAdapter.py
@@ -23,8 +23,9 @@ class ObjectAdapter:
     An object adapter is the main server-side Ice API. It has two main purposes:
 
     - accept incoming connections from clients and dispatch requests received over these connections
-      (see :func:`activate`); and
-    - maintain servants that handle the requests (see :func:`add`, :func:`addDefaultServant`).
+      (see :meth:`Ice.ObjectAdapter.activate`); and
+    - maintain servants that handle the requests (see :meth:`Ice.ObjectAdapter.add`,
+      :meth:`Ice.ObjectAdapter.addDefaultServant`).
 
     An object adapter can dispatch "bidirectional requests"--requests it receives over an outgoing connection
     instead of a more common incoming connection. It can also dispatch collocated requests (with no connection at all).
@@ -70,7 +71,7 @@ class ObjectAdapter:
     def hold(self) -> None:
         """
         Stops reading requests from incoming connections. Outstanding dispatches are not affected.
-        The object adapter can be reactivated with :func:`activate`.
+        The object adapter can be reactivated with :meth:`Ice.ObjectAdapter.activate`.
 
         Notes
         -----
@@ -81,8 +82,8 @@ class ObjectAdapter:
 
     def waitForHold(self) -> None:
         """
-        Waits until the object adapter is in the holding state (see :func:`hold`) and the dispatch of requests received
-        over incoming connections has completed.
+        Waits until the object adapter is in the holding state (see :meth:`Ice.ObjectAdapter.hold`) and the dispatch of
+        requests received over incoming connections has completed.
 
         Notes
         -----
@@ -99,7 +100,7 @@ class ObjectAdapter:
         Deactivates this object adapter: stops accepting new connections from clients and closes gracefully all
         incoming connections created by this object adapter once all outstanding dispatches have completed.
         If this object adapter is indirect, this function also unregisters the object adapter from the locator
-        (see :func:`activate`).
+        (see :meth:`Ice.ObjectAdapter.activate`).
 
         This function does not cancel outstanding dispatches: it lets them execute until completion.
         A deactivated object adapter cannot be reactivated again; it can only be destroyed.
@@ -108,8 +109,9 @@ class ObjectAdapter:
 
     def waitForDeactivate(self) -> None:
         """
-        Waits until :func:`deactivate` is called on this object adapter and all connections accepted by this object adapter
-        are closed. A connection is closed only after all outstanding dispatches on this connection have completed.
+        Waits until :meth:`Ice.ObjectAdapter.deactivate` is called on this object adapter and all connections accepted
+        by this object adapter are closed. A connection is closed only after all outstanding dispatches on this
+        connection have completed.
         """
         # If invoked by the main thread, waitForDeactivate only blocks for the specified timeout in order to give us a
         # chance to handle signals.
@@ -118,12 +120,13 @@ class ObjectAdapter:
 
     def isDeactivated(self) -> bool:
         """
-        Checks whether or not :func:`deactivate` was called on this object adapter.
+        Checks whether or not :meth:`Ice.ObjectAdapter.deactivate` was called on this object adapter.
 
         Returns
         -------
         bool
-            ``True`` if :func:`deactivate` has been called on this object adapter, ``False`` otherwise.
+            ``True`` if :meth:`Ice.ObjectAdapter.deactivate` has been called on this object adapter, ``False``
+            otherwise.
         """
         return self._impl.isDeactivated()
 
@@ -141,7 +144,7 @@ class ObjectAdapter:
 
         Notes
         -----
-        This function is equivalent to calling :func:`addFacet` with an empty facet.
+        This function is equivalent to calling :meth:`Ice.ObjectAdapter.addFacet` with an empty facet.
 
         Parameters
         ----------
@@ -245,7 +248,7 @@ class ObjectAdapter:
           - If a servant locator is found, the object adapter tries to find a servant using this servant locator.
 
         - If all the previous steps fail, the object adapter gives up and the caller receives an
-          :class:`ObjectNotExistException` or a :class:`FacetNotExistException`.
+          :class:`Ice.ObjectNotExistException` or a :class:`Ice.FacetNotExistException`.
 
         Parameters
         ----------
@@ -413,7 +416,8 @@ class ObjectAdapter:
 
     def findByProxy(self, proxy: ObjectPrx) -> Object | None:
         """
-        Looks up a servant with an identity and a facet. It's equivalent to calling :func:`findFacet`.
+        Looks up a servant with an identity and a facet. It's equivalent to calling
+        :meth:`Ice.ObjectAdapter.findFacet`.
 
         Notes
         -----

--- a/python/python/Ice/ObjectPrx.py
+++ b/python/python/Ice/ObjectPrx.py
@@ -744,7 +744,7 @@ class ObjectPrx(IcePy.ObjectPrx):
 
         See Also
         --------
-        :meth:`Ice.ObjectPrx.ice_collocationOptimized`
+        :meth:`~Ice.ObjectPrx.ice_collocationOptimized`
         """
         return super().ice_isCollocationOptimized()
 
@@ -975,7 +975,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         connection and ignore the return value.
 
         When this proxy reaches its target object through collocation optimization (see
-        :meth:`Ice.ObjectPrx.ice_collocationOptimized`), this function returns ``None``: collocated invocations
+        :meth:`~Ice.ObjectPrx.ice_collocationOptimized`), this function returns ``None``: collocated invocations
         don't use a connection.
         """
         return super().ice_getConnection()
@@ -999,7 +999,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         connection and ignore the result.
 
         When this proxy reaches its target object through collocation optimization (see
-        :meth:`Ice.ObjectPrx.ice_collocationOptimized`), the :class:`~collections.abc.Awaitable` holds ``None``:
+        :meth:`~Ice.ObjectPrx.ice_collocationOptimized`), the :class:`~collections.abc.Awaitable` holds ``None``:
         collocated invocations don't use a connection.
         """
         return super().ice_getConnectionAsync()
@@ -1020,10 +1020,10 @@ class ObjectPrx(IcePy.ObjectPrx):
 
         Notes
         -----
-        A proxy with connection caching disabled (see :meth:`Ice.ObjectPrx.ice_connectionCached`) never caches a
+        A proxy with connection caching disabled (see :meth:`~Ice.ObjectPrx.ice_connectionCached`) never caches a
         connection: for such a proxy, this function always returns ``None``. This function also returns ``None`` when
         this proxy reaches its target object through collocation optimization (see
-        :meth:`Ice.ObjectPrx.ice_collocationOptimized`): collocated invocations don't use a connection.
+        :meth:`~Ice.ObjectPrx.ice_collocationOptimized`): collocated invocations don't use a connection.
         """
         return super().ice_getCachedConnection()
 

--- a/python/python/Ice/ObjectPrx.py
+++ b/python/python/Ice/ObjectPrx.py
@@ -186,7 +186,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         Awaitable[ObjectPrx | None]
-            An :class:`Awaitable` that completes when the invocation completes.
+            An :class:`~collections.abc.Awaitable` that completes when the invocation completes.
             It holds a new proxy with the requested facet, or ``None`` if the source proxy is ``None`` or if the
             target object/facet does not support the requested type.
         """
@@ -248,7 +248,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         Awaitable[bool]
-            An :class:`Awaitable` that completes when the invocation completes.
+            An :class:`~collections.abc.Awaitable` that completes when the invocation completes.
             It holds ``True`` if the target object implements the Slice interface specified by ``id``
             or implements a derived interface, ``False`` otherwise.
         """
@@ -277,7 +277,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         Awaitable[None]
-            An :class:`Awaitable` that completes when the invocation completes.
+            An :class:`~collections.abc.Awaitable` that completes when the invocation completes.
         """
         return Object._op_ice_ping.invokeAsync(self, ((), context))
 
@@ -309,7 +309,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         Awaitable[list[str]]
-            An :class:`Awaitable` that completes when the invocation completes.
+            An :class:`~collections.abc.Awaitable` that completes when the invocation completes.
             It holds the Slice type IDs of the interfaces supported by the target object, in alphabetical order.
         """
         return Object._op_ice_ids.invokeAsync(self, ((), context))
@@ -342,7 +342,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         Awaitable[str]
-            An :class:`Awaitable` that completes when the invocation completes.
+            An :class:`~collections.abc.Awaitable` that completes when the invocation completes.
             It holds the Slice type ID of the most-derived interface.
         """
         return Object._op_ice_id.invokeAsync(self, ((), context))
@@ -398,12 +398,13 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         Awaitable[tuple[bool, bytes]]
-            An :class:`Awaitable` that completes when the invocation completes. It holds a success flag and an
-            encapsulation. If the operation completed successfully, the flag is ``True`` and the encapsulation
-            contains the encoded out-parameters and return value (the return value follows any out-parameters).
-            If the operation raised a user exception, the flag is ``False`` and the encapsulation contains the
-            encoded user exception. If the operation raised a runtime exception, the :class:`Awaitable` raises it
-            directly. When this proxy is a oneway, datagram, or batch proxy, the flag is always ``True`` and the
+            An :class:`~collections.abc.Awaitable` that completes when the invocation completes. It holds a success
+            flag and an encapsulation. If the operation completed successfully, the flag is ``True`` and the
+            encapsulation contains the encoded out-parameters and return value (the return value follows any
+            out-parameters). If the operation raised a user exception, the flag is ``False`` and the encapsulation
+            contains the encoded user exception. If the operation raised a runtime exception, the
+            :class:`~collections.abc.Awaitable` raises it directly.
+            When this proxy is a oneway, datagram, or batch proxy, the flag is always ``True`` and the
             encapsulation is empty.
         """
         return super().ice_invokeAsync(operation, mode, inParams, ctx)
@@ -743,7 +744,7 @@ class ObjectPrx(IcePy.ObjectPrx):
 
         See Also
         --------
-        ice_collocationOptimized
+        :meth:`Ice.ObjectPrx.ice_collocationOptimized`
         """
         return super().ice_isCollocationOptimized()
 
@@ -974,8 +975,8 @@ class ObjectPrx(IcePy.ObjectPrx):
         connection and ignore the return value.
 
         When this proxy reaches its target object through collocation optimization (see
-        ``ice_collocationOptimized``), this function returns ``None``: collocated invocations don't use
-        a connection.
+        :meth:`Ice.ObjectPrx.ice_collocationOptimized`), this function returns ``None``: collocated invocations
+        don't use a connection.
         """
         return super().ice_getConnection()
 
@@ -983,13 +984,13 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         Gets the connection for this proxy. If the proxy does not yet have an established connection
         or its connection is closed or being closed, it first attempts to create a new connection.
-        For a fixed proxy, the returned :class:`Awaitable` holds the connection this proxy is bound to,
+        For a fixed proxy, the returned :class:`~collections.abc.Awaitable` holds the connection this proxy is bound to,
         even when this connection is closed.
 
         Returns
         -------
         Awaitable[Connection | None]
-            An :class:`Awaitable` that completes when the connection is available.
+            An :class:`~collections.abc.Awaitable` that completes when the connection is available.
             It holds the Connection for this proxy.
 
         Notes
@@ -998,8 +999,8 @@ class ObjectPrx(IcePy.ObjectPrx):
         connection and ignore the result.
 
         When this proxy reaches its target object through collocation optimization (see
-        ``ice_collocationOptimized``), the :class:`Awaitable` holds ``None``: collocated invocations
-        don't use a connection.
+        :meth:`Ice.ObjectPrx.ice_collocationOptimized`), the :class:`~collections.abc.Awaitable` holds ``None``:
+        collocated invocations don't use a connection.
         """
         return super().ice_getConnectionAsync()
 
@@ -1019,10 +1020,10 @@ class ObjectPrx(IcePy.ObjectPrx):
 
         Notes
         -----
-        A proxy with connection caching disabled (see ``ice_connectionCached``) never caches a connection:
-        for such a proxy, this function always returns ``None``. This function also returns ``None`` when
+        A proxy with connection caching disabled (see :meth:`Ice.ObjectPrx.ice_connectionCached`) never caches a
+        connection: for such a proxy, this function always returns ``None``. This function also returns ``None`` when
         this proxy reaches its target object through collocation optimization (see
-        ``ice_collocationOptimized``): collocated invocations don't use a connection.
+        :meth:`Ice.ObjectPrx.ice_collocationOptimized`): collocated invocations don't use a connection.
         """
         return super().ice_getCachedConnection()
 
@@ -1039,7 +1040,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         Awaitable[None]
-            An :class:`Awaitable` that completes when the flush completes.
+            An :class:`~collections.abc.Awaitable` that completes when the flush completes.
         """
         return super().ice_flushBatchRequestsAsync()
 

--- a/python/python/Ice/ProcessLogger.py
+++ b/python/python/Ice/ProcessLogger.py
@@ -27,7 +27,7 @@ def getProcessLogger() -> Logger:
 def setProcessLogger(logger: Logger):
     """
     Sets the per-process logger. Communicators created after this call use this logger unless a logger is set in
-    :class:`InitializationData` or configured through logger properties such as ``Ice.LogFile``.
+    :class:`Ice.InitializationData` or configured through logger properties such as ``Ice.LogFile``.
 
     Parameters
     ----------

--- a/python/python/Ice/ServantLocator.py
+++ b/python/python/Ice/ServantLocator.py
@@ -12,7 +12,8 @@ class ServantLocator(ABC):
 
     Notes
     -----
-    For simple cases, you should consider using a default servant instead (see :func:`ObjectAdapter.addDefaultServant`).
+    For simple cases, you should consider using a default servant instead
+    (see :meth:`Ice.ObjectAdapter.addDefaultServant`).
     """
 
     @abstractmethod
@@ -25,11 +26,12 @@ class ServantLocator(ABC):
         The caller (the object adapter) does not insert the returned servant into its Active Servant Map.
         This must be done by the servant locator implementation, if this is desired.
 
-        The implementation can raise any exception, including :class:`UserException`.
+        The implementation can raise any exception, including :class:`Ice.UserException`.
         The Ice runtime will marshal this exception in the response.
 
-        If you call :func:`locate` from your own code, you must also call :func:`finished` when you have finished using
-        the servant, provided that :func:`locate` did not return ``None``.
+        If you call :meth:`Ice.ServantLocator.locate` from your own code, you must also call
+        :meth:`Ice.ServantLocator.finished` when you have finished using the servant, provided that
+        :meth:`Ice.ServantLocator.locate` did not return ``None``.
 
         Parameters
         ----------
@@ -41,31 +43,33 @@ class ServantLocator(ABC):
         Object | tuple[Object, object | None] | None
             The located servant, or ``None`` if no suitable servant was found. The servant can also be returned as
             a ``(servant, cookie)`` tuple, where the cookie is an arbitrary object that will be passed to
-            :func:`finished`.
+            :meth:`Ice.ServantLocator.finished`.
         """
         pass
 
     @abstractmethod
     def finished(self, current: Current, servant: Object, cookie: object | None):
         """
-        Notifies this servant locator that the dispatch on the servant returned by :func:`locate` is complete.
-        The object adapter calls this function only when :func:`locate` didn't return ``None``.
+        Notifies this servant locator that the dispatch on the servant returned by
+        :meth:`Ice.ServantLocator.locate` is complete. The object adapter calls this function only when
+        :meth:`Ice.ServantLocator.locate` didn't return ``None``.
 
         Notes
         -----
 
-        The implementation can raise any exception, including :class:`UserException`.
-        The Ice runtime will marshal this exception in the response. If both the dispatch and :func:`finished` raise
-        an exception, the exception raised by :func:`finished` prevails and is marshaled back to the client.
+        The implementation can raise any exception, including :class:`Ice.UserException`.
+        The Ice runtime will marshal this exception in the response. If both the dispatch and
+        :meth:`Ice.ServantLocator.finished` raise an exception, the exception raised by
+        :meth:`Ice.ServantLocator.finished` prevails and is marshaled back to the client.
 
         Parameters
         ----------
         current : Current
             Information about the incoming request for which a servant was located.
         servant : Object
-            The servant that was returned by :func:`locate`.
+            The servant that was returned by :meth:`Ice.ServantLocator.locate`.
         cookie : object | None
-            The cookie that was returned by :func:`locate`.
+            The cookie that was returned by :meth:`Ice.ServantLocator.locate`.
         """
         pass
 

--- a/python/python/Ice/ServantLocator.py
+++ b/python/python/Ice/ServantLocator.py
@@ -29,9 +29,9 @@ class ServantLocator(ABC):
         The implementation can raise any exception, including :class:`Ice.UserException`.
         The Ice runtime will marshal this exception in the response.
 
-        If you call :meth:`Ice.ServantLocator.locate` from your own code, you must also call
-        :meth:`Ice.ServantLocator.finished` when you have finished using the servant, provided that
-        :meth:`Ice.ServantLocator.locate` did not return ``None``.
+        If you call :meth:`~Ice.ServantLocator.locate` from your own code, you must also call
+        :meth:`~Ice.ServantLocator.finished` when you have finished using the servant, provided that
+        :meth:`~Ice.ServantLocator.locate` did not return ``None``.
 
         Parameters
         ----------
@@ -43,7 +43,7 @@ class ServantLocator(ABC):
         Object | tuple[Object, object | None] | None
             The located servant, or ``None`` if no suitable servant was found. The servant can also be returned as
             a ``(servant, cookie)`` tuple, where the cookie is an arbitrary object that will be passed to
-            :meth:`Ice.ServantLocator.finished`.
+            :meth:`~Ice.ServantLocator.finished`.
         """
         pass
 
@@ -51,25 +51,25 @@ class ServantLocator(ABC):
     def finished(self, current: Current, servant: Object, cookie: object | None):
         """
         Notifies this servant locator that the dispatch on the servant returned by
-        :meth:`Ice.ServantLocator.locate` is complete. The object adapter calls this function only when
-        :meth:`Ice.ServantLocator.locate` didn't return ``None``.
+        :meth:`~Ice.ServantLocator.locate` is complete. The object adapter calls this function only when
+        :meth:`~Ice.ServantLocator.locate` didn't return ``None``.
 
         Notes
         -----
 
         The implementation can raise any exception, including :class:`Ice.UserException`.
         The Ice runtime will marshal this exception in the response. If both the dispatch and
-        :meth:`Ice.ServantLocator.finished` raise an exception, the exception raised by
-        :meth:`Ice.ServantLocator.finished` prevails and is marshaled back to the client.
+        :meth:`~Ice.ServantLocator.finished` raise an exception, the exception raised by
+        :meth:`~Ice.ServantLocator.finished` prevails and is marshaled back to the client.
 
         Parameters
         ----------
         current : Current
             Information about the incoming request for which a servant was located.
         servant : Object
-            The servant that was returned by :meth:`Ice.ServantLocator.locate`.
+            The servant that was returned by :meth:`~Ice.ServantLocator.locate`.
         cookie : object | None
-            The cookie that was returned by :meth:`Ice.ServantLocator.locate`.
+            The cookie that was returned by :meth:`~Ice.ServantLocator.locate`.
         """
         pass
 

--- a/python/python/Ice/ToStringMode.py
+++ b/python/python/Ice/ToStringMode.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 class ToStringMode(Enum):
     """
-    The output mode for xxxToString functions such as :func:`identityToString`.
+    The output mode for xxxToString functions such as :func:`Ice.identityToString`.
     The actual encoding format for the string is the same for all modes: you don't need to specify an
     encoding format or mode when reading such a string.
     """

--- a/python/python/Ice/Util.py
+++ b/python/python/Ice/Util.py
@@ -38,7 +38,7 @@ def initialize(
     Creates a new communicator.
 
     This function is provided for backwards compatibility.
-    New code should call the :class:`Communicator` constructor directly.
+    New code should call the :class:`Ice.Communicator` constructor directly.
 
     Parameters
     ----------
@@ -142,7 +142,7 @@ def createProperties(args: list[str] | None = None, defaults: Properties | None 
     Creates a property set initialized from command-line arguments and a default property set.
 
     This function is provided for backwards compatibility.
-    New code should call the :class:`Properties` constructor directly.
+    New code should call the :class:`Ice.Properties` constructor directly.
 
     Parameters
     ----------
@@ -168,10 +168,10 @@ def loadSlice(args: list[str]) -> None:
 
     This function does not generate any code for Slice files included by the Slice files being loaded.
     It is the caller's responsibility to load all necessary Slice definitions. This can be done in a single call to
-    :func:`loadSlice` by providing all Slice files (including included files) in the `args` parameter,
-    or by making multiple calls to :func:`loadSlice`.
+    :func:`Ice.loadSlice` by providing all Slice files (including included files) in the `args` parameter,
+    or by making multiple calls to :func:`Ice.loadSlice`.
 
-    When :func:`loadSlice` is called multiple times with the same Slice file,
+    When :func:`Ice.loadSlice` is called multiple times with the same Slice file,
     the corresponding Python code is not reloaded.
 
     Parameters

--- a/python/python/IcePy-stubs/__init__.pyi
+++ b/python/python/IcePy-stubs/__init__.pyi
@@ -157,7 +157,7 @@ class Connection:
 
         When a connection receives a request, it dispatches this request using its associated object adapter.
         If the associated object adapter is ``None``, the connection rejects any incoming request with an
-        :class:`ObjectNotExistException`.
+        :class:`Ice.ObjectNotExistException`.
 
         The default object adapter of an incoming connection is the object adapter that created this connection;
         the default object adapter of an outgoing connection is the communicator's default object adapter.
@@ -306,9 +306,9 @@ class Connection:
 
     def throwException(self) -> None:
         """
-        Raises an exception that provides the reason for the closure of this connection. For example,
-        this function raises :class:`CloseConnectionException` when the connection was closed gracefully by the peer;
-        it raises :class:`ConnectionAbortedException` when the connection is aborted with :func:`abort`.
+        Raises an exception that provides the reason for the closure of this connection. For example, this function
+        raises :class:`Ice.CloseConnectionException` when the connection was closed gracefully by the peer; it raises
+        :class:`Ice.ConnectionAbortedException` when the connection is aborted with :meth:`~Ice.Connection.abort`.
         This function does nothing if the connection is not yet closing or closed.
         """
         ...
@@ -708,8 +708,8 @@ class WSConnectionInfo(ConnectionInfo):
     """Provides access to the connection details of a WebSocket connection."""
 
     headers: dict[str, str]
-    """dict[str, str]: The HTTP headers from the WebSocket upgrade handshake: the request headers for an incoming
-    connection, and the response headers for an outgoing connection."""
+    """dict[str, str]: The HTTP headers from the WebSocket upgrade handshake, with the request headers for an incoming
+    connection and the response headers for an outgoing connection."""
 
 class WSEndpointInfo(EndpointInfo):
     """Provides access to a WebSocket endpoint's information."""


### PR DESCRIPTION
This PR makes the hand-written Python docstrings use Sphinx cross-reference roles consistently, so that references to other API members render as links in the generated API reference.

- References now use fully-qualified roles (`:meth:`Ice.Class.method``, `:class:`Ice.Class``), which is what resolves with our autodoc setup. Same-class self-references use the `~` form (`:meth:`~Ice.Communicator.shutdown``) so the rendered text stays short. `:func:` is reserved for module-level functions such as `Ice.loadSlice`.
- Double-backtick literals that name API methods (e.g. ``ice_collocationOptimized`` in `ObjectPrx.py`) are converted to roles. Property names, environment variables, and parameter names remain literals.
- Unqualified `:class:`Awaitable``/`:class:`Callable`` (which resolved to nothing) now point to `collections.abc` and link to the Python documentation via intersphinx.
- Also fixed the `AlreadyRegisteredException.kindOfObject` summary, which napoleon misparsed as a type declaration because it ended with a colon.
- The IcePy C docstrings render on the same `Ice.*` pages, so they get the same treatment: qualified roles in `Connection.cpp` and `Init.cpp`, and a rewording of the `WSConnectionInfo.headers` getter docstring, which napoleon misparsed the same way as `kindOfObject`.

The generated files (from slice2py) already emit qualified roles and are unchanged.

Verified with a nitpicky Sphinx build: no new unresolved-reference warnings, and the converted references render as links.

Fixes #6342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)