### PR TITLE
Document that Logger and observer implementations must not throw

### DIFF
--- a/cpp/include/Ice/Logger.h
+++ b/cpp/include/Ice/Logger.h
@@ -34,20 +34,24 @@ namespace Ice
         /// Prints a message.
         /// The message is printed literally, without any decorations such as executable name or timestamp.
         /// @param message The message to log.
+        /// @remark An implementation of this function must not throw exceptions.
         virtual void print(const std::string& message) = 0;
 
         /// Logs a trace message.
         /// @param category The trace category.
         /// @param message The trace message to log.
+        /// @remark An implementation of this function must not throw exceptions.
         virtual void trace(const std::string& category, const std::string& message) = 0;
 
         /// Logs a warning message.
         /// @param message The warning message to log.
+        /// @remark An implementation of this function must not throw exceptions.
         /// @see #error
         virtual void warning(const std::string& message) = 0;
 
         /// Logs an error message.
         /// @param message The error message to log.
+        /// @remark An implementation of this function must not throw exceptions.
         /// @see #warning
         virtual void error(const std::string& message) = 0;
 

--- a/csharp/src/Ice/Instrumentation.cs
+++ b/csharp/src/Ice/Instrumentation.cs
@@ -7,6 +7,9 @@ namespace Ice.Instrumentation;
 /// <summary>
 /// The base interface for Ice observers.
 /// </summary>
+/// <remarks>The Ice runtime calls observers while updating its internal state and does not guard against exceptions
+/// they throw. Implementations of this interface and its derived interfaces must not throw exceptions: a thrown
+/// exception can leave the Ice runtime in an inconsistent state or terminate the process.</remarks>
 public interface Observer
 {
     /// <summary>
@@ -200,6 +203,15 @@ public interface ObserverUpdater
     void updateThreadObservers();
 }
 
+/// <summary>
+/// The communicator observer interface used by the Ice runtime to obtain and update observers for its observable
+/// objects. This interface should be implemented by add-ins that wish to observe Ice objects in order to collect
+/// statistics. An instance of this interface can be provided to the Ice runtime through the communicator
+/// initialization data.
+/// </summary>
+/// <remarks>The Ice runtime calls this interface while updating its internal state and does not guard against
+/// exceptions it throws. An implementation of this interface must not throw exceptions: a thrown exception can leave
+/// the Ice runtime in an inconsistent state or terminate the process.</remarks>
 public interface CommunicatorObserver
 {
     /// <summary>

--- a/csharp/src/Ice/Logger.cs
+++ b/csharp/src/Ice/Logger.cs
@@ -8,6 +8,10 @@ namespace Ice;
 /// Represents Ice's abstraction for logging and tracing. Applications can provide their own logger by
 /// implementing this interface and setting a logger on the communicator.
 /// </summary>
+/// <remarks>The Ice runtime calls <see cref="print" />, <see cref="trace" />, <see cref="warning" /> and
+/// <see cref="error" /> while performing internal operations, including from its last-resort exception handlers.
+/// Implementations of these methods must not throw exceptions: a thrown exception can leave the Ice runtime in an
+/// inconsistent state or terminate the process.</remarks>
 public interface Logger : IDisposable
 {
     /// <summary>
@@ -15,6 +19,7 @@ public interface Logger : IDisposable
     /// timestamp.
     /// </summary>
     /// <param name="message">The message to log.</param>
+    /// <remarks>An implementation of this method must not throw exceptions.</remarks>
     void print(string message);
 
     /// <summary>
@@ -22,18 +27,21 @@ public interface Logger : IDisposable
     /// </summary>
     /// <param name="category">The trace category.</param>
     /// <param name="message">The trace message to log.</param>
+    /// <remarks>An implementation of this method must not throw exceptions.</remarks>
     void trace(string category, string message);
 
     /// <summary>
     /// Logs a warning message.
     /// </summary>
     /// <param name="message">The warning message to log.</param>
+    /// <remarks>An implementation of this method must not throw exceptions.</remarks>
     void warning(string message);
 
     /// <summary>
     /// Logs an error message.
     /// </summary>
     /// <param name="message">The error message to log.</param>
+    /// <remarks>An implementation of this method must not throw exceptions.</remarks>
     void error(string message);
 
     /// <summary>

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/CommunicatorObserver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/CommunicatorObserver.java
@@ -14,6 +14,10 @@ import java.util.Map;
  * its observable objects. This interface should be implemented by add-ins that wish to observe Ice
  * objects in order to collect statistics. An instance of this interface can be provided to the Ice
  * runtime through the Ice communicator initialization data.
+ *
+ * <p>The Ice runtime calls this interface while updating its internal state and does not guard against exceptions
+ * it throws. An implementation of this interface must not throw exceptions: a thrown exception can leave the Ice
+ * runtime in an inconsistent state or terminate an Ice runtime thread.
  */
 public interface CommunicatorObserver {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/Observer.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instrumentation/Observer.java
@@ -4,6 +4,10 @@ package com.zeroc.Ice.Instrumentation;
 
 /**
  * The object observer interface used by instrumented objects to notify the observer of their existence.
+ *
+ * <p>The Ice runtime calls observers while updating its internal state and does not guard against exceptions they
+ * throw. Implementations of this interface and its derived interfaces must not throw exceptions: a thrown exception
+ * can leave the Ice runtime in an inconsistent state or terminate an Ice runtime thread.
  */
 public interface Observer {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Logger.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Logger.java
@@ -5,11 +5,18 @@ package com.zeroc.Ice;
 /**
  * Represents Ice's abstraction for logging and tracing.
  * Applications can provide their own logger by implementing this interface and setting a logger on the communicator.
+ *
+ * <p>The Ice runtime calls {@link #print}, {@link #trace}, {@link #warning} and {@link #error} while performing
+ * internal operations, including from its last-resort exception handlers. Implementations of these methods must not
+ * throw exceptions: a thrown exception can leave the Ice runtime in an inconsistent state or terminate an Ice
+ * runtime thread.
  */
 public interface Logger extends AutoCloseable {
     /**
      * Prints a message.
      * The message is printed literally, without any decorations such as executable name or timestamp.
+     *
+     * <p>An implementation of this method must not throw exceptions.
      *
      * @param message the message to log
      */
@@ -17,6 +24,8 @@ public interface Logger extends AutoCloseable {
 
     /**
      * Logs a trace message.
+     *
+     * <p>An implementation of this method must not throw exceptions.
      *
      * @param category the trace category
      * @param message the trace message to log
@@ -26,6 +35,8 @@ public interface Logger extends AutoCloseable {
     /**
      * Logs a warning message.
      *
+     * <p>An implementation of this method must not throw exceptions.
+     *
      * @param message the warning message to log
      * @see #error
      */
@@ -33,6 +44,8 @@ public interface Logger extends AutoCloseable {
 
     /**
      * Logs an error message.
+     *
+     * <p>An implementation of this method must not throw exceptions.
      *
      * @param message the error message to log
      * @see #warning

--- a/js/packages/ice/src/Ice/Logger.d.ts
+++ b/js/packages/ice/src/Ice/Logger.d.ts
@@ -5,6 +5,9 @@ declare module "@zeroc/ice" {
         /**
          * Represents Ice's abstraction for logging and tracing. Applications can provide their own logger by
          * implementing this abstraction and supplying a logger in {@link InitializationData}.
+         * @remarks The Ice runtime calls {@link print}, {@link trace}, {@link warning} and {@link error} while
+         * performing internal operations. Implementations of these methods must not throw exceptions: a thrown
+         * exception can leave the Ice runtime in an inconsistent state or terminate the program.
          * @see {@link InitializationData}
          */
         interface Logger {
@@ -12,6 +15,7 @@ declare module "@zeroc/ice" {
              * Prints a message. The message is printed literally, without any decorations such as executable name or
              * timestamp.
              * @param message The message to log.
+             * @remarks An implementation of this method must not throw exceptions.
              */
             print(message: string): void;
 
@@ -19,12 +23,14 @@ declare module "@zeroc/ice" {
              * Logs a trace message.
              * @param category The trace category.
              * @param message The trace message to log.
+             * @remarks An implementation of this method must not throw exceptions.
              */
             trace(category: string, message: string): void;
 
             /**
              * Logs a warning message.
              * @param message The warning message to log.
+             * @remarks An implementation of this method must not throw exceptions.
              * @see #error
              */
             warning(message: string): void;
@@ -32,6 +38,7 @@ declare module "@zeroc/ice" {
             /**
              * Logs an error message.
              * @param message The error message to log.
+             * @remarks An implementation of this method must not throw exceptions.
              * @see #warning
              */
             error(message: string): void;

--- a/python/python/Ice/Logger.py
+++ b/python/python/Ice/Logger.py
@@ -8,6 +8,10 @@ class Logger(ABC):
     Represents Ice's abstraction for logging and tracing.
 
     Applications can provide their own logger by implementing this abstraction and setting a logger on the communicator.
+
+    The Ice runtime calls :meth:`print`, :meth:`trace`, :meth:`warning` and :meth:`error` from contexts where
+    exceptions cannot be handled. Implementations of these methods must not raise exceptions: a raised exception can
+    terminate the process.
     """
 
     @abstractmethod
@@ -16,6 +20,8 @@ class Logger(ABC):
         Prints a message.
 
         The message is printed literally, without any decorations such as executable name or timestamp.
+
+        An implementation of this method must not raise exceptions.
 
         Parameters
         ----------
@@ -34,6 +40,8 @@ class Logger(ABC):
         """
         Logs a trace message.
 
+        An implementation of this method must not raise exceptions.
+
         Parameters
         ----------
         category : str
@@ -48,6 +56,8 @@ class Logger(ABC):
         """
         Logs a warning message.
 
+        An implementation of this method must not raise exceptions.
+
         Parameters
         ----------
         message : str
@@ -59,6 +69,8 @@ class Logger(ABC):
     def error(self, message: str):
         """
         Logs an error message.
+
+        An implementation of this method must not raise exceptions.
 
         Parameters
         ----------


### PR DESCRIPTION
This change ports the C++ no-throw remarks on `Logger`, `Observer` and `CommunicatorObserver` to the other mappings that need them, with mapping-specific consequences:

- **C#**: "can leave the Ice runtime in an inconsistent state or terminate the process." The thread pool's dispatch and run-loop catch handlers recover by calling `logger.error`, so a consistently-throwing logger escapes the backstop and takes down the process (an unhandled exception on a .NET thread is fatal); the thread observer's `detach()` on worker-thread exit runs outside any try block and has the same effect.
- **Java**: "can leave the Ice runtime in an inconsistent state or terminate an Ice runtime thread." The escape paths mirror C#, but an exception escaping a thread's `run()` kills only that thread — the JVM continues.
- **Python**: "can terminate the process" — the same consequence as C++, because IcePy's `LoggerWrapper` converts a raised Python exception into a C++ exception rethrown from inside the Ice core, where it can surface in destructors and `noexcept` functions.
- **JavaScript**: "can leave the Ice runtime in an inconsistent state or terminate the program." A throwing logger propagates through the runtime's internals; in Node.js, a throw escaping an I/O event callback is an uncaught exception and exits the process by default.

Since these mappings have no equivalent of `noexcept`, each of the four logging methods — the ones that can become `noexcept` in C++ down the road — additionally carries a one-sentence remark: "An implementation of this method must not throw/raise exceptions." The C++ `Logger` methods get the same per-method remark for consistency.

The remaining mappings need nothing:

- **Swift**: the `Logger` protocol methods are declared non-throwing, so the compiler already enforces the contract.
- **Ruby**, **PHP**, **MATLAB**: these mappings only expose Ice's own logger; applications cannot implement a custom one.

Instrumentation observers exist only in C++, C# and Java; the observer remarks follow the C++ scoping (interface-level on the `Observer` base and `CommunicatorObserver`).

The C# `CommunicatorObserver` interface had no doc comment at all; this change adds its summary, ported from the C++ header, since StyleCop (SA1604) rejects `<remarks>` on an element without a `<summary>`. The other undocumented public C# types noticed along the way are tracked by #6568.

Fixes #6334

🤖 Generated with [Claude Code](https://claude.com/claude-code)
