### PR TITLE
Restore the swift nightly no-changes guard

### DIFF
--- a/packaging/swift/update-ice-swift-nightly.sh
+++ b/packaging/swift/update-ice-swift-nightly.sh
@@ -116,6 +116,10 @@ done
 git add .
 git config user.name "ZeroC"
 git config user.email "git@zeroc.com"
-git commit -m "ice: ${version} ${QUALITY} build"
-git tag -a "${version}" -m "ice: ${version} ${QUALITY} build"
-git push origin "${CHANNEL}" --tags
+if ! git diff --cached --quiet; then
+    git commit -m "ice: ${version} ${QUALITY} build"
+    git tag -a "${version}" -m "ice: ${version} ${QUALITY} build"
+    git push origin "${CHANNEL}" --tags
+else
+    echo "No changes to commit"
+fi


### PR DESCRIPTION
Forward-port from the 3.8 branch: #4916 made the swift nightly publish tolerate runs with no changes to commit, but the rewrite in #5017 dropped the guard on main, so the job fails again whenever the nightly has nothing new. This restores the guard while keeping the quoted `"${CHANNEL}"` from #5017.