### PR TITLE
Don't use the CFStreams' socket after a buffer-size helper closes the fd

### DIFF
--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -482,6 +482,7 @@ IceObjC::StreamTransceiver::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceObjC::StreamTransceiver::getInfo(bool incoming, string adapterName, string connectionId) const
 {
+    lock_guard lock(_mutex);
     if (_fd == INVALID_SOCKET)
     {
         return make_shared<TCPConnectionInfo>(incoming, std::move(adapterName), std::move(connectionId));
@@ -529,6 +530,7 @@ IceObjC::StreamTransceiver::checkSendSize(const Buffer& /*buf*/)
 void
 IceObjC::StreamTransceiver::setBufferSize(int rcvSize, int sndSize)
 {
+    lock_guard lock(_mutex);
     try
     {
         setTcpBufSize(_fd, rcvSize, sndSize, _instance);

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -96,6 +96,13 @@ SocketOperation
 IceObjC::StreamTransceiver::registerWithRunLoop(SocketOperation op)
 {
     lock_guard lock(_mutex);
+    if (_state == StateConnected && _fd == INVALID_SOCKET)
+    {
+        // A failed getInfo or setBufferSize call closed the fd. The streams still reference the closed number, so
+        // don't schedule them with the run loop; report the operations as ready so the thread pool calls read or
+        // write, which throws.
+        return op;
+    }
     SocketOperation readyOp = SocketOperationNone;
     if (op & SocketOperationConnect)
     {
@@ -343,6 +350,12 @@ IceObjC::StreamTransceiver::write(Buffer& buf)
     // the stream notification callbacks with an internal lock held.
     {
         lock_guard lock(_mutex);
+        if (_fd == INVALID_SOCKET)
+        {
+            // The streams perform their I/O on the socket recorded in _fd; a failed getInfo or setBufferSize call
+            // closed it.
+            throw ConnectionLostException(__FILE__, __LINE__);
+        }
         if (_error)
         {
             checkErrorStatus(_writeStream.get(), 0, __FILE__, __LINE__);
@@ -394,6 +407,12 @@ IceObjC::StreamTransceiver::read(Buffer& buf)
     // the stream notification callbacks with an internal lock held.
     {
         lock_guard lock(_mutex);
+        if (_fd == INVALID_SOCKET)
+        {
+            // The streams perform their I/O on the socket recorded in _fd; a failed getInfo or setBufferSize call
+            // closed it.
+            throw ConnectionLostException(__FILE__, __LINE__);
+        }
         if (_error)
         {
             checkErrorStatus(0, _readStream.get(), __FILE__, __LINE__);

--- a/cpp/src/Ice/ios/StreamTransceiver.h
+++ b/cpp/src/Ice/ios/StreamTransceiver.h
@@ -77,7 +77,9 @@ namespace IceObjC
         bool _opening;
 
         // Protects the state shared with the run-loop thread, which doesn't use the Connection's mutex — including
-        // _fd (inherited from NativeInfo), whose writers hold the Connection's mutex in addition to this one.
+        // _fd (inherited from NativeInfo), whose writers hold the Connection's mutex in addition to this one. The
+        // exception is close(), which writes _fd unlocked: it only runs after the selector's finish handshake, when
+        // the run-loop thread no longer uses this transceiver.
         mutable std::mutex _mutex;
         bool _error;
 

--- a/cpp/src/Ice/ios/StreamTransceiver.h
+++ b/cpp/src/Ice/ios/StreamTransceiver.h
@@ -76,7 +76,9 @@ namespace IceObjC
         bool _writeStreamRegistered;
         bool _opening;
 
-        std::mutex _mutex;
+        // Protects the state shared with the run-loop thread, which doesn't use the Connection's mutex — including
+        // _fd (inherited from NativeInfo), whose writers hold the Connection's mutex in addition to this one.
+        mutable std::mutex _mutex;
         bool _error;
 
         State _state;


### PR DESCRIPTION
On iOS, `getInfo` and `setBufferSize` call socket helpers that close the fd on failure and then clear the transceiver's `_fd` — but the CFStream pair created by the connector/acceptor keeps performing its I/O on that socket, and the connection remains active. The next I/O then hits `assert(_fd != INVALID_SOCKET)` in debug builds, or lets `CFReadStreamRead`/`CFWriteStreamWrite` run against a number another thread may have reused.

This change closes the window in two places:

- `write()` and `read()` throw `ConnectionLostException` when `_fd` is `INVALID_SOCKET`, before touching the streams. These calls are serialized with `getInfo`/`setBufferSize` by the connection mutex, so the check at the top of the call is sufficient and the asserts deeper in the loops remain valid. This also covers `ssl`: SecureTransport routes all its I/O — including handshake records and the close notification — through the delegate's `read`/`write`, and its I/O callbacks already map `ConnectionLostException` to `errSSLClosedGraceful`.
- `registerWithRunLoop()` no longer schedules the streams with the run loop when the connected transceiver has lost its fd; it reports the requested operations as ready instead, so the thread pool immediately calls `read`/`write` and fails there.

The issue suggested detaching the CFStreams inside `getInfo`/`setBufferSize`, in the shape of #6546. That's not safe here: those methods run on an application thread, there is no CFStream API to drop the socket short of closing the stream, and the read stream is typically scheduled with the run loop exactly when the connection is idle — a stream registered with a run loop must only be used from the run loop thread (see the comment in `EventHandlerWrapper::ready`). The `registerWithRunLoop` guard is the run-loop-thread-safe equivalent: the selector stops arming the dead streams the next time it touches the handler.

Verified with a full semantic check of the file against the iphonesimulator SDK (`clang++ -fsyntax-only`); the file is compiled out of macOS builds.

No changelog entry: the trigger requires `getsockopt`/`setsockopt` to fail on a live socket, same as #6393.

Fixes #6555

🤖 Generated with [Claude Code](https://claude.com/claude-code)
