### PR TITLE
Use a monotonic clock for the timed waits of Ice.Future

### DIFF
--- a/python/python/Ice/Future.py
+++ b/python/python/Ice/Future.py
@@ -252,7 +252,6 @@ class Future(Awaitable[_T]):
 
         while testFn():
             if timeout is not None:
-                # Use a monotonic clock: a wall-clock adjustment must not shorten or lengthen the wait.
                 start = time.monotonic()
                 self._condition.wait(timeout)
                 # Subtract the elapsed time so far from the timeout

--- a/python/python/Ice/Future.py
+++ b/python/python/Ice/Future.py
@@ -252,10 +252,11 @@ class Future(Awaitable[_T]):
 
         while testFn():
             if timeout is not None:
-                start = time.time()
+                # Use a monotonic clock: a wall-clock adjustment must not shorten or lengthen the wait.
+                start = time.monotonic()
                 self._condition.wait(timeout)
                 # Subtract the elapsed time so far from the timeout
-                timeout -= time.time() - start
+                timeout -= time.monotonic() - start
                 if timeout <= 0:
                     return False
             else:


### PR DESCRIPTION
Part of #6115 (finding 2).

`Ice.Future._wait` computes how much of the caller's timeout is left by subtracting two `time.time()` readings.
`time.time()` is the wall clock, so an NTP correction or a manual clock change during the wait lengthens or shortens
the remaining timeout of `Future.result`, `Future.exception` and `InvocationFuture.sent`. `time.monotonic()` is the
clock meant for measuring durations, and it is what `threading.Condition.wait` already uses for its own timeout.

## Testing

No test: reproducing this needs a wall-clock step, so a test would have to monkeypatch the clock `Ice.Future` reads —
either the process-global `time.time` while Ice threads are running, or the module's `time` binding — out of
proportion to a two-line fix.

No changelog entry: the wait is only wrong while the system clock is being stepped.
