### PR TITLE
Untap aws/tap on macOS runners

### DIFF
--- a/.github/actions/setup-cpp/action.yml
+++ b/.github/actions/setup-cpp/action.yml
@@ -12,6 +12,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Homebrew 6 requires third-party taps to be trusted, and the runner image ships aws/tap
+    # untrusted, so every brew command warns. We install nothing from it; untapping leaves the
+    # preinstalled aws CLI in place.
+    - name: Untap aws/tap on macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew untap aws/tap || true
+
     - name: Install dependencies on macOS
       if: runner.os == 'macOS' && inputs.profile == 'full'
       shell: bash


### PR DESCRIPTION
Homebrew 6 requires third-party taps to be trusted, and the GitHub macOS runner image ships `aws/tap` untrusted. Every `brew` command in a macOS job therefore emits a `##[warning]` annotation, and Homebrew ignores that tap anyway.

- Untap `aws/tap` in `setup-cpp`, which runs before the first `brew` command in every macOS job that uses Homebrew.
- Untapping does not uninstall anything, so the preinstalled `aws` CLI keeps working.

The `3.8` branch carries its own copy of this action and hits the same warning, so this needs a cherry-pick there for 3.8.3.