### PR TITLE
Fix post-destroy crashes in IcePy communicator wrapper accessors

### DIFF
--- a/changelog.d/python/6587.md
+++ b/changelog.d/python/6587.md
@@ -1,0 +1,3 @@
+- Fixed interpreter crashes in `ObjectAdapter.getCommunicator` and `ObjectPrx.ice_getCommunicator` when called
+  after the communicator was destroyed. These methods now raise `CommunicatorDestroyedException` in this situation;
+  previously, `ice_getCommunicator` could also return `None`.

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -1068,7 +1068,12 @@ communicatorSetWrapper(CommunicatorObject* self, PyObject* args)
 extern "C" PyObject*
 communicatorGetWrapper(CommunicatorObject* self, PyObject* /*args*/)
 {
-    assert(self->wrapper);
+    if (!self->wrapper)
+    {
+        // The wrapper is cleared when the communicator is destroyed.
+        setPythonException(make_exception_ptr(Ice::CommunicatorDestroyedException{__FILE__, __LINE__}));
+        return nullptr;
+    }
     return Py_NewRef(self->wrapper);
 }
 
@@ -1589,18 +1594,15 @@ IcePy::createCommunicator(const Ice::CommunicatorPtr& communicator)
 PyObject*
 IcePy::getCommunicatorWrapper(const Ice::CommunicatorPtr& communicator)
 {
+    // The map entry is erased when the communicator object is deallocated, and the wrapper is cleared when the
+    // communicator is destroyed.
     auto p = communicatorMap.find(communicator);
-    assert(p != communicatorMap.end());
-    auto* obj = reinterpret_cast<CommunicatorObject*>(p->second);
-    if (obj->wrapper)
+    if (p == communicatorMap.end() || !reinterpret_cast<CommunicatorObject*>(p->second)->wrapper)
     {
-        return Py_NewRef(obj->wrapper);
+        setPythonException(make_exception_ptr(Ice::CommunicatorDestroyedException{__FILE__, __LINE__}));
+        return nullptr;
     }
-    else
-    {
-        // Communicator must have been destroyed already.
-        return Py_None;
-    }
+    return Py_NewRef(reinterpret_cast<CommunicatorObject*>(p->second)->wrapper);
 }
 
 Ice::SliceLoaderPtr

--- a/python/modules/IcePy/Future.cpp
+++ b/python/modules/IcePy/Future.cpp
@@ -8,7 +8,10 @@ PyObject*
 IcePy::wrapFuture(const Ice::CommunicatorPtr& communicator, PyObject* future)
 {
     PyObjectHandle communicatorHandle{IcePy::getCommunicatorWrapper(communicator)};
-    assert(communicatorHandle.get());
+    if (!communicatorHandle.get())
+    {
+        return nullptr;
+    }
     return wrapFuture(communicatorHandle.get(), future);
 }
 

--- a/python/python/Ice/ObjectAdapter.py
+++ b/python/python/Ice/ObjectAdapter.py
@@ -53,6 +53,11 @@ class ObjectAdapter:
         -------
         Communicator
             This object adapter's communicator.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         communicator = self._impl.getCommunicator()
         return communicator._getWrapper()

--- a/python/python/Ice/ObjectPrx.py
+++ b/python/python/Ice/ObjectPrx.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Self, overload
 
 import IcePy
 
+from .LocalExceptions import CommunicatorDestroyedException
 from .Object import Object
 
 if TYPE_CHECKING:
@@ -212,6 +213,11 @@ class ObjectPrx(IcePy.ObjectPrx):
         -------
         Communicator
             The communicator that created this proxy.
+
+        Raises
+        ------
+        CommunicatorDestroyedException
+            If the communicator has been destroyed.
         """
         return super().ice_getCommunicator()
 
@@ -1056,9 +1062,13 @@ class ObjectPrx(IcePy.ObjectPrx):
         return super().ice_toString()
 
     def __repr__(self) -> str:
+        try:
+            communicator = repr(self.ice_getCommunicator())
+        except CommunicatorDestroyedException:
+            communicator = "<destroyed communicator>"
         return (
             f"{self.__class__.__module__}.{self.__class__.__qualname__}("
-            f"communicator={self.ice_getCommunicator()!r}, "
+            f"communicator={communicator}, "
             f"proxyString={self.ice_toString()!r})"
         )
 

--- a/python/test/Ice/adapterDeactivation/AllTests.py
+++ b/python/test/Ice/adapterDeactivation/AllTests.py
@@ -46,6 +46,18 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.TestInt
     adapter.destroy()
     print("ok")
 
+    sys.stdout.write("testing getCommunicator on a destroyed communicator... ")
+    sys.stdout.flush()
+    comm = Ice.initialize()
+    bidirAdapter = comm.createObjectAdapter("")
+    comm.destroy()
+    try:
+        bidirAdapter.getCommunicator()
+        test(False)
+    except Ice.CommunicatorDestroyedException:
+        pass
+    print("ok")
+
     sys.stdout.write("testing connection closure... ")
     sys.stdout.flush()
     for _ in range(10):

--- a/python/test/Ice/proxy/AllTests.py
+++ b/python/test/Ice/proxy/AllTests.py
@@ -1,5 +1,6 @@
 # Copyright (c) ZeroC, Inc.
 
+import gc
 import sys
 from typing import cast
 
@@ -443,6 +444,28 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.MyInter
     sys.stdout.flush()
 
     test(base.ice_getCommunicator() == communicator)
+
+    # ice_getCommunicator raises CommunicatorDestroyedException once the communicator is destroyed, including after
+    # the communicator object itself is garbage collected.
+    comm = Ice.initialize()
+    p = comm.stringToProxy(f"test:{helper.getTestEndpoint()}")
+    assert p is not None
+    comm.destroy()
+    try:
+        p.ice_getCommunicator()
+        test(False)
+    except Ice.CommunicatorDestroyedException:
+        pass
+    del comm
+    gc.collect()
+    try:
+        p.ice_getCommunicator()
+        test(False)
+    except Ice.CommunicatorDestroyedException:
+        pass
+
+    # repr never raises, even on a proxy whose communicator was destroyed.
+    test("destroyed communicator" in repr(p))
 
     print("ok")
 


### PR DESCRIPTION
Fixes #6587.

Both post-destroy hazards now raise `CommunicatorDestroyedException`:

- `_getWrapper` (reached via `ObjectAdapter.getCommunicator`) no longer asserts/crashes when the wrapper was cleared by destroy.
- `IcePy::getCommunicatorWrapper` (reached via `ObjectPrx.ice_getCommunicator`) no longer asserts/crashes when the `communicatorMap` entry is gone because the communicator object was deallocated. Its `Py_None` return for the destroyed-but-alive case is replaced by the same exception, so the two states are indistinguishable to the application.
- `wrapFuture` propagates the failure instead of asserting, and `ObjectPrx.__repr__` tolerates the destroyed state so `repr()` never raises.