### PR TITLE
Don't hang in IceBT AcceptorI.close when the ready callback was never installed

### DIFF
--- a/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/AcceptorI.java
+++ b/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/AcceptorI.java
@@ -32,6 +32,7 @@ final class AcceptorI implements Acceptor {
     public void close() {
         synchronized (this) {
             _closed = true;
+            notify(); // Notify the acceptor thread
         }
 
         if (_socket != null) {
@@ -136,11 +137,14 @@ final class AcceptorI implements Acceptor {
 
     private void runAccept() {
         synchronized (this) {
-            // Wait for the ready callback to be set by the selector.
-            while (_readyCallback == null) {
+            // Wait for the ready callback to be set by the selector, or for the acceptor to be closed.
+            while (_readyCallback == null && !_closed) {
                 try {
                     wait();
                 } catch (InterruptedException ex) {}
+            }
+            if (_closed) {
+                return;
             }
         }
 


### PR DESCRIPTION
`AcceptorI.runAccept()` parks on the object monitor until the ready callback is installed, and only `setReadyCallback` notifies. When `close()` runs before the callback is installed — `IncomingConnectionFactory.createAcceptor` closes the acceptor when anything throws between `listen()` and the thread pool's `initialize`, for example `CommunicatorDestroyedException` while the communicator is being destroyed — the accept thread waits forever and `close()` hangs in `_thread.join()`; closing the server socket doesn't help a thread that hasn't reached `accept()` yet.

With this change, `close()` notifies under the monitor, and the wait loop also exits when the acceptor is closed, returning before entering the accept loop. The `_pending` cleanup at the end of `runAccept` is safely skipped on this path: nothing can have been accepted yet.

The C++ acceptor has no such wait; the startup end of its callback window is tracked separately by #6550 (3.9.0).

No changelog entry: creating an object adapter while another thread destroys the communicator is a real but super narrow use case.

Fixes #6551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
