### PR TITLE
Untie the IcePy background waits from the lifetime of the Python object

### DIFF
--- a/changelog.d/python/6115.md
+++ b/changelog.d/python/6115.md
@@ -1,0 +1,3 @@
+- Fixed a hang in Ice for Python: when an `ObjectAdapter.waitForHold`, `ObjectAdapter.waitForDeactivate` or
+  `Communicator.waitForShutdown` call was interrupted - by a keyboard interrupt, for example - and the object was later
+  garbage-collected while the underlying wait was still blocked, the interpreter could freeze.

--- a/changelog.d/python/6115.md
+++ b/changelog.d/python/6115.md
@@ -1,3 +1,2 @@
-- Fixed a hang in Ice for Python: when an `ObjectAdapter.waitForHold`, `ObjectAdapter.waitForDeactivate` or
-  `Communicator.waitForShutdown` call was interrupted - by a keyboard interrupt, for example - and the object was later
-  garbage-collected while the underlying wait was still blocked, the interpreter could freeze.
+- Fixed a hang in Ice for Python: when a keyboard interrupt (Ctrl-C) interrupted a call to
+  `Communicator.waitForShutdown`, the interpreter could later freeze - typically when the program exits.

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -436,9 +436,16 @@ communicatorWaitForShutdown(CommunicatorObject* self, PyObject* args)
         {
             if (self->shutdownFuture == nullptr)
             {
-                self->shutdownFuture = new std::future<void>();
-                *self->shutdownFuture =
-                    std::async(std::launch::async, [&self] { (*self->communicator)->waitForShutdown(); });
+                try
+                {
+                    self->shutdownFuture = new std::future<void>{
+                        waitInThread([communicator = *self->communicator] { communicator->waitForShutdown(); })};
+                }
+                catch (...) // starting the wait can fail, for example when the system is out of resources
+                {
+                    setPythonException(current_exception());
+                    return nullptr;
+                }
             }
 
             {

--- a/python/modules/IcePy/ObjectAdapter.cpp
+++ b/python/modules/IcePy/ObjectAdapter.cpp
@@ -380,8 +380,16 @@ adapterWaitForHold(ObjectAdapterObject* self, PyObject* args)
         {
             if (!self->holdFuture)
             {
-                self->holdFuture = new std::future<void>();
-                *self->holdFuture = std::async(std::launch::async, [&self] { (*self->adapter)->waitForHold(); });
+                try
+                {
+                    self->holdFuture =
+                        new std::future<void>{waitInThread([adapter = *self->adapter] { adapter->waitForHold(); })};
+                }
+                catch (...) // starting the wait can fail, for example when the system is out of resources
+                {
+                    setPythonException(current_exception());
+                    return nullptr;
+                }
             }
 
             {
@@ -469,9 +477,16 @@ adapterWaitForDeactivate(ObjectAdapterObject* self, PyObject* args)
         {
             if (!self->deactivateFuture)
             {
-                self->deactivateFuture = new std::future<void>();
-                *self->deactivateFuture =
-                    std::async(std::launch::async, [&self] { (*self->adapter)->waitForDeactivate(); });
+                try
+                {
+                    self->deactivateFuture = new std::future<void>{
+                        waitInThread([adapter = *self->adapter] { adapter->waitForDeactivate(); })};
+                }
+                catch (...) // starting the wait can fail, for example when the system is out of resources
+                {
+                    setPythonException(current_exception());
+                    return nullptr;
+                }
             }
 
             {

--- a/python/modules/IcePy/Thread.h
+++ b/python/modules/IcePy/Thread.h
@@ -7,8 +7,42 @@
 #include "Ice/Ice.h"
 #include "Util.h"
 
+#include <future>
+#include <memory>
+#include <thread>
+
 namespace IcePy
 {
+    /// Executes a blocking wait in a new detached thread, and returns a future that completes when this wait
+    /// completes.
+    ///
+    /// The wait must not use any Python state: it keeps running - and the returned future remains safe to destroy -
+    /// after the Python object that started this wait is deallocated. This is why we don't use std::async here: the
+    /// destructor of a future returned by std::async waits for the completion of the task.
+    ///
+    /// Throws when the thread cannot be started, in which case no wait is in progress.
+    template<typename Wait> std::future<void> waitInThread(Wait wait)
+    {
+        auto promise{std::make_shared<std::promise<void>>()};
+        std::future<void> future{promise->get_future()};
+
+        std::thread{[wait = std::move(wait), promise]
+                    {
+                        try
+                        {
+                            wait();
+                            promise->set_value();
+                        }
+                        catch (...)
+                        {
+                            promise->set_exception(std::current_exception());
+                        }
+                    }}
+            .detach();
+
+        return future;
+    }
+
     /// Release Python's Global Interpreter Lock during potentially time-consuming (and non-Python related) work.
     class AllowThreads
     {


### PR DESCRIPTION
Part of #6115 (findings 4 and 5).

`adapterWaitForHold` / `adapterWaitForDeactivate` — and `communicatorWaitForShutdown` — run their blocking wait in a
`std::async(std::launch::async, ...)` task, so that a call from the main thread can return to the interpreter
periodically and let it deliver signals. Tying that task to a `std::future` has three consequences:

1. **The future's destructor joins the task.** `adapterDealloc` destroys both futures while holding the GIL. A task
   that is still blocked — exactly the state left behind when a `waitForHold()` / `waitForDeactivate()` is interrupted,
   for instance by Ctrl-C — then freezes the interpreter at adapter garbage collection: the wait can only end once
   another thread activates, deactivates or destroys the adapter, and that thread needs the GIL.
2. **Use after free.** `adapterDealloc` deletes `self->adapter` before destroying the futures, and the task
   dereferences `*self->adapter`.
3. **Dangling capture.** The task lambdas capture the `self` function parameter *by reference* (`[&self]`), and the
   task can start after that function has returned.

Rather than reorder the deallocation and release the GIL around the joins — which would still block the deallocating
thread for as long as the wait lasts — this PR detaches the wait from the Python object. The new `waitInThread` helper
in `Thread.h` runs the wait in a detached `std::thread` and completes a `std::promise`: the thread keeps its own
`Ice::ObjectAdapterPtr` / `Ice::CommunicatorPtr` and never touches Python state, and destroying a promise-backed future
waits for nothing. `adapterDealloc` and `communicatorDealloc` therefore need no change at all.

`communicatorWaitForShutdown` had the same dangling `[&self]` capture, and gets the same helper.

The three call sites also handle a failure to *start* the wait, which the old code got wrong twice over: it stored
`new std::future<void>()` in `self->holdFuture` *before* calling `std::async`, so a failed launch left an invalid
future behind for the next line to wait on, and the exception escaped the `extern "C"` frame. The field now stays null
and the failure is translated with `setPythonException`.

**Finding 5 of the issue is not a bug**, and this PR does not act on it. `Ice::ObjectAdapter::waitForDeactivate` is
declared `noexcept` in `cpp/include/Ice/ObjectAdapter.h`, so the non-main-thread branch of `adapterWaitForDeactivate`
cannot propagate a C++ exception into its `extern "C"` frame. That is precisely why it has no try/catch, while its
`waitForHold` twin — whose callee is not `noexcept` — does.

## Testing

No test: reproducing the hang requires interrupting a wait and then having the adapter garbage-collected while the task
is still blocked. A test for that would be far larger and flakier than the fix. The normal paths through these
functions stay covered by the existing tests — `python/test/Ice/adapterDeactivation` calls `waitForDeactivate`, and
nearly every Python test server calls `communicator.waitForShutdown()`.
