### PR TITLE
Fix leak of the IcePy slice loader callable when validation fails

### DIFF
--- a/python/modules/IcePy/PySliceLoader.cpp
+++ b/python/modules/IcePy/PySliceLoader.cpp
@@ -9,10 +9,10 @@ using namespace std;
 
 IcePy::PySliceLoader::PySliceLoader(PyObject* sliceLoader) : _sliceLoader{Py_NewRef(sliceLoader)}
 {
-    assert(_sliceLoader);
-    assert(_sliceLoader != Py_None);
+    assert(_sliceLoader.get());
+    assert(_sliceLoader.get() != Py_None);
 
-    if (!PyCallable_Check(_sliceLoader))
+    if (!PyCallable_Check(_sliceLoader.get()))
     {
         throw Ice::InitializationException{__FILE__, __LINE__, "sliceLoader must be a callable"};
     }
@@ -20,9 +20,8 @@ IcePy::PySliceLoader::PySliceLoader(PyObject* sliceLoader) : _sliceLoader{Py_New
 
 IcePy::PySliceLoader::~PySliceLoader()
 {
-    // Called by destroy/destroyAsync with the GIL locked.
+    // Called by destroy/destroyAsync with the GIL locked; releasing _sliceLoader requires the GIL.
     assert(PyGILState_Check());
-    Py_DECREF(_sliceLoader);
 }
 
 Ice::ValuePtr
@@ -32,7 +31,7 @@ IcePy::PySliceLoader::newClassInstance(string_view typeId) const
     assert(PyGILState_Check());
 
     PyObjectHandle obj{
-        PyObject_CallFunction(_sliceLoader, "s#", typeId.data(), static_cast<Py_ssize_t>(typeId.size()))};
+        PyObject_CallFunction(_sliceLoader.get(), "s#", typeId.data(), static_cast<Py_ssize_t>(typeId.size()))};
 
     if (!obj)
     {

--- a/python/modules/IcePy/PySliceLoader.h
+++ b/python/modules/IcePy/PySliceLoader.h
@@ -5,6 +5,7 @@
 
 #include "Config.h"
 #include "Ice/Ice.h"
+#include "Util.h"
 
 namespace IcePy
 {
@@ -20,7 +21,7 @@ namespace IcePy
         // TODO: we currently don't support loading of custom Slice exceptions from Python.
 
     private:
-        PyObject* _sliceLoader;
+        PyObjectHandle _sliceLoader;
     };
 }
 


### PR DESCRIPTION
Closes #6605.

`PySliceLoader`'s constructor took a strong reference to its `sliceLoader` argument with `Py_NewRef` into a raw `PyObject*` member before validating it. When the argument was not callable, the constructor threw `InitializationException` and the reference was stranded: the destructor of a partially constructed object never runs, and a raw pointer member has no cleanup of its own — the mirror image of #6600 on the same error path, a leak instead of a crash.

The member is now an owning `PyObjectHandle`, like the `ThreadHook` and the other `InitializationData` wrappers, so the reference is released even when validation throws. The destructor keeps its `PyGILState_Check` assert — the handle's release still requires the GIL — since `PyObjectHandle`'s own destructor performs a bare `Py_XDECREF` with no GIL check.