### PR TITLE
Commit a DataStorm subscriber's initialization state only with its sample delivery

### DIFF
--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -228,11 +228,8 @@ DataElementI::attach(
         initializationBatches.push_back(std::move(initializationBatch));
     }
 
-    // subscriberInitialized marks the subscriber initialized and advances its lastId past the acked samples, and
-    // TopicI::attachElementsAck runs the returned closures only once every spec in the ack has attached. Defer the
-    // whole call into the closure so the subscriber state is committed together with the sample delivery: if
-    // attaching a later spec throws, the closure never runs, no state is committed for samples that were never
-    // delivered, and the peer still offers them on the next initialization.
+    // The closure commits the subscriber state (initialized, lastId advanced past the acked samples) together with
+    // the sample delivery, or not at all.
     return [=, self = shared_from_this()]()
     {
         auto samplesI = session->subscriberInitialized(topicId, id > 0 ? data.id : -data.id, data.samples, key, self);
@@ -856,9 +853,7 @@ DataReaderI::initSamples(
             catch (const std::exception& ex)
             {
                 // Checking an inline key calls the reader's key filter, which is application code. A filter that
-                // throws drops the sample, like a filter that returns false. The reader is marked initialized with
-                // its lastId advanced before the batch is delivered, so letting the exception escape would discard
-                // the rest of a batch the peer never offers again.
+                // throws drops the sample, like a filter that returns false.
                 Warning out(_traceLevels->logger);
                 out << "dropped sample " << sample->id << ": the key filter failed:\n" << ex.what();
                 continue;

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -228,14 +228,19 @@ DataElementI::attach(
         initializationBatches.push_back(std::move(initializationBatch));
     }
 
-    auto samplesI =
-        session->subscriberInitialized(topicId, id > 0 ? data.id : -data.id, data.samples, key, shared_from_this());
-    if (!samplesI.empty())
+    // subscriberInitialized marks the subscriber initialized and advances its lastId past the acked samples, and
+    // TopicI::attachElementsAck runs the returned closures only once every spec in the ack has attached. Defer the
+    // whole call into the closure so the subscriber state is committed together with the sample delivery: if
+    // attaching a later spec throws, the closure never runs, no state is committed for samples that were never
+    // delivered, and the peer still offers them on the next initialization.
+    return [=, self = shared_from_this()]()
     {
-        return [=, samplesI = std::move(samplesI), self = shared_from_this()]()
-        { self->initSamples(samplesI, topicId, data.id, priority, now, id < 0); };
-    }
-    return nullptr;
+        auto samplesI = session->subscriberInitialized(topicId, id > 0 ? data.id : -data.id, data.samples, key, self);
+        if (!samplesI.empty())
+        {
+            self->initSamples(samplesI, topicId, data.id, priority, now, id < 0);
+        }
+    };
 }
 
 bool
@@ -841,9 +846,28 @@ DataReaderI::initSamples(
     map<shared_ptr<Key>, shared_ptr<Sample>> previousByKey = _lastByKey;
     for (const auto& sample : samples)
     {
-        if (checkKey && !matchKey(sample->key))
+        if (checkKey)
         {
-            continue;
+            bool matched;
+            try
+            {
+                matched = matchKey(sample->key);
+            }
+            catch (const std::exception& ex)
+            {
+                // Checking an inline key calls the reader's key filter, which is application code. A filter that
+                // throws drops the sample, like a filter that returns false. The reader is marked initialized with
+                // its lastId advanced before the batch is delivered, so letting the exception escape would discard
+                // the rest of a batch the peer never offers again.
+                Warning out(_traceLevels->logger);
+                out << "dropped sample " << sample->id << ": the key filter failed:\n" << ex.what();
+                continue;
+            }
+
+            if (!matched)
+            {
+                continue;
+            }
         }
 
         // Apply discard policies:

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -191,10 +191,10 @@ namespace DataStormI
         /// @param now The timestamp indicating when the attachment was requested.
         /// @param initializationBatches Output parameter filled with the initialization batches built from the
         /// publisher's queued samples. This parameter is always empty when the method is called on the subscriber side.
-        /// @return A function that initializes the reader with the prepared samples:
-        /// - For a publisher, this method always returns a `nullptr` function.
-        /// - For a subscriber, this method returns a function that initializes the reader with samples provided by the
-        /// peer.
+        /// @return A function that commits the subscriber's initialization state for the attached element and delivers
+        /// the samples provided by the peer, if any. The caller runs it only once every element in the acknowledgment
+        /// has attached. Returns `nullptr` when the element was left unattached because its sample filter could not be
+        /// decoded.
         [[nodiscard]] std::function<void()> attach(
             std::int64_t topicId,
             std::int64_t id,

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1447,7 +1447,8 @@ SessionI::subscriberInitialized(
     const shared_ptr<Key>& key,
     const std::shared_ptr<DataElementI>& element)
 {
-    // Called with the session locked, from DataElementI::attach.
+    // Called with the session and topic locked, from the initialization closure returned by DataElementI::attach,
+    // which TopicI::attachElementsAck runs once every spec in the ack has attached.
     assert(_topics.find(topicId) != _topics.end());
     TopicSubscriber& subscriber = _topics.at(topicId).getSubscriber(element->getTopic());
     ElementSubscribers* elementSubscribers = subscriber.get(elementId);

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -401,6 +401,9 @@ namespace DataStormI
         [[nodiscard]] DataStormContract::LongLongDict
         getLastIds(std::int64_t topic, std::int64_t keyOrFilterId, const std::shared_ptr<DataElementI>& element);
 
+        /// Marks the subscriber initialized and advances its lastId past the acked samples.
+        ///
+        /// @return The samples the subscriber should be initialized with.
         [[nodiscard]] std::vector<std::shared_ptr<Sample>> subscriberInitialized(
             std::int64_t,
             std::int64_t,

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -374,6 +374,34 @@ void ::Reader::run(int argc, char* argv[])
     }
 
     {
+        // The writer queues k1, k2 and sentinel before this reader attaches, so they arrive as one initialization
+        // batch. The filter throws on k1: that sample is dropped like a rejected key, and k2 and sentinel are still
+        // delivered.
+        Topic<string, string> topic(node, "initKeyFilterThrow");
+        topic.setKeyFilter<string>(
+            "throwOnKey",
+            [](const string& boom)
+            {
+                return [boom](const string& key)
+                {
+                    if (key == boom)
+                    {
+                        throw runtime_error("the key filter failed");
+                    }
+                    return true;
+                };
+            });
+
+        Topic<string, string> readyTopic(node, "initKeyFilterThrowReady");
+        auto ready = makeSingleKeyReader(readyTopic, "ready", "", config);
+        test(ready.getNextUnread().getValue() == "go");
+
+        auto reader = makeFilteredKeyReader(topic, Filter<string>("throwOnKey", "k1"), "", config);
+        test(reader.getNextUnread().getKey() == "k2");
+        test(reader.getNextUnread().getKey() == "sentinel");
+    }
+
+    {
         Topic<string, string> topic(node, "filtered reader key/value filter");
 
         {

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -395,6 +395,42 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // The same reader-side key filter also runs during initialization: this writer queues its samples before the
+    // reader attaches, so the reader receives them as one initialization batch. A key the filter throws on must be
+    // dropped like a key the filter rejects, without discarding the rest of the batch.
+    cout << "testing filtered reader whose key filter throws during initialization... " << flush;
+    {
+        Topic<string, string> topic(node, "initKeyFilterThrow");
+        topic.setKeyFilter<string>(
+            "throwOnKey",
+            [](const string& boom)
+            {
+                return [boom](const string& key)
+                {
+                    if (key == boom)
+                    {
+                        throw runtime_error("the key filter failed");
+                    }
+                    return true;
+                };
+            });
+
+        auto writer = makeAnyKeyWriter(topic, "", config);
+        writer.add("k1", "v1");
+        writer.add("k2", "v2");
+        writer.add("sentinel", "v3");
+
+        // Signal the reader only once the history is complete, so every sample reaches the reader through the
+        // initialization and none through the live path.
+        Topic<string, string> readyTopic(node, "initKeyFilterThrowReady");
+        auto ready = makeSingleKeyWriter(readyTopic, "ready", "", config);
+        ready.add("go");
+
+        writer.waitForReaders(1);
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
     cout << "testing filtered sample reader... " << flush;
     {
         Topic<string, string> topic(node, "filtered reader key/value filter");


### PR DESCRIPTION
Fixes #6324.

`TopicI::attachElementsAck` runs the initialization closures only once every spec in the ack has attached, but
`DataElementI::attach` called `subscriberInitialized` eagerly while the loop was still attaching later specs,
marking the subscriber initialized and advancing its `lastId`. Anything that threw in a later iteration unwound
the loop and destroyed the pending closures: the reader was left initialized with `lastId` advanced past samples
it never received, `getLastIds` advertised that id on the next attach, and the peer's `getSamples` skips
everything at `id <= lastId` — so those samples were never offered again, not even after a reconnect, since
re-adding a subscriber resets `initialized` but preserves `lastId`.

## The fix

Two changes, both in `DataElementI.cpp`:

- `DataElementI::attach` defers the whole `subscriberInitialized` call into the closure it returns, so the
  subscriber state is committed together with the sample delivery, or not at all. If attaching a later spec
  throws, the closure never runs, nothing is committed and nothing is delivered, and the peer still offers the
  samples on the next initialization — on the wire the failure looks exactly like it does today for the throwing
  element. The specs attached before the throw are left uninitialized since their closures never ran, so `s()`
  drops their live samples until a reconnect — where before they kept flowing, minus the permanently lost
  history. Recoverable instead of permanent, the right trade. The closure is
  now returned unconditionally, so the empty-samples commit (`initialized = true` with nothing to deliver) rides
  in it too. A per-spec `try`/`catch` around the callback instead would not work with the old structure: the
  state was already committed by the time the callback threw, so catching it would leave the subscriber falsely
  initialized.

- `DataReaderI::initSamples` guards its `matchKey` call — the initialization twin of the guard `queue` has had
  since #6344, and the one call on the delivery path that runs the application's key filter unguarded. Both
  delivery paths (the ack closure above and `SessionI::initSamples`) commit the subscriber state immediately
  before delivering, so a throwing filter aborted a delivery whose state was already committed, with the same
  permanent loss. A filter that throws now drops that sample like a filter that returns false, with a warning.

## Test

New paired case in `cpp/test/DataStorm/events`, next to the #6344 one: an any-key writer queues `k1`, `k2` and
`sentinel` and only then signals on a ready topic; the filtered reader, whose filter throws on `k1`, is created
after the signal, so all three samples arrive as one initialization batch. On `origin/main` the run hangs — the
throw aborts the initialization after the reader's state is committed, and `k2`/`sentinel` are never delivered.
With this change `k1` is dropped with a warning and the other two arrive. Verified red on `origin/main` (library
rebuilt without the src change, test kept) and green with it; the `events` suite ran 7× with no flake and all
12 DataStorm suites pass on macOS. clang-format-19 clean.

The any-key writer is deliberate: keyed writers would evaluate the throwing filter at attach time and reproduce
#6478 instead (fixed by #6578, not yet merged). The test covers the `matchKey` half; the deferral half has no
direct test — turning it red needs a throw from a later spec plus a reconnect to observe the loss, the same
disproportionate-harness verdict as #6308.

## Not addressed here

The "collateral when the exception escapes the ack" section of #6324: when a spec does still throw (a user
encoder in `getSamples`, or an exception not derived from `std::exception`), the ack dispatch is still
abandoned — the initialization batches this node owed the peer's readers and the `removedIds` are lost, and the
specs after the throwing one don't attach. With this change that failure no longer corrupts `lastId`, so a
reconnect recovers the samples. Making the ack continue past a failing spec is #6541 (decoder throws) and #6578
(filter throws), and the remaining ack-wide continuation semantics are 3.9.0 work, as the issue notes.

No changelog fragment, matching #6322, #6344 and #6522, the closest fixes in this family.

## Conflicts with the open DataStorm PRs

- #6541: none — the merge is clean, and its early `return nullptr` when a sample filter fails to decode composes
  correctly with this change: an element left unattached now also commits nothing.
- #6578: trivial append-append conflict in the two `events` test files (both add a case right after the #6344
  block); whichever merges second keeps both blocks.

