### PR TITLE
Update the 3.8 compat baseline tests for behavior changed since 3.8.2

### DIFF
--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -284,11 +284,13 @@ void ::Writer::run(int argc, char* argv[])
         test(skw.getLast().getKey() == "key");
         test(skw.getLast().getValue() == "");
         test(skw.getLast().getEvent() == SampleEvent::Remove);
-        skw.partialUpdate<string>("partialupdate")("update");
-        test(skw.getLast().getKey() == "key");
-        test(skw.getLast().getValue() == "");
-        test(skw.getLast().getUpdateTag() == "partialupdate");
-        test(skw.getLast().getEvent() == SampleEvent::PartialUpdate);
+        // As of 3.8.3, a partial update on a key with no current value throws; the 3.8.2 block below is
+        // disabled.
+        // skw.partialUpdate<string>("partialupdate")("update");
+        // test(skw.getLast().getKey() == "key");
+        // test(skw.getLast().getValue() == "");
+        // test(skw.getLast().getUpdateTag() == "partialupdate");
+        // test(skw.getLast().getEvent() == SampleEvent::PartialUpdate);
 
         ostringstream os;
         os << skw.getLast();

--- a/cpp/test/Ice/adapterDeactivation/AllTests.cpp
+++ b/cpp/test/Ice/adapterDeactivation/AllTests.cpp
@@ -343,7 +343,9 @@ allTests(Test::TestHelper* helper)
     cout << "ok" << endl;
 
     cout << "testing whether server is gone... " << flush;
-    if (obj->ice_getConnection()) // not collocated
+    // As of 3.8.3, ice_getConnection reconnects (and here throws) when the close initiated by the
+    // deactivation has already been processed; the cached connection detects collocation without any I/O.
+    if (obj->ice_getCachedConnection()) // not collocated
     {
         try
         {

--- a/cpp/test/Ice/binding/AllTests.cpp
+++ b/cpp/test/Ice/binding/AllTests.cpp
@@ -60,9 +60,10 @@ allTests(Test::TestHelper* helper)
         com->deactivateObjectAdapter(adapter);
 
         const TestIntfPrx& test3(test1.value());
-        test(test3->ice_getConnection() == test1->ice_getConnection());
-        test(test3->ice_getConnection() == test2->ice_getConnection());
-
+        // As of 3.8.3, ice_getConnection attempts to reconnect once the close initiated by the deactivation
+        // has been processed; the assertions below are disabled.
+        // test(test3->ice_getConnection() == test1->ice_getConnection());
+        // test(test3->ice_getConnection() == test2->ice_getConnection());
         try
         {
             test3->ice_ping();

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -493,7 +493,9 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
     string isSecure;
     if (!collocated)
     {
-        Ice::EndpointInfoPtr endpointInfo = metrics->ice_getConnection()->getEndpoint()->getInfo();
+        // Use the cached connection: as of 3.8.3, ice_getConnection would re-establish a closed connection,
+        // which changes the connection metrics the test asserts on.
+        Ice::EndpointInfoPtr endpointInfo = metrics->ice_getCachedConnection()->getEndpoint()->getInfo();
         {
             ostringstream os;
             os << endpointInfo->type();
@@ -607,7 +609,9 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         props["IceMX.Metrics.View.Map.Connection.GroupBy"] = "none";
         updateProps(clientProps, serverProps, update.get(), props, "Connection");
 
-        metrics->ice_getConnection()->close().get();
+        // Use the cached connection: as of 3.8.3, ice_getConnection would re-establish a closed connection,
+        // which changes the connection metrics the test asserts on.
+        metrics->ice_getCachedConnection()->close().get();
 
         // TODO: this appears necessary on slow macos VMs to give time to the server to clean-up the connection.
         this_thread::sleep_for(chrono::milliseconds(100));

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -644,14 +644,16 @@ allTests(TestHelper* helper)
 
     test(base->ice_invocationTimeout(10)->ice_getInvocationTimeout() == 10ms);
 
-    test(base->ice_invocationTimeout(0)->ice_getInvocationTimeout() == 0ms);
-    test(base->ice_invocationTimeout(0ms)->ice_getInvocationTimeout() == 0ms);
+    // 3.8.3 normalizes zero and negative timeouts to -1 in the proxy's inline setters, so a test built
+    // against the 3.8.2 headers observes platform-dependent values; the assertions below are disabled.
+    // test(base->ice_invocationTimeout(0)->ice_getInvocationTimeout() == 0ms);
+    // test(base->ice_invocationTimeout(0ms)->ice_getInvocationTimeout() == 0ms);
 
     test(base->ice_invocationTimeout(-1)->ice_getInvocationTimeout() == -1ms);
     test(base->ice_invocationTimeout(-1ms)->ice_getInvocationTimeout() == -1ms);
 
-    test(base->ice_invocationTimeout(-2)->ice_getInvocationTimeout() == -2ms);
-    test(base->ice_invocationTimeout(-2ms)->ice_getInvocationTimeout() == -2ms);
+    // test(base->ice_invocationTimeout(-2)->ice_getInvocationTimeout() == -2ms);
+    // test(base->ice_invocationTimeout(-2ms)->ice_getInvocationTimeout() == -2ms);
 
     test(base->ice_locatorCacheTimeout(10)->ice_getLocatorCacheTimeout() == 10s);
 
@@ -661,8 +663,8 @@ allTests(TestHelper* helper)
     test(base->ice_locatorCacheTimeout(-1)->ice_getLocatorCacheTimeout() == -1s);
     test(base->ice_locatorCacheTimeout(-1s)->ice_getLocatorCacheTimeout() == -1s);
 
-    test(base->ice_locatorCacheTimeout(-2)->ice_getLocatorCacheTimeout() == -2s);
-    test(base->ice_locatorCacheTimeout(-2s)->ice_getLocatorCacheTimeout() == -2s);
+    // test(base->ice_locatorCacheTimeout(-2)->ice_getLocatorCacheTimeout() == -2s);
+    // test(base->ice_locatorCacheTimeout(-2s)->ice_getLocatorCacheTimeout() == -2s);
 
     cout << "ok" << endl;
 

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -354,7 +354,9 @@ public class AllTests : global::Test.AllTests
 
         output.Write("testing whether server is gone... ");
         output.Flush();
-        if (obj.ice_getConnection() is null) // collocated
+        // As of 3.8.3, ice_getConnection reconnects (and throws) when the close initiated by the
+        // deactivation has already been processed; the cached connection detects collocation without any I/O.
+        if (obj.ice_getCachedConnection() is null) // collocated
         {
             obj.ice_ping();
             output.WriteLine("ok");

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -74,9 +74,10 @@ public class AllTests : global::Test.AllTests
             com.deactivateObjectAdapter(adapter);
 
             Test.TestIntfPrx test3 = Test.TestIntfPrxHelper.uncheckedCast(test1);
-            test(test3.ice_getConnection() == test1.ice_getConnection());
-            test(test3.ice_getConnection() == test2.ice_getConnection());
-
+            // As of 3.8.3, ice_getConnection attempts to reconnect once the close initiated by the deactivation
+            // has been processed; the assertions below are disabled.
+            // test(test3.ice_getConnection() == test1.ice_getConnection());
+            // test(test3.ice_getConnection() == test2.ice_getConnection());
             try
             {
                 test3.ice_ping();

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -572,7 +572,9 @@ public class AllTests : Test.AllTests
         string isSecure = "";
         if (!collocated)
         {
-            Ice.EndpointInfo endpointInfo = metrics.ice_getConnection().getEndpoint().getInfo();
+            // Use the cached connection: as of 3.8.3, ice_getConnection would re-establish a closed connection,
+            // which changes the connection metrics the test asserts on.
+            Ice.EndpointInfo endpointInfo = metrics.ice_getCachedConnection().getEndpoint().getInfo();
             type = $"{endpointInfo.type()}";
             isSecure = endpointInfo.secure() ? "True" : "False";
         }
@@ -676,7 +678,9 @@ public class AllTests : Test.AllTests
             props["IceMX.Metrics.View.Map.Connection.GroupBy"] = "none";
             updateProps(clientProps, serverProps, update, props, "Connection");
 
-            await metrics.ice_getConnection().closeAsync();
+            // Use the cached connection: as of 3.8.3, ice_getConnection would re-establish a closed connection,
+            // which changes the connection metrics the test asserts on.
+            await metrics.ice_getCachedConnection().closeAsync();
 
             var m = (MetricsPrx)metrics.ice_connectionId("Con1");
             m.ice_ping();

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -575,13 +575,15 @@ public class AllTests : global::Test.AllTests
         test(baseProxy.ice_collocationOptimized(true).ice_isCollocationOptimized());
         test(!baseProxy.ice_collocationOptimized(false).ice_isCollocationOptimized());
 
-        test(baseProxy.ice_invocationTimeout(0).ice_getInvocationTimeout() == TimeSpan.Zero);
+        // Zero and negative invocation timeouts, and negative locator cache timeouts, normalize to -1 as of
+        // 3.8.3; the assertions on the changed values are disabled.
+        // test(baseProxy.ice_invocationTimeout(0).ice_getInvocationTimeout() == TimeSpan.Zero);
         test(baseProxy.ice_invocationTimeout(-1).ice_getInvocationTimeout() == TimeSpan.FromMilliseconds(-1));
-        test(baseProxy.ice_invocationTimeout(-2).ice_getInvocationTimeout() == TimeSpan.FromMilliseconds(-2));
+        // test(baseProxy.ice_invocationTimeout(-2).ice_getInvocationTimeout() == TimeSpan.FromMilliseconds(-2));
 
         test(baseProxy.ice_locatorCacheTimeout(0).ice_getLocatorCacheTimeout() == TimeSpan.Zero);
         test(baseProxy.ice_locatorCacheTimeout(-1).ice_getLocatorCacheTimeout() == TimeSpan.FromSeconds(-1));
-        test(baseProxy.ice_locatorCacheTimeout(-2).ice_getLocatorCacheTimeout() == TimeSpan.FromSeconds(-2));
+        // test(baseProxy.ice_locatorCacheTimeout(-2).ice_getLocatorCacheTimeout() == TimeSpan.FromSeconds(-2));
 
         output.WriteLine("ok");
 

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
@@ -393,7 +393,9 @@ public class AllTests {
 
         out.print("testing whether server is gone... ");
         out.flush();
-        if (obj.ice_getConnection() == null) { // collocated
+        // As of 3.8.3, ice_getConnection reconnects (and throws) when the close initiated by the
+        // deactivation has already been processed; the cached connection detects collocation without any I/O.
+        if (obj.ice_getCachedConnection() == null) { // collocated
             obj.ice_ping(); // works fine
             out.println("ok");
             out.flush();

--- a/java/test/src/main/java/test/Ice/binding/AllTests.java
+++ b/java/test/src/main/java/test/Ice/binding/AllTests.java
@@ -82,9 +82,10 @@ public class AllTests {
             rcom.deactivateObjectAdapter(adapter);
 
             TestIntfPrx test3 = TestIntfPrx.uncheckedCast(test1);
-            test(test3.ice_getConnection() == test1.ice_getConnection());
-            test(test3.ice_getConnection() == test2.ice_getConnection());
-
+            // As of 3.8.3, ice_getConnection attempts to reconnect once the close initiated by the deactivation
+            // has been processed; the assertions below are disabled.
+            // test(test3.ice_getConnection() == test1.ice_getConnection());
+            // test(test3.ice_getConnection() == test2.ice_getConnection());
             try {
                 test3.ice_ping();
                 test(false);

--- a/java/test/src/main/java/test/Ice/metrics/AllTests.java
+++ b/java/test/src/main/java/test/Ice/metrics/AllTests.java
@@ -438,8 +438,10 @@ public class AllTests {
         String type = "";
         String isSecure = "";
         if (!collocated) {
+            // Use the cached connection: as of 3.8.3, ice_getConnection would re-establish a closed connection,
+            // which changes the connection metrics the test asserts on.
             EndpointInfo endpointInfo =
-                metrics.ice_getConnection().getEndpoint().getInfo();
+                metrics.ice_getCachedConnection().getEndpoint().getInfo();
             type = Short.toString(endpointInfo.type());
             isSecure = endpointInfo.secure() ? "true" : "false";
         }
@@ -565,7 +567,9 @@ public class AllTests {
             props.put("IceMX.Metrics.View.Map.Connection.GroupBy", "none");
             updateProps(clientProps, serverProps, props, "Connection");
 
-            metrics.ice_getConnection().close();
+            // Use the cached connection: as of 3.8.3, ice_getConnection would re-establish a closed connection,
+            // which changes the connection metrics the test asserts on.
+            metrics.ice_getCachedConnection().close();
 
             MetricsPrx m = metrics.ice_connectionId("Con1");
             m.ice_ping();

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -655,15 +655,17 @@ public class AllTests {
             base.ice_invocationTimeout(10)
                 .ice_getInvocationTimeout()
                 .equals(Duration.ofMillis(10)));
-        test(base.ice_invocationTimeout(0).ice_getInvocationTimeout().equals(Duration.ZERO));
+        // Zero and negative invocation timeouts, and negative locator cache timeouts, normalize to -1 as of
+        // 3.8.3; the assertions on the changed values are disabled.
+        // test(base.ice_invocationTimeout(0).ice_getInvocationTimeout().equals(Duration.ZERO));
         test(
             base.ice_invocationTimeout(-1)
                 .ice_getInvocationTimeout()
                 .equals(Duration.ofMillis(-1)));
-        test(
-            base.ice_invocationTimeout(-2)
-                .ice_getInvocationTimeout()
-                .equals(Duration.ofMillis(-2)));
+        // test(
+        //     base.ice_invocationTimeout(-2)
+        //         .ice_getInvocationTimeout()
+        //         .equals(Duration.ofMillis(-2)));
 
         test(
             base.ice_locatorCacheTimeout(10)
@@ -674,10 +676,10 @@ public class AllTests {
             base.ice_locatorCacheTimeout(-1)
                 .ice_getLocatorCacheTimeout()
                 .equals(Duration.ofSeconds(-1)));
-        test(
-            base.ice_locatorCacheTimeout(-2)
-                .ice_getLocatorCacheTimeout()
-                .equals(Duration.ofSeconds(-2)));
+        // test(
+        //     base.ice_locatorCacheTimeout(-2)
+        //         .ice_getLocatorCacheTimeout()
+        //         .equals(Duration.ofSeconds(-2)));
 
         // Ensure that the proxy methods can be called unambiguously with the correct return type.
         var diamondClass = DiamondClassPrx.uncheckedCast(base);

--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -59,13 +59,14 @@ class Writer(Client, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
+            # The lookup identity changed in 3.8.3; this baseline only runs against 3.8 libraries.
             # Need to use --interface 127.0.0.1 for the macOS GitHub runners.
             if isinstance(platform, Darwin):
                 props["DataStorm.Node.Multicast.Proxy"] = (
-                    f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
+                    f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
                 )
             else:
-                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port}"
+                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(
@@ -91,13 +92,14 @@ class Reader(Server, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
+            # The lookup identity changed in 3.8.3; this baseline only runs against 3.8 libraries.
             # Need to use --interface 127.0.0.1 for the macOS GitHub runners.
             if isinstance(platform, Darwin):
                 props["DataStorm.Node.Multicast.Proxy"] = (
-                    f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
+                    f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
                 )
             else:
-                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port}"
+                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(


### PR DESCRIPTION
Updates the compat baseline tests so the Binary Compatibility job passes against the 3.8 HEAD libraries. Only test and test-script files differ from `v3.8.2`, so the tests still build against 3.8.2 headers and generated code. Where behavior changed, the 3.8.2 assertions are commented out rather than deleted, so a diff against `v3.8.2` shows exactly what was disabled.

- `ice_getConnection` reconnects when the cached connection is closed (#6256) — `adapterDeactivation`, `binding`, `metrics`.
- Invocation and locator-cache timeout normalization (#6235, #6304) — `proxy`.
- The DataStorm lookup identity is now `DataStorm/Lookup2` (#6138) — `scripts/DataStormUtil.py`.
- A DataStorm partial update on a key with no value now throws (#6083) — `DataStorm/api`.

This baseline is run against the 3.8 libraries by the Binary Compatibility job in #6645. Keeping it green under the normal CI workflows is best effort only, and it does not pass today: the `ssl` configs fail because the certificates committed on `v3.8.2` have expired and we do not want to regenerate them on this tag, and DataStorm fails because `Lookup2` is not the identity 3.8.2 registers.

On the C++ `proxy` timeouts: 3.8.3 normalizes in the inline setter in `Proxy.h` so that code built against older headers keeps the old values. That holds on Unix, where the body is compiled into the caller, but not on Windows — `ObjectPrx` is dllexported and MSVC exports its `Proxy<>` base template members, so the caller binds to the DLL and picks up the new normalization. A 3.8.2 caller therefore sees 0 on Unix and -1 on Windows, and no single expectation fits both.
