### PR TITLE
Match the WebSocket Connection header by token instead of by substring

### DIFF
--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -52,6 +52,25 @@ namespace
     const string _iceProtocol = "ice.zeroc.com";                   // NOLINT(cert-err58-cpp)
     const string _wsUUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"; // NOLINT(cert-err58-cpp)
 
+    // Returns true if the Connection header field - a comma-separated list of tokens, already trimmed and lowercased
+    // by HttpParser::getHeader - includes the "upgrade" token required by RFC 6455 section 4. splitString is not used
+    // here because it gives quotes their Ice property-list meaning: it would accept a quoted "upgrade", and reject a
+    // list holding a token that legitimately contains an apostrophe.
+    bool hasUpgradeToken(string_view connectionField)
+    {
+        while (!connectionField.empty())
+        {
+            auto comma = connectionField.find(',');
+            string_view token = connectionField.substr(0, comma);
+            connectionField.remove_prefix(comma == string_view::npos ? connectionField.size() : comma + 1);
+            if (IceInternal::trim(token) == "upgrade")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     //
     // Rename to avoid conflict with OS 10.10 htonll
     //
@@ -963,7 +982,7 @@ IceInternal::WSTransceiver::handleRequest(Buffer& responseBuffer)
     {
         throw WebSocketException("missing value for Connection field");
     }
-    else if (val.find("upgrade") == string::npos)
+    else if (!hasUpgradeToken(val))
     {
         throw WebSocketException("invalid value '" + val + "' for Connection field");
     }
@@ -1142,7 +1161,7 @@ IceInternal::WSTransceiver::handleResponse()
     {
         throw WebSocketException("missing value for Connection field");
     }
-    else if (val.find("upgrade") == string::npos)
+    else if (!hasUpgradeToken(val))
     {
         throw WebSocketException("invalid value '" + val + "' for Connection field");
     }

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -53,9 +53,7 @@ namespace
     const string _wsUUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"; // NOLINT(cert-err58-cpp)
 
     // Returns true if the Connection header field - a comma-separated list of tokens, already trimmed and lowercased
-    // by HttpParser::getHeader - includes the "upgrade" token required by RFC 6455 section 4. splitString is not used
-    // here because it gives quotes their Ice property-list meaning: it would accept a quoted "upgrade", and reject a
-    // list holding a token that legitimately contains an apostrophe.
+    // by HttpParser::getHeader - includes the "upgrade" token required by RFC 6455 section 4.
     bool hasUpgradeToken(string_view connectionField)
     {
         while (!connectionField.empty())

--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -756,7 +756,7 @@ internal sealed class WSTransceiver : Transceiver
         }
         else if (val != "websocket")
         {
-            throw new WebSocketException("invalid value `" + val + "' for Upgrade field");
+            throw new WebSocketException("invalid value '" + val + "' for Upgrade field");
         }
 
         //
@@ -770,7 +770,7 @@ internal sealed class WSTransceiver : Transceiver
         }
         else if (!hasUpgradeToken(val))
         {
-            throw new WebSocketException("invalid value `" + val + "' for Connection field");
+            throw new WebSocketException("invalid value '" + val + "' for Connection field");
         }
 
         //
@@ -783,7 +783,7 @@ internal sealed class WSTransceiver : Transceiver
         }
         else if (val != "13")
         {
-            throw new WebSocketException("unsupported WebSocket version `" + val + "'");
+            throw new WebSocketException("unsupported WebSocket version '" + val + "'");
         }
 
         //
@@ -796,12 +796,12 @@ internal sealed class WSTransceiver : Transceiver
         if (val != null)
         {
             string[] protocols = Ice.UtilInternal.StringUtil.splitString(val, ",") ??
-                throw new WebSocketException("invalid value `" + val + "' for WebSocket protocol");
+                throw new WebSocketException("invalid value '" + val + "' for WebSocket protocol");
             foreach (string p in protocols)
             {
                 if (!p.Trim().Equals(_iceProtocol, StringComparison.Ordinal))
                 {
-                    throw new WebSocketException("unknown value `" + p + "' for WebSocket protocol");
+                    throw new WebSocketException("unknown value '" + p + "' for WebSocket protocol");
                 }
                 addProtocol = true;
             }
@@ -816,7 +816,7 @@ internal sealed class WSTransceiver : Transceiver
         byte[] decodedKey = Convert.FromBase64String(key);
         if (decodedKey.Length != 16)
         {
-            throw new WebSocketException("invalid value `" + key + "' for WebSocket key");
+            throw new WebSocketException("invalid value '" + key + "' for WebSocket key");
         }
 
         //
@@ -931,7 +931,7 @@ internal sealed class WSTransceiver : Transceiver
         }
         else if (val != "websocket")
         {
-            throw new WebSocketException("invalid value `" + val + "' for Upgrade field");
+            throw new WebSocketException("invalid value '" + val + "' for Upgrade field");
         }
 
         //
@@ -947,7 +947,7 @@ internal sealed class WSTransceiver : Transceiver
         }
         else if (!hasUpgradeToken(val))
         {
-            throw new WebSocketException("invalid value `" + val + "' for Connection field");
+            throw new WebSocketException("invalid value '" + val + "' for Connection field");
         }
 
         //
@@ -960,7 +960,7 @@ internal sealed class WSTransceiver : Transceiver
         val = _parser.getHeader("Sec-WebSocket-Protocol", true);
         if (val != null && !val.Equals(_iceProtocol, StringComparison.Ordinal))
         {
-            throw new WebSocketException("invalid value `" + val + "' for WebSocket protocol");
+            throw new WebSocketException("invalid value '" + val + "' for WebSocket protocol");
         }
 
         //
@@ -981,7 +981,7 @@ internal sealed class WSTransceiver : Transceiver
 #pragma warning restore CA5350
         if (!val.Equals(Convert.ToBase64String(hash), StringComparison.Ordinal))
         {
-            throw new WebSocketException("invalid value `" + val + "' for Sec-WebSocket-Accept");
+            throw new WebSocketException("invalid value '" + val + "' for Sec-WebSocket-Accept");
         }
     }
 

--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -693,20 +693,9 @@ internal sealed class WSTransceiver : Transceiver
     }
 
     // Returns true if the Connection header field - a comma-separated list of tokens, already trimmed and lowercased
-    // by HttpParser.getHeader - includes the "upgrade" token required by RFC 6455 section 4. StringUtil.splitString is
-    // not used here because it gives quotes their Ice property-list meaning: it would accept a quoted "upgrade", and
-    // reject a list holding a token that legitimately contains an apostrophe.
-    private static bool hasUpgradeToken(string connectionField)
-    {
-        foreach (string token in connectionField.Split(','))
-        {
-            if (token.Trim().Equals("upgrade", StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-        return false;
-    }
+    // by HttpParser.getHeader - includes the "upgrade" token required by RFC 6455 section 4.
+    private static bool hasUpgradeToken(string connectionField) =>
+        connectionField.Split(',').Any(token => token.Trim().Equals("upgrade", StringComparison.Ordinal));
 
     private void init(ProtocolInstance instance, Transceiver del)
     {

--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -692,6 +692,22 @@ internal sealed class WSTransceiver : Transceiver
         Debug.Assert(_readBufferSize > 256);
     }
 
+    // Returns true if the Connection header field - a comma-separated list of tokens, already trimmed and lowercased
+    // by HttpParser.getHeader - includes the "upgrade" token required by RFC 6455 section 4. StringUtil.splitString is
+    // not used here because it gives quotes their Ice property-list meaning: it would accept a quoted "upgrade", and
+    // reject a list holding a token that legitimately contains an apostrophe.
+    private static bool hasUpgradeToken(string connectionField)
+    {
+        foreach (string token in connectionField.Split(','))
+        {
+            if (token.Trim().Equals("upgrade", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void init(ProtocolInstance instance, Transceiver del)
     {
         _instance = instance;
@@ -763,7 +779,7 @@ internal sealed class WSTransceiver : Transceiver
         {
             throw new WebSocketException("missing value for Connection field");
         }
-        else if (!val.Contains("upgrade", StringComparison.Ordinal))
+        else if (!hasUpgradeToken(val))
         {
             throw new WebSocketException("invalid value `" + val + "' for Connection field");
         }
@@ -940,7 +956,7 @@ internal sealed class WSTransceiver : Transceiver
         {
             throw new WebSocketException("missing value for Connection field");
         }
-        else if (!val.Contains("upgrade", StringComparison.Ordinal))
+        else if (!hasUpgradeToken(val))
         {
             throw new WebSocketException("invalid value `" + val + "' for Connection field");
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
@@ -427,6 +427,20 @@ final class WSTransceiver implements Transceiver {
         _pingPayload = new byte[0];
     }
 
+    // Returns true if the Connection header field - a comma-separated list of tokens, already trimmed
+    // and lowercased by HttpParser.getHeader - includes the "upgrade" token required by RFC 6455
+    // section 4. StringUtil.splitString is not used here because it gives quotes their Ice
+    // property-list meaning: it would accept a quoted "upgrade", and reject a list holding a token
+    // that legitimately contains an apostrophe.
+    private static boolean hasUpgradeToken(String connectionField) {
+        for (String token : connectionField.split(",")) {
+            if ("upgrade".equals(token.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void handleRequest(Buffer responseBuffer) {
         // The opening handshake must be a GET request (RFC 6455 section 4.1). We check the message type first
         // because method() (used just below) and uri() (used later) assert the parser holds a request.
@@ -459,7 +473,7 @@ final class WSTransceiver implements Transceiver {
         val = _parser.getHeader("Connection", true);
         if (val == null) {
             throw new WebSocketException("missing value for Connection field");
-        } else if (val.indexOf("upgrade") == -1) {
+        } else if (!hasUpgradeToken(val)) {
             throw new WebSocketException("invalid value `" + val + "' for Connection field");
         }
 
@@ -605,7 +619,7 @@ final class WSTransceiver implements Transceiver {
         val = _parser.getHeader("Connection", true);
         if (val == null) {
             throw new WebSocketException("missing value for Connection field");
-        } else if (val.indexOf("upgrade") == -1) {
+        } else if (!hasUpgradeToken(val)) {
             throw new WebSocketException("invalid value `" + val + "' for Connection field");
         }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
@@ -427,9 +427,8 @@ final class WSTransceiver implements Transceiver {
         _pingPayload = new byte[0];
     }
 
-    // Returns true if the Connection header field - a comma-separated list of tokens, already trimmed
-    // and lowercased by HttpParser.getHeader - includes the "upgrade" token required by RFC 6455
-    // section 4.
+    // Returns true if the Connection header field - a comma-separated list of tokens, already trimmed and lowercased
+    // by HttpParser.getHeader - includes the "upgrade" token required by RFC 6455 section 4.
     private static boolean hasUpgradeToken(String connectionField) {
         for (String token : connectionField.split(",")) {
             if ("upgrade".equals(token.trim())) {
@@ -463,7 +462,7 @@ final class WSTransceiver implements Transceiver {
         if (val == null) {
             throw new WebSocketException("missing value for Upgrade field");
         } else if (!"websocket".equals(val)) {
-            throw new WebSocketException("invalid value `" + val + "' for Upgrade field");
+            throw new WebSocketException("invalid value '" + val + "' for Upgrade field");
         }
 
         // "A |Connection| header field that includes the token 'Upgrade',
@@ -472,7 +471,7 @@ final class WSTransceiver implements Transceiver {
         if (val == null) {
             throw new WebSocketException("missing value for Connection field");
         } else if (!hasUpgradeToken(val)) {
-            throw new WebSocketException("invalid value `" + val + "' for Connection field");
+            throw new WebSocketException("invalid value '" + val + "' for Connection field");
         }
 
         // "A |Sec-WebSocket-Version| header field, with a value of 13."
@@ -480,7 +479,7 @@ final class WSTransceiver implements Transceiver {
         if (val == null) {
             throw new WebSocketException("missing value for WebSocket version");
         } else if (!"13".equals(val)) {
-            throw new WebSocketException("unsupported WebSocket version `" + val + "'");
+            throw new WebSocketException("unsupported WebSocket version '" + val + "'");
         }
 
         // "Optionally, a |Sec-WebSocket-Protocol| header field, with a list
@@ -491,12 +490,12 @@ final class WSTransceiver implements Transceiver {
         if (val != null) {
             String[] protocols = StringUtil.splitString(val, ",");
             if (protocols == null) {
-                throw new WebSocketException("invalid value `" + val + "' for WebSocket protocol");
+                throw new WebSocketException("invalid value '" + val + "' for WebSocket protocol");
             }
             for (String p : protocols) {
                 if (!_iceProtocol.equals(p.trim())) {
                     throw new WebSocketException(
-                        "unknown value `" + p + "' for WebSocket protocol");
+                        "unknown value '" + p + "' for WebSocket protocol");
                 }
                 addProtocol = true;
             }
@@ -512,10 +511,10 @@ final class WSTransceiver implements Transceiver {
         try {
             byte[] decodedKey = Base64.decode(key);
             if (decodedKey.length != 16) {
-                throw new WebSocketException("WebSocket key `" + key + "' has invalid length");
+                throw new WebSocketException("WebSocket key '" + key + "' has invalid length");
             }
         } catch (IllegalArgumentException ex) {
-            throw new WebSocketException("invalid base64 value `" + key + "' for WebSocket key");
+            throw new WebSocketException("invalid base64 value '" + key + "' for WebSocket key");
         }
 
         // Optionally validate the Origin header against the adapter's allowed-origins list.
@@ -607,7 +606,7 @@ final class WSTransceiver implements Transceiver {
         if (val == null) {
             throw new WebSocketException("missing value for Upgrade field");
         } else if (!"websocket".equals(val)) {
-            throw new WebSocketException("invalid value `" + val + "' for Upgrade field");
+            throw new WebSocketException("invalid value '" + val + "' for Upgrade field");
         }
 
         // "If the response lacks a |Connection| header field or the
@@ -618,7 +617,7 @@ final class WSTransceiver implements Transceiver {
         if (val == null) {
             throw new WebSocketException("missing value for Connection field");
         } else if (!hasUpgradeToken(val)) {
-            throw new WebSocketException("invalid value `" + val + "' for Connection field");
+            throw new WebSocketException("invalid value '" + val + "' for Connection field");
         }
 
         // "If the response includes a |Sec-WebSocket-Protocol| header field
@@ -628,7 +627,7 @@ final class WSTransceiver implements Transceiver {
         //  the WebSocket Connection_."
         val = _parser.getHeader("Sec-WebSocket-Protocol", true);
         if (val != null && !_iceProtocol.equals(val)) {
-            throw new WebSocketException("invalid value `" + val + "' for WebSocket protocol");
+            throw new WebSocketException("invalid value '" + val + "' for WebSocket protocol");
         }
 
         // "If the response lacks a |Sec-WebSocket-Accept| header field or
@@ -648,7 +647,7 @@ final class WSTransceiver implements Transceiver {
             final MessageDigest sha1 = MessageDigest.getInstance("SHA1");
             sha1.update(input.getBytes(_ascii));
             if (!val.equals(Base64.encode(sha1.digest()))) {
-                throw new WebSocketException("invalid value `" + val + "' for Sec-WebSocket-Accept");
+                throw new WebSocketException("invalid value '" + val + "' for Sec-WebSocket-Accept");
             }
         } catch (NoSuchAlgorithmException ex) {
             throw new WebSocketException(ex);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
@@ -429,9 +429,7 @@ final class WSTransceiver implements Transceiver {
 
     // Returns true if the Connection header field - a comma-separated list of tokens, already trimmed
     // and lowercased by HttpParser.getHeader - includes the "upgrade" token required by RFC 6455
-    // section 4. StringUtil.splitString is not used here because it gives quotes their Ice
-    // property-list meaning: it would accept a quoted "upgrade", and reject a list holding a token
-    // that legitimately contains an apostrophe.
+    // section 4.
     private static boolean hasUpgradeToken(String connectionField) {
         for (String token : connectionField.split(",")) {
             if ("upgrade".equals(token.trim())) {

--- a/scripts/tests/Ice/wsAllowedOrigins.py
+++ b/scripts/tests/Ice/wsAllowedOrigins.py
@@ -139,8 +139,7 @@ class WSConnectionHeaderTestCase(ClientServerTestCase):
             ("upgrade", True, "lowercase token"),
             ("keep-alive, Upgrade", True, "token in a list"),
             ("Upgrade , keep-alive", True, "token with surrounding whitespace"),
-            # An apostrophe is a legal token character, and quotes are not stripped from a token: a header field is
-            # not an Ice property list.
+            # An apostrophe is a legal token character, while a quote is not part of the token it surrounds.
             ("foo'bar, Upgrade", True, "token containing an apostrophe"),
             ("notupgrade", False, "token containing 'upgrade' as a substring"),
             ("keep-alive, upgraded", False, "list without an 'upgrade' token"),

--- a/scripts/tests/Ice/wsAllowedOrigins.py
+++ b/scripts/tests/Ice/wsAllowedOrigins.py
@@ -117,6 +117,45 @@ class WSAllowedOriginsPortTestCase(ClientServerTestCase):
         current.writeln("ok")
 
 
+class WSConnectionHeaderTestCase(ClientServerTestCase):
+    # The Connection header field is a comma-separated list of tokens, and RFC 6455 section 4 requires one of them to
+    # be an ASCII case-insensitive match for "Upgrade". A value that merely embeds "upgrade" inside a longer token,
+    # such as "notupgrade", is not such a token and must not open a WebSocket connection.
+    def __init__(self):
+        ClientServerTestCase.__init__(
+            self,
+            "Connection header token",
+            server=Server(quiet=True, waitForShutdown=False),
+        )
+
+    def runClientSide(self, current: Driver.Current) -> None:
+        current.write("testing Connection header token matching... ")
+        host = current.host
+        assert host is not None
+        port = current.driver.getTestPort(0)
+        cases = [
+            # (Connection header value, expected to be accepted, description)
+            ("Upgrade", True, "single token"),
+            ("upgrade", True, "lowercase token"),
+            ("keep-alive, Upgrade", True, "token in a list"),
+            ("Upgrade , keep-alive", True, "token with surrounding whitespace"),
+            # An apostrophe is a legal token character, and quotes are not stripped from a token: a header field is
+            # not an Ice property list.
+            ("foo'bar, Upgrade", True, "token containing an apostrophe"),
+            ("notupgrade", False, "token containing 'upgrade' as a substring"),
+            ("keep-alive, upgraded", False, "list without an 'upgrade' token"),
+            ("keep-alive", False, "list without an 'upgrade' token or substring"),
+            ('"Upgrade"', False, "double-quoted token"),
+            ("'Upgrade'", False, "single-quoted token"),
+        ]
+        for connection, expected_accepted, label in cases:
+            accepted, status = probe(host, port, None, connection=connection)
+            if accepted != expected_accepted:
+                action = "accepted" if accepted else "rejected"
+                raise RuntimeError("{0}: server {1} unexpectedly (status: {2})".format(label, action, status))
+        current.writeln("ok")
+
+
 class WSPingTestCase(ClientServerTestCase):
     # Exercises the WebSocket PING/PONG control-frame path. A zero-length ping (the common keep-alive case sent by
     # browsers and load balancers) must elicit an empty pong; before the corresponding fix the server formed
@@ -151,6 +190,7 @@ TestSuite(
         WSAllowedOriginsTestCase(),
         WSAllowedOriginsWildcardTestCase(),
         WSAllowedOriginsPortTestCase(),
+        WSConnectionHeaderTestCase(),
         WSPingTestCase(),
     ],
 )

--- a/scripts/ws_origin_probe.py
+++ b/scripts/ws_origin_probe.py
@@ -35,20 +35,27 @@ import socket
 import sys
 
 
-def probe(host: str, port: int, origin: str | None, timeout: float = 5.0) -> tuple[bool, str]:
+def probe(
+    host: str,
+    port: int,
+    origin: str | None,
+    timeout: float = 5.0,
+    connection: str = "Upgrade",
+) -> tuple[bool, str]:
     """
     Send a WebSocket upgrade and return (accepted, status_line).
 
     'accepted' is True iff the server responded with HTTP/1.1 101 ...
     'status_line' is the first line of the response, or a short error
     string if the server closed the connection without writing one.
+    'connection' is the value of the Connection request header.
     """
     key = base64.b64encode(os.urandom(16)).decode("ascii")
     lines = [
         "GET / HTTP/1.1",
         f"Host: {host}:{port}",
         "Upgrade: websocket",
-        "Connection: Upgrade",
+        f"Connection: {connection}",
         f"Sec-WebSocket-Key: {key}",
         "Sec-WebSocket-Version: 13",
         "Sec-WebSocket-Protocol: ice.zeroc.com",
@@ -109,6 +116,11 @@ def main() -> int:
     p.add_argument("port", type=int)
     p.add_argument("--origin", help="Value for the Origin request header")
     p.add_argument(
+        "--connection",
+        default="Upgrade",
+        help="Value for the Connection request header (default: Upgrade)",
+    )
+    p.add_argument(
         "--cases",
         action="store_true",
         help="Run a standard battery of cases; pass --allowed for known-good origins",
@@ -126,7 +138,7 @@ def main() -> int:
         return run_cases(args.host, args.port, args.allowed)
 
     try:
-        accepted, status = probe(args.host, args.port, args.origin)
+        accepted, status = probe(args.host, args.port, args.origin, connection=args.connection)
     except Exception as e:
         print(f"error: {e}", file=sys.stderr)
         return 2


### PR DESCRIPTION
Closes #6119

The WebSocket opening handshake accepted any `Connection` field that merely contained `upgrade` somewhere in it, so a
peer sending `Connection: notupgrade` opened a WebSocket connection. RFC 6455 section 4 requires the field to include a
token that is an ASCII case-insensitive match for `Upgrade`.

Both the server (`handleRequest`) and the client (`handleResponse`) path now split the field on commas and compare whole
tokens, in C++, C# and Java. JavaScript delegates to the platform `WebSocket`; every other mapping wraps the C++ core.

The split is hand-rolled rather than delegated to `splitString`, which the issue suggests reusing from the neighbouring
`Sec-WebSocket-Protocol` check. That helper gives quotes their Ice property-list meaning, and both failure modes
reproduce against a real server:

- `Connection: "Upgrade"` — quotes stripped, handshake accepted with `101 Switching Protocols`, even though DQUOTE is
  not a valid token character.
- `Connection: foo'bar, Upgrade` — rejected, even though an apostrophe is a legal RFC 7230 `tchar`; `splitString` reads
  it as an unmatched quote.

Both cases are in the new test matrix.

## Tests

The shared `Ice/wsAllowedOrigins` suite already drives raw handshakes over a socket, so the new case covers the server
path in all three mappings at once; `scripts/ws_origin_probe.py` gained a `connection` parameter to set the header.
Verified red before the fix (`notupgrade` returns `101 Switching Protocols`) and green after, in each mapping. The
`ws`/`wss` runs of `Ice/operations`, `Ice/proxy` and `Ice/info` also pass.

The client `handleResponse` path is not covered: it calls the same helper as the server path, and exercising it would
need a fake WebSocket server replying with a malformed `Connection` header.

## Notes

No changelog fragment: no conforming peer is affected, and every value the old code accepted that held a genuine
`upgrade` token is still accepted.

Two malformed-input behaviors are left alone as out of scope. `Connection: "x, Upgrade, y"` still passes — rejecting it
means validating every element against the `tchar` grammar, which is a much broader strictness change and is not a
regression here. And the three mappings disagree on control characters such as vertical tab; that divergence originates
in each mapping's `HttpParser` field-level trim, not in this helper.
