### PR TITLE
Use 'method' in Python and JavaScript API docs

### DIFF
--- a/js/packages/ice/src/Ice/IncomingRequest.d.ts
+++ b/js/packages/ice/src/Ice/IncomingRequest.d.ts
@@ -3,7 +3,7 @@
 declare module "@zeroc/ice" {
     namespace Ice {
         /**
-         * Represents a request received by a connection. It's the argument to the dispatch function on Object.
+         * Represents a request received by a connection. It's the argument to the dispatch method on Object.
          * @see {@link Object.dispatch}.
          */
         class IncomingRequest {

--- a/js/packages/ice/src/Ice/ObjectAdapter.d.ts
+++ b/js/packages/ice/src/Ice/ObjectAdapter.d.ts
@@ -144,7 +144,7 @@ declare module "@zeroc/ice" {
             removeFacet(id: Identity, facet: string): Ice.Object;
 
             /**
-             * Removes all facets with the given identity from the Active Servant Map. The function completely removes
+             * Removes all facets with the given identity from the Active Servant Map. This method completely removes
              * the Ice object, including its default facet.
              * @param id The identity of the Ice object to be removed.
              * @returns A collection containing all the facet names and servants of the removed Ice object.
@@ -166,7 +166,7 @@ declare module "@zeroc/ice" {
              * @param id The identity of an Ice object.
              * @returns The servant that implements the Ice object with the given identity, or null if no such servant
              * has been found.
-             * @remarks This function only tries to find the servant in the ASM and among the default servants. It does
+             * @remarks This method only tries to find the servant in the ASM and among the default servants. It does
              * not attempt to locate a servant using servant locators.
              */
             find(id: Identity): Ice.Object | null;
@@ -178,7 +178,7 @@ declare module "@zeroc/ice" {
              * @param facet The facet of an Ice object. An empty facet means the default facet.
              * @returns The servant that implements the Ice object with the given identity and facet, or null if no
              * such servant has been found.
-             * @remarks This function only tries to find the servant in the ASM and among the default servants. It does
+             * @remarks This method only tries to find the servant in the ASM and among the default servants. It does
              * not attempt to locate a servant using servant locators.
              */
             findFacet(id: Identity, facet: string): Ice.Object | null;

--- a/js/packages/ice/src/Ice/ObjectPrx.d.ts
+++ b/js/packages/ice/src/Ice/ObjectPrx.d.ts
@@ -327,11 +327,11 @@ declare module "@zeroc/ice" {
             /**
              * Gets the connection for this proxy. If the proxy does not yet have an established connection or its
              * connection is closed or being closed, it first attempts to create a new connection. For a fixed
-             * proxy, this function returns the connection this proxy is bound to, even when this connection is
+             * proxy, this method returns the connection this proxy is bound to, even when this connection is
              * closed.
              *
              * @returns An asynchronous result that resolves to the connection used by this proxy.
-             * @remarks You can call this function to establish a connection or associate the proxy with an existing
+             * @remarks You can call this method to establish a connection or associate the proxy with an existing
              * connection.
              */
             ice_getConnection(): AsyncResult<Connection>;
@@ -339,14 +339,14 @@ declare module "@zeroc/ice" {
             /**
              * Gets the cached Connection for this proxy. Once this proxy has been associated with a connection
              * (typically during its first invocation), it caches this connection and continues using it for
-             * subsequent invocations, until an invocation on this proxy fails. This function never attempts to
-             * establish a connection. For a fixed proxy, this function returns the connection this proxy is bound
-             * to, even when this connection is closed. This function never throws.
+             * subsequent invocations, until an invocation on this proxy fails. This method never attempts to
+             * establish a connection. For a fixed proxy, this method returns the connection this proxy is bound
+             * to, even when this connection is closed. This method never throws.
              *
              * @returns The cached connection, or `null` if this proxy doesn't have a cached connection. The
              * returned connection can be closed.
              * @remarks A proxy with connection caching disabled (see {@link ice_connectionCached}) never caches a
-             * connection: for such a proxy, this function always returns `null`.
+             * connection: for such a proxy, this method always returns `null`.
              */
             ice_getCachedConnection(): Connection | null;
 

--- a/js/packages/ice/src/Ice/OutputStream.d.ts
+++ b/js/packages/ice/src/Ice/OutputStream.d.ts
@@ -128,8 +128,8 @@ declare module "@zeroc/ice" {
 
             /**
              * Encodes the state of class instances whose insertion was delayed during a previous call to
-             * {@link OutputStream#writeValue}. This function must be called only once. For backward compatibility with
-             * encoding version 1.0, this function must be called only when non-optional fields or parameters use class
+             * {@link OutputStream#writeValue}. This method must be called only once. For backward compatibility with
+             * encoding version 1.0, this method must be called only when non-optional fields or parameters use class
              * types.
              */
             writePendingValues(): void;

--- a/js/packages/ice/src/Ice/ServantLocator.d.ts
+++ b/js/packages/ice/src/Ice/ServantLocator.d.ts
@@ -34,7 +34,7 @@ declare module "@zeroc/ice" {
 
             /**
              * Notifies this servant locator that the dispatch on the servant returned by {@link locate} is complete.
-             * The object adapter calls this function only when {@link locate} returns a non-null servant.
+             * The object adapter calls this method only when {@link locate} returns a non-null servant.
              *
              * @remarks The implementation can throw any exception, including {@link UserException}. The Ice runtime
              * marshals this exception in the response. If both the dispatch and `finished` throw an exception, the

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -92,7 +92,7 @@ CommunicatorDestroyedException
 Disables the inactivity check on this connection.
 
 By default, Ice will close connections that remain inactive for a certain period.
-This function disables that behavior for this connection.)";
+This method disables that behavior for this connection.)";
 
     constexpr const char* connectionSetAdapter_doc = R"(setAdapter(adapter: Ice.ObjectAdapter | None) -> None
 
@@ -190,7 +190,7 @@ Returns a description of the connection as human readable text, suitable for log
 
 Notes
 -----
-This function remains usable after the connection is closed or aborted.
+This method remains usable after the connection is closed or aborted.
 
 Returns
 -------
@@ -228,10 +228,10 @@ sndSize : int
 
     constexpr const char* connectionThrowException_doc = R"(throwException() -> None
 
-Raises an exception that provides the reason for the closure of this connection. For example, this function
+Raises an exception that provides the reason for the closure of this connection. For example, this method
 raises :class:`Ice.CloseConnectionException` when the connection was closed gracefully by the peer; it raises
 :class:`Ice.ConnectionAbortedException` when the connection is aborted with :meth:`~Ice.Connection.abort`.
-This function does nothing if the connection is not yet closing or closed.)";
+This method does nothing if the connection is not yet closing or closed.)";
 }
 
 namespace IcePy

--- a/python/python/Ice/Communicator.py
+++ b/python/python/Ice/Communicator.py
@@ -78,7 +78,7 @@ class Communicator:
         Parameters
         ----------
         args : list[str] | None, optional
-            The command-line arguments, parsed into Ice properties by this function.
+            The command-line arguments, parsed into Ice properties by this constructor.
         eventLoop : asyncio.AbstractEventLoop | None, optional
             An asyncio event loop used to run coroutines and wrap futures. If provided, a new event loop adapter is
             created and configured with the communicator. This adapter is responsible for executing coroutines returned
@@ -130,8 +130,8 @@ class Communicator:
 
     def destroy(self) -> None:
         """
-        Destroys this communicator. This function calls :meth:`~Ice.Communicator.shutdown` implicitly. Calling this
-        function destroys all object adapters, and closes all outgoing connections. This function waits for all
+        Destroys this communicator. This method calls :meth:`~Ice.Communicator.shutdown` implicitly. Calling this
+        method destroys all object adapters, and closes all outgoing connections. This method waits for all
         outstanding dispatches to complete before returning. This includes "bidirectional dispatches" that execute on
         outgoing connections.
         """
@@ -157,16 +157,16 @@ class Communicator:
 
     def shutdown(self) -> None:
         """
-        Shuts down this communicator. This function calls :meth:`Ice.ObjectAdapter.deactivate` on all object adapters
+        Shuts down this communicator. This method calls :meth:`Ice.ObjectAdapter.deactivate` on all object adapters
         created by this communicator. Shutting down a communicator has no effect on outgoing connections.
         """
         self._impl.shutdown()
 
     def waitForShutdown(self) -> None:
         """
-        Waits for shutdown to complete. This function calls :meth:`Ice.ObjectAdapter.waitForDeactivate` on all object
+        Waits for shutdown to complete. This method calls :meth:`Ice.ObjectAdapter.waitForDeactivate` on all object
         adapters created by this communicator. In a client application that does not accept incoming connections, this
-        function returns as soon as another thread calls :meth:`~Ice.Communicator.shutdown` or
+        method returns as soon as another thread calls :meth:`~Ice.Communicator.shutdown` or
         :meth:`~Ice.Communicator.destroy` on this communicator.
         """
         # If invoked by the main thread, waitForShutdown only blocks for the specified timeout in order to give us a
@@ -328,9 +328,9 @@ class Communicator:
 
     def createObjectAdapterWithEndpoints(self, name: str, endpoints: str) -> ObjectAdapter:
         """
-        Creates a new object adapter with endpoints. This function sets the property ``name.Endpoints``, and then
-        calls :meth:`~Ice.Communicator.createObjectAdapter`. It is provided as a convenience function. Calling this
-        function with an empty name will result in a UUID being generated for the name.
+        Creates a new object adapter with endpoints. This method sets the property ``name.Endpoints``, and then
+        calls :meth:`~Ice.Communicator.createObjectAdapter`. It is provided as a convenience method. Calling this
+        method with an empty name will result in a UUID being generated for the name.
 
         Parameters
         ----------
@@ -354,8 +354,8 @@ class Communicator:
 
     def createObjectAdapterWithRouter(self, name: str, router: RouterPrx) -> ObjectAdapter:
         """
-        Creates a new object adapter with a router. This function creates a routed object adapter.
-        Calling this function with an empty name will result in a UUID being generated for the name.
+        Creates a new object adapter with a router. This method creates a routed object adapter.
+        Calling this method with an empty name will result in a UUID being generated for the name.
 
         Parameters
         ----------
@@ -380,7 +380,7 @@ class Communicator:
     def getDefaultObjectAdapter(self) -> ObjectAdapter | None:
         """
         Gets the object adapter that is associated by default with new outgoing connections created by this
-        communicator. This function returns ``None`` unless you set a non-``None`` default object adapter using
+        communicator. This method returns ``None`` unless you set a non-``None`` default object adapter using
         :meth:`~Ice.Communicator.setDefaultObjectAdapter`.
 
         Returns
@@ -398,7 +398,7 @@ class Communicator:
     def setDefaultObjectAdapter(self, adapter: ObjectAdapter | None):
         """
         Sets the object adapter that will be associated with new outgoing connections created by this communicator.
-        This function has no effect on existing outgoing connections, or on incoming connections.
+        This method has no effect on existing outgoing connections, or on incoming connections.
 
         Parameters
         ----------
@@ -474,7 +474,7 @@ class Communicator:
     def setDefaultRouter(self, router: RouterPrx | None):
         """
         Sets the default router of this communicator. All newly created proxies will use this default router.
-        This function has no effect on existing proxies.
+        This method has no effect on existing proxies.
 
         Notes
         -----
@@ -511,7 +511,7 @@ class Communicator:
     def setDefaultLocator(self, locator: LocatorPrx | None):
         """
         Sets the default locator of this communicator. All newly created proxies will use this default locator.
-        This function has no effect on existing proxies or object adapters.
+        This method has no effect on existing proxies or object adapters.
 
         Notes
         -----
@@ -575,13 +575,13 @@ class Communicator:
         """
         Adds the Admin object with all its facets to the provided object adapter.
         If ``Ice.Admin.ServerId`` is set and the provided object adapter has a :class:`Ice.LocatorPrx`,
-        this function registers the Admin's Process facet with the locator's :class:`Ice.LocatorRegistryPrx`.
+        this method registers the Admin's Process facet with the locator's :class:`Ice.LocatorRegistryPrx`.
 
         Parameters
         ----------
         adminAdapter : ObjectAdapter | None
             The object adapter used to host the Admin object; if it is ``None`` and ``Ice.Admin.Endpoints`` is set,
-            this function uses the ``Ice.Admin`` object adapter, after creating and activating this adapter.
+            this method uses the ``Ice.Admin`` object adapter, after creating and activating this adapter.
         adminId : Identity
             The identity of the Admin object.
 
@@ -593,7 +593,7 @@ class Communicator:
         Raises
         ------
         InitializationException
-            If this function is called more than once.
+            If this method is called more than once.
         CommunicatorDestroyedException
             If the communicator has been destroyed.
         """
@@ -603,10 +603,10 @@ class Communicator:
         """
         Gets a proxy to the main facet of the Admin object.
 
-        This function also creates the Admin object and creates and activates the ``Ice.Admin`` object adapter to host
-        this Admin object if ``Ice.Admin.Endpoints`` is set. The identity of the Admin object created by this function
+        This method also creates the Admin object and creates and activates the ``Ice.Admin`` object adapter to host
+        this Admin object if ``Ice.Admin.Endpoints`` is set. The identity of the Admin object created by this method
         is ``{value of Ice.Admin.InstanceName}/admin``, or ``{UUID}/admin`` when ``Ice.Admin.InstanceName`` is not set.
-        If ``Ice.Admin.DelayCreation`` is ``0`` or not set, this function is called by the communicator initialization,
+        If ``Ice.Admin.DelayCreation`` is ``0`` or not set, this method is called by the communicator initialization,
         after initialization of all plugins.
 
         Returns

--- a/python/python/Ice/EventLoopAdapter.py
+++ b/python/python/Ice/EventLoopAdapter.py
@@ -18,8 +18,8 @@ class EventLoopAdapter(ABC):
     @abstractmethod
     def runCoroutine(self, coroutine: Coroutine) -> FutureLike:
         """
-        Runs a coroutine in the application-configured event loop. The Ice runtime will call this function to run
-        coroutines returned by async dispatch methods. This function is called from the Ice dispatch thread.
+        Runs a coroutine in the application-configured event loop. The Ice runtime will call this method to run
+        coroutines returned by async dispatch methods. This method is called from the Ice dispatch thread.
 
         Parameters
         ----------
@@ -37,7 +37,7 @@ class EventLoopAdapter(ABC):
     def wrapFuture(self, future: Future) -> Awaitable:
         """
         Wraps an :class:`Ice.Future` so that it can be awaited in the application event loop.
-        The Ice runtime calls this function before returning a future to the application.
+        The Ice runtime calls this method before returning a future to the application.
 
         Parameters
         ----------

--- a/python/python/Ice/Future.py
+++ b/python/python/Ice/Future.py
@@ -119,14 +119,14 @@ class Future(Awaitable[_T]):
         """
         Retrieves the result of this future's operation.
 
-        If the operation has not completed, this function will wait up to ``timeout``-many seconds for it to finish.
-        If the operation raised an exception, this function raises the same exception.
+        If the operation has not completed, this method will wait up to ``timeout``-many seconds for it to finish.
+        If the operation raised an exception, this method raises the same exception.
 
         Parameters
         ----------
         timeout : int | float | None, optional
             Maximum time (in seconds) to wait for the result.
-            If ``None`` (the default), this function waits indefinitely until the operation completes.
+            If ``None`` (the default), this method waits indefinitely until the operation completes.
             A timeout of ``0`` returns immediately (a non-blocking poll), raising :class:`Ice.TimeoutException`
             if the result is not yet available.
 
@@ -161,13 +161,13 @@ class Future(Awaitable[_T]):
         """
         Retrieves the exception raised by this future's operation.
 
-        If the operation has not completed, this function will wait up to ``timeout``-many seconds for it to finish.
+        If the operation has not completed, this method will wait up to ``timeout``-many seconds for it to finish.
 
         Parameters
         ----------
         timeout : int | float | None, optional
             Maximum time (in seconds) to wait for the exception.
-            If ``None`` (the default), this function waits indefinitely until the operation completes.
+            If ``None`` (the default), this method waits indefinitely until the operation completes.
             A timeout of ``0`` returns immediately (a non-blocking poll), raising :class:`Ice.TimeoutException`
             if the operation has not yet completed.
 
@@ -195,10 +195,10 @@ class Future(Awaitable[_T]):
         """
         Sets the result of this future and marks it as completed.
 
-        This function stores the provided ``result`` and transitions the future's state to "done".
+        This method stores the provided ``result`` and transitions the future's state to "done".
         Any registered callbacks are executed after the state update.
 
-        If the future is not in a running state, this function has no effect.
+        If the future is not in a running state, this method has no effect.
 
         Parameters
         ----------
@@ -221,10 +221,10 @@ class Future(Awaitable[_T]):
         """
         Sets an exception for this future and marks it as completed.
 
-        This function stores the provided exception ``ex`` and transitions the future's state to "done".
+        This method stores the provided exception ``ex`` and transitions the future's state to "done".
         Any registered callbacks are executed after the state update.
 
-        If the future is not in a running state, this function has no effect.
+        If the future is not in a running state, this method has no effect.
 
         Parameters
         ----------
@@ -364,13 +364,13 @@ class FutureLike(Protocol[_T_co]):
         """
         Retrieves the result of the ``Future``.
 
-        If the ``Future`` has not completed, this function will wait up to ``timeout``-many seconds for it to finish.
+        If the ``Future`` has not completed, this method will wait up to ``timeout``-many seconds for it to finish.
 
         Parameters
         ----------
         timeout : int | float | None, optional
             Maximum time (in seconds) to wait for the result.
-            If ``None`` (the default), this function waits indefinitely until the operation completes.
+            If ``None`` (the default), this method waits indefinitely until the operation completes.
 
         Returns
         -------

--- a/python/python/Ice/InitializationData.py
+++ b/python/python/Ice/InitializationData.py
@@ -25,7 +25,7 @@ class InitializationData:
     ----------
     properties : Ice.Properties | None
         The properties for the communicator.
-        If not ``None``, this corresponds to the object returned by the :meth:`Ice.Communicator.getProperties` function.
+        If not ``None``, this corresponds to the object returned by the :meth:`Ice.Communicator.getProperties` method.
     logger : Ice.Logger | None
         The logger for the communicator.
     threadStart : Callable[[], None] | None
@@ -46,7 +46,7 @@ class InitializationData:
         enqueued is discarded.
     eventLoopAdapter : Ice.EventLoopAdapter | None
         An event loop adapter used to run coroutines and wrap futures. If provided, this adapter is responsible for
-        executing coroutines returned by Ice asynchronous dispatch functions and for wrapping Ice futures (from Ice
+        executing coroutines returned by Ice asynchronous dispatch methods and for wrapping Ice futures (from Ice
         Async APIs) into futures that can be awaited in the application's event loop.
     sliceLoader : Callable[[str], Ice.Value | Ice.UserException | None] | None
         A :class:`~collections.abc.Callable` used to create instances of Slice classes and user exceptions.

--- a/python/python/Ice/InvocationFuture.py
+++ b/python/python/Ice/InvocationFuture.py
@@ -34,7 +34,7 @@ class InvocationFuture(Future):
         """
         Cancels the invocation.
 
-        This function invokes :meth:`Ice.Future.cancel` to cancel the underlying future.
+        This method invokes :meth:`Ice.Future.cancel` to cancel the underlying future.
         If the cancellation is successful, the associated invocation is also cancelled.
 
         Cancelling an invocation prevents a queued invocation from being sent.
@@ -104,13 +104,13 @@ class InvocationFuture(Future):
         """
         Waits until the invocation has been sent.
 
-        If the invocation has not been sent, this function will wait up to ``timeout``-many seconds for it to send.
+        If the invocation has not been sent, this method will wait up to ``timeout``-many seconds for it to send.
 
         Parameters
         ----------
         timeout : int | float | None, optional
             Maximum time (in seconds) to wait for the invocation to be sent.
-            If ``None`` (the default), this function waits indefinitely.
+            If ``None`` (the default), this method waits indefinitely.
             A timeout of ``0`` returns immediately (a non-blocking poll), raising :class:`Ice.TimeoutException`
             if the invocation has not yet been sent.
 

--- a/python/python/Ice/ObjectAdapter.py
+++ b/python/python/Ice/ObjectAdapter.py
@@ -69,7 +69,7 @@ class ObjectAdapter:
         Notes
         -----
         When this object adapter is an indirect object adapter configured with a locator proxy, this
-        function also registers the object adapter's published endpoints with this locator.
+        method also registers the object adapter's published endpoints with this locator.
         """
         self._impl.activate()
 
@@ -80,7 +80,7 @@ class ObjectAdapter:
 
         Notes
         -----
-        This function is provided for backward compatibility with older versions of Ice.
+        This method is provided for backward compatibility with older versions of Ice.
         Don't use it in new applications.
         """
         self._impl.hold()
@@ -92,7 +92,7 @@ class ObjectAdapter:
 
         Notes
         -----
-        This function is provided for backward compatibility with older versions of Ice.
+        This method is provided for backward compatibility with older versions of Ice.
         Don't use it in new applications.
         """
         # If invoked by the main thread, waitForHold only blocks for the specified timeout in order to give us a chance
@@ -104,10 +104,10 @@ class ObjectAdapter:
         """
         Deactivates this object adapter: stops accepting new connections from clients and closes gracefully all
         incoming connections created by this object adapter once all outstanding dispatches have completed.
-        If this object adapter is indirect, this function also unregisters the object adapter from the locator
+        If this object adapter is indirect, this method also unregisters the object adapter from the locator
         (see :meth:`~Ice.ObjectAdapter.activate`).
 
-        This function does not cancel outstanding dispatches: it lets them execute until completion.
+        This method does not cancel outstanding dispatches: it lets them execute until completion.
         A deactivated object adapter cannot be reactivated again; it can only be destroyed.
         """
         self._impl.deactivate()
@@ -138,7 +138,7 @@ class ObjectAdapter:
     def destroy(self) -> None:
         """
         Destroys this object adapter and cleans up all resources associated with it.
-        Once this function has returned, you can recreate another object adapter with the same name.
+        Once this method has returned, you can recreate another object adapter with the same name.
         """
         self._impl.destroy()
 
@@ -149,7 +149,7 @@ class ObjectAdapter:
 
         Notes
         -----
-        This function is equivalent to calling :meth:`~Ice.ObjectAdapter.addFacet` with an empty facet.
+        This method is equivalent to calling :meth:`~Ice.ObjectAdapter.addFacet` with an empty facet.
 
         Parameters
         ----------
@@ -316,7 +316,7 @@ class ObjectAdapter:
 
     def removeAllFacets(self, id: Identity) -> dict[str, Object]:
         """
-        Removes all facets with the given identity from the Active Servant Map. This function completely removes the
+        Removes all facets with the given identity from the Active Servant Map. This method completely removes the
         Ice object, including its default facet.
 
         Parameters
@@ -363,7 +363,7 @@ class ObjectAdapter:
 
         Notes
         -----
-        This function only tries to find the servant in the ASM and among the default servants.
+        This method only tries to find the servant in the ASM and among the default servants.
         It does not attempt to locate a servant using servant locators.
 
         Parameters
@@ -385,7 +385,7 @@ class ObjectAdapter:
 
         Notes
         -----
-        This function only tries to find the servant in the ASM and among the default servants.
+        This method only tries to find the servant in the ASM and among the default servants.
         It does not attempt to locate a servant using servant locators.
 
         Parameters
@@ -426,7 +426,7 @@ class ObjectAdapter:
 
         Notes
         -----
-        This function only tries to find the servant in the ASM and among the default servants.
+        This method only tries to find the servant in the ASM and among the default servants.
         It does not attempt to locate a servant using servant locators.
 
         Parameters
@@ -593,7 +593,7 @@ class ObjectAdapter:
 
         Notes
         -----
-        This function remains usable after the object adapter has been deactivated.
+        This method remains usable after the object adapter has been deactivated.
 
         Returns
         -------
@@ -608,7 +608,7 @@ class ObjectAdapter:
 
         Notes
         -----
-        This function remains usable after the object adapter has been deactivated.
+        This method remains usable after the object adapter has been deactivated.
 
         Returns
         -------

--- a/python/python/Ice/ObjectPrx.py
+++ b/python/python/Ice/ObjectPrx.py
@@ -378,7 +378,7 @@ class ObjectPrx(IcePy.ObjectPrx):
             and the encapsulation contains the encoded out-parameters and return value (the return value follows
             any out-parameters). If the operation raised a user exception, the flag is ``False`` and the
             encapsulation contains the encoded user exception. If the operation raised a runtime exception, this
-            function raises it directly. When this proxy is a oneway, datagram, or batch proxy, the flag is
+            method raises it directly. When this proxy is a oneway, datagram, or batch proxy, the flag is
             always ``True`` and the encapsulation is empty.
         """
         return super().ice_invoke(operation, mode, inParams, ctx)
@@ -967,7 +967,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         Gets the connection for this proxy. If the proxy does not yet have an established connection
         or its connection is closed or being closed, it first attempts to create a new connection.
-        For a fixed proxy, this function returns the connection this proxy is bound to, even when
+        For a fixed proxy, this method returns the connection this proxy is bound to, even when
         this connection is closed.
 
         Returns
@@ -977,11 +977,11 @@ class ObjectPrx(IcePy.ObjectPrx):
 
         Notes
         -----
-        You can call this function to establish a connection or associate the proxy with an existing
+        You can call this method to establish a connection or associate the proxy with an existing
         connection and ignore the return value.
 
         When this proxy reaches its target object through collocation optimization (see
-        :meth:`~Ice.ObjectPrx.ice_collocationOptimized`), this function returns ``None``: collocated invocations
+        :meth:`~Ice.ObjectPrx.ice_collocationOptimized`), this method returns ``None``: collocated invocations
         don't use a connection.
         """
         return super().ice_getConnection()
@@ -1001,7 +1001,7 @@ class ObjectPrx(IcePy.ObjectPrx):
 
         Notes
         -----
-        You can call this function to establish a connection or associate the proxy with an existing
+        You can call this method to establish a connection or associate the proxy with an existing
         connection and ignore the result.
 
         When this proxy reaches its target object through collocation optimization (see
@@ -1014,9 +1014,9 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         Gets the Connection cached by this proxy. Once this proxy has been associated with a connection
         (typically during its first invocation), it caches this connection and continues using it for
-        subsequent invocations, until an invocation on this proxy fails. This function never attempts to
-        establish a connection. For a fixed proxy, this function returns the connection this proxy is bound
-        to, even when this connection is closed. This function never raises an exception.
+        subsequent invocations, until an invocation on this proxy fails. This method never attempts to
+        establish a connection. For a fixed proxy, this method returns the connection this proxy is bound
+        to, even when this connection is closed. This method never raises an exception.
 
         Returns
         -------
@@ -1027,7 +1027,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         Notes
         -----
         A proxy with connection caching disabled (see :meth:`~Ice.ObjectPrx.ice_connectionCached`) never caches a
-        connection: for such a proxy, this function always returns ``None``. This function also returns ``None`` when
+        connection: for such a proxy, this method always returns ``None``. This method also returns ``None`` when
         this proxy reaches its target object through collocation optimization (see
         :meth:`~Ice.ObjectPrx.ice_collocationOptimized`): collocated invocations don't use a connection.
         """

--- a/python/python/Ice/ServantLocator.py
+++ b/python/python/Ice/ServantLocator.py
@@ -51,7 +51,7 @@ class ServantLocator(ABC):
     def finished(self, current: Current, servant: Object, cookie: object | None):
         """
         Notifies this servant locator that the dispatch on the servant returned by
-        :meth:`~Ice.ServantLocator.locate` is complete. The object adapter calls this function only when
+        :meth:`~Ice.ServantLocator.locate` is complete. The object adapter calls this method only when
         :meth:`~Ice.ServantLocator.locate` didn't return ``None``.
 
         Notes

--- a/python/python/IcePy-stubs/__init__.pyi
+++ b/python/python/IcePy-stubs/__init__.pyi
@@ -147,7 +147,7 @@ class Connection:
         Disables the inactivity check on this connection.
 
         By default, Ice will close connections that remain inactive for a certain period.
-        This function disables that behavior for this connection.
+        This method disables that behavior for this connection.
         """
         ...
 
@@ -260,7 +260,7 @@ class Connection:
 
         Notes
         -----
-        This function remains usable after the connection is closed or aborted.
+        This method remains usable after the connection is closed or aborted.
 
         Returns
         -------
@@ -306,10 +306,10 @@ class Connection:
 
     def throwException(self) -> None:
         """
-        Raises an exception that provides the reason for the closure of this connection. For example, this function
+        Raises an exception that provides the reason for the closure of this connection. For example, this method
         raises :class:`Ice.CloseConnectionException` when the connection was closed gracefully by the peer; it raises
         :class:`Ice.ConnectionAbortedException` when the connection is aborted with :meth:`~Ice.Connection.abort`.
-        This function does nothing if the connection is not yet closing or closed.
+        This method does nothing if the connection is not yet closing or closed.
         """
         ...
 


### PR DESCRIPTION
This PR is a mechanical terminology sweep of the hand-written runtime API docs: the Python docstrings (including the `Connection` docstrings embedded in IcePy and their mirrored copies in the IcePy stubs) and the JavaScript `.d.ts` doc comments now say "method" when referring to a member of a class, matching each language's standard terminology.

Occurrences of "function" that genuinely refer to functions are unchanged: free functions (`Ice.initialize`, `Ice.loadSlice`, `wrap_future`, ...) and callback parameters. The `Communicator.__init__` docstring now says "this constructor". The Slice compilers don't emit any "function" doc text of their own, so generated code is unaffected.

Fixes #6336

🤖 Generated with [Claude Code](https://claude.com/claude-code)