### PR TITLE
Implement standard Ruby comparison semantics for Slice enums and Identity

### DIFF
--- a/changelog.d/ruby/ruby-comparison-semantics.md
+++ b/changelog.d/ruby/ruby-comparison-semantics.md
@@ -1,0 +1,4 @@
+- The comparison methods (`<=>`, `==`, `eql?`) of Ice types in Ruby (Slice-generated enums, `Ice::Identity`,
+  `Ice::ObjectPrx`, and `Ice::Endpoint`) now follow standard Ruby semantics for an operand of a different type: `==`
+  and `eql?` return `false` and `<=>` returns `nil`, instead of raising an exception. On enums, which are
+  `Comparable`, ordered comparisons such as `<` still raise `ArgumentError`.

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -782,9 +782,7 @@ Slice::Ruby::CodeVisitor::visitEnum(const EnumPtr& p)
     //
     _out << sp << nl << "def <=>(other)";
     _out.inc();
-    _out << nl << "other.is_a?(" << name << ") or raise ArgumentError, \"value must be " << getArticleFor(name) << ' '
-         << name << "\"";
-    _out << nl << "@value <=> other.to_i";
+    _out << nl << "@value <=> other.to_i if other.is_a?(" << name << ")";
     _out.dec();
     _out << nl << "end";
 

--- a/ruby/ruby/Ice/CompressBatch.rb
+++ b/ruby/ruby/Ice/CompressBatch.rb
@@ -23,8 +23,7 @@ module Ice
         end
 
         def <=>(other)
-            other.is_a?(CompressBatch) or raise ArgumentError, "value must be a CompressBatch"
-            @value <=> other.to_i
+            @value <=> other.to_i if other.is_a?(CompressBatch)
         end
 
         def hash

--- a/ruby/ruby/Ice/EndpointSelectionType.rb
+++ b/ruby/ruby/Ice/EndpointSelectionType.rb
@@ -23,8 +23,7 @@ module Ice
         end
 
         def <=>(other)
-            other.is_a?(EndpointSelectionType) or raise ArgumentError, "value must be an EndpointSelectionType"
-            @value <=> other.to_i
+            @value <=> other.to_i if other.is_a?(EndpointSelectionType)
         end
 
         def hash

--- a/ruby/ruby/Ice/IdentitySpaceship.rb
+++ b/ruby/ruby/Ice/IdentitySpaceship.rb
@@ -5,6 +5,7 @@ require_relative 'Identity.rb'
 module Ice
     class Identity
         def <=>(other)
+            return nil unless other.is_a?(Identity)
             n = self.name <=> other.name
             if n == 0
                 return self.category <=> other.category

--- a/ruby/ruby/Ice/ToStringMode.rb
+++ b/ruby/ruby/Ice/ToStringMode.rb
@@ -23,8 +23,7 @@ module Ice
         end
 
         def <=>(other)
-            raise ArgumentError, "value must be a ToStringMode" unless other.is_a?(ToStringMode)
-            @value <=> other.to_i
+            @value <=> other.to_i if other.is_a?(ToStringMode)
         end
 
         def hash

--- a/ruby/ruby/Ice/Value.rb
+++ b/ruby/ruby/Ice/Value.rb
@@ -67,8 +67,7 @@ module Ice
       end
 
       def <=>(other)
-          other.is_a?(FormatType) or raise ArgumentError, "value must be a FormatType"
-          @val <=> other.to_i
+          @val <=> other.to_i if other.is_a?(FormatType)
       end
 
       def hash

--- a/ruby/test/Ice/enums/AllTests.rb
+++ b/ruby/test/Ice/enums/AllTests.rb
@@ -89,6 +89,16 @@ def allTests(helper, communicator)
     test(Test::SimpleEnum::from_int(1) == Test::SimpleEnum::Green);
     test(Test::SimpleEnum::from_int(2) == Test::SimpleEnum::Blue);
 
+    #
+    # Standard Ruby semantics for a non-enumerator operand: == returns false, <=> returns nil.
+    #
+    test(Test::SimpleEnum::Red < Test::SimpleEnum::Green);
+    test(!(Test::SimpleEnum::Red == 0));
+    test(Test::SimpleEnum::Red != nil);
+    test((Test::SimpleEnum::Red <=> 0).nil?);
+    test((Test::SimpleEnum::Red <=> nil).nil?);
+    test(![Test::SimpleEnum::Red].include?(0));
+
     puts "ok"
 
     print "testing enum operations... "

--- a/ruby/test/Ice/enums/AllTests.rb
+++ b/ruby/test/Ice/enums/AllTests.rb
@@ -98,6 +98,11 @@ def allTests(helper, communicator)
     test((Test::SimpleEnum::Red <=> 0).nil?);
     test((Test::SimpleEnum::Red <=> nil).nil?);
     test(![Test::SimpleEnum::Red].include?(0));
+    begin
+        Test::SimpleEnum::Red < 0
+        test(false)
+    rescue ArgumentError
+    end
 
     puts "ok"
 

--- a/ruby/test/Ice/proxy/AllTests.rb
+++ b/ruby/test/Ice/proxy/AllTests.rb
@@ -394,6 +394,16 @@ def allTests(helper, communicator)
     ident2 = Ice::stringToIdentity(communicator.identityToString(ident))
     test(ident == ident2)
 
+    #
+    # Standard Ruby semantics for a non-Identity operand: == and eql? return false, <=> returns nil.
+    #
+    test((ident <=> Ice::Identity.new("test2", "\x7f\u20ac")) == -1)
+    test(!(ident == "not an identity"))
+    test(!ident.eql?("not an identity"))
+    test(ident != nil)
+    test((ident <=> "not an identity").nil?)
+    test((ident <=> nil).nil?)
+
     test(base.ice_facet("facet").ice_getFacet() == "facet")
     test(base.ice_adapterId("id").ice_getAdapterId() == "id")
     test(base.ice_twoway().ice_isTwoway())


### PR DESCRIPTION
Slice-generated enums (and the hand-written `Ice::FormatType`, `Ice::ToStringMode`, `Ice::CompressBatch` and `Ice::EndpointSelectionType`) raised `ArgumentError` from `<=>` for a foreign operand, and `Comparable#==` propagated that exception, so `enum == nil`, `case`/`when` and `include?` raised instead of returning `false`. `Ice::Identity#<=>` called `other.name` unguarded and raised `NoMethodError`.

With this fix, `<=>` returns `nil` for an incomparable operand, which makes `Comparable#==` return `false`, per standard Ruby semantics; ordered comparisons such as `<` still raise `ArgumentError`. Same fix as the Endpoint and ObjectPrx ones in #6631 and #6637; the changelog fragment covers the whole family.

Fixes #6643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)