### PR TITLE
Fix IceDiscovery latency-window arithmetic in C# and Java

### DIFF
--- a/csharp/src/IceDiscovery/LookupI.cs
+++ b/csharp/src/IceDiscovery/LookupI.cs
@@ -81,7 +81,7 @@ internal abstract class Request<T>
 internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
 {
     public AdapterRequest(LookupI lookup, string id, int retryCount)
-        : base(lookup, id, retryCount) => _start = DateTime.Now.Ticks;
+        : base(lookup, id, retryCount) => _start = Stopwatch.GetTimestamp();
 
     public override bool retry()
     {
@@ -93,7 +93,7 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
 
             // Restart the replica-group latency window so it's measured from this round rather than from request
             // creation.
-            _start = DateTime.Now.Ticks;
+            _start = Stopwatch.GetTimestamp();
             return true;
         }
         return false;
@@ -107,9 +107,11 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
             if (_latency == TimeSpan.Zero)
             {
                 // The aggregation window is the measured response time, scaled by IceDiscovery.LatencyMultiplier,
-                // with a 1ms floor so we never schedule a degenerate zero-length window.
-                double responseTimeMs = TimeSpan.FromTicks(DateTime.Now.Ticks - _start).TotalMilliseconds;
-                _latency = TimeSpan.FromMilliseconds(Math.Max(1, (long)(responseTimeMs * lookup_.latencyMultiplier())));
+                // clamped to the timer's valid delay range, with a 1ms floor so we never schedule a degenerate
+                // zero-length window.
+                double responseTimeMs = Stopwatch.GetElapsedTime(_start).TotalMilliseconds;
+                _latency = TimeSpan.FromMilliseconds(
+                    Math.Clamp(responseTimeMs * lookup_.latencyMultiplier(), 1, int.MaxValue));
                 lookup_.timer().cancel(this);
                 lookup_.timer().schedule(this, _latency);
             }

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
@@ -134,9 +134,10 @@ class LookupI implements Lookup {
                 _proxies.add(proxy);
                 if (_latency == 0) {
                     // The aggregation window is the measured response time, scaled by IceDiscovery.LatencyMultiplier,
-                    // with a 1ms floor so we never schedule a degenerate zero-length window.
-                    long responseTimeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - _start);
-                    _latency = Math.max(1, responseTimeMs * _latencyMultiplier);
+                    // with a 1ms floor so we never schedule a degenerate zero-length window. The scaling is applied in
+                    // nanoseconds so a sub-millisecond response time isn't truncated to zero before scaling.
+                    _latency = Math.max(
+                        1, TimeUnit.NANOSECONDS.toMillis((System.nanoTime() - _start) * _latencyMultiplier));
                     cancelTimer();
                     scheduleTimer(_latency);
                 }


### PR DESCRIPTION
This PR fixes the two IceDiscovery replica-group latency-window residuals.

- C#: `AdapterRequest` measured the response time with `DateTime.Now` (local wall-clock time) and scheduled the scaled aggregation window unbounded. The Timer rejects delays above `int.MaxValue` milliseconds, so an oversized product (extreme `IceDiscovery.LatencyMultiplier`, or a wall-clock jump during the lookup) made `Timer.schedule` throw after the request's timeout timer was already cancelled, stranding the request in the lookup table — later lookups for the same adapter id would join the dead request and wait forever. The response time is now measured with the monotonic `Stopwatch` clock and the scaled window is clamped to the timer's valid delay range.

- Java: the measured response time was truncated to whole milliseconds before applying `IceDiscovery.LatencyMultiplier`, so a sub-millisecond response always produced the 1 ms floor regardless of the multiplier. The multiplication is now applied in nanoseconds and converted to milliseconds once, as in C++.

No changelog entry: neither symptom is observable during normal operations.

Fixes #6625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)