### PR TITLE
Implement standard Ruby comparison semantics for ObjectPrx

### DIFF
--- a/ruby/src/IceRuby/Endpoint.cpp
+++ b/ruby/src/IceRuby/Endpoint.cpp
@@ -78,7 +78,6 @@ IceRuby_Endpoint_cmp(VALUE self, VALUE other)
     {
         if (!checkEndpoint(other))
         {
-            // The standard Ruby behavior: <=> returns nil when the operands are not comparable.
             return Qnil;
         }
         Ice::EndpointPtr p1 = Ice::EndpointPtr(*reinterpret_cast<Ice::EndpointPtr*>(DATA_PTR(self)));

--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -762,13 +762,9 @@ IceRuby_ObjectPrx_cmp(VALUE self, VALUE other)
 {
     ICE_RUBY_TRY
     {
-        if (NIL_P(other))
-        {
-            return INT2NUM(1);
-        }
         if (!checkProxy(other))
         {
-            throw RubyException(rb_eTypeError, "argument must be a proxy");
+            return Qnil;
         }
         Ice::ObjectPrx p1 = getProxy(self);
         Ice::ObjectPrx p2 = getProxy(other);

--- a/ruby/test/Ice/proxy/AllTests.rb
+++ b/ruby/test/Ice/proxy/AllTests.rb
@@ -439,6 +439,15 @@ def allTests(helper, communicator)
 
     compObj = communicator.stringToProxy("foo")
 
+    #
+    # Standard Ruby semantics for a non-proxy operand: == and eql? return false, <=> returns nil.
+    #
+    test(compObj != nil)
+    test(!(compObj == "not a proxy"))
+    test(!compObj.eql?("not a proxy"))
+    test((compObj <=> nil).nil?)
+    test((compObj <=> "not a proxy").nil?)
+
     test(compObj.ice_facet("facet") == compObj.ice_facet("facet"))
     test(compObj.ice_facet("facet") != compObj.ice_facet("facet1"))
     #test(compObj.ice_facet("facet") < compObj.ice_facet("facet1"))


### PR DESCRIPTION
`ObjectPrx#<=>` raised `TypeError` for a non-proxy operand (and returned 1 for `nil`), and `==`/`eql?` inherited this behavior since they delegate to the same comparator. This is nonstandard Ruby: `==`/`eql?` should return `false` and `<=>` should return `nil` when the operands are not comparable. Same fix as #6631 for `Endpoint`; `ObjectPrx` was the last remaining class with this defect.

This PR also removes the comment #6631 added to the `Endpoint` comparator: we don't comment code that implements the standard behavior.

Fixes #6634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)