### PR TITLE
Treat a key filter that throws while a peer attaches as not matching

### DIFF
--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -168,8 +168,21 @@ TopicI::matchKeyFilter(const shared_ptr<Filter>& filter, const shared_ptr<Key>& 
         // unattached and lets the attach continue with the topic's remaining keys and filters, the way a predicate
         // that returns false does. Letting the exception escape would instead abandon the whole attach, and since
         // the session protocol is fire-and-forget the peer would never learn that nothing was attached.
+
+        // The key's toString runs the application's formatter, which can throw too — plausibly, when the same
+        // type's filter just threw. Fall back to a placeholder rather than let it escape the guard.
+        string keyString;
+        try
+        {
+            keyString = key->toString();
+        }
+        catch (const std::exception&)
+        {
+            keyString = "<unavailable>";
+        }
+
         Warning out(_traceLevels->logger);
-        out << "topic '" << _name << "': did not attach the elements for key '" << key->toString() << "': the '"
+        out << "topic '" << _name << "': did not attach the elements for key '" << keyString << "': the '"
             << filter->getName() << "' key filter failed:\n"
             << ex.what();
         return false;

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -166,8 +166,7 @@ TopicI::matchKeyFilter(const shared_ptr<Filter>& filter, const shared_ptr<Key>& 
     {
         // The filter predicate is application code. Treating a throwing predicate as not matching leaves this key
         // unattached and lets the attach continue with the topic's remaining keys and filters, the way a predicate
-        // that returns false does. Letting the exception escape would instead abandon the whole attach, and since
-        // the session protocol is fire-and-forget the peer would never learn that nothing was attached.
+        // that returns false does.
 
         // The key's toString runs the application's formatter — more application code — so it can throw too; the
         // placeholder keeps such a throw from escaping the guard.

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -4,6 +4,7 @@
 #include "NodeI.h"
 #include "SessionI.h"
 #include "TopicFactoryI.h"
+#include "TraceUtil.h"
 
 using namespace std;
 using namespace DataStormI;
@@ -154,6 +155,27 @@ TopicI::getTags() const
     return tags;
 }
 
+bool
+TopicI::matchKeyFilter(const shared_ptr<Filter>& filter, const shared_ptr<Key>& key) const
+{
+    try
+    {
+        return filter->match(key);
+    }
+    catch (const std::exception& ex)
+    {
+        // The filter predicate is application code. Treating a throwing predicate as not matching leaves this key
+        // unattached and lets the attach continue with the topic's remaining keys and filters, the way a predicate
+        // that returns false does. Letting the exception escape would instead abandon the whole attach, and since
+        // the session protocol is fire-and-forget the peer would never learn that nothing was attached.
+        Warning out(_traceLevels->logger);
+        out << "topic '" << _name << "': did not attach the elements for key '" << key->toString() << "': the '"
+            << filter->getName() << "' key filter failed:\n"
+            << ex.what();
+        return false;
+    }
+}
+
 ElementSpecSeq
 TopicI::getElementSpecs(int64_t topicId, const ElementInfoSeq& infos, const shared_ptr<SessionI>& session)
 {
@@ -189,7 +211,7 @@ TopicI::getElementSpecs(int64_t topicId, const ElementInfoSeq& infos, const shar
             // Add filtered elements matching the key.
             for (const auto& [filter, filteredDataElements] : _filteredElements)
             {
-                if (filter->match(key))
+                if (matchKeyFilter(filter, key))
                 {
                     ElementDataSeq elements;
                     for (const auto& dataElement : filteredDataElements)
@@ -231,7 +253,7 @@ TopicI::getElementSpecs(int64_t topicId, const ElementInfoSeq& infos, const shar
             // Add key elements matching the filter.
             for (const auto& [key, keyDataElements] : _keyElements)
             {
-                if (peerFilter->match(key))
+                if (matchKeyFilter(peerFilter, key))
                 {
                     ElementDataSeq elements;
                     for (const auto& dataElement : keyDataElements)
@@ -372,7 +394,7 @@ TopicI::attachElements(
                 }
 
                 // Iterate over the data elements for the matching key, attaching them to the data elements of the spec.
-                if (spec.id > 0 || filter->match(key))
+                if (spec.id > 0 || matchKeyFilter(filter, key))
                 {
                     for (const auto& dataElement : p->second)
                     {
@@ -417,7 +439,7 @@ TopicI::attachElements(
                     key = _keyFactory->decode(_instance->getCommunicator(), spec.value);
                 }
 
-                if (spec.id < 0 || filter->match(key))
+                if (spec.id < 0 || matchKeyFilter(filter, key))
                 {
                     for (const auto& dataElement : p->second)
                     {
@@ -494,7 +516,7 @@ TopicI::attachElementsAck(
                                 initCb = dataElement
                                              ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);
                             }
-                            else if (filter->match(key)) // Filter
+                            else if (matchKeyFilter(filter, key)) // Filter
                             {
                                 initCb = dataElement
                                              ->attach(topicId, spec.id, key, filter, session, prx, data, now, batches);
@@ -558,7 +580,7 @@ TopicI::attachElementsAck(
                                     dataElement
                                         ->attach(topicId, spec.id, nullptr, filter, session, prx, data, now, batches);
                             }
-                            else if (filter->match(key))
+                            else if (matchKeyFilter(filter, key))
                             {
                                 initCb = dataElement
                                              ->attach(topicId, spec.id, key, nullptr, session, prx, data, now, batches);

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -169,8 +169,8 @@ TopicI::matchKeyFilter(const shared_ptr<Filter>& filter, const shared_ptr<Key>& 
         // that returns false does. Letting the exception escape would instead abandon the whole attach, and since
         // the session protocol is fire-and-forget the peer would never learn that nothing was attached.
 
-        // The key's toString runs the application's formatter, which can throw too — plausibly, when the same
-        // type's filter just threw. Fall back to a placeholder rather than let it escape the guard.
+        // The key's toString runs the application's formatter — more application code — so it can throw too; the
+        // placeholder keeps such a throw from escaping the guard.
         string keyString;
         try
         {

--- a/cpp/src/DataStorm/TopicI.h
+++ b/cpp/src/DataStorm/TopicI.h
@@ -118,6 +118,13 @@ namespace DataStormI
         void remove(const std::shared_ptr<DataElementI>&, const std::vector<std::shared_ptr<Key>>&);
 
     protected:
+        /// Checks whether a key filter matches a key.
+        ///
+        /// @param filter The key filter.
+        /// @param key The key to match.
+        /// @return `true` if the filter matches the key; `false` otherwise, including when the filter throws.
+        [[nodiscard]] bool matchKeyFilter(const std::shared_ptr<Filter>& filter, const std::shared_ptr<Key>& key) const;
+
         void waitForListeners(int count) const;
         [[nodiscard]] bool hasListeners() const;
         void notifyListenerWaiters() const;

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -348,6 +348,32 @@ void ::Reader::run(int argc, char* argv[])
     }
 
     {
+        // One filtered reader over two keyed writers, with a key filter that throws on "k1". The reader attaches to
+        // the writer of "k2" and receives its samples; the writer of "k1" stays unattached.
+        Topic<string, string> topic(node, "attachKeyFilterThrow");
+        topic.setKeyFilter<string>(
+            "throwOnKey",
+            [](const string& boom)
+            {
+                return [boom](const string& key)
+                {
+                    if (key == boom)
+                    {
+                        throw runtime_error("the key filter failed");
+                    }
+                    return true;
+                };
+            });
+
+        auto reader = makeFilteredKeyReader(topic, Filter<string>("throwOnKey", "k1"), "", config);
+        reader.waitForWriters(1);
+
+        auto sample = reader.getNextUnread();
+        test(sample.getKey() == "k2");
+        test(sample.getValue() == "v2");
+    }
+
+    {
         Topic<string, string> topic(node, "filtered reader key/value filter");
 
         {

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -365,6 +365,36 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // A filtered reader attaching to keyed writers evaluates the key filter once per key. The key the filter throws
+    // on stays unattached; the topic's other keys still attach.
+    cout << "testing key filter that throws while a peer attaches... " << flush;
+    {
+        Topic<string, string> topic(node, "attachKeyFilterThrow");
+        topic.setKeyFilter<string>(
+            "throwOnKey",
+            [](const string& boom)
+            {
+                return [boom](const string& key)
+                {
+                    if (key == boom)
+                    {
+                        throw runtime_error("the key filter failed");
+                    }
+                    return true;
+                };
+            });
+
+        auto writer1 = makeSingleKeyWriter(topic, "k1", "", config);
+        auto writer2 = makeSingleKeyWriter(topic, "k2", "", config);
+
+        writer2.waitForReaders(1);
+        test(!writer1.hasReaders());
+
+        writer2.add("v2");
+        writer2.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
     cout << "testing filtered sample reader... " << flush;
     {
         Topic<string, string> topic(node, "filtered reader key/value filter");


### PR DESCRIPTION
Fixes #6478.

A topic evaluates a key filter — the predicate an application registers with `Topic::setKeyFilter` — while it
computes the element specs for an attaching peer and while it attaches the peer's elements. The predicate was
called unguarded at all five of those sites, so a throw escaped the attach dispatch. Nothing was attached, not
just the element whose key the predicate threw on, and because the session protocol is fire-and-forget the peer
was never told: both nodes waited forever, the writer in `waitForReaders` and the reader in `waitForWriters`.
The only diagnostic was a generic dispatch warning naming neither the topic nor the filter:

```
-! writer: warning: failed to dispatch attachTopic to p/1 over 127.0.0.1:60749<->127.0.0.1:12020:
   the key filter failed
```

`TopicI` now calls the predicate through `matchKeyFilter`, which treats a throw as "does not match" — the same
degradation `DataReaderI::queue` has applied to a live sample since #6344 — and logs a warning naming the topic,
the key, and the filter:

```
-! writer: warning: topic 'attachKeyFilterThrow': did not attach the elements for key 'k2:k1': the 'throwOnKey'
   key filter failed:
   the key filter failed
```

The topic's remaining keys and filters attach as usual, so one key the filter throws on no longer suppresses the
whole topic in either direction.

New paired test in `cpp/test/DataStorm/events`, next to the #6344 case: two keyed writers on `k1` and `k2`, one
filtered reader, and a key filter that throws on `k1`. Without the fix the writer never gets past
`waitForReaders(1)` and the run times out; with it the reader attaches to the writer of `k2` and reads its
sample, while the writer of `k1` stays unattached. All 109 C++ suites pass.

## Notes

Disjoint from #6541, which guards the *decoders* on these same paths — the key factory, the key filter factory,
and the sample filter factory. This one guards the *predicate*, which #6541 leaves unguarded; I confirmed the
hang still reproduces with this test on top of f396c995. The two changes touch adjacent lines in the same hunks,
so whichever merges second needs a small rebase.

Not addressed here: `DataReaderI::initSamples` calls `matchKey` unguarded (`DataElementI.cpp:814`), the
initialization twin of the `queue` call #6344 guarded. A throw there does not hang the attach — the elements are
attached by that point — but it does abort the initialization callbacks queued after it. Already tracked by
#6324, whose "same residual in the sibling path" section covers exactly this site.

No changelog fragment, matching #6344 and #6522, the two closest fixes in this family.

