### PR TITLE
Destroy the IcePy wait thread's captures before completing the future

### DIFF
--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -272,6 +272,10 @@ communicatorDealloc(CommunicatorObject* self)
 
     delete self->shutdownException;
     delete self->shutdownFuture;
+
+    // Keep this after the communicator release above: it ensures the last release of the
+    // ExecutorPtr - which releases a Python object - always runs here with the GIL held,
+    // never in ~Instance (which can run with the GIL released).
     delete self->executor;
     Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
 }

--- a/python/modules/IcePy/Thread.cpp
+++ b/python/modules/IcePy/Thread.cpp
@@ -5,6 +5,40 @@
 using namespace std;
 using namespace IcePy;
 
+std::future<void>
+IcePy::waitInThread(std::function<void()> wait)
+{
+    auto promise{make_shared<std::promise<void>>()};
+    std::future<void> future{promise->get_future()};
+
+    std::thread{[wait = std::move(wait), promise]() mutable
+                {
+                    exception_ptr ex;
+                    try
+                    {
+                        wait();
+                    }
+                    catch (...)
+                    {
+                        ex = current_exception();
+                    }
+
+                    wait = nullptr; // destroy the captures before making the future ready
+
+                    if (ex)
+                    {
+                        promise->set_exception(ex);
+                    }
+                    else
+                    {
+                        promise->set_value();
+                    }
+                }}
+        .detach();
+
+    return future;
+}
+
 IcePy::AllowThreads::AllowThreads() { _state = PyEval_SaveThread(); }
 
 IcePy::AllowThreads::~AllowThreads() { PyEval_RestoreThread(_state); }

--- a/python/modules/IcePy/Thread.h
+++ b/python/modules/IcePy/Thread.h
@@ -21,35 +21,11 @@ namespace IcePy
     /// after the Python object that started this wait is deallocated. This is why we don't use std::async here: the
     /// destructor of a future returned by std::async waits for the completion of the task.
     ///
-    /// The thread destroys the wait callable before making the future ready. Once the future is ready, the caller
-    /// can release its own references at any time, so this thread must not remain an owner of any reference captured
-    /// by the wait (such as the communicator): releasing the last one here could run destructors that release Python
-    /// objects without holding the GIL, possibly after interpreter finalization.
+    /// The thread destroys the wait callable before making the future ready. This allows the caller to control when
+    /// destructors run.
     ///
     /// Throws when the thread cannot be started, in which case no wait is in progress.
-    inline std::future<void> waitInThread(std::function<void()> wait)
-    {
-        auto promise{std::make_shared<std::promise<void>>()};
-        std::future<void> future{promise->get_future()};
-
-        std::thread{[wait = std::move(wait), promise]() mutable
-                    {
-                        try
-                        {
-                            wait();
-                            wait = nullptr; // destroy the captures before making the future ready
-                            promise->set_value();
-                        }
-                        catch (...)
-                        {
-                            wait = nullptr; // destroy the captures before making the future ready
-                            promise->set_exception(std::current_exception());
-                        }
-                    }}
-            .detach();
-
-        return future;
-    }
+    std::future<void> waitInThread(std::function<void()> wait);
 
     /// Release Python's Global Interpreter Lock during potentially time-consuming (and non-Python related) work.
     class AllowThreads

--- a/python/modules/IcePy/Thread.h
+++ b/python/modules/IcePy/Thread.h
@@ -7,6 +7,7 @@
 #include "Ice/Ice.h"
 #include "Util.h"
 
+#include <functional>
 #include <future>
 #include <memory>
 #include <thread>
@@ -20,21 +21,28 @@ namespace IcePy
     /// after the Python object that started this wait is deallocated. This is why we don't use std::async here: the
     /// destructor of a future returned by std::async waits for the completion of the task.
     ///
+    /// The thread destroys the wait callable before making the future ready. Once the future is ready, the caller
+    /// can release its own references at any time, so this thread must not remain an owner of any reference captured
+    /// by the wait (such as the communicator): releasing the last one here could run destructors that release Python
+    /// objects without holding the GIL, possibly after interpreter finalization.
+    ///
     /// Throws when the thread cannot be started, in which case no wait is in progress.
-    template<typename Wait> std::future<void> waitInThread(Wait wait)
+    inline std::future<void> waitInThread(std::function<void()> wait)
     {
         auto promise{std::make_shared<std::promise<void>>()};
         std::future<void> future{promise->get_future()};
 
-        std::thread{[wait = std::move(wait), promise]
+        std::thread{[wait = std::move(wait), promise]() mutable
                     {
                         try
                         {
                             wait();
+                            wait = nullptr; // destroy the captures before making the future ready
                             promise->set_value();
                         }
                         catch (...)
                         {
+                            wait = nullptr; // destroy the captures before making the future ready
                             promise->set_exception(std::current_exception());
                         }
                     }}


### PR DESCRIPTION
The detached thread started by `waitInThread` now destroys the wait callable (and any strong references it captures, such as the communicator) before making the future ready, on both the value and the exception paths, so it can never end up performing the last release and running `~Instance` off a Python thread.

Deterministic red/green repro: https://gist.github.com/pepone/c3189a66fc9b618271001f090a148c12

Closes #6575.
