### PR TITLE
Fix RPM builds that define nameprefix

### DIFF
--- a/changelog.d/packaging/6528.md
+++ b/changelog.d/packaging/6528.md
@@ -1,0 +1,1 @@
+- Fixed RPM builds that rebrand the packages with the `nameprefix` macro: such builds previously failed during `%prep`.

--- a/packaging/rpm/ice.spec
+++ b/packaging/rpm/ice.spec
@@ -325,7 +325,7 @@ network programming interfaces and allows you to focus your efforts on
 your application logic.
 
 %prep
-%setup -q -n %{name}-%{archive_tag}
+%setup -q -n ice-%{archive_tag}
 
 %build
 #


### PR DESCRIPTION
The `%setup` directive derived the source directory name from the prefixed package name (`%{name}-%{archive_tag}`), while the source archive always extracts to an `ice-` directory, so any build defining `nameprefix` failed in `%prep`.

Verified on AlmaLinux 9: with the original spec, `rpmbuild -bp --define "nameprefix zeroc-"` fails in `%prep`; with this fix, `%prep` succeeds both with and without `nameprefix` defined.

Fixes #6528

🤖 Generated with [Claude Code](https://claude.com/claude-code)