### PR TITLE
Fix a use-after-free in IcePy's destroyAsync callback and reject empty locate return tuples

### DIFF
--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -294,8 +294,7 @@ communicatorDestroy(CommunicatorObject* self, PyObject* /*args*/)
     }
 
     // Break cyclic reference between this object and its Python wrapper.
-    Py_XDECREF(self->wrapper);
-    self->wrapper = nullptr;
+    Py_CLEAR(self->wrapper);
 
     if (PyErr_Occurred())
     {
@@ -326,6 +325,9 @@ communicatorDestroyAsync(CommunicatorObject* self, PyObject* args)
 
     // We create a new reference to `completed` to ensure it remains alive until the callback is invoked.
     // This is necessary in case the user abandons the future, for example by cancelling it.
+    // We also create a new reference to this communicator object: the callback below can outlive all other
+    // references, and it must keep the object alive until it's done using it.
+    Py_INCREF(reinterpret_cast<PyObject*>(self));
     (*self->communicator)
         ->destroyAsync(
             [self, completed = Py_NewRef(completed)]()
@@ -342,9 +344,14 @@ communicatorDestroyAsync(CommunicatorObject* self, PyObject* args)
                     (*self->executor)->setCommunicator(nullptr); // Break cyclic reference.
                 }
 
-                // Break cyclic reference between this object and its Python wrapper.
-                Py_XDECREF(self->wrapper);
-                self->wrapper = nullptr;
+                // Break cyclic reference between this object and its Python wrapper. Py_CLEAR nulls the field
+                // before releasing the reference, as releasing it can deallocate the wrapper, which in turn
+                // releases its own reference to this object.
+                Py_CLEAR(self->wrapper);
+
+                // Release the reference created when this callback was registered. This can deallocate the
+                // communicator object, so self must not be used past this point.
+                Py_DECREF(reinterpret_cast<PyObject*>(self));
 
                 PyObject* emptyArgs = PyTuple_New(0);
                 if (!emptyArgs)

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -344,9 +344,7 @@ communicatorDestroyAsync(CommunicatorObject* self, PyObject* args)
                     (*self->executor)->setCommunicator(nullptr); // Break cyclic reference.
                 }
 
-                // Break cyclic reference between this object and its Python wrapper. Py_CLEAR nulls the field
-                // before releasing the reference, as releasing it can deallocate the wrapper, which in turn
-                // releases its own reference to this object.
+                // Break cyclic reference between this object and its Python wrapper.
                 Py_CLEAR(self->wrapper);
 
                 // Release the reference created when this callback was registered. This can deallocate the
@@ -377,7 +375,9 @@ communicatorDestroyAsync(CommunicatorObject* self, PyObject* args)
 
 #if PY_VERSION_HEX >= 0x030D0000
                 // With Python 3.13 and later, we use Py_IsFinalizing to conditionally release the references to
-                // completed and emptyArgs when the interpreter is not finalizing.
+                // completed and emptyArgs when the interpreter is not finalizing. With earlier Python versions,
+                // which don't provide Py_IsFinalizing, we deliberately always leak these references: destroyAsync
+                // typically runs once per communicator, so the leak is small and bounded.
                 if (!Py_IsFinalizing())
                 {
                     Py_DECREF(completed);

--- a/python/modules/IcePy/ObjectAdapter.cpp
+++ b/python/modules/IcePy/ObjectAdapter.cpp
@@ -159,7 +159,7 @@ IcePy::ServantLocatorWrapper::locate(const Ice::Current& current, shared_ptr<voi
     PyObject* cookieObj{Py_None};
     if (PyTuple_Check(res.get()))
     {
-        if (PyTuple_GET_SIZE(res.get()) > 2)
+        if (PyTuple_GET_SIZE(res.get()) == 0 || PyTuple_GET_SIZE(res.get()) > 2)
         {
             const Ice::CommunicatorPtr com{current.adapter->getCommunicator()};
             if (com->getProperties()->getIcePropertyAsInt("Ice.Warn.Dispatch") > 0)

--- a/python/test/Ice/servantLocator/AllTests.py
+++ b/python/test/Ice/servantLocator/AllTests.py
@@ -239,6 +239,12 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
         ).ice_ping()
     except Ice.ObjectNotExistException:
         pass
+    try:
+        cast(
+            Ice.ObjectPrx, communicator.stringToProxy("emptyTupleReturnValue:{0}".format(helper.getTestEndpoint()))
+        ).ice_ping()
+    except Ice.ObjectNotExistException:
+        pass
     print("ok")
 
     return obj

--- a/python/test/Ice/servantLocator/AllTests.py
+++ b/python/test/Ice/servantLocator/AllTests.py
@@ -231,18 +231,21 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
         cast(
             Ice.ObjectPrx, communicator.stringToProxy("invalidReturnValue:{0}".format(helper.getTestEndpoint()))
         ).ice_ping()
+        test(False)
     except Ice.ObjectNotExistException:
         pass
     try:
         cast(
             Ice.ObjectPrx, communicator.stringToProxy("invalidReturnType:{0}".format(helper.getTestEndpoint()))
         ).ice_ping()
+        test(False)
     except Ice.ObjectNotExistException:
         pass
     try:
         cast(
             Ice.ObjectPrx, communicator.stringToProxy("emptyTupleReturnValue:{0}".format(helper.getTestEndpoint()))
         ).ice_ping()
+        test(False)
     except Ice.ObjectNotExistException:
         pass
     print("ok")

--- a/python/test/Ice/servantLocator/TestAMDI.py
+++ b/python/test/Ice/servantLocator/TestAMDI.py
@@ -121,6 +121,9 @@ class ServantLocatorI(Ice.ServantLocator):
         if current.id.name == "invalidReturnType":
             return "invalid"  # type: ignore
 
+        if current.id.name == "emptyTupleReturnValue":
+            return ()  # type: ignore
+
         test(current.id.name == "locate" or current.id.name == "finished")
         if current.id.name == "locate":
             self.exception(current)

--- a/python/test/Ice/servantLocator/TestI.py
+++ b/python/test/Ice/servantLocator/TestI.py
@@ -108,6 +108,9 @@ class ServantLocatorI(Ice.ServantLocator):
         if current.id.name == "invalidReturnType":
             return "invalid"  # type: ignore
 
+        if current.id.name == "emptyTupleReturnValue":
+            return ()  # type: ignore
+
         test(current.id.name == "locate" or current.id.name == "finished")
         if current.id.name == "locate":
             self.exception(current)


### PR DESCRIPTION
The completion callback that IcePy registers with `Communicator::destroyAsync` captured the communicator object without holding a reference, and broke the cyclic reference to the Python wrapper by releasing the wrapper before clearing the field. When the wrapper cycle held the last references, releasing the wrapper deallocated the communicator object and the subsequent field write landed on freed memory. The callback now owns a reference to the communicator object and breaks the cycle with `Py_CLEAR`.

Also reject an empty tuple returned by `ServantLocator.locate` like the other invalid return values, instead of reading the tuple's first element out of bounds.

Fixes zeroc-ice/ice-audit#119