### PR TITLE
Track Slice include dependencies in the CompileSlice plugin

### DIFF
--- a/changelog.d/swift/6629.md
+++ b/changelog.d/swift/6629.md
@@ -1,0 +1,6 @@
+- Fixed a bug in the CompileSlice plugin: editing a Slice file included by other Slice files left the Swift code
+  generated from those other files stale. The plugin now tracks Slice include dependencies, and also regenerates the
+  Swift code when `slice2swift` itself changes.
+
+- The CompileSlice plugin now reports an error when two Slice files in the same target have the same file name,
+  instead of failing later with a "multiple producers" build error.

--- a/changelog.d/swift/6629.md
+++ b/changelog.d/swift/6629.md
@@ -1,6 +1,3 @@
-- Fixed a bug in the CompileSlice plugin: editing a Slice file included by other Slice files left the Swift code
-  generated from those other files stale. The plugin now tracks Slice include dependencies, and also regenerates the
-  Swift code when `slice2swift` itself changes.
-
-- The CompileSlice plugin now reports an error when two Slice files in the same target have the same file name,
-  instead of failing later with a "multiple producers" build error.
+- The CompileSlice plugin now tracks Slice include dependencies: editing a Slice file included by other Slice files
+  regenerates the Swift code for those files as well. The plugin also regenerates the Swift code when `slice2swift`
+  itself changes.

--- a/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
+++ b/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
@@ -164,6 +164,12 @@ struct CompileSlicePlugin {
         searchPathDirs.append(Self.iceSliceDir)
 
         sliceSources = Self.uniqueFiles(sliceSources)
+
+        // Nothing to generate, and slice2swift rejects an empty file list.
+        guard !sliceSources.isEmpty else {
+            return []
+        }
+
         let includeArguments = searchPathDirs.map { "-I\($0.path)" }
 
         // slice2swift names each generated file after the base name of its Slice file, so two sources

--- a/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
+++ b/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
@@ -137,9 +137,10 @@ struct CompileSlicePlugin {
                 if sourceFileOrDirectory.pathExtension == "ice" {
                     sliceSources.append(sourceFileOrDirectory)
                 } else {
+                    // Standardized because contentsOfDirectory(at:) does not follow a symbolic link.
                     sliceSources.append(
                         contentsOf: try FileManager.default.contentsOfDirectory(
-                            at: sourceFileOrDirectory,
+                            at: sourceFileOrDirectory.standardizedFileURL,
                             includingPropertiesForKeys: nil
                         ).filter { $0.pathExtension == "ice" })
                 }

--- a/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
+++ b/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
@@ -158,11 +158,6 @@ struct CompileSlicePlugin {
         }
         searchPathDirs.append(Self.iceSliceDir)
 
-        // Nothing to generate.
-        guard !sliceSources.isEmpty else {
-            return []
-        }
-
         let includeArguments = searchPathDirs.map { "-I\($0.path)" }
 
         // Ask the compiler which files each source includes, so that editing an included file

--- a/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
+++ b/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
@@ -38,6 +38,8 @@ extension CompileSlicePlugin: BuildToolPlugin {
 enum PluginError: Error, CustomStringConvertible, LocalizedError {
     case invalidTarget(String)
     case missingIceSliceFiles(String)
+    case duplicateSliceFileName(String, String)
+    case dependencyScanFailed(String)
 
     var description: String {
         switch self {
@@ -45,6 +47,12 @@ enum PluginError: Error, CustomStringConvertible, LocalizedError {
             return "Expected a SwiftSourceModuleTarget but got '\(targetType)'."
         case .missingIceSliceFiles(let path):
             return "The Ice Slice files are missing. Expected location: '\(path)'."
+        case .duplicateSliceFileName(let first, let second):
+            return
+                "The Slice files '\(first)' and '\(second)' have the same file name and would generate "
+                + "the same Swift file."
+        case .dependencyScanFailed(let reason):
+            return "Could not determine the Slice include dependencies: \(reason)."
         }
     }
 
@@ -122,7 +130,7 @@ struct CompileSlicePlugin {
             .url
 
         // Decode config and apply additional sources and search paths.
-        var searchPaths: [String] = []
+        var searchPathDirs: [URL] = []
         if let configFileURL = configFileURL {
             let configData = try Data(contentsOf: configFileURL)
             let config = try JSONDecoder().decode(Config.self, from: configData)
@@ -145,7 +153,7 @@ struct CompileSlicePlugin {
             // Add additional search paths from config.search_paths.
             // These paths are relative to the config file location.
             for path in config.search_paths ?? [] {
-                searchPaths.append("-I\(baseDirectory.appending(path: path).path)")
+                searchPathDirs.append(baseDirectory.appending(path: path))
             }
         }
 
@@ -153,7 +161,36 @@ struct CompileSlicePlugin {
         guard FileManager.default.fileExists(atPath: Self.iceSliceDir.appending(path: "Ice/Identity.ice").path) else {
             throw PluginError.missingIceSliceFiles(Self.iceSliceDir.path)
         }
-        searchPaths.append("-I\(Self.iceSliceDir.path)")
+        searchPathDirs.append(Self.iceSliceDir)
+
+        sliceSources = Self.uniqueFiles(sliceSources)
+        let includeArguments = searchPathDirs.map { "-I\($0.path)" }
+
+        // slice2swift names each generated file after the base name of its Slice file, so two sources
+        // with the same file name would produce build commands fighting over one output.
+        var sourcesByName: [String: URL] = [:]
+        for sliceSource in sliceSources {
+            let name = sliceSource.deletingPathExtension().lastPathComponent
+            if let other = sourcesByName.updateValue(sliceSource, forKey: name) {
+                throw PluginError.duplicateSliceFileName(other.path, sliceSource.path)
+            }
+        }
+
+        // Ask the compiler which files each source includes, so that editing an included file
+        // regenerates every file that includes it.
+        let dependencies = try Self.sliceDependencies(
+            slice2swift: slice2swift,
+            includeArguments: includeArguments,
+            sources: sliceSources
+        )
+
+        // A source missing from the report would silently lose its dependencies, so treat it as an error
+        // rather than generating Swift code that later goes stale.
+        if let dependencies {
+            for sliceSource in sliceSources where dependencies[sliceSource.path] == nil {
+                throw PluginError.dependencyScanFailed("nothing was reported for '\(sliceSource.path)'")
+            }
+        }
 
         // Create the build commands for each Slice file.
         return sliceSources.map { sliceSource in
@@ -164,13 +201,106 @@ struct CompileSlicePlugin {
             return .buildCommand(
                 displayName: "Compile Slice \(sliceSource.lastPathComponent)",
                 executable: slice2swift,
-                arguments: searchPaths + ["--output-dir", outputDir.path, sliceSource.path],
-                // It's important to declare both the Slice file and the config file as input files so the build system can
-                // detect changes. This also avoids warnings about unused files.
-                // TODO: We should also include imported Slice dependencies as inputs.
-                inputFiles: [sliceSource] + (configFileURL.map { [$0] } ?? []),
+                arguments: includeArguments + ["--output-dir", outputDir.path, sliceSource.path],
+                // The build system re-runs this command when any declared input changes, so it must see
+                // everything slice2swift reads: the compiler, the config file and the included Slice files.
+                inputFiles: [sliceSource, slice2swift]
+                    + (dependencies?[sliceSource.path] ?? [])
+                    + (configFileURL.map { [$0] } ?? []),
                 outputFiles: [URL(fileURLWithPath: outputFile.path)]
             )
+        }
+    }
+
+    /// Runs `slice2swift --depend-xml` to find the Slice files each source includes, directly or
+    /// transitively. Returns nil when the compiler rejects the Slice files: the build commands then report
+    /// those errors, and the next successful run restores the dependencies.
+    private static func sliceDependencies(
+        slice2swift: URL,
+        includeArguments: [String],
+        sources: [URL]
+    ) throws -> [String: [URL]]? {
+        let process = Process()
+        process.executableURL = slice2swift
+        process.arguments = includeArguments + ["--depend-xml"] + sources.map { $0.path }
+
+        let standardOutput = Pipe()
+        process.standardOutput = standardOutput
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            throw PluginError.dependencyScanFailed("'\(slice2swift.path)' could not be run")
+        }
+
+        // Read before waiting so a large dependency graph cannot fill the pipe and deadlock.
+        let output = standardOutput.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        // The compiler reports nothing when any of the Slice files fails to parse.
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        guard let dependencies = DependencyParser().parse(output) else {
+            throw PluginError.dependencyScanFailed("the output of '--depend-xml' could not be parsed")
+        }
+        return dependencies
+    }
+
+    /// Standardizes the given file URLs and removes duplicates, preserving their order.
+    private static func uniqueFiles(_ urls: [URL]) -> [URL] {
+        var seen = Set<String>()
+        return urls.map { $0.standardizedFileURL }.filter { seen.insert($0.path).inserted }
+    }
+}
+
+/// Parses the output of `slice2swift --depend-xml`: one `<source>` element per Slice file, holding a
+/// `<dependsOn>` element per included file. The compiler flattens transitive includes for us.
+private final class DependencyParser: NSObject, XMLParserDelegate {
+    private var dependencies: [String: [URL]] = [:]
+    private var currentSource: String?
+
+    func parse(_ data: Data) -> [String: [URL]]? {
+        let parser = XMLParser(data: data)
+        parser.delegate = self
+        return parser.parse() ? dependencies : nil
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName: String?,
+        attributes: [String: String]
+    ) {
+        guard let name = attributes["name"] else {
+            return
+        }
+        let url = URL(fileURLWithPath: name).standardizedFileURL
+
+        switch elementName {
+        case "source":
+            currentSource = url.path
+            dependencies[url.path] = []
+        case "dependsOn":
+            if let currentSource {
+                dependencies[currentSource]?.append(url)
+            }
+        default:
+            break
+        }
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName: String?
+    ) {
+        if elementName == "source" {
+            currentSource = nil
         }
     }
 }

--- a/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
+++ b/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
@@ -48,9 +48,8 @@ enum PluginError: Error, CustomStringConvertible, LocalizedError {
         case .missingIceSliceFiles(let path):
             return "The Ice Slice files are missing. Expected location: '\(path)'."
         case .duplicateSliceFileName(let first, let second):
-            return
-                "The Slice files '\(first)' and '\(second)' have the same file name and would generate "
-                + "the same Swift file."
+            let generated = URL(fileURLWithPath: first).deletingPathExtension().lastPathComponent + ".swift"
+            return "The Slice files '\(first)' and '\(second)' would both generate '\(generated)'."
         case .dependencyScanFailed(let reason):
             return "Could not determine the Slice include dependencies: \(reason)."
         }

--- a/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
+++ b/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
@@ -158,6 +158,9 @@ struct CompileSlicePlugin {
         }
         searchPathDirs.append(Self.iceSliceDir)
 
+        // slice2swift resolves the paths it reports, so match it before looking dependencies up.
+        sliceSources = sliceSources.map { $0.standardizedFileURL }
+
         let includeArguments = searchPathDirs.map { "-I\($0.path)" }
 
         // Ask the compiler which files each source includes, so that editing an included file

--- a/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
+++ b/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
@@ -164,7 +164,7 @@ struct CompileSlicePlugin {
 
         sliceSources = Self.uniqueFiles(sliceSources)
 
-        // Nothing to generate, and slice2swift rejects an empty file list.
+        // Nothing to generate.
         guard !sliceSources.isEmpty else {
             return []
         }

--- a/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
+++ b/swift/Plugins/CompileSlice/CompileSlicePlugin.swift
@@ -38,7 +38,6 @@ extension CompileSlicePlugin: BuildToolPlugin {
 enum PluginError: Error, CustomStringConvertible, LocalizedError {
     case invalidTarget(String)
     case missingIceSliceFiles(String)
-    case duplicateSliceFileName(String, String)
     case dependencyScanFailed(String)
 
     var description: String {
@@ -47,9 +46,6 @@ enum PluginError: Error, CustomStringConvertible, LocalizedError {
             return "Expected a SwiftSourceModuleTarget but got '\(targetType)'."
         case .missingIceSliceFiles(let path):
             return "The Ice Slice files are missing. Expected location: '\(path)'."
-        case .duplicateSliceFileName(let first, let second):
-            let generated = URL(fileURLWithPath: first).deletingPathExtension().lastPathComponent + ".swift"
-            return "The Slice files '\(first)' and '\(second)' would both generate '\(generated)'."
         case .dependencyScanFailed(let reason):
             return "Could not determine the Slice include dependencies: \(reason)."
         }
@@ -162,24 +158,12 @@ struct CompileSlicePlugin {
         }
         searchPathDirs.append(Self.iceSliceDir)
 
-        sliceSources = Self.uniqueFiles(sliceSources)
-
         // Nothing to generate.
         guard !sliceSources.isEmpty else {
             return []
         }
 
         let includeArguments = searchPathDirs.map { "-I\($0.path)" }
-
-        // slice2swift names each generated file after the base name of its Slice file, so two sources
-        // with the same file name would produce build commands fighting over one output.
-        var sourcesByName: [String: URL] = [:]
-        for sliceSource in sliceSources {
-            let name = sliceSource.deletingPathExtension().lastPathComponent
-            if let other = sourcesByName.updateValue(sliceSource, forKey: name) {
-                throw PluginError.duplicateSliceFileName(other.path, sliceSource.path)
-            }
-        }
 
         // Ask the compiler which files each source includes, so that editing an included file
         // regenerates every file that includes it.
@@ -252,12 +236,6 @@ struct CompileSlicePlugin {
             throw PluginError.dependencyScanFailed("the output of '--depend-xml' could not be parsed")
         }
         return dependencies
-    }
-
-    /// Standardizes the given file URLs and removes duplicates, preserving their order.
-    private static func uniqueFiles(_ urls: [URL]) -> [URL] {
-        var seen = Set<String>()
-        return urls.map { $0.standardizedFileURL }.filter { seen.insert($0.path).inserted }
     }
 }
 


### PR DESCRIPTION
Each `slice2swift` build command declared only its own `.ice` file as an input, so the build system never saw
`#include` dependencies and editing an included Slice file left the Swift code generated from the files that include
it stale.

- Runs `slice2swift --depend-xml` once per target when creating the build commands, and declares the reported
  include closure as inputs for each generated file.
- Declares `slice2swift` as an input, so rebuilding the compiler regenerates the Swift code.
- Reports an error when the dependencies cannot be determined at all, rather than generating code that later goes
  stale. Slice files that fail to parse are left to the build commands, which report the errors as usual.

SwiftPM build commands cannot consume a dependency file, so the plugin runs the dependency scan itself during build
planning.

Fixes #6629
