### PR TITLE
Fill C# API doc-comment gaps and hide implementation classes from docfx

### DIFF
--- a/csharp/docfx/filterConfig.yml
+++ b/csharp/docfx/filterConfig.yml
@@ -5,3 +5,13 @@ apiRules:
 - exclude:
     uidRegex: ^Ice\.UtilInternal\..*
     type: Type
+# Implementation classes that are public but are not part of the API.
+- exclude:
+    uidRegex: ^Ice\.ConnectionI$
+    type: Type
+- exclude:
+    uidRegex: ^Ice\.ImplicitContextI$
+    type: Type
+- exclude:
+    uidRegex: ^Ice\.ObjectPrxHelperBase(\..*)?$
+    type: Type

--- a/csharp/src/Ice/Instrumentation.cs
+++ b/csharp/src/Ice/Instrumentation.cs
@@ -105,6 +105,9 @@ public enum ConnectionState
     ConnectionStateClosed
 }
 
+/// <summary>
+/// Represents an observer for Ice connections.
+/// </summary>
 public interface ConnectionObserver : Observer
 {
     /// <summary>
@@ -120,6 +123,9 @@ public interface ConnectionObserver : Observer
     void receivedBytes(int num);
 }
 
+/// <summary>
+/// Represents an observer for dispatches.
+/// </summary>
 public interface DispatchObserver : Observer
 {
     /// <summary>
@@ -134,6 +140,9 @@ public interface DispatchObserver : Observer
     void reply(int size);
 }
 
+/// <summary>
+/// Represents an observer for remote or collocated invocations.
+/// </summary>
 public interface ChildInvocationObserver : Observer
 {
     /// <summary>
@@ -143,14 +152,24 @@ public interface ChildInvocationObserver : Observer
     void reply(int size);
 }
 
+/// <summary>
+/// Represents an observer for remote invocations.
+/// </summary>
 public interface RemoteObserver : ChildInvocationObserver
 {
 }
 
+/// <summary>
+/// Represents an observer for collocated invocations.
+/// </summary>
 public interface CollocatedObserver : ChildInvocationObserver
 {
 }
 
+/// <summary>
+/// Represents an observer for invocations on proxies. A proxy invocation can either result in a collocated or remote
+/// invocation. If it results in a remote invocation, a sub-observer is requested for the remote invocation.
+/// </summary>
 public interface InvocationObserver : Observer
 {
     /// <summary>
@@ -183,6 +202,14 @@ public interface InvocationObserver : Observer
     CollocatedObserver getCollocatedObserver(ObjectAdapter adapter, int requestId, int size);
 }
 
+/// <summary>
+/// The observer updater interface. This interface is implemented by the Ice runtime and an instance of this interface
+/// is provided by the Ice communicator on initialization to the <see cref="CommunicatorObserver" /> object set with
+/// the communicator initialization data. The Ice communicator calls
+/// <see cref="CommunicatorObserver.setObserverUpdater" /> to provide the observer updater. This interface can be used
+/// by add-ins implementing the <see cref="CommunicatorObserver" /> interface to update the observers of connections
+/// and threads.
+/// </summary>
 public interface ObserverUpdater
 {
     /// <summary>

--- a/csharp/src/Ice/MetricsObserverI.cs
+++ b/csharp/src/Ice/MetricsObserverI.cs
@@ -5,8 +5,15 @@ using System.Diagnostics;
 
 namespace IceMX;
 
+/// <summary>
+/// Helper class for metrics operations.
+/// </summary>
+/// <typeparam name="T">The metrics type.</typeparam>
 public class MetricsHelper<T> where T : Metrics
 {
+    /// <summary>
+    /// Resolves attribute values from metrics objects.
+    /// </summary>
     public class AttributeResolver
     {
         private abstract class Resolver
@@ -238,8 +245,16 @@ public class MetricsHelper<T> where T : Metrics
     private readonly AttributeResolver _attributes;
 }
 
+/// <summary>
+/// Observer implementation for metrics collection.
+/// </summary>
+/// <typeparam name="T">The metrics type.</typeparam>
 public class Observer<T> : Stopwatch, Ice.Instrumentation.Observer where T : Metrics, new()
 {
+    /// <summary>
+    /// Represents a function that updates a metrics object.
+    /// </summary>
+    /// <param name="m">The metrics object to update.</param>
     public delegate void MetricsUpdate(T m);
 
     public virtual void attach() => Start();
@@ -338,6 +353,11 @@ public class Observer<T> : Stopwatch, Ice.Instrumentation.Observer where T : Met
     private long _previousDelay;
 }
 
+/// <summary>
+/// Factory for creating observer instances for metrics collection.
+/// </summary>
+/// <typeparam name="T">The metrics type.</typeparam>
+/// <typeparam name="O">The observer type.</typeparam>
 public class ObserverFactory<T, O> where T : Metrics, new() where O : Observer<T>, new()
 {
     public ObserverFactory(Ice.Internal.MetricsAdminI metrics, string name)

--- a/csharp/src/Ice/SSL/ConnectionInfo.cs
+++ b/csharp/src/Ice/SSL/ConnectionInfo.cs
@@ -17,12 +17,13 @@ public sealed class ConnectionInfo : Ice.ConnectionInfo
     public readonly string cipher;
 
     /// <summary>
-    /// The certificate chain.
+    /// The peer's certificate, in a single-element array; empty when the peer did not provide a certificate.
     /// </summary>
     public readonly X509Certificate2[] certs;
 
     /// <summary>
-    /// The certificate chain verification status.
+    /// The certificate verification status. This field is always <see langword="true" />: a connection whose
+    /// certificate verification fails is aborted during the SSL handshake.
     /// </summary>
     public readonly bool verified;
 

--- a/csharp/src/Ice/SSL/ConnectionInfo.cs
+++ b/csharp/src/Ice/SSL/ConnectionInfo.cs
@@ -6,10 +6,24 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Ice.SSL;
 
+/// <summary>
+/// Provides access to the connection details of an SSL connection.
+/// </summary>
 public sealed class ConnectionInfo : Ice.ConnectionInfo
 {
+    /// <summary>
+    /// The negotiated cipher suite.
+    /// </summary>
     public readonly string cipher;
+
+    /// <summary>
+    /// The certificate chain.
+    /// </summary>
     public readonly X509Certificate2[] certs;
+
+    /// <summary>
+    /// The certificate chain verification status.
+    /// </summary>
     public readonly bool verified;
 
     internal ConnectionInfo(Ice.ConnectionInfo underlying, string cipher, X509Certificate2[] certs, bool verified)

--- a/csharp/src/Ice/SSL/EndpointInfo.cs
+++ b/csharp/src/Ice/SSL/EndpointInfo.cs
@@ -4,6 +4,9 @@
 
 namespace Ice.SSL;
 
+/// <summary>
+/// Provides access to an SSL endpoint's information.
+/// </summary>
 public sealed class EndpointInfo : Ice.EndpointInfo
 {
     internal EndpointInfo(Ice.EndpointInfo underlying)


### PR DESCRIPTION
This PR closes the doc-comment gaps in the public C# API:

- The seven observer interfaces in `Ice/Instrumentation.cs` (`ConnectionObserver`, `DispatchObserver`, `ChildInvocationObserver`, `RemoteObserver`, `CollocatedObserver`, `InvocationObserver`, `ObserverUpdater`) get type-level summaries ported from the C++ header, with explicit `<see cref>` links where the C++ comments rely on doxygen autolink.
- `Ice.SSL.ConnectionInfo` and `Ice.SSL.EndpointInfo` get class summaries from the C++ headers, and the `cipher`/`certs`/`verified` fields get doc comments describing the C# behavior (`certs` holds at most the peer's own certificate, and `verified` is always `true` on an established connection).
- The public IceMX helpers in `MetricsObserverI.cs` (`MetricsHelper<T>`, `AttributeResolver`, `Observer<T>`, `ObserverFactory<T, O>`, and the `MetricsUpdate` delegate) get summaries and `<typeparam>` docs matching the Java IceMX classes.

`SliceAttribute`, `SliceTypeIdAttribute`, and `TypeExtensions` turned out to be documented already (since #5868): each has a `// Corresponds to IceRPC's ...` line comment between the doc comment and the type declaration, which fooled the scan behind the issue report.

For the implementation classes that leak into the rendered API reference, this PR takes the docfx route instead of doc comments: `filterConfig.yml` now excludes `Ice.ConnectionI`, `Ice.ImplicitContextI`, and `Ice.ObjectPrxHelperBase` (including its nested `GetConnectionTaskCompletionCallback`, which the issue's scan missed). How proxies and connections are implemented is not relevant to users, and hiding the pages requires no API-surface change in 3.8.x. With `ObjectPrxHelperBase` hidden, the generated proxy helper pages (e.g. `RouterPrxHelper`) no longer list its members under Inherited Members; the `ice_*` operations remain documented on the `ObjectPrx` interface where users look for them. Nothing outside `src/Ice` references `ConnectionI` or `ImplicitContextI`, so they can become `internal` in 3.9 (#6586); `ObjectPrxHelperBase` itself must remain public, since every slice2cs-generated proxy helper derives from it, but its nested `GetConnectionTaskCompletionCallback` can become private.

Verified with a clean `docfx metadata` + `docfx build` run: the implementation-class pages are gone, `ObjectPrx`/`ObjectPrxHelper` still render, the new summaries appear in the generated output, and both the library build and the docfx build complete with zero warnings.

Not in this PR: enabling SA1600 (it flags every undocumented public member — 1,656 warnings on the Ice library today, a much larger sweep), and doc comments for the slice2cs-generated result records (e.g. `MetricsAdmin_GetMetricsViewNamesResult`), which need a slice2cs change.

Fixes #6568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
