### PR TITLE
Use the S3_DOWNLOADS_BUCKET variable in all release workflows

### DIFF
--- a/.github/workflows/build-deb-ice-repo-packages.yml
+++ b/.github/workflows/build-deb-ice-repo-packages.yml
@@ -57,10 +57,11 @@ jobs:
             UPLOAD_PATH="ice/${QUALITY}/${CHANNEL}/${DISTRIBUTION}"
           fi
 
-          aws s3 cp build/*.deb "s3://zeroc-downloads/${UPLOAD_PATH}/"
+          aws s3 cp build/*.deb "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}/"
         env:
           QUALITY: ${{ inputs.quality }}
           DISTRIBUTION: ${{ matrix.distribution }}
+          S3_DOWNLOADS_BUCKET: ${{ vars.S3_DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 

--- a/.github/workflows/build-rpm-ice-repo-packages.yml
+++ b/.github/workflows/build-rpm-ice-repo-packages.yml
@@ -57,10 +57,11 @@ jobs:
             UPLOAD_PATH="ice/${QUALITY}/${CHANNEL}/${DISTRIBUTION}"
           fi
 
-          aws s3 cp build/RPMS/noarch/*.rpm "s3://zeroc-downloads/${UPLOAD_PATH}/"
+          aws s3 cp build/RPMS/noarch/*.rpm "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}/"
         env:
           QUALITY: ${{ inputs.quality }}
           DISTRIBUTION: ${{ matrix.distribution }}
+          S3_DOWNLOADS_BUCKET: ${{ vars.S3_DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 

--- a/.github/workflows/prune-nightly-artifacts.yml
+++ b/.github/workflows/prune-nightly-artifacts.yml
@@ -23,6 +23,7 @@ jobs:
             env:
               CHANNEL: ${{ inputs.channel }}
               DRY_RUN: '0'
+              S3_DOWNLOADS_BUCKET: ${{ vars.S3_DOWNLOADS_BUCKET }}
               AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
               AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             run: |

--- a/.github/workflows/publish-cpp-swift-deps.yml
+++ b/.github/workflows/publish-cpp-swift-deps.yml
@@ -45,9 +45,10 @@ jobs:
           else
             UPLOAD_PATH="ice/${QUALITY}/${CHANNEL}"
           fi
-          aws s3 sync staging/cpp-swift-deps/ "s3://zeroc-downloads/${UPLOAD_PATH}/" --exclude "*" --include "*.zip"
+          aws s3 sync staging/cpp-swift-deps/ "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}/" --exclude "*" --include "*.zip"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           CHANNEL: ${{ inputs.channel }}
           QUALITY: ${{ inputs.quality }}
+          S3_DOWNLOADS_BUCKET: ${{ vars.S3_DOWNLOADS_BUCKET }}

--- a/.github/workflows/publish-deb-packages.yml
+++ b/.github/workflows/publish-deb-packages.yml
@@ -66,7 +66,7 @@ jobs:
 
           echo "Syncing current repository from S3..."
           mkdir -p "${UPLOAD_PATH}"
-          aws s3 sync "s3://zeroc-downloads/${UPLOAD_PATH}" "${UPLOAD_PATH}"
+          aws s3 sync "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}" "${UPLOAD_PATH}"
           echo "Creating/updating repository with new DEB packages..."
           docker run --rm \
             -v "$GITHUB_WORKSPACE:/workspace" \
@@ -85,10 +85,11 @@ jobs:
           # the build-deb-ice-repo-packages workflow
           aws s3 sync \
             "${UPLOAD_PATH}" \
-            "s3://zeroc-downloads/${UPLOAD_PATH}" \
+            "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}" \
             --delete \
             --exclude "ice-repo-*.deb"
         env:
+          S3_DOWNLOADS_BUCKET: ${{ vars.S3_DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GPG_KEY: ${{ secrets.ICE_3_8_CI_SIGNER_KEY }}

--- a/.github/workflows/publish-matlab-packages.yml
+++ b/.github/workflows/publish-matlab-packages.yml
@@ -42,16 +42,17 @@ jobs:
         run: |
           if [ "${QUALITY}" = "stable" ]; then
             UPLOAD_PATH="ice/${CHANNEL}"
-            aws s3 cp staging/matlab-packages-windows-*/ice-*-win.mltbx "s3://zeroc-downloads/${UPLOAD_PATH}/"
-            aws s3 cp staging/matlab-packages-ubuntu-*/ice-*-linux.mltbx "s3://zeroc-downloads/${UPLOAD_PATH}/"
+            aws s3 cp staging/matlab-packages-windows-*/ice-*-win.mltbx "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}/"
+            aws s3 cp staging/matlab-packages-ubuntu-*/ice-*-linux.mltbx "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}/"
           else
             UPLOAD_PATH="ice/${QUALITY}/${CHANNEL}"
             # Rename the Toolbox files to ice-nightly-R2025b-<os>.mltbx if it's the nightly channel
-            aws s3 cp staging/matlab-packages-windows-*/ice-*-R2025b-win.mltbx "s3://zeroc-downloads/${UPLOAD_PATH}/ice-${QUALITY}-R2025b-win.mltbx"
-            aws s3 cp staging/matlab-packages-ubuntu-*/ice-*-R2025b-linux.mltbx "s3://zeroc-downloads/${UPLOAD_PATH}/ice-${QUALITY}-R2025b-linux.mltbx"
+            aws s3 cp staging/matlab-packages-windows-*/ice-*-R2025b-win.mltbx "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}/ice-${QUALITY}-R2025b-win.mltbx"
+            aws s3 cp staging/matlab-packages-ubuntu-*/ice-*-R2025b-linux.mltbx "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}/ice-${QUALITY}-R2025b-linux.mltbx"
           fi
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           CHANNEL: ${{ inputs.channel }}
           QUALITY: ${{ inputs.quality }}
+          S3_DOWNLOADS_BUCKET: ${{ vars.S3_DOWNLOADS_BUCKET }}

--- a/.github/workflows/publish-rpm-packages.yml
+++ b/.github/workflows/publish-rpm-packages.yml
@@ -84,7 +84,7 @@ jobs:
 
           echo "Syncing current repository from S3..."
           mkdir -p "${DISTRIBUTION}"
-          aws s3 sync "s3://zeroc-downloads/${UPLOAD_PATH}" "${DISTRIBUTION}"
+          aws s3 sync "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}" "${DISTRIBUTION}"
 
           echo "Creating/updating repository with new RPMs..."
           docker_args=(
@@ -103,12 +103,13 @@ jobs:
           # the build-rpm-ice-repo-packages workflow
           aws s3 sync \
             "${DISTRIBUTION}" \
-            "s3://zeroc-downloads/${UPLOAD_PATH}" \
+            "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}" \
             --delete \
             --exclude "ice-repo-*.noarch.rpm"
         env:
           CHANNEL: ${{ inputs.channel }}
           QUALITY: ${{ inputs.quality }}
+          S3_DOWNLOADS_BUCKET: ${{ vars.S3_DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GPG_KEY: ${{ secrets.ICE_3_8_CI_SIGNER_KEY }}

--- a/.github/workflows/publish-symbols-sources.yml
+++ b/.github/workflows/publish-symbols-sources.yml
@@ -57,15 +57,16 @@ jobs:
           UPLOAD_PATH="ice/${QUALITY}/${CHANNEL}"
 
           # Upload zip to S3
-          aws s3 cp "staging/windows-indexed-pdbs-${VERSION}.zip" "s3://zeroc-downloads/${UPLOAD_PATH}/windows-indexed-pdbs-${VERSION}.zip"
+          aws s3 cp "staging/windows-indexed-pdbs-${VERSION}.zip" "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}/windows-indexed-pdbs-${VERSION}.zip"
 
           # Upload sources to S3 (version is already in the directory structure)
-          aws s3 sync "staging/windows-symbols-sources/sources/" "s3://zeroc-downloads/${UPLOAD_PATH}/sources/"
+          aws s3 sync "staging/windows-symbols-sources/sources/" "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}/sources/"
           # Upload symbol store to S3 (version is already in the directory structure)
-          aws s3 sync "staging/windows-symbols-sources/symbols/" "s3://zeroc-downloads/${UPLOAD_PATH}/symbols/"
+          aws s3 sync "staging/windows-symbols-sources/symbols/" "s3://${S3_DOWNLOADS_BUCKET}/${UPLOAD_PATH}/symbols/"
         env:
           CHANNEL: ${{ inputs.channel }}
           QUALITY: ${{ inputs.quality }}
+          S3_DOWNLOADS_BUCKET: ${{ vars.S3_DOWNLOADS_BUCKET }}
 
   # Stable releases - incremental update to shared symbol store with proper 000admin handling
   # Downloads existing 000admin, uses symstore add to create proper transaction, uploads result
@@ -77,6 +78,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       S3_BUCKET: ${{ vars.S3_SYMBOLS_BUCKET }}
+      S3_DOWNLOADS_BUCKET: ${{ vars.S3_DOWNLOADS_BUCKET }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -129,7 +131,7 @@ jobs:
           Compress-Archive -Path "staging/windows-indexed-pdbs" -DestinationPath "staging/$zipName"
 
           # Upload zip to S3
-          aws s3 cp "staging/$zipName" "s3://zeroc-downloads/ice/${{ inputs.channel }}/$zipName"
+          aws s3 cp "staging/$zipName" "s3://${{ env.S3_DOWNLOADS_BUCKET }}/ice/${{ inputs.channel }}/$zipName"
 
           # Upload sources to S3
           aws s3 sync "staging/windows-symbols-sources/sources/" "s3://${{ env.S3_BUCKET }}/sources/ice/"

--- a/packaging/release/prune-nightly-artifacts.sh
+++ b/packaging/release/prune-nightly-artifacts.sh
@@ -5,7 +5,7 @@ trap 'echo "🔥 ERROR: command \"$BASH_COMMAND\" exited with code $?" >&2' ERR
 
 # Config (override via env)
 # Note: Set S3_DOWNLOADS_BUCKET in GitHub repository variables
-BUCKET="${BUCKET:-${S3_DOWNLOADS_BUCKET:-zeroc-downloads}}"  # S3 bucket name
+BUCKET="${BUCKET:-${S3_DOWNLOADS_BUCKET:?}}"  # S3 bucket name
 CHANNEL="${CHANNEL:-3.9}"                   # release channel (e.g., 3.9, 3.8)
 PREFIX="${PREFIX:-ice/nightly/$CHANNEL/}"   # no leading slash
 DAYS_TO_KEEP="${DAYS_TO_KEEP:-7}"           # default: keep last 7 days


### PR DESCRIPTION
The prune-nightly-artifacts workflow never passed `S3_DOWNLOADS_BUCKET` to `prune-nightly-artifacts.sh`, so the script always fell back to its hard-coded `zeroc-downloads` default. Since the prune job runs with `DRY_RUN=0`, repointing the repository variable would have left the publish workflows writing to the new bucket while the nightly prune kept deleting from the old one.

This PR wires the variable into the prune workflow and replaces the remaining hard-coded `zeroc-downloads` references in the build and publish workflows, following the pattern already used by `publish-brew-packages`, `publish-icegridgui-macos-app`, and `publish-windows-installer`. With the variable at its current value (`zeroc-downloads`) the change is a behavioral no-op.

Validated with `actionlint -shellcheck=` on all touched workflows.

Fixes #6130