### PR TITLE
Implement standard Ruby comparison semantics for Endpoint

### DIFF
--- a/ruby/src/IceRuby/Endpoint.cpp
+++ b/ruby/src/IceRuby/Endpoint.cpp
@@ -76,13 +76,10 @@ IceRuby_Endpoint_cmp(VALUE self, VALUE other)
 {
     ICE_RUBY_TRY
     {
-        if (NIL_P(other))
-        {
-            return INT2NUM(1);
-        }
         if (!checkEndpoint(other))
         {
-            throw RubyException(rb_eTypeError, "argument must be an endpoint");
+            // The standard Ruby behavior: <=> returns nil when the operands are not comparable.
+            return Qnil;
         }
         Ice::EndpointPtr p1 = Ice::EndpointPtr(*reinterpret_cast<Ice::EndpointPtr*>(DATA_PTR(self)));
         Ice::EndpointPtr p2 = Ice::EndpointPtr(*reinterpret_cast<Ice::EndpointPtr*>(DATA_PTR(other)));

--- a/ruby/test/Ice/proxy/AllTests.rb
+++ b/ruby/test/Ice/proxy/AllTests.rb
@@ -571,6 +571,15 @@ def allTests(helper, communicator)
     test({e1 => "v"}[e3] == "v")                      # usable as a value-based Hash key
 
     #
+    # Standard Ruby semantics for a non-Endpoint operand: == and eql? return false, <=> returns nil.
+    #
+    test(e1 != nil)
+    test(!(e1 == "not an endpoint"))
+    test(!e1.eql?("not an endpoint"))
+    test((e1 <=> nil).nil?)
+    test((e1 <=> "not an endpoint").nil?)
+
+    #
     # ice_endpoints accepts any object implementing Ruby's to_ary array-conversion protocol.
     #
     toAry = Object.new


### PR DESCRIPTION
`Endpoint#<=>` raised `TypeError` for a non-Endpoint operand (and returned 1 for `nil`), and `==`/`eql?` inherited this behavior since they delegate to the same comparator. This is nonstandard Ruby: `==`/`eql?` should return `false` and `<=>` should return `nil` when the operands are not comparable. The standard semantics is what makes an Endpoint work naturally with `Hash` and `Set`.

This PR makes the comparator return `nil` for any non-Endpoint operand; `==`/`eql?` consequently return `false`. This matches the existing `Connection#eql?` behavior.

The existing changelog text in [3.8/changelog.d/ruby/endpoint-comparison.md](https://github.com/zeroc-ice/ice/blob/3.8/changelog.d/ruby/endpoint-comparison.md) doesn't need fixing.

Fixes #6619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
