### PR TITLE
Share the syslog connection among all communicators in a process

### DIFF
--- a/changelog.d/cpp/6620.md
+++ b/changelog.d/cpp/6620.md
@@ -1,0 +1,6 @@
+- Fixed syslog logging (`Ice.UseSyslog=1`) with multiple communicators in the same process. Previously, each
+  communicator opened and closed the process-global syslog connection independently, corrupting the shared logging
+  state. All communicators now share a single syslog connection: the first communicator's program name provides the
+  syslog ident, and a communicator with a different program name logs it at the beginning of each message. In
+  particular, an IceBox server configured with `Ice.UseSyslog=1` and `IceBox.InheritProperties=1` now logs all its
+  services to syslog.

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -66,7 +66,6 @@
 #    include <csignal>
 #    include <pwd.h>
 #    include <sys/types.h>
-#    include <syslog.h>
 #endif
 
 #if defined(__linux__) || defined(__GLIBC__)
@@ -87,7 +86,6 @@ namespace
     struct sigaction oldAction;
 #endif
     bool printProcessIdDone = false;
-    string identForOpenlog;
 
     //
     // Should be called with staticMutex locked
@@ -1020,15 +1018,6 @@ IceInternal::Instance::initialize(const Ice::CommunicatorPtr& communicator)
                 sigemptyset(&action.sa_mask);
                 action.sa_flags = 0;
                 sigaction(SIGPIPE, &action, &oldAction);
-                if (_initData.properties->getIcePropertyAsInt("Ice.UseSyslog") > 0)
-                {
-                    identForOpenlog = programName;
-                    if (identForOpenlog.empty())
-                    {
-                        identForOpenlog = "<Unknown Ice Program>";
-                    }
-                    openlog(identForOpenlog.c_str(), LOG_PID, LOG_USER);
-                }
 #else
                 logStdErrConvert = _initData.properties->getIcePropertyAsInt("Ice.LogStdErr.Convert") > 0 &&
                                    _initData.properties->getIceProperty("Ice.StdErr").empty();
@@ -1377,12 +1366,6 @@ IceInternal::Instance::~Instance()
 
 #ifndef _WIN32
         sigaction(SIGPIPE, &oldAction, nullptr);
-
-        if (!identForOpenlog.empty())
-        {
-            closelog();
-            identForOpenlog.clear();
-        }
 #endif
     }
 }

--- a/cpp/src/Ice/SysLoggerI.cpp
+++ b/cpp/src/Ice/SysLoggerI.cpp
@@ -10,154 +10,169 @@ using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
-// syslog's openlog/closelog and its ident are process-global, and openlog retains the ident pointer rather than
-// copying it. We therefore allow at most one SysLoggerI alive at a time, so the ident never dangles and closelog never
-// tears down a connection another logger is still using. The constructor claims this flag; the destructor releases it.
-std::mutex Ice::SysLoggerI::_mutex;
-bool Ice::SysLoggerI::_active = false;
-
-Ice::SysLoggerI::SysLoggerI(string prefix, string_view facilityString) : _facility(0), _prefix(std::move(prefix))
+namespace
 {
-    if (facilityString == "LOG_KERN")
+    // openlog/closelog and the syslog ident are process-global, and openlog retains the ident pointer rather than
+    // copying it. All SysLoggerI instances therefore share a single openlog call: the first instance donates its
+    // prefix as the process-wide ident, and the last instance to be destroyed calls closelog. sysLogMutex guards
+    // this state and serializes the syslog calls.
+    mutex sysLogMutex;
+    int sysLogCount = 0;
+    string sysLogIdent;
+
+    int parseFacility(string_view facilityString)
     {
-        _facility = LOG_KERN;
-    }
-    else if (facilityString == "LOG_USER")
-    {
-        _facility = LOG_USER;
-    }
-    else if (facilityString == "LOG_MAIL")
-    {
-        _facility = LOG_MAIL;
-    }
-    else if (facilityString == "LOG_DAEMON")
-    {
-        _facility = LOG_DAEMON;
-    }
-    else if (facilityString == "LOG_AUTH")
-    {
-        _facility = LOG_AUTH;
-    }
-    else if (facilityString == "LOG_SYSLOG")
-    {
-        _facility = LOG_SYSLOG;
-    }
-    else if (facilityString == "LOG_LPR")
-    {
-        _facility = LOG_LPR;
-    }
-    else if (facilityString == "LOG_NEWS")
-    {
-        _facility = LOG_NEWS;
-    }
-    else if (facilityString == "LOG_UUCP")
-    {
-        _facility = LOG_UUCP;
-    }
-    else if (facilityString == "LOG_CRON")
-    {
-        _facility = LOG_CRON;
-    }
+        if (facilityString == "LOG_KERN")
+        {
+            return LOG_KERN;
+        }
+        else if (facilityString == "LOG_USER")
+        {
+            return LOG_USER;
+        }
+        else if (facilityString == "LOG_MAIL")
+        {
+            return LOG_MAIL;
+        }
+        else if (facilityString == "LOG_DAEMON")
+        {
+            return LOG_DAEMON;
+        }
+        else if (facilityString == "LOG_AUTH")
+        {
+            return LOG_AUTH;
+        }
+        else if (facilityString == "LOG_SYSLOG")
+        {
+            return LOG_SYSLOG;
+        }
+        else if (facilityString == "LOG_LPR")
+        {
+            return LOG_LPR;
+        }
+        else if (facilityString == "LOG_NEWS")
+        {
+            return LOG_NEWS;
+        }
+        else if (facilityString == "LOG_UUCP")
+        {
+            return LOG_UUCP;
+        }
+        else if (facilityString == "LOG_CRON")
+        {
+            return LOG_CRON;
+        }
 #    ifdef LOG_AUTHPRIV
-    else if (facilityString == "LOG_AUTHPRIV")
-    {
-        _facility = LOG_AUTHPRIV;
-    }
+        else if (facilityString == "LOG_AUTHPRIV")
+        {
+            return LOG_AUTHPRIV;
+        }
 #    endif
 #    ifdef LOG_FTP
-    else if (facilityString == "LOG_FTP")
-    {
-        _facility = LOG_FTP;
-    }
+        else if (facilityString == "LOG_FTP")
+        {
+            return LOG_FTP;
+        }
 #    endif
-    else if (facilityString == "LOG_LOCAL0")
-    {
-        _facility = LOG_LOCAL0;
+        else if (facilityString == "LOG_LOCAL0")
+        {
+            return LOG_LOCAL0;
+        }
+        else if (facilityString == "LOG_LOCAL1")
+        {
+            return LOG_LOCAL1;
+        }
+        else if (facilityString == "LOG_LOCAL2")
+        {
+            return LOG_LOCAL2;
+        }
+        else if (facilityString == "LOG_LOCAL3")
+        {
+            return LOG_LOCAL3;
+        }
+        else if (facilityString == "LOG_LOCAL4")
+        {
+            return LOG_LOCAL4;
+        }
+        else if (facilityString == "LOG_LOCAL5")
+        {
+            return LOG_LOCAL5;
+        }
+        else if (facilityString == "LOG_LOCAL6")
+        {
+            return LOG_LOCAL6;
+        }
+        else if (facilityString == "LOG_LOCAL7")
+        {
+            return LOG_LOCAL7;
+        }
+        else
+        {
+            throw InitializationException(
+                __FILE__,
+                __LINE__,
+                "Invalid value for Ice.SyslogFacility: " + string{facilityString});
+        }
     }
-    else if (facilityString == "LOG_LOCAL1")
-    {
-        _facility = LOG_LOCAL1;
-    }
-    else if (facilityString == "LOG_LOCAL2")
-    {
-        _facility = LOG_LOCAL2;
-    }
-    else if (facilityString == "LOG_LOCAL3")
-    {
-        _facility = LOG_LOCAL3;
-    }
-    else if (facilityString == "LOG_LOCAL4")
-    {
-        _facility = LOG_LOCAL4;
-    }
-    else if (facilityString == "LOG_LOCAL5")
-    {
-        _facility = LOG_LOCAL5;
-    }
-    else if (facilityString == "LOG_LOCAL6")
-    {
-        _facility = LOG_LOCAL6;
-    }
-    else if (facilityString == "LOG_LOCAL7")
-    {
-        _facility = LOG_LOCAL7;
-    }
-    else
-    {
-        throw InitializationException(
-            __FILE__,
-            __LINE__,
-            "Invalid value for Ice.SyslogFacility: " + string{facilityString});
-    }
+}
 
-    claimSyslog(__FILE__, __LINE__);
-
-    int logopt = LOG_PID | LOG_CONS;
-    openlog(_prefix.c_str(), logopt, _facility);
+Ice::SysLoggerI::SysLoggerI(string prefix, string_view facilityString)
+    : SysLoggerI(std::move(prefix), parseFacility(facilityString))
+{
 }
 
 Ice::SysLoggerI::SysLoggerI(string prefix, int facility) : _facility(facility), _prefix(std::move(prefix))
 {
-    claimSyslog(__FILE__, __LINE__);
-
-    int logopt = LOG_PID | LOG_CONS;
-    openlog(_prefix.c_str(), logopt, facility);
+    lock_guard lock(sysLogMutex);
+    if (sysLogCount++ == 0)
+    {
+        sysLogIdent = _prefix;
+        // The facility argument is only a default for syslog calls that don't specify one; each log method passes
+        // this logger's facility with the message priority.
+        openlog(sysLogIdent.c_str(), LOG_PID | LOG_CONS, 0);
+    }
+    if (!_prefix.empty() && _prefix != sysLogIdent)
+    {
+        _bodyPrefix = _prefix + ": ";
+    }
 }
 
 Ice::SysLoggerI::~SysLoggerI()
 {
-    lock_guard lock(_mutex);
-    closelog();
-    _active = false;
+    lock_guard lock(sysLogMutex);
+    if (--sysLogCount == 0)
+    {
+        closelog();
+    }
 }
 
 void
 Ice::SysLoggerI::print(const string& message)
 {
-    lock_guard lock(_mutex);
-    syslog(LOG_INFO, "%s", message.c_str());
+    lock_guard lock(sysLogMutex);
+    syslog(_facility | LOG_INFO, "%s", (_bodyPrefix + message).c_str());
 }
 
 void
 Ice::SysLoggerI::trace(const string& category, const string& message)
 {
-    lock_guard lock(_mutex);
-    string s = category + ": " + message;
-    syslog(LOG_INFO, "%s", s.c_str());
+    lock_guard lock(sysLogMutex);
+    string s = _bodyPrefix + category + ": " + message;
+    syslog(_facility | LOG_INFO, "%s", s.c_str());
 }
 
 void
 Ice::SysLoggerI::warning(const string& message)
 {
-    lock_guard lock(_mutex);
-    syslog(LOG_WARNING, "%s", message.c_str());
+    lock_guard lock(sysLogMutex);
+    syslog(_facility | LOG_WARNING, "%s", (_bodyPrefix + message).c_str());
 }
 
 void
 Ice::SysLoggerI::error(const string& message)
 {
-    lock_guard lock(_mutex);
-    syslog(LOG_ERR, "%s", message.c_str());
+    lock_guard lock(sysLogMutex);
+    syslog(_facility | LOG_ERR, "%s", (_bodyPrefix + message).c_str());
 }
 
 string
@@ -167,21 +182,9 @@ Ice::SysLoggerI::getPrefix()
 }
 
 Ice::LoggerPtr
-Ice::SysLoggerI::cloneWithPrefix(string)
+Ice::SysLoggerI::cloneWithPrefix(string prefix)
 {
-    // syslog is process-global, so a second SysLoggerI would fight over the global openlog ident and connection.
-    throw FeatureNotSupportedException(__FILE__, __LINE__, "the Ice syslog logger does not support cloneWithPrefix");
-}
-
-void
-Ice::SysLoggerI::claimSyslog(const char* file, int line)
-{
-    lock_guard lock(_mutex);
-    if (_active)
-    {
-        throw InitializationException(file, line, "another Ice syslog logger is already active in this process");
-    }
-    _active = true;
+    return make_shared<SysLoggerI>(std::move(prefix), _facility);
 }
 
 #endif

--- a/cpp/src/Ice/SysLoggerI.cpp
+++ b/cpp/src/Ice/SysLoggerI.cpp
@@ -4,6 +4,8 @@
 
 #    include "SysLoggerI.h"
 #    include "Ice/LocalExceptions.h"
+
+#    include <mutex>
 #    include <syslog.h>
 
 using namespace std;

--- a/cpp/src/Ice/SysLoggerI.cpp
+++ b/cpp/src/Ice/SysLoggerI.cpp
@@ -20,7 +20,10 @@ namespace
     // this state and serializes the syslog calls.
     mutex sysLogMutex;
     int sysLogCount = 0;
-    string sysLogIdent;
+
+    // Intentionally leaked: openlog retains the ident pointer, and a logger stored in a global can still call syslog
+    // during static destruction, so this buffer must never be freed.
+    string& sysLogIdent = *new string;
 
     int parseFacility(string_view facilityString)
     {
@@ -151,30 +154,31 @@ Ice::SysLoggerI::~SysLoggerI()
 void
 Ice::SysLoggerI::print(const string& message)
 {
+    // The Logger contract requires these methods not to throw, so we let syslog do the formatting instead of
+    // building a std::string that could throw bad_alloc.
     lock_guard lock(sysLogMutex);
-    syslog(_facility | LOG_INFO, "%s", (_bodyPrefix + message).c_str());
+    syslog(_facility | LOG_INFO, "%s%s", _bodyPrefix.c_str(), message.c_str());
 }
 
 void
 Ice::SysLoggerI::trace(const string& category, const string& message)
 {
     lock_guard lock(sysLogMutex);
-    string s = _bodyPrefix + category + ": " + message;
-    syslog(_facility | LOG_INFO, "%s", s.c_str());
+    syslog(_facility | LOG_INFO, "%s%s: %s", _bodyPrefix.c_str(), category.c_str(), message.c_str());
 }
 
 void
 Ice::SysLoggerI::warning(const string& message)
 {
     lock_guard lock(sysLogMutex);
-    syslog(_facility | LOG_WARNING, "%s", (_bodyPrefix + message).c_str());
+    syslog(_facility | LOG_WARNING, "%s%s", _bodyPrefix.c_str(), message.c_str());
 }
 
 void
 Ice::SysLoggerI::error(const string& message)
 {
     lock_guard lock(sysLogMutex);
-    syslog(_facility | LOG_ERR, "%s", (_bodyPrefix + message).c_str());
+    syslog(_facility | LOG_ERR, "%s%s", _bodyPrefix.c_str(), message.c_str());
 }
 
 string

--- a/cpp/src/Ice/SysLoggerI.cpp
+++ b/cpp/src/Ice/SysLoggerI.cpp
@@ -23,7 +23,7 @@ namespace
 
     // Intentionally leaked: openlog retains the ident pointer, and a logger stored in a global can still call syslog
     // during static destruction, so this buffer must never be freed.
-    string& sysLogIdent = *new string;
+    string& sysLogIdent = *new string; // NOLINT(cert-err58-cpp)
 
     int parseFacility(string_view facilityString)
     {

--- a/cpp/src/Ice/SysLoggerI.h
+++ b/cpp/src/Ice/SysLoggerI.h
@@ -16,6 +16,9 @@ namespace Ice
         SysLoggerI(std::string prefix, int facility);
         ~SysLoggerI() override;
 
+        SysLoggerI(const SysLoggerI&) = delete;
+        SysLoggerI& operator=(const SysLoggerI&) = delete;
+
         void print(const std::string&) final;
         void trace(const std::string&, const std::string&) final;
         void warning(const std::string&) final;

--- a/cpp/src/Ice/SysLoggerI.h
+++ b/cpp/src/Ice/SysLoggerI.h
@@ -5,7 +5,6 @@
 
 #include "Ice/Logger.h"
 
-#include <mutex>
 #include <string_view>
 
 namespace Ice
@@ -25,16 +24,11 @@ namespace Ice
         LoggerPtr cloneWithPrefix(std::string) final;
 
     private:
-        // Claims the process-wide syslog logger, throwing if another SysLoggerI is already active.
-        static void claimSyslog(const char* file, int line);
-
-        int _facility;
+        const int _facility;
         const std::string _prefix;
 
-        // openlog/closelog and the syslog ident are process-global, so at most one SysLoggerI may be active at a time.
-        // _mutex (shared by all instances) guards _active and serializes the syslog calls.
-        static std::mutex _mutex;
-        static bool _active;
+        // Prepended to each message when this logger's prefix differs from the process-wide syslog ident.
+        std::string _bodyPrefix;
     };
 }
 


### PR DESCRIPTION
A syslog logger created for a second communicator with `Ice.UseSyslog=1` threw `InitializationException` (the one-syslog-logger-per-process rule). IceBox manufactures exactly that setup from a stock configuration: with `Ice.UseSyslog=1` and `IceBox.InheritProperties=1`, every service communicator creates its own syslog logger, so the second service failed to load.

Since openlog is last-caller-wins on process-global state, `SysLoggerI` now calls it exactly once and routes all per-logger variation through the individual `syslog` calls:

- The first `SysLoggerI` donates its prefix as the process-wide syslog ident; the last one destroyed calls `closelog`.
- Each `syslog` call passes the logger's facility in the message priority (`facility | level`), so per-communicator `Ice.SyslogFacility` values work without touching `openlog`.
- A logger whose prefix differs from the process ident prepends it to the message body, so IceBox service messages remain distinguishable.
- `cloneWithPrefix` is supported again.

This PR also deletes an `openlog`/`closelog` pair in `Instance.cpp`. In the original 2001 design, `Instance` owned the process's single `openlog` and `SysLoggerI` was a plain `syslog()` wrapper; when `SysLoggerI` started calling `openlog` itself to use `Ice.ProgramName` as the ident (2009, bug 2614), the `Instance` calls became dead weight: its `openlog` was immediately overridden by the `SysLoggerI` one, and its `closelog` on last-communicator-destroy could close the connection under a logger that outlives its communicator. `SysLoggerI` is now the sole owner of the openlog state.

Verified by interposing `openlog`/`syslog`/`closelog` in a test program: two concurrent communicators with different facilities and program names, plus a clone, produce a single `openlog`, correctly-tagged messages, and a single `closelog` after the last logger is destroyed; a communicator created after that re-opens with its own ident.

Fixes #6620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)