### PR TITLE
Make transceiver getInfo non-closing and close the connection when setBufferSize fails (C#, Java)

### DIFF
--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1338,7 +1338,16 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             {
                 throw _exception;
             }
-            _transceiver.setBufferSize(rcvSize, sndSize);
+            try
+            {
+                _transceiver.setBufferSize(rcvSize, sndSize);
+            }
+            catch (LocalException ex)
+            {
+                // The failing call may have closed the socket, so close the connection as well.
+                setState(StateClosed, ex);
+                throw;
+            }
             _info = null; // Invalidate the cached connection info
         }
     }

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1713,7 +1713,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         }
         catch (LocalException ex)
         {
-            _logger.error("unexpected connection exception:\n" + ex + "\n" + _transceiver.ToString());
+            _logger.error("unexpected connection exception:\n" + ex + "\n" + _desc);
         }
 
         if (_instance.initializationData().observer is not null)
@@ -2672,7 +2672,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         return _info;
     }
 
-    private void warning(string msg, System.Exception ex) => _logger.warning($"{msg}:\n{ex}\n{_transceiver}");
+    private void warning(string msg, System.Exception ex) => _logger.warning($"{msg}:\n{ex}\n{_desc}");
 
     private void observerStartRead(Ice.Internal.Buffer buf)
     {

--- a/csharp/src/Ice/Internal/Network.cs
+++ b/csharp/src/Ice/Internal/Network.cs
@@ -279,6 +279,31 @@ internal sealed class Network
         return sz;
     }
 
+    // Non-throwing variants that return 0 on failure and never close the socket.
+    internal static int getSendBufferSizeNoThrow(Socket socket)
+    {
+        try
+        {
+            return (int)socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    internal static int getRecvBufferSizeNoThrow(Socket socket)
+    {
+        try
+        {
+            return (int)socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
     internal static void setReuseAddress(Socket socket, bool reuse)
     {
         try

--- a/csharp/src/Ice/Internal/TcpTransceiver.cs
+++ b/csharp/src/Ice/Internal/TcpTransceiver.cs
@@ -51,19 +51,27 @@ internal sealed class TcpTransceiver : Transceiver
         }
         else
         {
-            EndPoint localEndpoint = Network.getLocalAddress(_stream.fd());
-            EndPoint remoteEndpoint = Network.getRemoteAddress(_stream.fd());
+            try
+            {
+                EndPoint localEndpoint = Network.getLocalAddress(_stream.fd());
+                EndPoint remoteEndpoint = Network.getRemoteAddress(_stream.fd());
 
-            return new TCPConnectionInfo(
-                incoming,
-                adapterName,
-                connectionId,
-                Network.endpointAddressToString(localEndpoint),
-                Network.endpointPort(localEndpoint),
-                Network.endpointAddressToString(remoteEndpoint),
-                Network.endpointPort(remoteEndpoint),
-                Network.getRecvBufferSize(_stream.fd()),
-                Network.getSendBufferSize(_stream.fd()));
+                return new TCPConnectionInfo(
+                    incoming,
+                    adapterName,
+                    connectionId,
+                    Network.endpointAddressToString(localEndpoint),
+                    Network.endpointPort(localEndpoint),
+                    Network.endpointAddressToString(remoteEndpoint),
+                    Network.endpointPort(remoteEndpoint),
+                    Network.getRecvBufferSizeNoThrow(_stream.fd()),
+                    Network.getSendBufferSizeNoThrow(_stream.fd()));
+            }
+            catch (ObjectDisposedException)
+            {
+                // Treat a disposed socket like a null fd.
+                return new TCPConnectionInfo(incoming, adapterName, connectionId);
+            }
         }
     }
 

--- a/csharp/src/Ice/Internal/UdpTransceiver.cs
+++ b/csharp/src/Ice/Internal/UdpTransceiver.cs
@@ -490,7 +490,8 @@ internal sealed class UdpTransceiver : Transceiver
         {
             return new UDPConnectionInfo(incoming, adapterName, connectionId);
         }
-        else
+
+        try
         {
             EndPoint localEndpoint = Network.getLocalAddress(_fd);
 
@@ -531,6 +532,11 @@ internal sealed class UdpTransceiver : Transceiver
                     _rcvSize,
                     _sndSize);
             }
+        }
+        catch (ObjectDisposedException)
+        {
+            // Treat a disposed socket like a null fd.
+            return new UDPConnectionInfo(incoming, adapterName, connectionId);
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -956,7 +956,13 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         if (_state >= StateClosed) {
             throw (LocalException) _exception.fillInStackTrace();
         }
-        _transceiver.setBufferSize(rcvSize, sndSize);
+        try {
+            _transceiver.setBufferSize(rcvSize, sndSize);
+        } catch (LocalException ex) {
+            // The failing call may have closed the socket, so close the connection as well.
+            setState(StateClosed, ex);
+            throw ex;
+        }
         _info = null; // Invalidate the cached connection info
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
@@ -419,6 +419,23 @@ public final class Network {
         }
     }
 
+    // Non-throwing variants that return 0 on failure and never close the channel.
+    public static int getSendBufferSizeNoThrow(SocketChannel fd) {
+        try {
+            return fd.socket().getSendBufferSize();
+        } catch (IOException ex) {
+            return 0;
+        }
+    }
+
+    public static int getRecvBufferSizeNoThrow(SocketChannel fd) {
+        try {
+            return fd.socket().getReceiveBufferSize();
+        } catch (IOException ex) {
+            return 0;
+        }
+    }
+
     public static void setRecvBufferSize(ServerSocketChannel fd, int size) {
         try {
             ServerSocket socket = fd.socket();
@@ -476,6 +493,23 @@ public final class Network {
         } catch (IOException ex) {
             closeSocketNoThrow(fd);
             throw new SocketException(ex);
+        }
+    }
+
+    // Non-throwing variants that return 0 on failure and never close the channel.
+    public static int getSendBufferSizeNoThrow(DatagramChannel fd) {
+        try {
+            return fd.socket().getSendBufferSize();
+        } catch (IOException ex) {
+            return 0;
+        }
+    }
+
+    public static int getRecvBufferSizeNoThrow(DatagramChannel fd) {
+        try {
+            return fd.socket().getReceiveBufferSize();
+        } catch (IOException ex) {
+            return 0;
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpTransceiver.java
@@ -70,6 +70,8 @@ final class TcpTransceiver implements Transceiver {
         if (_stream.fd() == null) {
             return new TCPConnectionInfo(incoming, adapterName, connectionId);
         } else {
+            // A closed SocketChannel's socket still reports its addresses, so there is no need to check
+            // whether the channel is open.
             Socket socket = _stream.fd().socket();
 
             String remoteAddress = "";
@@ -79,12 +81,8 @@ final class TcpTransceiver implements Transceiver {
                 remotePort = socket.getPort();
             }
 
-            int rcvSize = 0;
-            int sndSize = 0;
-            if (!socket.isClosed()) {
-                rcvSize = Network.getRecvBufferSize(_stream.fd());
-                sndSize = Network.getSendBufferSize(_stream.fd());
-            }
+            int rcvSize = Network.getRecvBufferSizeNoThrow(_stream.fd());
+            int sndSize = Network.getSendBufferSizeNoThrow(_stream.fd());
 
             return new TCPConnectionInfo(
                 incoming,

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
@@ -193,17 +193,14 @@ final class UdpTransceiver implements Transceiver {
 
     @Override
     public ConnectionInfo getInfo(boolean incoming, String adapterName, String connectionId) {
-        if (_fd == null) {
+        // A closed channel reports no local address, so treat it like a null fd.
+        if (_fd == null || !_fd.isOpen()) {
             return new UDPConnectionInfo(incoming, adapterName, connectionId);
         } else {
             DatagramSocket socket = _fd.socket();
 
-            int rcvSize = 0;
-            int sndSize = 0;
-            if (!socket.isClosed()) {
-                rcvSize = Network.getRecvBufferSize(_fd);
-                sndSize = Network.getSendBufferSize(_fd);
-            }
+            int rcvSize = Network.getRecvBufferSizeNoThrow(_fd);
+            int sndSize = Network.getSendBufferSizeNoThrow(_fd);
 
             if (_state == StateNotConnected) {
                 assert _incoming;


### PR DESCRIPTION
This PR ports #6591 to C# and Java.

A transceiver's `getInfo` reads the send/receive buffer sizes with the `Network` buffer-size helpers, which close the socket when the read fails: a purely informational call could destroy the transport (#6580, #6581). In C#, reading the endpoints of a socket disposed by an earlier failure additionally threw a raw `ObjectDisposedException` through the Ice API.

With this change, `getInfo` can no longer close the socket:

- New non-throwing, non-closing `Network` helpers (`getRecvBufferSizeNoThrow`/`getSendBufferSizeNoThrow`) report 0 in the practically unreachable failure case, and the TCP and UDP transceivers use them in `getInfo`. In Java both the `SocketChannel` and `DatagramChannel` variants are added, since the Java UDP transceiver reads the sizes live instead of from a cache like C++/C#. The throwing helpers remain for the socket-setup paths and `setTcpBufSize`, where close-on-failure is load-bearing for the unwind.
- The C# TCP and UDP `getInfo` treat a disposed socket like a null fd and return the default connection info — the C# equivalent of the C++ `INVALID_SOCKET` check, needed because C# transceivers keep their socket field when a buffer-size helper closes the socket.
- The Java `getInfo` `isClosed()` guards are subsumed: reading a closed socket's buffer size reports 0. The TCP address reads remain valid after close (the remote address is retained and the local address degrades to the wildcard), but a closed `DatagramChannel`'s socket adaptor reports a null local address, so the UDP `getInfo` treats a closed channel like a null fd — the Java counterpart of the C# disposed-socket guard.

`setBufferSize` is different: it's a requested mutation, and the failing helper closes the socket. `ConnectionI.setBufferSize` now closes the connection (`setState(StateClosed, ex)`) and rethrows, so a connection never stays Active after its transport fails; a later call rethrows the recorded exception from the state check. The handler catches `LocalException` — the transceiver failure surfaces as `Ice.SocketException` — and the observer update on the StateClosed transition gets the degraded info from `getInfo` instead of an exception, so `setState` needs no special handling.

Supersedes #6584.

Verified with the Ice/info test in both mappings.

No changelog entry: same trigger rarity as #6591.

Fixes #6580
Fixes #6581

🤖 Generated with [Claude Code](https://claude.com/claude-code)
