### PR TITLE
Fix IcePHP crash when a required return value is combined with an optional(0) out parameter

### DIFF
--- a/changelog.d/php/6126.md
+++ b/changelog.d/php/6126.md
@@ -1,0 +1,3 @@
+- Fixed a crash that occurred when invoking an operation that combines a non-optional return value with an out
+  parameter declared as `optional(0)`: the out parameter was mistaken for the return value while unmarshaling the
+  results.

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -494,7 +494,9 @@ IcePHP::TypedInvocation::unmarshalResults(int argc, zval* args, zval* ret, pair<
     for (const auto& info : _op->optionalOutParams)
     {
         auto cb = make_shared<ResultCallback>();
-        if (_op->returnType && info->tag == _op->returnType->tag)
+        // The optional return value is represented by the returnType ParamInfo itself in optionalOutParams; a required
+        // return value has no tag, so matching by tag could misroute an out parameter with tag 0 to the return value.
+        if (info == _op->returnType)
         {
             retCallback = cb;
         }

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -494,8 +494,7 @@ IcePHP::TypedInvocation::unmarshalResults(int argc, zval* args, zval* ret, pair<
     for (const auto& info : _op->optionalOutParams)
     {
         auto cb = make_shared<ResultCallback>();
-        // The optional return value is represented by the returnType ParamInfo itself in optionalOutParams; a required
-        // return value has no tag, so matching by tag could misroute an out parameter with tag 0 to the return value.
+        // The optional return value is represented in optionalOutParams by the returnType ParamInfo object itself.
         if (info == _op->returnType)
         {
             retCallback = cb;


### PR DESCRIPTION
In IcePHP result unmarshaling, the optional return value was identified by comparing tags. A required return value never gets a tag assigned and keeps the value-initialized tag 0, so for an operation combining a required return value with an `out optional(0)` parameter, the out parameter was routed to the return-value callback, its own callback slot stayed a null `shared_ptr`, and the result-copy loop dereferenced it — crashing the client on every such invocation.

The optional return value is represented in `optionalOutParams` by the `returnType` `ParamInfo` object itself, so this PR identifies it by identity instead of by tag. Python and Ruby route results by position and are not affected.

Fixes #6126