### PR TITLE
Reject mutually exclusive Ice.Communicator initialization arguments

### DIFF
--- a/changelog.d/python/communicator-mutually-exclusive-args.md
+++ b/changelog.d/python/communicator-mutually-exclusive-args.md
@@ -1,0 +1,4 @@
+- The `Ice.Communicator` constructor and `Ice.initialize` in Ice for Python now raise `ValueError` when the `initData`
+  argument is combined with the `args` or `eventLoop` argument. These arguments are mutually exclusive; previously the
+  extra argument was silently ignored, except for `Ice.Communicator(args, initData=initData)`, which replaced
+  `initData` with an object derived from `args`.

--- a/python/python/Ice/Communicator.py
+++ b/python/python/Ice/Communicator.py
@@ -87,9 +87,17 @@ class Communicator:
             provided, the event loop adapter can be set using the :attr:`InitializationData.eventLoopAdapter` attribute.
         initData : InitializationData | None, optional
             Options for the new communicator. This argument and the `args` argument are mutually exclusive.
+
+        Raises
+        ------
+        ValueError
+            If `initData` is provided together with `args` or `eventLoop`.
         """
+        if initData is not None and (args is not None or eventLoop is not None):
+            raise ValueError("the 'initData' argument is mutually exclusive with the 'args' and 'eventLoop' arguments")
+
         eventLoopAdapter = None
-        if initData:
+        if initData is not None:
             eventLoopAdapter = initData.eventLoopAdapter
         elif eventLoop:
             eventLoopAdapter = AsyncIOEventLoopAdapter(eventLoop)

--- a/python/python/Ice/Util.py
+++ b/python/python/Ice/Util.py
@@ -54,8 +54,17 @@ def initialize(
     -------
     Communicator
         The new communicator.
+
+    Raises
+    ------
+    ValueError
+        If ``initData`` is provided together with ``args`` or ``eventLoop``.
     """
-    return Communicator(initData=initData) if initData is not None else Communicator(args, eventLoop)
+    if initData is not None:
+        if args is not None or eventLoop is not None:
+            raise ValueError("the 'initData' argument is mutually exclusive with the 'args' and 'eventLoop' arguments")
+        return Communicator(initData=initData)
+    return Communicator(args, eventLoop)
 
 
 def stringVersion() -> str:

--- a/python/test/Ice/properties/Client.py
+++ b/python/test/Ice/properties/Client.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) ZeroC, Inc.
 
+import asyncio
 import sys
 
 from TestHelper import TestHelper, test
@@ -128,5 +129,41 @@ class Client(TestHelper):
         with Ice.initialize() as communicator:
             properties = communicator.getProperties()
             test(properties.getIceProperty("Ice.ProgramName") == "TestHelper.py")
+
+        print("ok")
+
+        sys.stdout.write("testing mutually exclusive communicator arguments... ")
+        sys.stdout.flush()
+
+        # initData is mutually exclusive with args and eventLoop; combining them must be rejected instead of
+        # silently ignoring one of the arguments.
+        initData = Ice.InitializationData()
+        eventLoop = asyncio.new_event_loop()
+        try:
+            try:
+                Ice.Communicator(args, initData=initData)  # type: ignore
+                test(False)
+            except ValueError:
+                pass
+
+            try:
+                Ice.Communicator(eventLoop=eventLoop, initData=initData)  # type: ignore
+                test(False)
+            except ValueError:
+                pass
+
+            try:
+                Ice.initialize(args, initData=initData)  # type: ignore
+                test(False)
+            except ValueError:
+                pass
+
+            try:
+                Ice.initialize(eventLoop=eventLoop, initData=initData)  # type: ignore
+                test(False)
+            except ValueError:
+                pass
+        finally:
+            eventLoop.close()
 
         print("ok")


### PR DESCRIPTION
Part of #6115 (finding 3).

The `Ice.Communicator` constructor and `Ice.initialize` document — through their overloads and their docstrings — that
`initData` is mutually exclusive with `args` and `eventLoop`. Combining them was accepted and silently dropped one of
the arguments:

- `Communicator(args, initData=initData)` took the event loop adapter from `initData`, then replaced `initData` itself
  with `InitializationData(properties=Properties(args))` — discarding the caller's properties, logger, executor, Slice
  loader and so on.
- `Communicator(eventLoop=eventLoop, initData=initData)` ignored `eventLoop`.
- `Ice.initialize(args, initData=initData)` ignored `args` and `eventLoop` outright.

Both now raise `ValueError`, which is what the Ice Python mapping raises for a bad argument elsewhere (`Ice.Proxy`,
`IcePy.Properties`, `IcePy.ObjectAdapter`, ...).

## Testing

`python/test/Ice/properties/Client.py` — a server-less client test — checks the three combinations. No in-tree caller
passes both.
