### PR TITLE
Prune nightly DEB packages through reprepro instead of deleting pool files

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,7 +16,9 @@ updating the Swift package manifest with release binary hashes), and then run `p
 
 The `nightly-release` workflow orchestrates the nightly path. It always runs `build-release`; when `publish` is true,
 it then prunes expired nightly artifacts and runs `publish-release`. Pruning must finish before publishing because it
-can remove packages from the APT and RPM repository trees, while the publish workflows regenerate their metadata.
+can remove packages from the RPM repository trees, while the publish workflows regenerate their metadata. The APT
+repositories are not touched by the prune: their packages, indices, and database are maintained by reprepro, which
+removes expired nightly packages during publish.
 Run `nightly-release` with `publish` false to build nightly artifacts without changing the repositories.
 
 The scheduler dispatches `nightly-release` for branches that contain this split workflow. Maintenance branches that

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -39,8 +39,10 @@ jobs:
 
   publish:
     name: Publish Release
-    # Pruning removes dated packages from the APT and RPM repositories without
-    # updating their metadata. Publishing must run afterwards to rebuild it.
+    # Pruning removes dated RPM packages and loose artifacts without updating
+    # repository metadata. Publishing must run afterwards to rebuild it. The
+    # APT repositories are not touched by the prune: reprepro removes expired
+    # nightly packages during publish, keeping metadata and pool consistent.
     if: ${{ inputs.publish == true }}
     needs:
       - build

--- a/.github/workflows/publish-deb-packages.yml
+++ b/.github/workflows/publish-deb-packages.yml
@@ -72,6 +72,7 @@ jobs:
             -v "$GITHUB_WORKSPACE:/workspace" \
             -e GPG_KEY="${GPG_KEY}" \
             -e GPG_KEY_ID="${GPG_KEY_ID}" \
+            -e DAYS_TO_KEEP="${DAYS_TO_KEEP}" \
             ghcr.io/zeroc-ice/deb-repo-builder:${CHANNEL} \
             /workspace/ice/packaging/deb/create-deb-repo.sh \
             --staging /workspace/staging/ \

--- a/packaging/deb/create-deb-repo.sh
+++ b/packaging/deb/create-deb-repo.sh
@@ -127,3 +127,42 @@ done < <(find "$STAGING/deb-packages-$DISTRIBUTION-amd64" -type f -name "*.dsc")
 for package in "${src_packages[@]}"; do
     reprepro -b "$DIST_DIR" includedsc "$CODENAME" "$package"
 done
+
+# For the nightly quality, remove packages older than DAYS_TO_KEEP days from the repository.
+# reprepro updates its database and the repository indices, and deletes the corresponding pool
+# files. This must be done here rather than by the standalone S3 prune
+# (packaging/release/prune-nightly-artifacts.sh): deleting pool objects behind reprepro's back
+# leaves the indices referencing missing files, which is how packages dropped from the build
+# ended up as permanent apt 404s.
+if [[ "$QUALITY" == "nightly" ]]; then
+    DAYS_TO_KEEP="${DAYS_TO_KEEP:-7}"
+    today_sec=$(date +%s)
+    declare -A old_versions=()
+
+    echo "Scanning for nightly versions older than $DAYS_TO_KEEP days..."
+    if ! versions=$(reprepro -b "$DIST_DIR" --list-format '${version}\n' list "$CODENAME"); then
+        echo "Warning: reprepro list failed, skipping nightly cleanup" >&2
+        versions=""
+    fi
+
+    while read -r version; do
+        if [[ "$version" =~ nightly([0-9]{8}) ]]; then
+            date_part="${BASH_REMATCH[1]}"
+            pkg_date_sec=$(date -d "$date_part" +%s 2>/dev/null || echo 0)
+            if (( pkg_date_sec <= 0 )); then
+                echo "Skipping version $version (invalid date: $date_part)"
+                continue
+            fi
+
+            age_days=$(( (today_sec - pkg_date_sec) / 86400 ))
+            if (( age_days > DAYS_TO_KEEP )); then
+                old_versions["$version"]=1
+            fi
+        fi
+    done <<< "$versions"
+
+    for version in "${!old_versions[@]}"; do
+        echo "Removing outdated nightly version $version..."
+        reprepro -b "$DIST_DIR" removefilter "$CODENAME" "Version (== $version)"
+    done
+fi

--- a/packaging/release/prune-nightly-artifacts.sh
+++ b/packaging/release/prune-nightly-artifacts.sh
@@ -48,6 +48,14 @@ for key in $keys; do
         continue
     fi
 
+    # The APT pool is managed by reprepro during publish (see packaging/deb/create-deb-repo.sh),
+    # which removes expired nightly packages together with their database and index entries.
+    # Deleting pool objects here would leave the APT indices referencing missing files.
+    if [[ "$key" == */pool/* ]]; then
+        ((++ignored))
+        continue
+    fi
+
     # Extract date part from various nightly formats:
     # - nightly.20250821, nightly-20250821, nightly20250821
     # - pre.20250821, pre-20250821


### PR DESCRIPTION
The standalone S3 prune deleted dated objects from the APT pool without updating reprepro's database, so the regenerated `Packages` indices kept referencing the deleted files. reprepro replaces packages that are still being built on every `includedeb`, but a package dropped from the build keeps its database entry forever while the prune removes its pool file. This is live today: both nightly channels serve `Packages` entries for `zeroc-ice-ice2slice` (removed from the build in #5261) whose pool files 404 — on 3.9 since March, on 3.8 since May.

This PR:

- Restores an age-based cleanup in `create-deb-repo.sh` for the nightly quality: `reprepro removefilter` drops versions older than `DAYS_TO_KEEP` (7) together with their database entries, indices, and pool files. It tolerates pool files a previous prune already deleted (reprepro logs "not found, forgetting anyway" and exits 0), so the first publish after this change purges the existing stale entries.
- Scopes the standalone prune to skip the reprepro-managed `pool/` objects. The RPM trees and loose dated artifacts still rely on the standalone prune (createrepo_c regenerates metadata from a directory rescan), so those remain covered.
- Updates the `nightly-release` comment and workflows README, which implied the APT metadata was regenerated from a pool rescan.

Verified with a containerized repro (debian:bookworm + reprepro) that publishes three nightly cycles with a discontinued package and simulates the S3 prune: before the fix, the `Packages` index retains an entry whose pool file was pruned; after the fix, the stale entry is removed on the next publish, versions newer than the cutoff are kept, and the publish exits 0. Also covered: a repository built entirely by the unpatched script and cleaned by the patched one (the exact first-production-run state), an empty staging directory against a fresh repository with no db, and a stubbed-`aws` dry run of the prune script confirming pool objects are skipped while dated RPMs and tarballs still prune.

One accepted edge: manually re-running `publish-release` with a nightly `run_id` older than `DAYS_TO_KEEP` now includes and then removes those packages; this is self-inflicted and heals on the next nightly.

Fixes #6080