### PR TITLE
Close the connection when getInfo or setBufferSize fails

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1855,7 +1855,17 @@ Ice::ConnectionI::getInfo() const
     {
         rethrow_exception(_exception);
     }
-    return initConnectionInfo();
+
+    try
+    {
+        return initConnectionInfo();
+    }
+    catch (...)
+    {
+        // The failing call may have closed the socket, so close the connection as well.
+        const_cast<ConnectionI*>(this)->setState(StateClosed, current_exception());
+        throw;
+    }
 }
 
 void
@@ -1866,7 +1876,17 @@ Ice::ConnectionI::setBufferSize(int32_t rcvSize, int32_t sndSize)
     {
         rethrow_exception(_exception);
     }
-    _transceiver->setBufferSize(rcvSize, sndSize);
+
+    try
+    {
+        _transceiver->setBufferSize(rcvSize, sndSize);
+    }
+    catch (...)
+    {
+        // The failing call may have closed the socket, so close the connection as well.
+        setState(StateClosed, current_exception());
+        throw;
+    }
     _info = nullptr; // Invalidate the cached connection info
 }
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -2225,8 +2225,13 @@ Ice::ConnectionI::setState(State state)
             }
             catch (const Ice::LocalException&)
             {
-                // initConnectionInfo can fail. The state transition must complete regardless, so we ignore this
-                // exception and skip the observer update.
+                // initConnectionInfo can fail. The transition to StateClosed cannot unwind — _threadPool->finish()
+                // has already run — so skip the observer update and let the transition complete. For any other
+                // transition, propagate: the caller closes the connection.
+                if (state != StateClosed)
+                {
+                    throw;
+                }
             }
 
             if (connectionInfo)

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -2218,9 +2218,23 @@ Ice::ConnectionI::setState(State state)
         ConnectionState newState = toConnectionState(state);
         if (oldState != newState)
         {
-            _observer.attach(
-                _instance->initializationData()
-                    .observer->getConnectionObserver(initConnectionInfo(), _endpoint, newState, _observer.get()));
+            ConnectionInfoPtr connectionInfo;
+            try
+            {
+                connectionInfo = initConnectionInfo();
+            }
+            catch (const Ice::LocalException&)
+            {
+                // initConnectionInfo can fail. The state transition must complete regardless, so we ignore this
+                // exception and skip the observer update.
+            }
+
+            if (connectionInfo)
+            {
+                _observer.attach(
+                    _instance->initializationData()
+                        .observer->getConnectionObserver(connectionInfo, _endpoint, newState, _observer.get()));
+            }
         }
         if (_observer && state == StateClosed && _exception)
         {


### PR DESCRIPTION
When a transceiver's `getInfo` or `setBufferSize` fails, the transceiver may have lost its socket — the buffer-size helpers close the fd before throwing — yet the connection remained Active. A second `Connection::setBufferSize` call then reached `setTcpBufSize`, which asserts the fd is valid: an abort in debug builds, a meaningless `EBADF` `SocketException` in release.

With this change, `ConnectionI::getInfo` and `ConnectionI::setBufferSize` close the connection (`setState(StateClosed, ...)`) when the transceiver call throws, and rethrow. A connection never stays Active after its transport fails, and later calls rethrow the original exception from the `_state >= StateClosed` check instead of reaching the transport. The asserts in `setTcpBufSize` and `UdpTransceiver::setBufferSize` remain valid preconditions.

The catch is `catch (...)`: the Transceiver interface doesn't guarantee the failure surfaces as a `SocketException`, and after any exception escapes these calls the transceiver's state is uncertain — closing is the safe response.

Verified on macOS: libIce builds cleanly and the Ice/info test passes.

No changelog entry: the first failure requires `setsockopt`/`getsockopt` to fail on a live socket (practically, an oversized buffer size on a BSD-family build), same as #6388 and #6393 which shipped without one.

Fixes #6561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
