### PR TITLE
Address follow-up review suggestions from #6576

### DIFF
--- a/changelog.d/php/6126.md
+++ b/changelog.d/php/6126.md
@@ -1,3 +1,6 @@
 - Fixed a crash that occurred when invoking an operation that combines a non-optional return value with an out
-  parameter declared as `optional(0)`: the out parameter was mistaken for the return value while unmarshaling the
-  results.
+  parameter declared as `optional(0)`, such as:
+
+  ```slice
+  string getName(out optional(0) int id);
+  ```

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -23,7 +23,7 @@ namespace IcePHP
     public:
         TypeInfoPtr type;
         bool optional;
-        int tag = -1; // a non-optional parameter or return value has no tag
+        int tag{-1}; // a non-optional parameter or return value has no tag
         int pos;
     };
     using ParamInfoPtr = std::shared_ptr<ParamInfo>;

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -23,7 +23,7 @@ namespace IcePHP
     public:
         TypeInfoPtr type;
         bool optional;
-        int tag;
+        int tag = -1; // a non-optional parameter or return value has no tag
         int pos;
     };
     using ParamInfoPtr = std::shared_ptr<ParamInfo>;


### PR DESCRIPTION
Follow-up to #6576, addressing two review suggestions posted after the merge:

- https://github.com/zeroc-ice/ice/pull/6576#discussion_r3777922908: give `ParamInfo::tag` a default member initializer of `-1`, so a non-optional parameter or return value never holds a valid tag value. Tags are only read for the entries of the tag-sorted optional parameter lists, all of which have a tag assigned.
- https://github.com/zeroc-ice/ice/pull/6576#discussion_r3777971937: reword the changelog entry to show an example of the affected operation instead of describing the implementation detail.