### PR TITLE
Remove release workflow inputs that nothing reads

### DIFF
--- a/.github/workflows/build-cpp-swift-deps.yml
+++ b/.github/workflows/build-cpp-swift-deps.yml
@@ -6,16 +6,10 @@ on:
       ice_version:
         required: true
         type: string
-      channel:
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       ice_version:
         description: "The Ice version number to use"
-        required: true
-      channel:
-        description: "The channel to publish to (e.g., 3.8, nightly)"
         required: true
 
 permissions:

--- a/.github/workflows/build-cpp-windows-binaries.yml
+++ b/.github/workflows/build-cpp-windows-binaries.yml
@@ -3,9 +3,6 @@ name: "Build C++ Windows Binaries"
 on:
   workflow_call:
     inputs:
-      ice_version:
-        required: false
-        type: string
       authenticode_sign:
         description: "Sign Windows binaries with Authenticode"
         required: false
@@ -13,9 +10,6 @@ on:
         default: false
   workflow_dispatch:
     inputs:
-      ice_version:
-        description: "The Ice version to build"
-        required: false
       authenticode_sign:
         description: "Sign Windows binaries with Authenticode"
         required: false

--- a/.github/workflows/build-icegridgui-jar.yml
+++ b/.github/workflows/build-icegridgui-jar.yml
@@ -2,15 +2,7 @@ name: "Build IceGrid GUI JAR"
 
 on:
   workflow_call:
-    inputs:
-      ice_version:
-        required: false
-        type: string
   workflow_dispatch:
-    inputs:
-      ice_version:
-        description: "The Ice version to build"
-        required: false
 
 jobs:
   build-icegridgui-jar:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -196,7 +196,6 @@ jobs:
     uses: ./.github/workflows/build-cpp-windows-binaries.yml
     needs: configure
     with:
-      ice_version: ${{ needs.configure.outputs.semver_version }}
       authenticode_sign: ${{ needs.configure.outputs.authenticode_sign == 'true' }}
     secrets: inherit
 
@@ -228,8 +227,6 @@ jobs:
     name: Build IceGrid GUI JAR
     uses: ./.github/workflows/build-icegridgui-jar.yml
     needs: configure
-    with:
-      ice_version: ${{ needs.configure.outputs.semver_version }}
     secrets: inherit
 
   build-windows-installer:
@@ -261,7 +258,6 @@ jobs:
     needs: configure
     with:
       ice_version: ${{ needs.configure.outputs.semver_version }}
-      channel: ${{ needs.configure.outputs.channel }}
     secrets: inherit
 
   build-all:


### PR DESCRIPTION
Three reusable workflows declared inputs that no step reads; `build-release.yml` passed real values into all three, which were silently discarded. In each case the right fix is deletion rather than wiring up:

- `build-cpp-windows-binaries.yml`: the `ice_version` consumption moved to `build-cpp-nuget-packages.yml` when the NuGet packaging was split out; the binaries build versions itself from the checked-out source.
- `build-icegridgui-jar.yml`: `ice_version` was never read; the jar is versioned by gradle from source.
- `build-cpp-swift-deps.yml`: `channel` was never read; this workflow only uploads artifacts and never publishes, so there is nothing for a channel to select. Removing it also stops manual dispatch from demanding a required value that has no effect. The sibling `ice_version` input is consumed and stays.

`build-release.yml` is the only caller of these workflows; the discarded values are no longer passed.

Fixes #6397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)