### PR TITLE
Don't use the OpenSSL BIO's fd after the delegate transceiver lost its fd

### DIFF
--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -539,15 +539,24 @@ OpenSSL::TransceiverI::getInfo(bool incoming, string adapterName, string connect
     // adapterName is the name of the object adapter currently associated with this connection, while _adapterName
     // represents the name of the object adapter that created this connection (incoming only).
 
+    Ice::ConnectionInfoPtr delegateInfo;
+    try
+    {
+        delegateInfo = _delegate->getInfo(incoming, std::move(adapterName), std::move(connectionId));
+    }
+    catch (...)
+    {
+        invalidateBIOFd();
+        throw;
+    }
+
     X509* peerCertificate = nullptr;
     if (_peerCertificate)
     {
         peerCertificate = X509_dup(_peerCertificate);
     }
 
-    return make_shared<ConnectionInfo>(
-        _delegate->getInfo(incoming, std::move(adapterName), std::move(connectionId)),
-        peerCertificate);
+    return make_shared<ConnectionInfo>(std::move(delegateInfo), peerCertificate);
 }
 
 void
@@ -558,7 +567,27 @@ OpenSSL::TransceiverI::checkSendSize(const IceInternal::Buffer&)
 void
 OpenSSL::TransceiverI::setBufferSize(int rcvSize, int sndSize)
 {
-    _delegate->setBufferSize(rcvSize, sndSize);
+    try
+    {
+        _delegate->setBufferSize(rcvSize, sndSize);
+    }
+    catch (...)
+    {
+        invalidateBIOFd();
+        throw;
+    }
+}
+
+void
+OpenSSL::TransceiverI::invalidateBIOFd() const
+{
+    if (_ssl && _delegate->getNativeInfo()->fd() == INVALID_SOCKET)
+    {
+        // The socket BIO installed in _ssl caches the fd number. The delegate no longer holds this fd, so invalidate
+        // the BIO's copy: later TLS I/O — including handshake records written from inside SSL_accept/SSL_connect —
+        // fails with EBADF instead of touching a reused descriptor.
+        BIO_set_fd(SSL_get_wbio(_ssl), INVALID_SOCKET, BIO_NOCLOSE);
+    }
 }
 
 int

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -165,7 +165,9 @@ OpenSSL::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal::
                         break;
                     }
 
-                    if (IceInternal::connectionLost() || IceInternal::getSocketErrno() == 0)
+                    // A handshake I/O failure after the delegate lost its fd is a connection loss.
+                    if (_delegate->getNativeInfo()->fd() == INVALID_SOCKET || IceInternal::connectionLost() ||
+                        IceInternal::getSocketErrno() == 0)
                     {
                         throw ConnectionLostException(__FILE__, __LINE__, IceInternal::getSocketErrno());
                     }

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -279,14 +279,19 @@ OpenSSL::TransceiverI::close()
 {
     if (_ssl)
     {
-        int err = SSL_shutdown(_ssl);
-
-        //
-        // Call it one more time if it returned 0.
-        //
-        if (err == 0)
+        // The socket BIO installed in _ssl during initialization caches the fd number. Skip the shutdown
+        // notification when the delegate no longer holds this fd.
+        if (_delegate->getNativeInfo()->fd() != INVALID_SOCKET)
         {
-            SSL_shutdown(_ssl);
+            int err = SSL_shutdown(_ssl);
+
+            //
+            // Call it one more time if it returned 0.
+            //
+            if (err == 0)
+            {
+                SSL_shutdown(_ssl);
+            }
         }
 
         SSL_free(_ssl);
@@ -319,6 +324,12 @@ OpenSSL::TransceiverI::write(IceInternal::Buffer& buf)
     if (buf.i == buf.b.end())
     {
         return IceInternal::SocketOperationNone;
+    }
+
+    // The socket BIO installed in _ssl caches the fd number; fail instead of letting OpenSSL use a stale number.
+    if (_delegate->getNativeInfo()->fd() == INVALID_SOCKET)
+    {
+        throw ConnectionLostException(__FILE__, __LINE__);
     }
 
     //
@@ -405,6 +416,12 @@ OpenSSL::TransceiverI::read(IceInternal::Buffer& buf)
     if (buf.i == buf.b.end())
     {
         return IceInternal::SocketOperationNone;
+    }
+
+    // The socket BIO installed in _ssl caches the fd number; fail instead of letting OpenSSL use a stale number.
+    if (_delegate->getNativeInfo()->fd() == INVALID_SOCKET)
+    {
+        throw ConnectionLostException(__FILE__, __LINE__);
     }
 
     _delegate->getNativeInfo()->ready(IceInternal::SocketOperationRead, false);

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.h
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.h
@@ -55,6 +55,8 @@ namespace Ice::SSL::OpenSSL
     private:
         friend class Ice::SSL::OpenSSL::SSLEngine;
 
+        void invalidateBIOFd() const;
+
         const InstancePtr _instance;
         const Ice::SSL::OpenSSL::SSLEnginePtr _engine;
         const std::string _host;


### PR DESCRIPTION
`OpenSSL::TransceiverI::initialize` snapshots the delegate's fd into a socket BIO installed in the SSL connection object. When a buffer-size helper fails and closes the fd, the delegate forgets it (`NativeInfo::clearFd()`, #6388), but nothing invalidates the copy held by the BIO — so a later `close()` still sends close_notify through the stale number, and `write()`/`read()` on a still-Active connection reach `SSL_write`/`SSL_read` the same way, potentially hitting an unrelated descriptor that reused the number.

This change closes the window in two layers:

- Entry guards: `close()` skips the shutdown notification and `write()`/`read()` throw `ConnectionLostException` when the delegate's fd is `INVALID_SOCKET`.
- BIO invalidation at the point of loss: `getInfo()` and `setBufferSize()` — the two operations whose delegate calls can clear the fd — invalidate the BIO's cached fd (`BIO_set_fd(..., INVALID_SOCKET, BIO_NOCLOSE)`) when that happens. This covers I/O issued from inside OpenSSL itself, where entry guards cannot help — in particular handshake records written by `SSL_accept`/`SSL_connect` after a `verifyCallback → getInfo()` failure — and every other `getInfo` caller. Subsequent BIO I/O fails with `EBADF` and no retry flag.

`getInfo()` also now duplicates the peer certificate only after the delegate call succeeds, so the `X509_dup` no longer leaks when that call throws.

Verified on Ubuntu 24.04: libIce builds cleanly and the IceSSL test suite passes.

No changelog entry: the trigger requires `getsockopt`/`setsockopt` to fail on a live socket, same as #6388 which also shipped without one.

Fixes #6393

🤖 Generated with [Claude Code](https://claude.com/claude-code)