### PR TITLE
Preserve the deadline in IceGrid ServerEntry synchronization waits

### DIFF
--- a/cpp/src/IceGrid/ServerCache.cpp
+++ b/cpp/src/IceGrid/ServerCache.cpp
@@ -707,22 +707,13 @@ void
 ServerEntry::waitImpl(chrono::seconds timeout)
 {
     unique_lock lock(_mutex);
-    if (timeout != 0s)
+    if (timeout > 0s)
     {
-        while (_synchronizing)
-        {
-            if (timeout > 0s)
-            {
-                if (_condVar.wait_for(lock, timeout) == cv_status::timeout)
-                {
-                    break; // Timeout
-                }
-            }
-            else
-            {
-                _condVar.wait(lock);
-            }
-        }
+        _condVar.wait_until(lock, chrono::steady_clock::now() + timeout, [this] { return !_synchronizing; });
+    }
+    else if (timeout < 0s)
+    {
+        _condVar.wait(lock, [this] { return !_synchronizing; });
     }
     if (_synchronizing) // If we are still synchronizing, throw SynchronizationException
     {


### PR DESCRIPTION
`ServerEntry` shares the `Allocatable` mutex and condition variable, so the condition variable is also notified by ordinary allocation state transitions. `ServerEntry::waitImpl` restarted a full `wait_for(timeout)` on every wake-up, so such notifications during a pending synchronization could extend the wait well past the requested timeout, delaying the `SynchronizationException`. It now waits on an absolute deadline with a predicate, so unrelated notifications can't extend the bound.

Addresses the deadline part of item 2 of #6626. The other part of item 2 (remote Glacier2 session-filter invocations while holding the shared mutex) is an instance of a broader pattern to address in 3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)