### PR TITLE
Make the fdToString helpers noexcept

### DIFF
--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -869,70 +869,86 @@ IceInternal::fdToRemoteAddress(SOCKET fd, Address& addr)
 }
 
 std::string
-IceInternal::fdToString(SOCKET fd, const NetworkProxyPtr& proxy, const Address& target)
+IceInternal::fdToString(SOCKET fd, const NetworkProxyPtr& proxy, const Address& target) noexcept
 {
     if (fd == INVALID_SOCKET)
     {
         return "<closed>";
     }
 
-    ostringstream s;
+    try
+    {
+        ostringstream s;
 
-    Address remoteAddr;
-    bool peerConnected = fdToRemoteAddress(fd, remoteAddr);
+        Address remoteAddr;
+        bool peerConnected = fdToRemoteAddress(fd, remoteAddr);
 
 #ifdef _WIN32
-    if (!peerConnected)
-    {
-        //
-        // The local address is only accessible with connected sockets on Windows.
-        //
-        s << "local address = <not available>";
-    }
-    else
+        if (!peerConnected)
+        {
+            //
+            // The local address is only accessible with connected sockets on Windows.
+            //
+            s << "local address = <not available>";
+        }
+        else
 #endif
-    {
-        Address localAddr;
-        fdToLocalAddress(fd, localAddr);
-        s << "local address = " << addrToString(localAddr);
-    }
-
-    if (proxy)
-    {
-        if (!peerConnected)
         {
-            remoteAddr = proxy->getAddress();
+            Address localAddr;
+            fdToLocalAddress(fd, localAddr);
+            s << "local address = " << addrToString(localAddr);
         }
-        s << "\n" + proxy->getName() + " proxy address = " << addrToString(remoteAddr);
-        s << "\nremote address = " << addrToString(target);
-    }
-    else
-    {
-        if (!peerConnected)
-        {
-            remoteAddr = target;
-        }
-        s << "\nremote address = " << addrToString(remoteAddr);
-    }
 
-    return s.str();
+        if (proxy)
+        {
+            if (!peerConnected)
+            {
+                remoteAddr = proxy->getAddress();
+            }
+            s << "\n" + proxy->getName() + " proxy address = " << addrToString(remoteAddr);
+            s << "\nremote address = " << addrToString(target);
+        }
+        else
+        {
+            if (!peerConnected)
+            {
+                remoteAddr = target;
+            }
+            s << "\nremote address = " << addrToString(remoteAddr);
+        }
+
+        return s.str();
+    }
+    catch (...)
+    {
+        // The description is best-effort: the address queries can fail only in extreme conditions such as kernel
+        // resource exhaustion.
+        return "<not available>";
+    }
 }
 
 std::string
-IceInternal::fdToString(SOCKET fd)
+IceInternal::fdToString(SOCKET fd) noexcept
 {
     if (fd == INVALID_SOCKET)
     {
         return "<closed>";
     }
 
-    Address localAddr;
-    fdToLocalAddress(fd, localAddr);
+    try
+    {
+        Address localAddr;
+        fdToLocalAddress(fd, localAddr);
 
-    Address remoteAddr;
-    bool peerConnected = fdToRemoteAddress(fd, remoteAddr);
+        Address remoteAddr;
+        bool peerConnected = fdToRemoteAddress(fd, remoteAddr);
 
-    return addressesToString(localAddr, remoteAddr, peerConnected);
+        return addressesToString(localAddr, remoteAddr, peerConnected);
+    }
+    catch (...)
+    {
+        return "<not available>";
+    }
 }
 
 void

--- a/cpp/src/Ice/Network.h
+++ b/cpp/src/Ice/Network.h
@@ -200,8 +200,8 @@ namespace IceInternal
     ICE_API std::string addrToString(const Address&);
     ICE_API void fdToLocalAddress(SOCKET, Address&);
     ICE_API bool fdToRemoteAddress(SOCKET, Address&);
-    ICE_API std::string fdToString(SOCKET, const NetworkProxyPtr&, const Address&);
-    ICE_API std::string fdToString(SOCKET);
+    ICE_API std::string fdToString(SOCKET, const NetworkProxyPtr&, const Address&) noexcept;
+    ICE_API std::string fdToString(SOCKET) noexcept;
     ICE_API void fdToAddressAndPort(SOCKET, std::string&, int&, std::string&, int&);
     ICE_API void addrToAddressAndPort(const Address&, std::string&, int&);
     ICE_API std::string addressesToString(const Address&, const Address&, bool);

--- a/cpp/src/Ice/StreamSocket.cpp
+++ b/cpp/src/Ice/StreamSocket.cpp
@@ -31,15 +31,7 @@ StreamSocket::StreamSocket(
         _state = _proxy ? StateProxyWrite : StateConnected;
     }
 #endif
-    try
-    {
-        _desc = fdToString(_fd, _proxy, _addr);
-    }
-    catch (const Ice::Exception&)
-    {
-        closeSocketNoThrow(_fd);
-        throw;
-    }
+    _desc = fdToString(_fd, _proxy, _addr);
 }
 
 StreamSocket::StreamSocket(ProtocolInstancePtr instance, SOCKET fd, const TcpBufSize& bufSize)
@@ -55,15 +47,7 @@ StreamSocket::StreamSocket(ProtocolInstancePtr instance, SOCKET fd, const TcpBuf
 #endif
 {
     init(bufSize);
-    try
-    {
-        _desc = fdToString(fd);
-    }
-    catch (const Ice::Exception&)
-    {
-        closeSocketNoThrow(fd);
-        throw;
-    }
+    _desc = fdToString(fd);
 }
 
 StreamSocket::~StreamSocket() { assert(_fd == INVALID_SOCKET); }

--- a/cpp/src/IceBT/Util.cpp
+++ b/cpp/src/IceBT/Util.cpp
@@ -143,20 +143,29 @@ namespace
 }
 
 string
-IceBT::fdToString(SOCKET fd)
+IceBT::fdToString(SOCKET fd) noexcept
 {
     if (fd == INVALID_SOCKET)
     {
         return "<closed>";
     }
 
-    SocketAddress localAddr;
-    fdToLocalAddress(fd, localAddr);
+    try
+    {
+        SocketAddress localAddr;
+        fdToLocalAddress(fd, localAddr);
 
-    SocketAddress remoteAddr;
-    bool peerConnected = fdToRemoteAddress(fd, remoteAddr);
+        SocketAddress remoteAddr;
+        bool peerConnected = fdToRemoteAddress(fd, remoteAddr);
 
-    return addressesToString(localAddr, remoteAddr, peerConnected);
+        return addressesToString(localAddr, remoteAddr, peerConnected);
+    }
+    catch (...)
+    {
+        // The description is best-effort: the address queries can fail only in extreme conditions such as kernel
+        // resource exhaustion.
+        return "<not available>";
+    }
 }
 
 void

--- a/cpp/src/IceBT/Util.h
+++ b/cpp/src/IceBT/Util.h
@@ -16,7 +16,7 @@ namespace IceBT
     std::string addrToString(const std::string&, std::int32_t);
     std::string addrToString(const SocketAddress&);
 
-    std::string fdToString(SOCKET);
+    std::string fdToString(SOCKET) noexcept;
     void fdToAddressAndChannel(SOCKET, std::string&, int&, std::string&, int&);
 }
 


### PR DESCRIPTION
## Summary

`fdToString` builds a best-effort description of a socket for tracing. Previously it could throw when `getsockname`/`getpeername` failed; most call sites didn't guard against this, and on the IceBT paths (accepted-socket constructor and outgoing `setFd`) a throw leaked the fd, since nothing closes it on those paths. The TCP `StreamSocket` constructors carried try/catch guards for the same reason.

This PR makes the `fdToString` overloads (Ice core and IceBT) `noexcept`: an address-query failure — only possible under extreme conditions such as kernel resource exhaustion — now yields the description `<not available>` instead of an exception. This fixes the IceBT fd leak and removes the TCP call-site guards. (The iOS stream transceiver already guarded this path with a catch-and-close.)

This PR addresses item 1 of #6627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
