### PR TITLE
Cancel reap tasks at module shutdown

### DIFF
--- a/changelog.d/php/6392.md
+++ b/changelog.d/php/6392.md
@@ -1,0 +1,3 @@
+- Fixed a leak: a communicator registered with an expiration time and never unregistered stayed alive past the end
+  of the PHP request, along with its connections and other resources, and the process reported "communicator not
+  destroyed during global destruction."

--- a/changelog.d/php/6392.md
+++ b/changelog.d/php/6392.md
@@ -1,3 +1,2 @@
-- Fixed a leak: a communicator registered with an expiration time and never unregistered stayed alive past the end
-  of the PHP request, along with its connections and other resources, and the process reported "communicator not
-  destroyed during global destruction."
+- Fixed a bug in Ice for PHP: a communicator registered with an expiration time was not destroyed during PHP
+  shutdown, and the Ice runtime reported the error "communicator not destroyed during global destruction".

--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -1548,6 +1548,18 @@ IcePHP::communicatorShutdown(void)
     {
         lock_guard lock(_registeredCommunicatorsMutex);
         _registeredCommunicators.swap(registeredCommunicators);
+
+        // Cancel any scheduled reap task to break the ActiveCommunicator <-> ReapCommunicatorTimerTask ownership
+        // cycle, which would otherwise keep the communicator alive past module shutdown.
+        for (const auto& entry : registeredCommunicators)
+        {
+            const ActiveCommunicatorPtr& ac = entry.second;
+            if (ac->reapTask)
+            {
+                _timer->cancel(ac->reapTask);
+                ac->reapTask = nullptr;
+            }
+        }
     }
 
     // Clearing the map releases the last remaining reference counts of the ActiveCommunicator objects. The

--- a/php/src/Communicator.h
+++ b/php/src/Communicator.h
@@ -22,8 +22,13 @@ extern "C"
 
 namespace IcePHP
 {
+    // Called when the PHP module is loaded and unloaded, i.e. once per process. communicatorShutdown destroys the
+    // communicators that outlived the requests that created them.
     bool communicatorInit(void);
     bool communicatorShutdown(void);
+
+    // Called at the start and end of each PHP request. communicatorRequestShutdown releases the request's hold on
+    // the communicators it used; a registered communicator survives until it expires or the module shuts down.
     bool communicatorRequestInit(void);
     bool communicatorRequestShutdown(void);
 

--- a/php/test/Ice/registeredCommunicator/Client.php
+++ b/php/test/Ice/registeredCommunicator/Client.php
@@ -72,6 +72,13 @@ class Client extends TestHelper
         $reapCommunicator->destroy();
         test(Ice\find("Reap") == null);
 
+        // A communicator registered with an expiration time and never unregistered must still be destroyed at module
+        // shutdown. The reap task holds the only remaining reference at that point, so if it isn't cancelled the
+        // communicator survives and PHP reports "communicator not destroyed during global destruction."
+        $communicator = Ice\initialize();
+        Ice\register($communicator, "Hello9", 40000);
+        test(Ice\find('Hello9') != null);
+
         // A proxy keeps its communicator alive at the C++ level, but not the PHP object that wraps it. Once that PHP
         // object is freed, ice_getCommunicator must return a working communicator by re-wrapping the same underlying
         // communicator.

--- a/php/test/Ice/registeredCommunicator/Client.php
+++ b/php/test/Ice/registeredCommunicator/Client.php
@@ -72,13 +72,6 @@ class Client extends TestHelper
         $reapCommunicator->destroy();
         test(Ice\find("Reap") == null);
 
-        // A communicator registered with an expiration time and never unregistered must still be destroyed at module
-        // shutdown. The reap task holds the only remaining reference at that point, so if it isn't cancelled the
-        // communicator survives and PHP reports "communicator not destroyed during global destruction."
-        $communicator = Ice\initialize();
-        Ice\register($communicator, "Hello9", 40000);
-        test(Ice\find('Hello9') != null);
-
         // A proxy keeps its communicator alive at the C++ level, but not the PHP object that wraps it. Once that PHP
         // object is freed, ice_getCommunicator must return a working communicator by re-wrapping the same underlying
         // communicator.


### PR DESCRIPTION
Registering a communicator with an expiration time creates a deliberate ownership cycle: `ActiveCommunicator` → `reapTask` → `ReapCommunicatorTimerTask` → `ActiveCommunicator`. `communicatorShutdown` dropped both external references — it cleared `_registeredCommunicators` and destroyed the timer — but never cleared `reapTask`, so the cycle survived module shutdown and the communicator was never destroyed. This is the path #6381 did not cover.

- `communicatorShutdown` now cancels and clears the reap tasks under `_registeredCommunicatorsMutex`, before the map is cleared. Destruction still happens outside the lock, since `Ice::Communicator::destroy` blocks.
- Documented the four lifecycle functions in `Communicator.h`, whose names read as if they were about a communicator's own lifecycle rather than the PHP module and request lifecycles.

`reapTask` is set in one place (`Ice_register`) and now cleared on all five paths that stop reaping: expiration, `Communicator::destroy`, re-registration, `Ice\unregister`, and module shutdown.

No test: the leak is only observable as a message from the Ice runtime's global-destruction check, and the client still exits 0, so the harness — which checks the exit status only — cannot catch it. Verified by hand instead, by building `ice.so` with and without the fix and running the reproduction from #6392.

Fixes #6392.
