### PR TITLE
Make transceiver getInfo non-closing and close the connection when setBufferSize fails

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1866,7 +1866,16 @@ Ice::ConnectionI::setBufferSize(int32_t rcvSize, int32_t sndSize)
     {
         rethrow_exception(_exception);
     }
-    _transceiver->setBufferSize(rcvSize, sndSize);
+    try
+    {
+        _transceiver->setBufferSize(rcvSize, sndSize);
+    }
+    catch (...)
+    {
+        // The failing call may have closed the socket, so close the connection as well.
+        setState(StateClosed, current_exception());
+        throw;
+    }
     _info = nullptr; // Invalidate the cached connection info
 }
 

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -1196,10 +1196,8 @@ IceInternal::setSendBufferSize(SOCKET fd, int sz)
 int
 IceInternal::getSendBufferSize(SOCKET fd)
 {
-    int sz;
-    socklen_t len = sizeof(sz);
-    if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, reinterpret_cast<char*>(&sz), &len) == SOCKET_ERROR ||
-        static_cast<unsigned int>(len) != sizeof(sz))
+    int sz = getSendBufferSizeNoThrow(fd);
+    if (sz == 0)
     {
         closeSocketNoThrow(fd);
         throw SocketException(__FILE__, __LINE__, getSocketErrno());
@@ -1220,13 +1218,37 @@ IceInternal::setRecvBufferSize(SOCKET fd, int sz)
 int
 IceInternal::getRecvBufferSize(SOCKET fd)
 {
+    int sz = getRecvBufferSizeNoThrow(fd);
+    if (sz == 0)
+    {
+        closeSocketNoThrow(fd);
+        throw SocketException(__FILE__, __LINE__, getSocketErrno());
+    }
+    return sz;
+}
+
+int
+IceInternal::getSendBufferSizeNoThrow(SOCKET fd) noexcept
+{
+    int sz;
+    socklen_t len = sizeof(sz);
+    if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, reinterpret_cast<char*>(&sz), &len) == SOCKET_ERROR ||
+        static_cast<unsigned int>(len) != sizeof(sz))
+    {
+        return 0;
+    }
+    return sz;
+}
+
+int
+IceInternal::getRecvBufferSizeNoThrow(SOCKET fd) noexcept
+{
     int sz;
     socklen_t len = sizeof(sz);
     if (getsockopt(fd, SOL_SOCKET, SO_RCVBUF, reinterpret_cast<char*>(&sz), &len) == SOCKET_ERROR ||
         static_cast<unsigned int>(len) != sizeof(sz))
     {
-        closeSocketNoThrow(fd);
-        throw SocketException(__FILE__, __LINE__, getSocketErrno());
+        return 0;
     }
     return sz;
 }

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -1099,7 +1099,7 @@ IceInternal::setTcpBufSize(SOCKET fd, int rcvSize, int sndSize, const ProtocolIn
         //
         setRecvBufferSize(fd, rcvSize);
         int size = getRecvBufferSize(fd);
-        if (size > 0 && size < rcvSize)
+        if (size < rcvSize)
         {
             // Warn if the size that was set is less than the requested size and
             // we have not already warned.
@@ -1122,7 +1122,7 @@ IceInternal::setTcpBufSize(SOCKET fd, int rcvSize, int sndSize, const ProtocolIn
         //
         setSendBufferSize(fd, sndSize);
         int size = getSendBufferSize(fd);
-        if (size > 0 && size < sndSize)
+        if (size < sndSize)
         {
             // Warn if the size that was set is less than the requested size and
             // we have not already warned.

--- a/cpp/src/Ice/Network.h
+++ b/cpp/src/Ice/Network.h
@@ -222,6 +222,10 @@ namespace IceInternal
     ICE_API void setRecvBufferSize(SOCKET, int);
     ICE_API int getRecvBufferSize(SOCKET);
 
+    // Non-throwing variants that return 0 on failure and never close the fd.
+    ICE_API int getSendBufferSizeNoThrow(SOCKET) noexcept;
+    ICE_API int getRecvBufferSizeNoThrow(SOCKET) noexcept;
+
     ICE_API void setMcastGroup(SOCKET, const Address&, const std::string&);
     ICE_API void setMcastInterface(SOCKET, const std::string&, const Address&);
     ICE_API void setMcastTtl(SOCKET, int, const Address&);

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -541,16 +541,7 @@ OpenSSL::TransceiverI::getInfo(bool incoming, string adapterName, string connect
     // adapterName is the name of the object adapter currently associated with this connection, while _adapterName
     // represents the name of the object adapter that created this connection (incoming only).
 
-    Ice::ConnectionInfoPtr delegateInfo;
-    try
-    {
-        delegateInfo = _delegate->getInfo(incoming, std::move(adapterName), std::move(connectionId));
-    }
-    catch (...)
-    {
-        invalidateBIOFd();
-        throw;
-    }
+    Ice::ConnectionInfoPtr delegateInfo = _delegate->getInfo(incoming, std::move(adapterName), std::move(connectionId));
 
     X509* peerCertificate = nullptr;
     if (_peerCertificate)

--- a/cpp/src/Ice/TcpTransceiver.cpp
+++ b/cpp/src/Ice/TcpTransceiver.cpp
@@ -114,19 +114,8 @@ IceInternal::TcpTransceiver::getInfo(bool incoming, string adapterName, string c
         int remotePort;
         fdToAddressAndPort(_stream->fd(), localAddress, localPort, remoteAddress, remotePort);
 
-        int rcvSize;
-        int sndSize;
-        try
-        {
-            rcvSize = getRecvBufferSize(_stream->fd());
-            sndSize = getSendBufferSize(_stream->fd());
-        }
-        catch (const SocketException&)
-        {
-            // The failing call closed the fd.
-            _stream->clearFd();
-            throw;
-        }
+        int rcvSize = getRecvBufferSizeNoThrow(_stream->fd());
+        int sndSize = getSendBufferSizeNoThrow(_stream->fd());
 
         return make_shared<TCPConnectionInfo>(
             incoming,

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -495,19 +495,8 @@ IceObjC::StreamTransceiver::getInfo(bool incoming, string adapterName, string co
         int remotePort;
         fdToAddressAndPort(_fd, localAddress, localPort, remoteAddress, remotePort);
 
-        int rcvSize;
-        int sndSize;
-        try
-        {
-            rcvSize = getRecvBufferSize(_fd);
-            sndSize = getSendBufferSize(_fd);
-        }
-        catch (const SocketException&)
-        {
-            // The failing call closed the fd.
-            const_cast<StreamTransceiver*>(this)->clearFd();
-            throw;
-        }
+        int rcvSize = getRecvBufferSizeNoThrow(_fd);
+        int sndSize = getSendBufferSizeNoThrow(_fd);
 
         return make_shared<TCPConnectionInfo>(
             incoming,

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -98,7 +98,7 @@ IceObjC::StreamTransceiver::registerWithRunLoop(SocketOperation op)
     lock_guard lock(_mutex);
     if (_state == StateConnected && _fd == INVALID_SOCKET)
     {
-        // A failed getInfo or setBufferSize call closed the fd. The streams still reference the closed number, so
+        // A failed setBufferSize call closed the fd. The streams still reference the closed number, so
         // don't schedule them with the run loop; report the operations as ready so the thread pool calls read or
         // write, which throws.
         return op;
@@ -352,8 +352,7 @@ IceObjC::StreamTransceiver::write(Buffer& buf)
         lock_guard lock(_mutex);
         if (_fd == INVALID_SOCKET)
         {
-            // The streams perform their I/O on the socket recorded in _fd; a failed getInfo or setBufferSize call
-            // closed it.
+            // The streams perform their I/O on the socket recorded in _fd; a failed setBufferSize call closed it.
             throw ConnectionLostException(__FILE__, __LINE__);
         }
         if (_error)
@@ -409,8 +408,7 @@ IceObjC::StreamTransceiver::read(Buffer& buf)
         lock_guard lock(_mutex);
         if (_fd == INVALID_SOCKET)
         {
-            // The streams perform their I/O on the socket recorded in _fd; a failed getInfo or setBufferSize call
-            // closed it.
+            // The streams perform their I/O on the socket recorded in _fd; a failed setBufferSize call closed it.
             throw ConnectionLostException(__FILE__, __LINE__);
         }
         if (_error)

--- a/cpp/src/IceBT/StreamSocket.cpp
+++ b/cpp/src/IceBT/StreamSocket.cpp
@@ -43,7 +43,7 @@ IceBT::StreamSocket::setBufferSize(SOCKET fd, int rcvSize, int sndSize)
         //
         IceInternal::setRecvBufferSize(fd, rcvSize);
         int size = IceInternal::getRecvBufferSize(fd);
-        if (size > 0 && size < rcvSize)
+        if (size < rcvSize)
         {
             //
             // Warn if the size that was set is less than the requested size and
@@ -68,7 +68,7 @@ IceBT::StreamSocket::setBufferSize(SOCKET fd, int rcvSize, int sndSize)
         //
         IceInternal::setSendBufferSize(fd, sndSize);
         int size = IceInternal::getSendBufferSize(fd);
-        if (size > 0 && size < sndSize)
+        if (size < sndSize)
         {
             // Warn if the size that was set is less than the requested size and
             // we have not already warned.

--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -141,19 +141,8 @@ IceBT::TransceiverI::getInfo(bool incoming, string adapterName, string connectio
         int remoteChannel;
         fdToAddressAndChannel(_stream->fd(), localAddress, localChannel, remoteAddress, remoteChannel);
 
-        int rcvSize;
-        int sndSize;
-        try
-        {
-            rcvSize = IceInternal::getRecvBufferSize(_stream->fd());
-            sndSize = IceInternal::getSendBufferSize(_stream->fd());
-        }
-        catch (const Ice::SocketException&)
-        {
-            // The failing call closed the fd.
-            _stream->clearFd();
-            throw;
-        }
+        int rcvSize = IceInternal::getRecvBufferSizeNoThrow(_stream->fd());
+        int sndSize = IceInternal::getSendBufferSizeNoThrow(_stream->fd());
 
         return make_shared<ConnectionInfo>(
             incoming,


### PR DESCRIPTION
A transceiver's `getInfo` reads the send/receive buffer sizes with the `Network` buffer-size helpers, which close the fd when `getsockopt` fails: a purely informational read could destroy the transport, and every `initConnectionInfo` call site inherited that hazard. #6567 addressed the fallout by closing the connection at the `Connection::getInfo`/`setBufferSize` entry points, but that still left other `initConnectionInfo` call sites exposed (#6588) and required tolerating observer-update failures inside `setState`.

This PR takes the opposite approach for `getInfo`: a failing `getsockopt` doesn't harm the socket — the damage came from the helpers closing it — so the TCP, iOS CFStream, and Bluetooth transceivers now read the buffer sizes with new non-throwing, non-closing helpers (`getRecvBufferSizeNoThrow`/`getSendBufferSizeNoThrow`), reporting 0 in the practically unreachable failure case. `getInfo` can no longer close the socket, and no `initConnectionInfo` call site needs special handling. The throwing helpers remain for the socket-setup paths and `setTcpBufSize`, where close-on-failure is load-bearing for the unwind, and are now thin wrappers over the non-throwing variants.

`setBufferSize` is different: it's a requested mutation, and the failing helper closes the fd. `ConnectionI::setBufferSize` now closes the connection (`setState(StateClosed, ...)`) and rethrows when the transceiver call throws — the part of #6567 this PR keeps, scoped to that one entry point. A connection never stays Active after its transport fails, and a later call rethrows the recorded exception from the `_state >= StateClosed` check instead of reaching `setTcpBufSize`'s fd assert. After a failed `setBufferSize` the transceiver's fd is cleared, so the `initConnectionInfo` in the StateClosed observer update returns the default info instead of throwing — `setState` needs no special handling.

Supersedes #6567.

Verified with the Ice/info test on macOS; libIce and IceBT compile on Ubuntu 24.04, and the CFStream transceiver compiles against the iphonesimulator SDK.

No changelog entry: the trigger requires `getsockopt`/`setsockopt` to fail on a live socket (practically, an oversized buffer size on a BSD-family system such as macOS), same as #6567 and #6388.

Fixes #6561
Fixes #6588

🤖 Generated with [Claude Code](https://claude.com/claude-code)
