### PR TITLE
Release the IcePy InitializationData wrappers with the GIL held

### DIFF
--- a/changelog.d/python/6579.md
+++ b/changelog.d/python/6579.md
@@ -1,0 +1,2 @@
+- Fixed a Python interpreter crash that could occur after the destruction of a communicator configured with
+  a custom logger, thread start/stop callbacks, or a batch request interceptor.

--- a/python/modules/IcePy/BatchRequestInterceptor.h
+++ b/python/modules/IcePy/BatchRequestInterceptor.h
@@ -25,6 +25,7 @@ namespace IcePy
     private:
         PyObjectHandle _interceptor;
     };
+    using BatchRequestInterceptorWrapperPtr = std::shared_ptr<BatchRequestInterceptorWrapper>;
 }
 
 #endif

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -63,8 +63,8 @@ namespace IcePy
         // with the GIL held, and not in ~Instance, which can run without the GIL.
         ExecutorPtr* executor;
         LoggerWrapperPtr* logger;
-        std::shared_ptr<ThreadHook>* threadHook;
-        std::shared_ptr<BatchRequestInterceptorWrapper>* batchRequestInterceptor;
+        ThreadHookPtr* threadHook;
+        BatchRequestInterceptorWrapperPtr* batchRequestInterceptor;
     };
 
     void removeSliceLoader(const Ice::CommunicatorPtr& communicator);
@@ -106,8 +106,8 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
     Ice::InitializationData initData;
     ExecutorPtr executorWrapper;
     LoggerWrapperPtr loggerWrapper;
-    shared_ptr<ThreadHook> threadHookWrapper;
-    shared_ptr<BatchRequestInterceptorWrapper> batchRequestInterceptorWrapper;
+    ThreadHookPtr threadHookWrapper;
+    BatchRequestInterceptorWrapperPtr batchRequestInterceptorWrapper;
 
     Ice::SliceLoaderPtr sliceLoader = DefaultSliceLoader::instance();
 
@@ -265,12 +265,12 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
 
     if (threadHookWrapper)
     {
-        self->threadHook = new shared_ptr<ThreadHook>(threadHookWrapper);
+        self->threadHook = new ThreadHookPtr(threadHookWrapper);
     }
 
     if (batchRequestInterceptorWrapper)
     {
-        self->batchRequestInterceptor = new shared_ptr<BatchRequestInterceptorWrapper>(batchRequestInterceptorWrapper);
+        self->batchRequestInterceptor = new BatchRequestInterceptorWrapperPtr(batchRequestInterceptorWrapper);
     }
 
     return 0;

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -57,7 +57,14 @@ namespace IcePy
         std::future<void>* shutdownFuture;
         std::exception_ptr* shutdownException;
         bool shutdown;
+
+        // Extra references to the Python-owning wrappers stored in the communicator's InitializationData. They
+        // ensure the final release of each wrapper - which releases Python objects - happens in communicatorDealloc
+        // with the GIL held, and not in ~Instance, which can run without the GIL.
         ExecutorPtr* executor;
+        LoggerWrapperPtr* logger;
+        std::shared_ptr<ThreadHook>* threadHook;
+        std::shared_ptr<BatchRequestInterceptorWrapper>* batchRequestInterceptor;
     };
 
     void removeSliceLoader(const Ice::CommunicatorPtr& communicator);
@@ -78,6 +85,9 @@ communicatorNew(PyTypeObject* type, PyObject* /*args*/, PyObject* /*kwds*/)
     self->shutdownException = nullptr;
     self->shutdown = false;
     self->executor = nullptr;
+    self->logger = nullptr;
+    self->threadHook = nullptr;
+    self->batchRequestInterceptor = nullptr;
     return self;
 }
 
@@ -95,6 +105,9 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
 
     Ice::InitializationData initData;
     ExecutorPtr executorWrapper;
+    LoggerWrapperPtr loggerWrapper;
+    shared_ptr<ThreadHook> threadHookWrapper;
+    shared_ptr<BatchRequestInterceptorWrapper> batchRequestInterceptorWrapper;
 
     Ice::SliceLoaderPtr sliceLoader = DefaultSliceLoader::instance();
 
@@ -122,14 +135,15 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
 
             if (logger.get())
             {
-                initData.logger = make_shared<LoggerWrapper>(logger.get());
+                loggerWrapper = make_shared<LoggerWrapper>(logger.get());
+                initData.logger = loggerWrapper;
             }
 
             if (threadStart.get() || threadStop.get())
             {
-                auto threadHook = make_shared<ThreadHook>(threadStart.get(), threadStop.get());
-                initData.threadStart = [threadHook]() { threadHook->start(); };
-                initData.threadStop = [threadHook]() { threadHook->stop(); };
+                threadHookWrapper = make_shared<ThreadHook>(threadStart.get(), threadStop.get());
+                initData.threadStart = [threadHook = threadHookWrapper]() { threadHook->start(); };
+                initData.threadStop = [threadHook = threadHookWrapper]() { threadHook->stop(); };
             }
 
             if (executor.get())
@@ -142,7 +156,7 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
 
             if (batchRequestInterceptor.get())
             {
-                auto batchRequestInterceptorWrapper =
+                batchRequestInterceptorWrapper =
                     make_shared<BatchRequestInterceptorWrapper>(batchRequestInterceptor.get());
                 initData.batchRequestInterceptor =
                     [batchRequestInterceptorWrapper](const Ice::BatchRequest& req, int count, int size)
@@ -244,6 +258,21 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
         executorWrapper->setCommunicator(communicator);
     }
 
+    if (loggerWrapper)
+    {
+        self->logger = new LoggerWrapperPtr(loggerWrapper);
+    }
+
+    if (threadHookWrapper)
+    {
+        self->threadHook = new shared_ptr<ThreadHook>(threadHookWrapper);
+    }
+
+    if (batchRequestInterceptorWrapper)
+    {
+        self->batchRequestInterceptor = new shared_ptr<BatchRequestInterceptorWrapper>(batchRequestInterceptorWrapper);
+    }
+
     return 0;
 }
 
@@ -273,10 +302,13 @@ communicatorDealloc(CommunicatorObject* self)
     delete self->shutdownException;
     delete self->shutdownFuture;
 
-    // Keep this after the communicator release above: it ensures the last release of the
-    // ExecutorPtr - which releases a Python object - always runs here with the GIL held,
-    // never in ~Instance (which can run with the GIL released).
+    // Keep these after the communicator release above: it ensures the last release of each wrapper - which
+    // releases Python objects - always runs here with the GIL held, never in ~Instance (which can run with the
+    // GIL released).
     delete self->executor;
+    delete self->logger;
+    delete self->threadHook;
+    delete self->batchRequestInterceptor;
     Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
 }
 

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -302,7 +302,7 @@ communicatorDealloc(CommunicatorObject* self)
     delete self->shutdownException;
     delete self->shutdownFuture;
 
-    // Keep these after the communicator release above: it ensures the last release of each wrapper - which
+    // Keep these after the communicator release above: they ensure the last release of each wrapper - which
     // releases Python objects - always runs here with the GIL held, never in ~Instance (which can run with the
     // GIL released).
     delete self->executor;

--- a/python/modules/IcePy/Thread.h
+++ b/python/modules/IcePy/Thread.h
@@ -63,6 +63,7 @@ namespace IcePy
         PyObjectHandle _threadStart;
         PyObjectHandle _threadStop;
     };
+    using ThreadHookPtr = std::shared_ptr<ThreadHook>;
 }
 
 #endif


### PR DESCRIPTION
Fixes #6579.

The communicator object kept an extra reference only to the executor wrapper, so the logger, thread hook, and batch request interceptor wrappers stored in `Ice::InitializationData` were released by `~Instance` — typically while `communicatorDealloc` holds no GIL (`AllowThreads`), and possibly on a non-Python thread. The final release of these wrappers releases Python objects, which requires the GIL: with Python 3.13, a communicator configured with a custom logger whose last Python reference was gone aborted with "Fatal Python error: PyThreadState_Get" during deallocation (with thread hooks and a batch request interceptor configured as well, it segfaults instead).

The communicator object now keeps a reference to each Python-owning wrapper and releases them all in `communicatorDealloc`, after the communicator itself and with the GIL held, extending the pattern already used for the executor.

Defect 2 of the issue (a foreign non-Python thread releasing the last `CommunicatorPtr`) is out of scope, as discussed in the issue.