### PR TITLE
Point the binary compatibility job at the 3.8.2 baseline tag

### DIFF
--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -3,15 +3,19 @@ name: Binary Compatibility
 on:
   workflow_dispatch:
 
-# Builds tests from a stable tag and distribution libraries from the branch HEAD, then swaps the HEAD libraries into
-# the stable test tree and runs the tests. If the tests pass, the HEAD libraries are binary-compatible with that stable
-# release.
+# Builds tests from a stable baseline and distribution libraries from the branch HEAD, then swaps the HEAD libraries
+# into the baseline test tree and runs the tests. If the tests pass, the HEAD libraries are binary-compatible with that
+# stable release.
+#
+# STABLE_TAG points at a baseline tag rather than the release tag itself: the release tree plus the test changes forced
+# by behavior we changed on purpose since that release. Only test and test-script files differ from the release, so the
+# tests still build against the release's headers and generated code. Cut a new baseline when a release ships.
 #
 # Each stable branch (3.7, 3.8) maintains its own copy of this workflow with branch-specific configuration below.
 
 # Branch-specific configuration:
 env:
-  STABLE_TAG: "v3.8.1"
+  STABLE_TAG: "binary-compat-3.8.2"
 
 jobs:
   compat:
@@ -175,8 +179,6 @@ jobs:
         shell: bash
 
       # Run the stable test suite against the HEAD libraries.
-      # Exclude IceSSL/configuration because the 3.8.0 test connects to the decommissioned Glacier2 demo proxy on
-      # zeroc.com (removed from HEAD by #5047).
       # Exclude Slice/macros because it compares compile-time and runtime Ice versions (Util.intVersion()), which
       # won't match when built and run with different patch versions.
       - name: Run compatibility tests
@@ -185,7 +187,7 @@ jobs:
         with:
           working_directory: stable
           flags: >-
-            --rfilter="IceSSL/configuration|Slice/macros"
+            --rfilter="Slice/macros"
             ${{ matrix.os == 'ubuntu-24.04' && '--languages=cpp,csharp,java' || '--languages=cpp' }}
 
       - name: Upload test results

--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -15,7 +15,7 @@ on:
 
 # Branch-specific configuration:
 env:
-  STABLE_TAG: "3.8.2-binary-compat"
+  STABLE_TAG: "v3.8.2-binary-compat"
 
 jobs:
   compat:

--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -18,7 +18,8 @@ on:
 
 # Branch-specific configuration:
 env:
-  STABLE_REF: "compat-3.8"
+  # TODO: temporary, pointed at the PR #6646 baseline for testing. Restore to "compat-3.8" before merging.
+  STABLE_REF: "compat-3.8-pr6646"
 
 jobs:
   compat:

--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -183,6 +183,8 @@ jobs:
         shell: bash
 
       # Run the stable test suite against the HEAD libraries.
+      # Exclude IceSSL/configuration because its FindCerts cases need the test certificates imported into the OS
+      # certificate store, which this job never does.
       # Exclude Slice/macros because it compares compile-time and runtime Ice versions (Util.intVersion()), which
       # won't match when built and run with different patch versions.
       - name: Run compatibility tests
@@ -191,7 +193,7 @@ jobs:
         with:
           working_directory: stable
           flags: >-
-            --rfilter="Slice/macros"
+            --rfilter="IceSSL/configuration|Slice/macros"
             ${{ matrix.os == 'ubuntu-24.04' && '--languages=cpp,csharp,java' || '--languages=cpp' }}
 
       - name: Upload test results

--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -15,7 +15,7 @@ on:
 
 # Branch-specific configuration:
 env:
-  STABLE_TAG: "binary-compat-3.8.2"
+  STABLE_TAG: "3.8.2-binary-compat"
 
 jobs:
   compat:

--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -2,20 +2,23 @@ name: Binary Compatibility
 
 on:
   workflow_dispatch:
+  # TODO: temporary, so the job can be exercised on the PR that changes it. Remove before merging.
+  pull_request:
+    branches: ["3.8"]
 
 # Builds tests from a stable baseline and distribution libraries from the branch HEAD, then swaps the HEAD libraries
 # into the baseline test tree and runs the tests. If the tests pass, the HEAD libraries are binary-compatible with that
 # stable release.
 #
-# STABLE_TAG points at a baseline tag rather than the release tag itself: the release tree plus the test changes forced
-# by behavior we changed on purpose since that release. Only test and test-script files differ from the release, so the
-# tests still build against the release's headers and generated code. Cut a new baseline when a release ships.
+# STABLE_REF points at a baseline branch rather than a release tag: the release tree plus the test changes forced by
+# behavior we changed on purpose since that release. Only test and test-script files differ from the release, so the
+# tests still build against the release's headers and generated code. Branch off the new release when one ships.
 #
 # Each stable branch (3.7, 3.8) maintains its own copy of this workflow with branch-specific configuration below.
 
 # Branch-specific configuration:
 env:
-  STABLE_TAG: "v3.8.2-binary-compat"
+  STABLE_REF: "compat-3.8"
 
 jobs:
   compat:
@@ -31,10 +34,10 @@ jobs:
         with:
           path: head
 
-      - name: Checkout stable (${{ env.STABLE_TAG }})
+      - name: Checkout stable (${{ env.STABLE_REF }})
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ env.STABLE_TAG }}
+          ref: ${{ env.STABLE_REF }}
           path: stable
 
       - name: macOS FQDN Fix

--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -2,9 +2,6 @@ name: Binary Compatibility
 
 on:
   workflow_dispatch:
-  # TODO: temporary, so the job can be exercised on the PR that changes it. Remove before merging.
-  pull_request:
-    branches: ["3.8"]
 
 # Builds tests from a stable baseline and distribution libraries from the branch HEAD, then swaps the HEAD libraries
 # into the baseline test tree and runs the tests. If the tests pass, the HEAD libraries are binary-compatible with that
@@ -18,8 +15,7 @@ on:
 
 # Branch-specific configuration:
 env:
-  # TODO: temporary, pointed at the PR #6646 baseline for testing. Restore to "compat-3.8" before merging.
-  STABLE_REF: "compat-3.8-pr6646"
+  STABLE_REF: "compat-3.8"
 
 jobs:
   compat:

--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -7,15 +7,16 @@ on:
 # into the baseline test tree and runs the tests. If the tests pass, the HEAD libraries are binary-compatible with that
 # stable release.
 #
-# STABLE_REF points at a baseline branch rather than a release tag: the release tree plus the test changes forced by
-# behavior we changed on purpose since that release. Only test and test-script files differ from the release, so the
-# tests still build against the release's headers and generated code. Branch off the new release when one ships.
+# STABLE_REF points at a baseline tag rather than the release tag itself: the release tree plus the test changes
+# forced by behavior we changed on purpose since that release. Only test and test-script files differ from the
+# release, so the tests still build against the release's headers and generated code. Cut a new baseline when a
+# release ships.
 #
 # Each stable branch (3.7, 3.8) maintains its own copy of this workflow with branch-specific configuration below.
 
 # Branch-specific configuration:
 env:
-  STABLE_REF: "compat-3.8"
+  STABLE_REF: "v3.8.2-binary-compat"
 
 jobs:
   compat:


### PR DESCRIPTION
The Binary Compatibility job has been failing 10 suites on [run 31997348506](https://github.com/zeroc-ice/ice/actions/runs/31997348506). None are real breaks — the v3.8.1 tests encode behavior we changed on purpose since, so the job could not go green whatever the libraries did.

- Rename `STABLE_TAG` to `STABLE_REF` and point it at `v3.8.2-binary-compat`: the `v3.8.2` tree plus the test and test-script changes that behavior change forced, and nothing else.
- Correct the `IceSSL/configuration` exclusion comment. It blamed a demo proxy removed by #5047; the suite actually fails because its FindCerts cases need certificates in the OS certificate store, which this job never sets up.
- Say what the baseline tag is, so the next release cuts a new one instead of pointing back at a bare release tag.
