### PR TITLE
Send the CA certificates held by IceSSL.CertFile to the peer

### DIFF
--- a/changelog.d/csharp/6534.md
+++ b/changelog.d/csharp/6534.md
@@ -1,0 +1,3 @@
+- The SSL transport now sends the CA certificates held by `IceSSL.CertFile` to the peer, so a peer that trusts only
+  the root CA can validate the chain. These intermediate certificates were previously dropped when the file was
+  loaded, and the peer had to obtain them elsewhere to accept the connection.

--- a/csharp/src/Ice/SSL/SSLEngine.cs
+++ b/csharp/src/Ice/SSL/SSLEngine.cs
@@ -23,6 +23,9 @@ internal class SSLEngine : IDisposable
 
     public void Dispose()
     {
+        // The certificate context holds on to the certificates released below.
+        _certificateContext = null;
+
         // Release the unmanaged key handles that back each X509Certificate2. The certificate
         // collection itself isn't IDisposable, so we have to walk its contents.
         if (_certs is not null)
@@ -97,7 +100,6 @@ internal class SSLEngine : IDisposable
 
             try
             {
-                X509Certificate2 cert;
                 X509KeyStorageFlags importFlags;
                 if (_useMachineContext)
                 {
@@ -108,6 +110,9 @@ internal class SSLEngine : IDisposable
                     importFlags = X509KeyStorageFlags.UserKeySet;
                 }
 
+                // With a PKCS#12 file holding a certificate chain, this returns the certificate with the private
+                // key.
+                X509Certificate2 cert;
                 if (passwordStr.Length > 0)
                 {
                     using SecureString password = createSecureString(passwordStr);
@@ -118,6 +123,37 @@ internal class SSLEngine : IDisposable
                     cert = new X509Certificate2(certFile, (string)null, importFlags);
                 }
                 _certs.Add(cert);
+
+                if (cert.HasPrivateKey)
+                {
+                    // The file can also hold the CA certificates that complete the chain of the certificate above.
+                    // SslStream only sends these intermediate certificates to the peer when we supply the
+                    // certificate through a certificate context; with a bare certificate, a peer that trusts only
+                    // the root CA sees a partial chain and rejects the connection.
+                    //
+                    // We keep the certificate loaded above as the one we present to the peer, and use this second
+                    // load only for the CA certificates: with .NET 8 on Windows, a certificate imported into a
+                    // collection loses its private key as soon as any copy of it is disposed, and
+                    // SslStreamCertificateContext.Create disposes its own copy of the certificate we give it.
+                    var fileCerts = new X509Certificate2Collection();
+                    fileCerts.Import(certFile, passwordStr.Length > 0 ? passwordStr : null, importFlags);
+
+                    // The certificates loaded above are released with the others in Dispose. We must not release
+                    // the private key holders any earlier: on Windows, a PKCS#12 file with a friendly name gives
+                    // all its loads the same key container, and disposing one of them erases the private key of
+                    // the certificate we present to the peer.
+                    _certs.AddRange(fileCerts);
+
+                    var caCerts = new X509Certificate2Collection();
+                    foreach (X509Certificate2 fileCert in fileCerts)
+                    {
+                        if (!fileCert.HasPrivateKey)
+                        {
+                            caCerts.Add(fileCert);
+                        }
+                    }
+                    _certificateContext = SslStreamCertificateContext.Create(cert, caCerts);
+                }
             }
             catch (CryptographicException ex)
             {
@@ -224,34 +260,44 @@ internal class SSLEngine : IDisposable
     {
         var authenticationOptions = new SslClientAuthenticationOptions
         {
-            ClientCertificates = _certs,
-            LocalCertificateSelectionCallback = (sender, targetHost, certs, remoteCertificate, acceptableIssuers) =>
-            {
-                if (certs == null || certs.Count == 0)
-                {
-                    return null;
-                }
-                else if (certs.Count == 1)
-                {
-                    return certs[0];
-                }
-
-                // Use the first certificate that match the acceptable issuers.
-                if (acceptableIssuers != null && acceptableIssuers.Length > 0)
-                {
-                    foreach (X509Certificate certificate in certs)
-                    {
-                        if (Array.IndexOf(acceptableIssuers, certificate.Issuer) != -1)
-                        {
-                            return certificate;
-                        }
-                    }
-                }
-                return certs[0];
-            },
             RemoteCertificateValidationCallback = remoteCertificateValidationCallback,
             TargetHost = host,
         };
+
+        if (_certificateContext is not null)
+        {
+            // The certificate context carries the intermediate CA certificates loaded with the certificate.
+            authenticationOptions.ClientCertificateContext = _certificateContext;
+        }
+        else
+        {
+            authenticationOptions.ClientCertificates = _certs;
+            authenticationOptions.LocalCertificateSelectionCallback =
+                (sender, targetHost, certs, remoteCertificate, acceptableIssuers) =>
+                {
+                    if (certs == null || certs.Count == 0)
+                    {
+                        return null;
+                    }
+                    else if (certs.Count == 1)
+                    {
+                        return certs[0];
+                    }
+
+                    // Use the first certificate that match the acceptable issuers.
+                    if (acceptableIssuers != null && acceptableIssuers.Length > 0)
+                    {
+                        foreach (X509Certificate certificate in certs)
+                        {
+                            if (Array.IndexOf(acceptableIssuers, certificate.Issuer) != -1)
+                            {
+                                return certificate;
+                            }
+                        }
+                    }
+                    return certs[0];
+                };
+        }
 
         authenticationOptions.CertificateChainPolicy = new X509ChainPolicy();
         if (_caCerts is null)
@@ -285,19 +331,22 @@ internal class SSLEngine : IDisposable
     internal SslServerAuthenticationOptions createServerAuthenticationOptions(
         RemoteCertificateValidationCallback remoteCertificateValidationCallback)
     {
-        // Get the certificate collection and select the first one.
-        X509Certificate2 cert = null;
-        if (_certs.Count > 0)
-        {
-            cert = _certs[0];
-        }
-
         var authenticationOptions = new SslServerAuthenticationOptions
         {
-            ServerCertificate = cert,
             ClientCertificateRequired = _verifyPeer > 0,
             RemoteCertificateValidationCallback = remoteCertificateValidationCallback,
         };
+
+        if (_certificateContext is not null)
+        {
+            // The certificate context carries the intermediate CA certificates loaded with the certificate.
+            authenticationOptions.ServerCertificateContext = _certificateContext;
+        }
+        else if (_certs.Count > 0)
+        {
+            // Get the certificate collection and select the first one.
+            authenticationOptions.ServerCertificate = _certs[0];
+        }
 
         authenticationOptions.CertificateChainPolicy = new X509ChainPolicy();
         if (_caCerts is null)
@@ -566,6 +615,11 @@ internal class SSLEngine : IDisposable
     private int _verifyPeer;
     private int _checkCRL;
     private X509Certificate2Collection _certs;
+
+    // The certificate context built from IceSSL.CertFile; it carries the CA certificates we send to the peer along
+    // with our certificate. It remains null when the certificate file holds no private key, and when the
+    // certificate comes from IceSSL.FindCert, where the platform completes the chain from the certificate store.
+    private SslStreamCertificateContext _certificateContext;
     private bool _useMachineContext;
     private X509Certificate2Collection _caCerts;
     private readonly TrustManager _trustManager;

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -729,6 +729,31 @@ public class AllTests : global::Test.AllTests
             }
             Console.Out.WriteLine("ok");
 
+            Console.Out.Write("testing certificate chains... ");
+            Console.Out.Flush();
+            {
+                // The server certificate is issued by ca1/i1/i2, and its certificate file holds the i1 and i2
+                // intermediate CA certificates. The client only trusts the ca1 root certificate, so the server must
+                // send the intermediate certificates for the client to validate the server certificate.
+                initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1");
+                using var comm = new Ice.Communicator(initData);
+                ServerFactoryPrx fact = Test.ServerFactoryPrxHelper.checkedCast(comm.stringToProxy(factoryRef));
+                test(fact != null);
+                d = createServerProps(defaultProperties, "ca1/i1/i2/server", "ca1/ca1");
+                ServerPrx server = fact.createServer(d);
+                try
+                {
+                    server.ice_ping();
+                }
+                catch (Ice.LocalException ex)
+                {
+                    Console.WriteLine(ex.ToString());
+                    test(false);
+                }
+                fact.destroyServer(server);
+            }
+            Console.Out.WriteLine("ok");
+
             if (Ice.Internal.AssemblyUtil.isWindows && isAdministrator)
             {
                 // LocalMachine certificate store is not supported on non Windows platforms.


### PR DESCRIPTION
Fixes #6534.

`IceSSL.CertFile` was loaded with the single-certificate `X509Certificate2` constructor, so the CA certificates a
PKCS#12 file holds alongside the end-entity certificate were dropped at load time. The server then set a bare
`ServerCertificate` and the client passed its certificate through `ClientCertificates`, neither of which lets
`SslStream` send intermediate certificates. A peer that trusts only the root CA saw a partial chain and rejected
the connection.

The file is now loaded a second time as a collection to pick up the certificates without a private key; these go to
`SslStreamCertificateContext.Create` along with the certificate we present, and the context is set as
`ServerCertificateContext` / `ClientCertificateContext`. `IceSSL.FindCert` keeps the `ClientCertificates` +
`LocalCertificateSelectionCallback` path, where the acceptable-issuer selection among several store identities
applies and the platform completes the chain from the certificate store.

### Why the certificate we present still comes from the constructor

The obvious implementation — import everything as a collection and take the private-key certificate from it — is
wrong on Windows with .NET 8:

- A certificate loaded through `X509Certificate2Collection.Import` loses its private key as soon as **any** copy of
  it is disposed (the "Windows private key lifetime simplified" breaking change, fixed in .NET 9). The single
  certificate constructor does not do this.
- `SslStreamCertificateContext.Create` disposes its own copy of the certificate it is given
  (`chain.ChainElements[0].Certificate.Dispose()`, "Dispose the copy of the target cert"), and .NET 8 runs that
  same `Create` on a bare `ServerCertificate` too.

For the same reason the second load is released only with everything else in `Dispose`, never earlier: as
`certs/makecerts.sh` documents, a PKCS#12 file with a friendly name gives all of its loads the same Windows key
container, so disposing one erases the private key of the certificate we present.

### Testing

`testCertificateChains` is ported from the C++ suite: the server is configured from `ca1/i1/i2/server.p12` and the
client trusts only the `ca1` root, with no certificate-store import. It fails before this change with
`SSL authentication failure: One or more certificates required to validate this certificate cannot be found.`

Two things worth knowing:

- On Windows this is not a pure on-wire assertion. When the OS cannot otherwise build the chain,
  `SslStreamCertificateContext` adds the intermediates to the CurrentUser/LocalMachine intermediate CA store — that
  is how Schannel comes to send them, so .NET performs the store import the C++ test does by hand.
- Client-side chains are not covered: the fixtures have no chained `clientAuth` certificate
  (`ca1/i1/i2/server` is `serverAuth` only), so covering that needs a new certificate. The existing mutual TLS tests
  do exercise the new `ClientCertificateContext` path, with a zero-intermediate chain.
