### PR TITLE
Catch and log exceptions raised by immediately-invoked future callbacks

### DIFF
--- a/changelog.d/python/future-callback-exception.md
+++ b/changelog.d/python/future-callback-exception.md
@@ -1,3 +1,3 @@
 - Fixed `Ice.Future.add_done_callback` and `Ice.InvocationFuture.add_sent_callback` in Ice for Python: when the future
-  was already completed - or the request already sent - an exception raised by the callback propagated to the caller
-  instead of being caught and logged like an exception raised by a callback registered earlier.
+  was already completed - or the request already sent - an exception raised by the callback propagated to the caller.
+  Such an exception is now caught and logged with Python's `logging` module.

--- a/changelog.d/python/future-callback-exception.md
+++ b/changelog.d/python/future-callback-exception.md
@@ -1,0 +1,3 @@
+- Fixed `Ice.Future.add_done_callback` and `Ice.InvocationFuture.add_sent_callback` in Ice for Python: when the future
+  was already completed - or the request already sent - an exception raised by the callback propagated to the caller
+  instead of being caught and logged like an exception raised by a callback registered earlier.

--- a/python/python/Ice/Future.py
+++ b/python/python/Ice/Future.py
@@ -102,6 +102,8 @@ class Future(Awaitable[_T]):
         Attaches a callback function which will be called when this future completes or is cancelled.
         If this future is already complete, ``fn`` is called immediately from the calling thread.
 
+        An exception raised by ``fn`` is caught and logged.
+
         Parameters
         ----------
         fn : Callable[[Future], Any]
@@ -111,7 +113,7 @@ class Future(Awaitable[_T]):
             if self._state == Future.StateRunning:
                 self._doneCallbacks.append(fn)
                 return
-        fn(self)
+        self._callCallbacks([fn])
 
     def result(self, timeout: int | float | None = None) -> _T:
         """

--- a/python/python/Ice/InvocationFuture.py
+++ b/python/python/Ice/InvocationFuture.py
@@ -86,6 +86,8 @@ class InvocationFuture(Future):
         Attaches a callback function which will be called when the invocation is sent.
         If the invocation has already been sent, ``fn`` is called immediately from the calling thread.
 
+        An exception raised by ``fn`` is caught and logged.
+
         Parameters
         ----------
         fn : Callable[[bool], None]
@@ -96,7 +98,7 @@ class InvocationFuture(Future):
             if not self._sent:
                 self._sentCallbacks.append(fn)
                 return
-        fn(self._sentSynchronously)
+        self._callSentCallbacks([fn], self._sentSynchronously)
 
     def sent(self, timeout: int | float | None = None) -> bool:
         """
@@ -151,11 +153,14 @@ class InvocationFuture(Future):
             self._sentCallbacks = []
             self._condition.notify_all()
 
+        self._callSentCallbacks(callbacks, sentSynchronously)
+
+    def _callSentCallbacks(self, callbacks: list[Callable[[bool], None]], sentSynchronously: bool):
         for callback in callbacks:
             try:
                 callback(sentSynchronously)
-            except Exception as ex:
-                logging.getLogger("Ice.Future").exception("sent callback raised exception: %s", ex)
+            except Exception:
+                logging.getLogger("Ice.Future").exception("sent callback raised exception")
 
 
 __all__ = ["InvocationFuture"]

--- a/python/test/Ice/ami/AllTests.py
+++ b/python/test/Ice/ami/AllTests.py
@@ -1,6 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
 import functools
+import logging
 import random
 import sys
 import threading
@@ -33,6 +34,17 @@ class CloseCallbackI:
 
     def __call__(self, connection: Ice.Connection) -> None:
         pass
+
+
+class RecordingLogHandler(logging.Handler):
+    """A logging handler that keeps the records it receives, so a test can check what was logged."""
+
+    def __init__(self):
+        logging.Handler.__init__(self)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
 
 
 class CallbackBase:
@@ -501,6 +513,39 @@ def allTestsFuture(helper: TestHelper, communicator: Ice.Communicator, collocate
     testController.resumeAdapter()
     for r in cbs:
         r.check()
+
+    print("ok")
+
+    sys.stdout.write("testing callback exception handling... ")
+    sys.stdout.flush()
+
+    # An exception raised by a done or sent callback must be caught and logged, and never propagate to the caller.
+    # This holds whether the callback was registered before or after the future completed / the request was sent.
+    def raiseInCallback(arg: Any) -> None:
+        raise RuntimeError("callback failure")
+
+    handler = RecordingLogHandler()
+    logger = logging.getLogger("Ice.Future")
+    logger.addHandler(handler)
+    propagate = logger.propagate
+    logger.propagate = False  # Keep the expected tracebacks out of the test output.
+    try:
+        pendingFuture = Ice.Future()
+        pendingFuture.add_done_callback(raiseInCallback)
+        pendingFuture.set_result(None)
+
+        Ice.Future.completed(None).add_done_callback(raiseInCallback)
+
+        sentFuture = cast(Ice.InvocationFuture, p.opAsync())
+        sentFuture.sent()
+        test(sentFuture.is_sent())
+        sentFuture.add_sent_callback(raiseInCallback)
+        sentFuture.result()
+    finally:
+        logger.propagate = propagate
+        logger.removeHandler(handler)
+
+    test(len(handler.records) == 3)
 
     print("ok")
 


### PR DESCRIPTION
Part of #6115 (finding 1).

`Ice.Future.add_done_callback` and `Ice.InvocationFuture.add_sent_callback` treat a callback differently depending on
when it is registered:

- registered while the future is still running, the callback later runs through `Future._callCallbacks` /
  `InvocationFuture.set_sent`, which catch and log any exception it raises;
- registered after the future completed (or after the request was sent), the callback runs immediately as `fn(self)` /
  `fn(self._sentSynchronously)` and its exception propagates to whoever called `add_done_callback` /
  `add_sent_callback`.

Which of the two paths a callback takes is a race in any real application, so an application can't rely on either
behavior. CPython has the same immediate-call path in `concurrent.futures.Future.add_done_callback` and wraps it in
`try/except Exception` + `LOGGER.exception`.

This PR routes the immediate call through the same catch-and-log helper as the deferred one. The sent-callback loop
moved into a new `InvocationFuture._callSentCallbacks` so both paths share it.

## Testing

`python/test/Ice/ami/AllTests.py` gets a "testing callback exception handling" block: a done callback registered before
completion, a done callback registered after completion, and a sent callback registered after the request was sent all
raise; the test checks that nothing propagates and that the three exceptions reach the `Ice.Future` logger. Against the
unfixed code, the second one escapes `add_done_callback` and fails the test.
