### PR TITLE
Remove PHP Code that is no Longer Relevant for PHP 8.4+

### DIFF
--- a/php/BUILDING.md
+++ b/php/BUILDING.md
@@ -19,7 +19,7 @@ flowchart LR
 
 ## Prerequisites
 
-1. PHP 8.0 or higher.
+1. PHP 8.4 or higher.
 2. The Slice-to-PHP compiler (`slice2php`).
 3. The Ice for C++ test suite, for running PHP client tests against the C++ servers.
 4. Python 3.12 is required to run the tests.

--- a/php/src/Config.h
+++ b/php/src/Config.h
@@ -70,14 +70,8 @@ ZEND_BEGIN_ARG_INFO(ice_void_arginfo, 0)
 ZEND_END_ARG_INFO()
 
 // An arginfo used for __toString() methods.
-#if PHP_VERSION_ID >= 80200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(ice_to_string_arginfo, IS_STRING, 0)
-ZEND_END_ARG_INFO()
-#else
-// The return type declaration is optional with PHP < 8.2
 ZEND_BEGIN_ARG_INFO(ice_to_string_arginfo, 0)
 ZEND_END_ARG_INFO()
-#endif
 
 #ifdef ZTS
 #    define ICE_G(v) TSRMG(ice_globals_id, zend_ice_globals*, v)

--- a/php/src/Config.h
+++ b/php/src/Config.h
@@ -70,7 +70,7 @@ ZEND_BEGIN_ARG_INFO(ice_void_arginfo, 0)
 ZEND_END_ARG_INFO()
 
 // An arginfo used for __toString() methods.
-ZEND_BEGIN_ARG_INFO(ice_to_string_arginfo, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(ice_to_string_arginfo, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #ifdef ZTS


### PR DESCRIPTION
This fixes #6563. The amount of relevant code was overstated... Still good to fix though.

We should not backport this to 3.7, and no changelog fragment. We already documented our minimum version.