### PR TITLE
Treat a sample filter that throws while a peer attaches as not matching

### DIFF
--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -1666,7 +1666,7 @@ KeyDataWriterI::getSamples(
         for (const auto& [baseKey, baseSample] : _lastByKey)
         {
             if (baseSample->id <= lastId || !baseSample->hasValue() || (key && key != baseSample->key) ||
-                (sampleFilter && !matchSampleFilter(baseSample)) || covered.count(baseSample->key))
+                covered.count(baseSample->key) || (sampleFilter && !matchSampleFilter(baseSample)))
             {
                 continue;
             }

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -1557,6 +1557,37 @@ KeyDataWriterI::getSamples(
     DataSamples initializationBatch;
     initializationBatch.id = _keys.empty() ? -_id : _id;
 
+    // Runs the peer reader's sample filter predicate, which is application code. Treating a throwing predicate as
+    // not matching skips this sample and lets the scan continue with the remaining samples, the way a predicate
+    // that returns false does.
+    auto matchSampleFilter = [&](const shared_ptr<Sample>& sample)
+    {
+        try
+        {
+            return sampleFilter->match(sample);
+        }
+        catch (const std::exception& ex)
+        {
+            // The element's toString runs the application's key formatter — more application code — so it can throw
+            // too; the placeholder keeps such a throw from escaping the guard.
+            string elementString;
+            try
+            {
+                elementString = toString();
+            }
+            catch (const std::exception&)
+            {
+                elementString = "<unavailable>";
+            }
+
+            Warning out(_traceLevels->logger);
+            out << elementString << ": did not send sample " << sample->id << " during initialization: the '"
+                << sampleFilter->getName() << "' sample filter failed:\n"
+                << ex.what();
+            return false;
+        }
+    };
+
     // Orders the source samples to deliver by id, caps them to the reader's history depth, and delivers them. A
     // partial base is sent as a full Update, and the earliest delivered sample of each key is likewise resolved to a
     // full value so the reader always has a base to merge later partial updates for that key onto.
@@ -1635,7 +1666,7 @@ KeyDataWriterI::getSamples(
         for (const auto& [baseKey, baseSample] : _lastByKey)
         {
             if (baseSample->id <= lastId || !baseSample->hasValue() || (key && key != baseSample->key) ||
-                (sampleFilter && !sampleFilter->match(baseSample)) || covered.count(baseSample->key))
+                (sampleFilter && !matchSampleFilter(baseSample)) || covered.count(baseSample->key))
             {
                 continue;
             }
@@ -1685,7 +1716,7 @@ KeyDataWriterI::getSamples(
             break;
         }
 
-        if ((!key || key == (*p)->key) && (!sampleFilter || sampleFilter->match(*p)))
+        if ((!key || key == (*p)->key) && (!sampleFilter || matchSampleFilter(*p)))
         {
             sources.push_back(*p);
             covered.insert((*p)->key);

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -506,9 +506,9 @@ void ::Reader::run(int argc, char* argv[])
         test(!filtered.hasUnread());
     }
 
-    // A late-joining sample-filtered reader over a writer whose queue holds a sample the filter predicate throws
-    // on. The writer treats that sample as not matching, so this reader attaches and is initialized with the other
-    // two samples.
+    // Create a sample-filtered reader after the writer queued three samples, one of which makes the
+    // filter predicate throw. The writer treats that sample as not matching, so the reader still
+    // attaches and is initialized with the other two samples.
     {
         Topic<string, string> topic(node, "attachSampleFilterThrow");
         Topic<string, int> barrier(node, "attachSampleFilterThrowBarrier");

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -506,6 +506,32 @@ void ::Reader::run(int argc, char* argv[])
         test(!filtered.hasUnread());
     }
 
+    // A late-joining sample-filtered reader over a writer whose queue holds a sample the filter predicate throws
+    // on. The writer treats that sample as not matching, so this reader attaches and is initialized with the other
+    // two samples.
+    {
+        Topic<string, string> topic(node, "attachSampleFilterThrow");
+        Topic<string, int> barrier(node, "attachSampleFilterThrowBarrier");
+        Topic<string, int> done(node, "attachSampleFilterThrowDone");
+
+        // Wait until the writer queued all three samples.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
+
+        auto reader = makeSingleKeyReader(topic, "elem", Filter<string>("throwOnValue", "boom"), "", config);
+        reader.waitForUnread(2);
+        auto samples = reader.getAllUnread();
+        test(samples.size() == 2);
+        test(samples[0].getEvent() == SampleEvent::Add);
+        test(samples[0].getValue() == "value1");
+        test(samples[1].getEvent() == SampleEvent::Update);
+        test(samples[1].getValue() == "value3");
+
+        // Signal the writer that the reader was initialized, so it can tear down.
+        auto doneWriter = makeSingleKeyWriter(done, "done");
+        doneWriter.waitForReaders();
+        doneWriter.update(0);
+    }
+
     // Coexisting any-key and filtered readers on the same topic: each keeps its own subscription. Both receive a
     // sample matching the filter, and destroying the filtered reader leaves the any-key reader subscribed.
     {

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -508,7 +508,8 @@ void ::Reader::run(int argc, char* argv[])
 
     // Create a sample-filtered reader after the writer queued three samples, one of which makes the
     // filter predicate throw. The writer treats that sample as not matching, so the reader still
-    // attaches and is initialized with the other two samples.
+    // attaches and is initialized with the other two samples. The reader matches any key, so the
+    // key the throwing sample was written for reaches the predicate too.
     {
         Topic<string, string> topic(node, "attachSampleFilterThrow");
         Topic<string, int> barrier(node, "attachSampleFilterThrowBarrier");
@@ -517,12 +518,14 @@ void ::Reader::run(int argc, char* argv[])
         // Wait until the writer queued all three samples.
         [[maybe_unused]] auto _ = makeSingleKeyReader(barrier, "barrier").getNextUnread();
 
-        auto reader = makeSingleKeyReader(topic, "elem", Filter<string>("throwOnValue", "boom"), "", config);
+        auto reader = makeAnyKeyReader(topic, Filter<string>("throwOnValue", "boom"), "", config);
         reader.waitForUnread(2);
         auto samples = reader.getAllUnread();
         test(samples.size() == 2);
+        test(samples[0].getKey() == "elem");
         test(samples[0].getEvent() == SampleEvent::Add);
         test(samples[0].getValue() == "value1");
+        test(samples[1].getKey() == "elem");
         test(samples[1].getEvent() == SampleEvent::Update);
         test(samples[1].getValue() == "value3");
 

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -494,9 +494,9 @@ void ::Writer::run(int argc, char* argv[])
 
     // A late-joining sample-filtered reader runs this writer's sample filter over the queued samples while it
     // attaches. The sample the predicate throws on is skipped like one the predicate rejects; the reader still
-    // attaches and is initialized with the samples the predicate accepts. The throwing sample is the writer's
-    // latest so that both attachment scans — the queued samples and the last value per key — run the predicate
-    // on it.
+    // attaches and is initialized with the samples the predicate accepts. The throwing sample is written last so
+    // it is both in the writer's queued history and the last value for its key; each attachment scan — over the
+    // queued samples and over the last value per key — then runs the predicate on it.
     cout << "testing sample filter that throws while a peer attaches... " << flush;
     {
         Topic<string, string> topic(node, "attachSampleFilterThrow");

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -494,9 +494,9 @@ void ::Writer::run(int argc, char* argv[])
 
     // A late-joining sample-filtered reader runs this writer's sample filter over the queued samples while it
     // attaches. The sample the predicate throws on is skipped like one the predicate rejects; the reader still
-    // attaches and is initialized with the samples the predicate accepts. The throwing sample is written last so
-    // it is both in the writer's queued history and the last value for its key; each attachment scan — over the
-    // queued samples and over the last value per key — then runs the predicate on it.
+    // attaches and is initialized with the samples the predicate accepts. The throwing sample is the only one
+    // written for its key, so the scan over the queued samples skips it without covering that key and the scan
+    // over the last value per key runs the predicate on it again; each attachment scan is therefore exercised.
     cout << "testing sample filter that throws while a peer attaches... " << flush;
     {
         Topic<string, string> topic(node, "attachSampleFilterThrow");
@@ -517,10 +517,10 @@ void ::Writer::run(int argc, char* argv[])
                 };
             });
 
-        auto writer = makeSingleKeyWriter(topic, "elem", "", config);
-        writer.add("value1");
-        writer.update("value3");
-        writer.update("boom");
+        auto writer = makeAnyKeyWriter(topic, "", config);
+        writer.add("elem", "value1");
+        writer.update("elem", "value3");
+        writer.update("boomElem", "boom");
 
         // The samples are queued; the reader may attach now.
         auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -492,6 +492,47 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // A late-joining sample-filtered reader runs this writer's sample filter over the queued samples while it
+    // attaches. The sample the predicate throws on is skipped like one the predicate rejects; the reader still
+    // attaches and is initialized with the samples the predicate accepts. The throwing sample is the writer's
+    // latest so that both attachment scans — the queued samples and the last value per key — run the predicate
+    // on it.
+    cout << "testing sample filter that throws while a peer attaches... " << flush;
+    {
+        Topic<string, string> topic(node, "attachSampleFilterThrow");
+        Topic<string, int> barrier(node, "attachSampleFilterThrowBarrier");
+        Topic<string, int> done(node, "attachSampleFilterThrowDone");
+
+        topic.setSampleFilter<string>(
+            "throwOnValue",
+            [](const string& boom)
+            {
+                return [boom](const Sample<string, string>& sample)
+                {
+                    if (sample.getValue() == boom)
+                    {
+                        throw runtime_error("the sample filter failed");
+                    }
+                    return true;
+                };
+            });
+
+        auto writer = makeSingleKeyWriter(topic, "elem", "", config);
+        writer.add("value1");
+        writer.update("value3");
+        writer.update("boom");
+
+        // The samples are queued; the reader may attach now.
+        auto barrierWriter = makeSingleKeyWriter(barrier, "barrier");
+        barrierWriter.waitForReaders();
+        barrierWriter.update(0);
+
+        // Gate teardown on the reader signalling it was initialized, so this writer never races the late reader's
+        // lifetime through a listener count that can drop back to zero before it is observed.
+        [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
+
     // An any-key reader and a filtered reader coexisting on the same topic must each keep their own subscription:
     // both receive matching samples, and destroying one must not detach the other.
     cout << "testing coexisting any-key and filtered readers... " << flush;

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -527,8 +527,9 @@ void ::Writer::run(int argc, char* argv[])
         barrierWriter.waitForReaders();
         barrierWriter.update(0);
 
-        // Gate teardown on the reader signalling it was initialized, so this writer never races the late reader's
-        // lifetime through a listener count that can drop back to zero before it is observed.
+        // Hold off teardown until the reader confirms it was initialized. Inferring the reader's progress
+        // from this writer's listener count would race the reader's lifetime: the count can rise and drop
+        // back to zero between two observations.
         [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
     }
     cout << "ok" << endl;


### PR DESCRIPTION
`KeyDataWriterI::getSamples` runs the peer reader's sample filter predicate — application code — unguarded at both of its scan sites while a peer attaches. The session protocol is fire-and-forget, so a predicate that throws escapes the oneway dispatch and aborts the attach: in `attachElements` no ack is sent and both nodes stall in `waitForReaders`/`waitForWriters`; in `attachElementsAck` the initialization batches are discarded and the peer's readers never initialize.

Following #6578's key filter treatment, catch around the predicate at both sites, log a warning naming the element and the filter, and treat the sample as not matching — the samples the filter accepts still attach and initialize.

The new events test attaches a late-joining any-key sample-filtered reader over a writer whose queued samples include one the predicate throws on. That sample is the only one written for its key, so the scan over the queued samples skips it without covering that key and the scan over the last value per key runs the predicate on it again — both guarded sites are exercised. Removing either guard hangs the test with `warning: failed to dispatch attachElements ... the sample filter failed` in the writer's log.

Closes #6596
