### PR TITLE
Escape the Slice Compiler's XML Output From `--list-generated`

### DIFF
--- a/changelog.d/general/6328.md
+++ b/changelog.d/general/6328.md
@@ -1,0 +1,2 @@
+- The `--list-generated` output of `slice2java` and `slice2matlab` is now always well-formed XML.
+  File names holding XML-significant characters such as `&` are properly escaped.

--- a/changelog.d/general/6328.md
+++ b/changelog.d/general/6328.md
@@ -1,2 +1,0 @@
-- The `--list-generated` output of `slice2java` and `slice2matlab` is now always well-formed XML.
-  File names holding XML-significant characters such as `&` are properly escaped.

--- a/cpp/src/Slice/FileTracker.cpp
+++ b/cpp/src/Slice/FileTracker.cpp
@@ -3,6 +3,7 @@
 #include "FileTracker.h"
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/FileUtil.h"
+#include "Util.h"
 
 #include <cassert>
 
@@ -75,10 +76,10 @@ Slice::FileTracker::dumpxml()
     {
         if (!p.second.empty())
         {
-            consoleOut << endl << "  <source name=\"" << p.first << "\">";
+            consoleOut << endl << "  <source name=\"" << escapeXMLAttribute(p.first) << "\">";
             for (const auto& q : p.second)
             {
-                consoleOut << endl << "    <file name=\"" << q << "\"/>";
+                consoleOut << endl << "    <file name=\"" << escapeXMLAttribute(q) << "\"/>";
             }
             consoleOut << endl << "  </source>";
         }

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -42,45 +42,6 @@ namespace
         }
     }
 
-    // Escapes a file name for use in a double-quoted XML attribute value.
-    string escapeXMLAttribute(string_view name)
-    {
-        ostringstream os;
-        for (char c : name)
-        {
-            switch (c)
-            {
-                case '&':
-                    os << "&amp;";
-                    break;
-                case '<':
-                    os << "&lt;";
-                    break;
-                case '>':
-                    os << "&gt;";
-                    break;
-                case '"':
-                    os << "&quot;";
-                    break;
-                // An XML parser replaces a literal tab, line feed or carriage return in an attribute value by a
-                // space. Character references survive this normalization.
-                case '\t':
-                    os << "&#x9;";
-                    break;
-                case '\n':
-                    os << "&#xA;";
-                    break;
-                case '\r':
-                    os << "&#xD;";
-                    break;
-                default:
-                    os << c;
-                    break;
-            }
-        }
-        return os.str();
-    }
-
     // Escapes a file name and wraps it in double quotes, to produce a JSON string.
     string toJSONString(string_view name)
     {
@@ -717,6 +678,45 @@ Slice::relativePath(const string& path1, const string& path2)
     newPath += f1;
 
     return newPath;
+}
+
+string
+Slice::escapeXMLAttribute(string_view name)
+{
+    ostringstream os;
+    for (char c : name)
+    {
+        switch (c)
+        {
+            case '&':
+                os << "&amp;";
+                break;
+            case '<':
+                os << "&lt;";
+                break;
+            case '>':
+                os << "&gt;";
+                break;
+            case '"':
+                os << "&quot;";
+                break;
+            // An XML parser replaces a literal tab, line feed or carriage return in an attribute value by a
+            // space. Character references survive this normalization.
+            case '\t':
+                os << "&#x9;";
+                break;
+            case '\n':
+                os << "&#xA;";
+                break;
+            case '\r':
+                os << "&#xD;";
+                break;
+            default:
+                os << c;
+                break;
+        }
+    }
+    return os.str();
 }
 
 void

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -90,6 +90,11 @@ namespace Slice
 
     [[nodiscard]] std::string relativePath(const std::string& path1, const std::string& path2);
 
+    /// Escapes a file name for use in a double-quoted XML attribute value.
+    /// @param name The file name to escape.
+    /// @return The escaped file name.
+    [[nodiscard]] std::string escapeXMLAttribute(std::string_view name);
+
     /// The DependencyGenerator class is used to collect dependencies of Slice units.
     class DependencyGenerator final
     {

--- a/java/test/src/main/java/test/Slice/generation/a&b/File3.ice
+++ b/java/test/src/main/java/test/Slice/generation/a&b/File3.ice
@@ -1,0 +1,12 @@
+// Copyright (c) ZeroC, Inc.
+
+#pragma once
+
+["java:identifier:test.Slice.generation.Test"]
+module Test
+{
+    interface Interface3
+    {
+        void method();
+    }
+}

--- a/java/test/src/main/java/test/Slice/generation/list-generated.out
+++ b/java/test/src/main/java/test/Slice/generation/list-generated.out
@@ -13,4 +13,10 @@
     <file name="classes/test/Slice/generation/Test/Interface2.java"/>
     <file name="classes/test/Slice/generation/Test/AsyncInterface2.java"/>
   </source>
+  <source name="a&amp;b/File3.ice">
+    <file name="classes/test/Slice/generation/Test/Interface3Prx.java"/>
+    <file name="classes/test/Slice/generation/Test/_Interface3PrxI.java"/>
+    <file name="classes/test/Slice/generation/Test/Interface3.java"/>
+    <file name="classes/test/Slice/generation/Test/AsyncInterface3.java"/>
+  </source>
 </generated>

--- a/scripts/tests/Slice/generation.py
+++ b/scripts/tests/Slice/generation.py
@@ -20,6 +20,7 @@ class SliceGenerationTestCase(ClientTestCase):
                 "classes",
                 "File1.ice",
                 "File2.ice",
+                "a&b/File3.ice",
             ],
         )
 


### PR DESCRIPTION
This PR fixes #6328.

The XML output produced from `--list-generated` with `slice2java` and `slice2matlab` is now correctly escaped.
The escaping logic was already added by #6323 and is re-used by this PR. It was just matter of calling it and adding a test.