### PR TITLE
Remove unreferenced IceImpl declarations

### DIFF
--- a/swift/src/IceImpl/ObjectAdapter.mm
+++ b/swift/src/IceImpl/ObjectAdapter.mm
@@ -2,9 +2,7 @@
 
 #import "include/ObjectAdapter.h"
 #import "Convert.h"
-#import "include/Communicator.h"
 #import "include/Config.h"
-#import "include/Connection.h"
 #import "include/DispatchAdapter.h"
 #import "include/ObjectPrx.h"
 
@@ -18,12 +16,6 @@
 - (NSString*)getName
 {
     return toNSString(self.objectAdapter->getName());
-}
-
-- (ICECommunicator*)getCommunicator
-{
-    auto comm = self.objectAdapter->getCommunicator();
-    return [ICECommunicator getHandle:comm];
 }
 
 - (BOOL)activate:(NSError* _Nullable* _Nonnull)error

--- a/swift/src/IceImpl/include/Communicator.h
+++ b/swift/src/IceImpl/include/Communicator.h
@@ -18,7 +18,6 @@ ICEIMPL_API @interface ICECommunicator : ICELocalObject
 - (bool)isShutdown;
 - (nullable id)stringToProxy:(NSString*)str
                        error:(NSError* _Nullable* _Nonnull)error NS_SWIFT_NAME(stringToProxy(str:));
-;
 - (nullable id)propertyToProxy:(NSString*)property
                          error:(NSError* _Nullable* _Nonnull)error NS_SWIFT_NAME(propertyToProxy(property:));
 - (nullable NSDictionary<NSString*, NSString*>*)proxyToProperty:(ICEObjectPrx*)prx
@@ -27,13 +26,11 @@ ICEIMPL_API @interface ICECommunicator : ICELocalObject
     NS_SWIFT_NAME(proxyToProperty(prx:property:));
 - (NSString*)identityToString:(NSString*)name
                      category:(NSString*)category NS_SWIFT_NAME(identityToString(name:category:));
-;
 - (nullable ICEObjectAdapter*)createObjectAdapter:(NSString*)name error:(NSError* _Nullable* _Nonnull)error;
 - (nullable ICEObjectAdapter*)createObjectAdapterWithEndpoints:(NSString*)name
                                                      endpoints:(NSString*)endpoints
                                                          error:(NSError* _Nullable* _Nonnull)error
     NS_SWIFT_NAME(createObjectAdapterWithEndpoints(name:endpoints:));
-;
 - (nullable ICEObjectAdapter*)createObjectAdapterWithRouter:(NSString*)name
                                                      router:(ICEObjectPrx*)router
                                                       error:(NSError* _Nullable* _Nonnull)error

--- a/swift/src/IceImpl/include/ObjectAdapter.h
+++ b/swift/src/IceImpl/include/ObjectAdapter.h
@@ -1,17 +1,14 @@
 // Copyright (c) ZeroC, Inc.
 #import "LocalObject.h"
 
-@class ICECommunicator;
 @class ICEObjectPrx;
 @class ICEEndpoint;
-@class ICEConnection;
 @protocol ICEDispatchAdapter;
 
 NS_ASSUME_NONNULL_BEGIN
 
 ICEIMPL_API @interface ICEObjectAdapter : ICELocalObject
 - (NSString*)getName;
-- (ICECommunicator*)getCommunicator;
 - (BOOL)activate:(NSError* _Nullable* _Nonnull)error;
 - (void)hold;
 - (void)waitForHold;

--- a/swift/src/IceImpl/include/ObjectPrx.h
+++ b/swift/src/IceImpl/include/ObjectPrx.h
@@ -1,14 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 #import "Config.h"
 
-@class ICEObjectPrx;
-@class ICEImplicitContext;
-@class ICEProperties;
 @class ICEEndpoint;
 @class ICEConnection;
-@class ICEInputStream;
 @class ICECommunicator;
-@protocol ICELoggerProtocol;
 @protocol ICEOutputStreamHelper;
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Removes dead declarations from the Objective-C++ `IceImpl` layer.

- `-[ICEObjectAdapter getCommunicator]` — `ObjectAdapterI.getCommunicator()` returns its own stored `communicator` and never calls through `handle`, so the selector had no callers. Removing it also makes the `ICECommunicator` forward declaration and the `Communicator.h` import dead.
- Six unused forward declarations across `ObjectPrx.h` and `ObjectAdapter.h`, including `ICEInputStream`, which names no type anywhere in the repository, and a self-forward-declaration of `ICEObjectPrx`.
- Three stray `;` empty declarations in `Communicator.h`.
- The now-unused `Connection.h` import in `ObjectAdapter.mm`.

Fixes #6455.
