### PR TITLE
Fix over-release of the IcePy thread hook callbacks when validation fails

### DIFF
--- a/python/modules/IcePy/Thread.cpp
+++ b/python/modules/IcePy/Thread.cpp
@@ -48,8 +48,8 @@ IcePy::AdoptThread::AdoptThread() { _state = PyGILState_Ensure(); }
 IcePy::AdoptThread::~AdoptThread() { PyGILState_Release(_state); }
 
 IcePy::ThreadHook::ThreadHook(PyObject* threadStart, PyObject* threadStop)
-    : _threadStart(threadStart),
-      _threadStop(threadStop)
+    : _threadStart(Py_XNewRef(threadStart)),
+      _threadStop(Py_XNewRef(threadStop))
 {
     if (threadStart && !PyCallable_Check(threadStart))
     {
@@ -60,11 +60,6 @@ IcePy::ThreadHook::ThreadHook(PyObject* threadStart, PyObject* threadStop)
     {
         throw Ice::InitializationException(__FILE__, __LINE__, "threadStop must be a callable");
     }
-
-    // Increment the reference count of the Python objects to ensure they are not garbage collected.
-    // The reference count will be decremented in the destructor of PyObjectHandle, which holds them.
-    Py_XINCREF(threadStart);
-    Py_XINCREF(threadStop);
 }
 
 void


### PR DESCRIPTION
Fixes #6600.

`ThreadHook`'s constructor adopted its borrowed `threadStart`/`threadStop` arguments into the owning `PyObjectHandle` members before validating them, and only incremented the reference counts after both checks passed. When either argument was not callable, the constructor threw `InitializationException` and the member destructors released references the constructor never owned: the callback objects were deallocated while the application's `InitializationData` still referenced them, and any later use of those attributes crashed.

The constructor now takes its references in the member-initializer list with `Py_XNewRef` — like the executor, logger, and batch request interceptor wrappers — keeping ownership balanced when validation throws.