### PR TITLE
Add comments explaining why a socket configuration failure cannot leak the fd

### DIFF
--- a/cpp/src/Ice/StreamSocket.cpp
+++ b/cpp/src/Ice/StreamSocket.cpp
@@ -444,6 +444,8 @@ StreamSocket::toString() const
 void
 StreamSocket::init(const TcpBufSize& bufSize)
 {
+    // Both calls close the fd before throwing a SocketException, so a failure cannot leak the fd — and since init
+    // is only called from constructors, the exception abandons the object and nothing uses the stale _fd afterward.
     setBlock(_fd, false);
     setTcpBufSize(_fd, bufSize.rcvSize(), bufSize.sndSize(), _instance);
 }

--- a/cpp/src/IceBT/StreamSocket.cpp
+++ b/cpp/src/IceBT/StreamSocket.cpp
@@ -15,6 +15,8 @@ IceBT::StreamSocket::StreamSocket(InstancePtr instance, SOCKET fd, const BTBufSi
       _instance(std::move(instance))
 {
     assert(fd != INVALID_SOCKET);
+    // Both calls close the fd before throwing a SocketException, so a failure cannot leak the fd — the exception
+    // abandons the object under construction and nothing uses the stale _fd afterward.
     IceInternal::setBlock(fd, false);
     setBufferSize(fd, bufSize.rcvSize(), bufSize.sndSize());
     _desc = fdToString(fd);


### PR DESCRIPTION
This PR adds short comments to `StreamSocket::init` (TCP) and the IceBT accepted-socket constructor to head off future audit findings like #6649, whose failure sequence doesn't hold up:

- Every reachable failure in the socket configuration calls (`setBlock`, `setRecvBufferSize`/`getRecvBufferSize`, ...) closes the fd before throwing a `SocketException`, so nothing leaks. The exception abandons the object under construction — its destructor doesn't run — and nothing uses the stale fd afterward.
- The only step that throws without closing the fd is the buffer-size warning check, and it throws `CommunicatorDestroyedException` only when the communicator's `Instance` object has already been destructed, not merely while `destroy()` is in progress (`Instance::getBufSizeWarn` is a plain mutex-protected map lookup with no state check). This cannot happen while a socket is being configured. For TCP, every caller holds a strong reference to the `Instance` up the call stack (thread pools, connection factories, connections). For IceBT, `Instance::destroy()` destroys the plug-in, whose engine teardown joins the connect threads and closes the DBus connection — joining the dispatch thread that delivers `NewConnection` — while the `Instance` is still alive.

See #6649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)