### PR TITLE
Fix retention of explicitly destroyed sessions in the IceGrid reaper

### DIFF
--- a/changelog.d/service-icegrid/reaper-destroyed-sessions.md
+++ b/changelog.d/service-icegrid/reaper-destroyed-sessions.md
@@ -1,0 +1,4 @@
+- Fixed a slow memory accumulation in the IceGrid registry: a session destroyed by the client was retained by the
+  registry until the connection used to create this session closed. This affects only registries with no node (a
+  common setup when using dynamic registration) and no replica, with sessions created and destroyed through Glacier2,
+  as Glacier2 maintains a long-lived connection to the registry.

--- a/cpp/src/IceGrid/ReapThread.cpp
+++ b/cpp/src/IceGrid/ReapThread.cpp
@@ -61,20 +61,8 @@ ReapThread::run()
                 }
                 // else session is already destroyed and we clean-up
 
-                // Remove the reapable
-                if (p->connection)
-                {
-                    auto q = _connections.find(p->connection);
-                    if (q != _connections.end())
-                    {
-                        q->second.erase(p->item);
-                        if (q->second.empty())
-                        {
-                            p->connection->setCloseCallback(nullptr);
-                            _connections.erase(q);
-                        }
-                    }
-                }
+                // Remove the reapable item
+                detachConnection(*p);
                 p = _sessions.erase(p);
             }
         }
@@ -130,6 +118,22 @@ ReapThread::add(const shared_ptr<Reapable>& reapable, chrono::seconds timeout, c
     {
         return;
     }
+
+    // The run thread can sleep forever when all remaining sessions have a 0s timeout, so it can't be relied upon to
+    // remove entries for sessions destroyed explicitly. Remove them now.
+    _sessions.remove_if(
+        [this](const ReapableItem& item)
+        {
+            if (item.item->timestamp())
+            {
+                return false;
+            }
+            else
+            {
+                detachConnection(item);
+                return true;
+            }
+        });
 
     // The timeout is 0s (public session timeouts) or >= 10s (node session timeout, replica session timeout).
     assert(timeout == 0s || timeout >= 10s);
@@ -218,4 +222,22 @@ ReapThread::calcWakeInterval()
 
     _wakeInterval = minimum;
     return oldWakeInterval == 0s || minimum < oldWakeInterval;
+}
+
+void
+ReapThread::detachConnection(const ReapableItem& item)
+{
+    if (item.connection)
+    {
+        auto p = _connections.find(item.connection);
+        if (p != _connections.end())
+        {
+            p->second.erase(item.item);
+            if (p->second.empty())
+            {
+                item.connection->setCloseCallback(nullptr);
+                _connections.erase(p);
+            }
+        }
+    }
 }

--- a/cpp/src/IceGrid/ReapThread.h
+++ b/cpp/src/IceGrid/ReapThread.h
@@ -93,9 +93,14 @@ namespace IceGrid
         void connectionClosed(const Ice::ConnectionPtr&);
 
     private:
+        struct ReapableItem;
+
         void run();
 
         bool calcWakeInterval();
+
+        // Removes the item's _connections entry, if any. Must be called with _mutex locked.
+        void detachConnection(const ReapableItem& item);
 
         Ice::CloseCallback _closeCallback;
         std::chrono::milliseconds _wakeInterval{0};
@@ -106,6 +111,7 @@ namespace IceGrid
             Ice::ConnectionPtr connection;
             std::chrono::milliseconds timeout;
         };
+
         std::list<ReapableItem> _sessions;
 
         std::map<Ice::ConnectionPtr, std::set<std::shared_ptr<Reapable>>> _connections;


### PR DESCRIPTION
A session destroyed explicitly (rather than through connection closure or timeout) remained registered with the IceGrid registry's reap thread until its connection closed: when all registered sessions have a 0s timeout, the reap thread sleeps forever and never sweeps destroyed entries. In a registry with no node and no replica — so no session with a positive timeout ever wakes the reap thread — sessions created and destroyed through Glacier2 accumulated for the lifetime of the shared Glacier2-to-registry connection, since Glacier2 binds all its sessions to that long-lived connection.

`ReapThread::add` now removes the entries of already-destroyed sessions while it holds the lock, so session churn cleans up after itself without waking the reap thread. The `_connections` bookkeeping (erasing the per-connection entry and clearing the close callback) is factored into a `detachConnection` helper shared with the run loop.

Addresses item 1 of #6626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)