### PR TITLE
Remove dead C++ standard check from matlab/config/Make.rules

### DIFF
--- a/matlab/config/Make.rules
+++ b/matlab/config/Make.rules
@@ -20,11 +20,9 @@ matlab_cflags = -fexceptions \
     -DMATLAB_MEX_FILE \
     -I$(MATLAB_HOME)/extern/include
 
+# The C++ standard comes from the platform-wide cppflags in config/Make.rules.$(os).
 matlab_cppflags := $(matlab_cflags)
 
-ifneq ($(shell $(CC) -E $(lang_srcdir)/../cpp/config/cplusplus_check.cpp 1> /dev/null 2>&1; echo $$?),0)
-matlab_cppflags := $(matlab_cppflags) -std=c++17
-endif
 matlab_ldflags  := -L$(MATLAB_HOME)/bin/glnxa64 -lmx -lmex -lmat -lm -lstdc++
 
 #

--- a/matlab/config/Make.rules
+++ b/matlab/config/Make.rules
@@ -20,7 +20,6 @@ matlab_cflags = -fexceptions \
     -DMATLAB_MEX_FILE \
     -I$(MATLAB_HOME)/extern/include
 
-# The C++ standard comes from the platform-wide cppflags in config/Make.rules.$(os).
 matlab_cppflags := $(matlab_cflags)
 
 matlab_ldflags  := -L$(MATLAB_HOME)/bin/glnxa64 -lmx -lmex -lmat -lm -lstdc++


### PR DESCRIPTION
`matlab/config/Make.rules` gated `-std=c++17` on preprocessing `cpp/config/cplusplus_check.cpp`, but that file was deleted in 0ae99440e7b (Dec 2023) when the C++ build switched to an unconditional `-std=c++17`. The MATLAB copy was left behind, so the shell command always failed and the branch always fired.

- Removed the `ifneq`/`endif` probe and the `-std=c++17` it appended.

Dropped the block outright rather than hardcoding a standard: the platform-wide `cppflags` in `config/Make.rules.$(os)` already set one and are composed ahead of the project flags. No behavior change — this Makefile only builds Linux MEX modules (`glnxa64`, `.mexa64`, `x86_64-linux-gnu`) and Linux is already `-std=c++17`, so the MATLAB flag was a duplicate.