### PR TITLE
Remove Dead and Outdated 'Buffer' Code from Python

### DIFF
--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -69,11 +69,6 @@ namespace IcePy
         PyObject_HEAD IcePy::ExceptionInfoPtr* info;
     };
 
-    struct BufferObject
-    {
-        PyObject_HEAD IcePy::BufferPtr* buffer;
-    };
-
     extern PyTypeObject TypeInfoType;
     extern PyTypeObject ExceptionInfoType;
 

--- a/python/modules/IcePy/Types.h
+++ b/python/modules/IcePy/Types.h
@@ -16,9 +16,6 @@
 
 namespace IcePy
 {
-    class Buffer;
-    using BufferPtr = std::shared_ptr<Buffer>;
-
     class ExceptionInfo;
     using ExceptionInfoPtr = std::shared_ptr<ExceptionInfo>;
     using ExceptionInfoList = std::vector<ExceptionInfoPtr>;
@@ -585,8 +582,6 @@ namespace IcePy
 
     PyObject* createException(const ExceptionInfoPtr&);
     ExceptionInfoPtr getException(PyObject*);
-
-    PyObject* createBuffer(const BufferPtr&);
 }
 
 extern "C" PyObject* IcePy_defineEnum(PyObject*, PyObject*);

--- a/python/test/Ice/timeout/Server.py
+++ b/python/test/Ice/timeout/Server.py
@@ -68,8 +68,7 @@ class Server(TestHelper):
         properties = self.createTestProperties(args)
 
         #
-        # The client sends large messages to cause the transport
-        # buffers to fill up.
+        # The client sends large messages to cause the transport buffers to fill up.
         #
         properties.setProperty("Ice.MessageSizeMax", "10000")
 


### PR DESCRIPTION
This PR implements #6452, removing all the vestigial buffer code.

I confirmed that yes, this is all totally dead code, and yes, it was replaced with the new `memoryview` metadata.
These leftovers should of been removed when we made that switch, but they slipped through.