### PR TITLE
Fix a race in the DataStorm events initialization key filter test

### DIFF
--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -399,6 +399,10 @@ void ::Reader::run(int argc, char* argv[])
         auto reader = makeFilteredKeyReader(topic, Filter<string>("throwOnKey", "k1"), "", config);
         test(reader.getNextUnread().getKey() == "k2");
         test(reader.getNextUnread().getKey() == "sentinel");
+
+        auto done = makeSingleKeyWriter(readyTopic, "done");
+        done.waitForReaders(1);
+        done.add("done");
     }
 
     {

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -426,8 +426,10 @@ void ::Writer::run(int argc, char* argv[])
         auto ready = makeSingleKeyWriter(readyTopic, "ready", "", config);
         ready.add("go");
 
-        writer.waitForReaders(1);
-        writer.waitForNoReaders();
+        // The reader acknowledges on the ready topic once it has read all its samples; keep the writers alive until
+        // then.
+        auto done = makeSingleKeyReader(readyTopic, "done");
+        test(done.getNextUnread().getValue() == "done");
     }
     cout << "ok" << endl;
 


### PR DESCRIPTION
The `initKeyFilterThrow` scenario added by #6594 hangs intermittently on the slower CI runners — most recently `el9-x86_64` and `amzn2023-aarch64` in [this run](https://github.com/zeroc-ice/ice/actions/runs/31893222429) (on a PR) and [this one](https://github.com/zeroc-ice/ice/actions/runs/31854025004) (on main), where the writer process was killed after the 6-hour job timeout.

The writer synchronized on `writer.waitForReaders(1)` followed by `writer.waitForNoReaders()`. Since the reader receives all three samples in its initialization batch — the point of the scenario — nothing keeps it alive after that batch arrives: its whole attach → initialize → detach lifecycle runs in about a millisecond after the writer publishes the "go" signal, with no further synchronization with the writer's main thread. The CI traces show the attach at 16:07:51.290 and the detach at .291; if the writer's main thread reaches `waitForReaders(1)` after that window, the listener count is already back at zero and the wait blocks forever (`waitForListeners` checks the current count and has no memory of past listeners).

The writer now waits for an explicit acknowledgment instead: after reading its samples, the reader publishes a `done` sample on the ready topic, with the writer subscribed to it. The acknowledgment orders the writer's teardown after the reader has read the batch, regardless of the reader's lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)