### PR TITLE
Close the connection when getInfo or setBufferSize fails (C#, Java)

### DIFF
--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1325,7 +1325,17 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             {
                 throw _exception;
             }
-            return initConnectionInfo();
+
+            try
+            {
+                return initConnectionInfo();
+            }
+            catch (LocalException ex)
+            {
+                // The failing call may have closed the socket, so close the connection as well.
+                setState(StateClosed, ex);
+                throw;
+            }
         }
     }
 
@@ -1338,7 +1348,17 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             {
                 throw _exception;
             }
-            _transceiver.setBufferSize(rcvSize, sndSize);
+
+            try
+            {
+                _transceiver.setBufferSize(rcvSize, sndSize);
+            }
+            catch (LocalException ex)
+            {
+                // The failing call may have closed the socket, so close the connection as well.
+                setState(StateClosed, ex);
+                throw;
+            }
             _info = null; // Invalidate the cached connection info
         }
     }
@@ -1713,19 +1733,33 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             ConnectionState newState = toConnectionState(state);
             if (oldState != newState)
             {
-                _observer = _instance.initializationData().observer.getConnectionObserver(
-                    initConnectionInfo(),
-                    _endpoint,
-                    newState,
-                    _observer);
-                if (_observer is not null)
+                ConnectionInfo connectionInfo = null;
+                try
                 {
-                    _observer.attach();
+                    connectionInfo = initConnectionInfo();
                 }
-                else
+                catch (System.Exception)
                 {
-                    _writeStreamPos = -1;
-                    _readStreamPos = -1;
+                    // initConnectionInfo can fail. The state transition must complete regardless, so we ignore this
+                    // exception and skip the observer update.
+                }
+
+                if (connectionInfo is not null)
+                {
+                    _observer = _instance.initializationData().observer.getConnectionObserver(
+                        connectionInfo,
+                        _endpoint,
+                        newState,
+                        _observer);
+                    if (_observer is not null)
+                    {
+                        _observer.attach();
+                    }
+                    else
+                    {
+                        _writeStreamPos = -1;
+                        _readStreamPos = -1;
+                    }
                 }
             }
             if (_observer is not null && state == StateClosed && _exception is not null)

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1740,8 +1740,13 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 }
                 catch (System.Exception)
                 {
-                    // initConnectionInfo can fail. The state transition must complete regardless, so we ignore this
-                    // exception and skip the observer update.
+                    // initConnectionInfo can fail. The transition to StateClosed cannot unwind — _threadPool.finish
+                    // has already run — so skip the observer update and let the transition complete. For any other
+                    // transition, propagate: the caller closes the connection.
+                    if (state != StateClosed)
+                    {
+                        throw;
+                    }
                 }
 
                 if (connectionInfo is not null)

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -1272,8 +1272,12 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 try {
                     connectionInfo = initConnectionInfo();
                 } catch (LocalException ex) {
-                    // initConnectionInfo can fail. The state transition must complete regardless, so we ignore this
-                    // exception and skip the observer update.
+                    // initConnectionInfo can fail. The transition to StateClosed cannot unwind — _threadPool.finish
+                    // has already run — so skip the observer update and let the transition complete. For any other
+                    // transition, propagate: the caller closes the connection.
+                    if (state != StateClosed) {
+                        throw ex;
+                    }
                 }
 
                 if (connectionInfo != null) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -948,7 +948,14 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         if (_state >= StateClosed) {
             throw (LocalException) _exception.fillInStackTrace();
         }
-        return initConnectionInfo();
+
+        try {
+            return initConnectionInfo();
+        } catch (LocalException ex) {
+            // The failing call may have closed the socket, so close the connection as well.
+            setState(StateClosed, ex);
+            throw ex;
+        }
     }
 
     @Override
@@ -956,7 +963,14 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         if (_state >= StateClosed) {
             throw (LocalException) _exception.fillInStackTrace();
         }
-        _transceiver.setBufferSize(rcvSize, sndSize);
+
+        try {
+            _transceiver.setBufferSize(rcvSize, sndSize);
+        } catch (LocalException ex) {
+            // The failing call may have closed the socket, so close the connection as well.
+            setState(StateClosed, ex);
+            throw ex;
+        }
         _info = null; // Invalidate the cached connection info
     }
 
@@ -1254,16 +1268,26 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             ConnectionState oldState = toConnectionState(_state);
             ConnectionState newState = toConnectionState(state);
             if (oldState != newState) {
-                _observer =
-                    _instance
-                        .initializationData()
-                        .observer
-                        .getConnectionObserver(initConnectionInfo(), _endpoint, newState, _observer);
-                if (_observer != null) {
-                    _observer.attach();
-                } else {
-                    _writeStreamPos = -1;
-                    _readStreamPos = -1;
+                ConnectionInfo connectionInfo = null;
+                try {
+                    connectionInfo = initConnectionInfo();
+                } catch (LocalException ex) {
+                    // initConnectionInfo can fail. The state transition must complete regardless, so we ignore this
+                    // exception and skip the observer update.
+                }
+
+                if (connectionInfo != null) {
+                    _observer =
+                        _instance
+                            .initializationData()
+                            .observer
+                            .getConnectionObserver(connectionInfo, _endpoint, newState, _observer);
+                    if (_observer != null) {
+                        _observer.attach();
+                    } else {
+                        _writeStreamPos = -1;
+                        _readStreamPos = -1;
+                    }
                 }
             }
             if (_observer != null && state == StateClosed && _exception != null) {


### PR DESCRIPTION
This PR ports #6567 to C# and Java.

When a transceiver's `getInfo` or `setBufferSize` fails, the transceiver may have lost its socket — the buffer-size helpers in `Network` close it before rethrowing — yet the connection remained Active. In C#, a second `Connection.setBufferSize` call then reached `Socket.SetSocketOption` on the disposed socket, and the resulting raw .NET `ObjectDisposedException` escaped through the Ice API. In Java, the connection lingered as an Active zombie on a closed channel until the next write failed, and further calls kept producing fresh `SocketException`s.

With this change, `ConnectionI.getInfo` and `ConnectionI.setBufferSize` close the connection (`setState(StateClosed, ...)`) when the transceiver call throws, and rethrow. A connection never stays Active after its transport fails, and later calls rethrow the recorded exception from the `_state >= StateClosed` check instead of reaching the transport.

As in the C++ PR, the observer update in `setState` tolerates an `initConnectionInfo` failure on the transition to `StateClosed` — the one transition that cannot unwind, since the thread pool's `finish` has already run — completing the transition with the observer update skipped. On any other transition the failure propagates as before, so a failure during connection start still fails the start cleanly. In C# this guard catches `System.Exception` rather than `LocalException`: on the teardown path the transceiver's `getInfo` reads `Socket.LocalEndPoint` on a disposed socket, which throws a raw `ObjectDisposedException`.

The `getInfo`/`setBufferSize` handlers catch `LocalException` — the closest C#/Java can get to the C++ `catch (...)`, since `setState` records the exception in the `LocalException`-typed `_exception` field.

Verified with the Ice/info test in both mappings.

No changelog entry: the first failure requires `setsockopt`/`getsockopt` to fail on a live socket (practically, an oversized buffer size on a BSD-family system), same as #6567.

Fixes #6580
Fixes #6581

🤖 Generated with [Claude Code](https://claude.com/claude-code)