### PR TITLE
Reformat the changelog Python example for Ruff 0.16

### DIFF
--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -1229,10 +1229,9 @@ initialization. See `InitializationData.pluginFactories`.
 
   ```python
   async def main():
-      async with Ice.initialize(
-          sys.argv,
-          eventLoop=asyncio.get_running_loop()) as communicator:
+      async with Ice.initialize(sys.argv, eventLoop=asyncio.get_running_loop()) as communicator:
           ...
+
 
   if __name__ == "__main__":
       asyncio.run(main())


### PR DESCRIPTION
The Python workflow on 3.8 fails in `ruff format --check`. Ruff 0.16 formats Python code blocks inside Markdown, and the `async with Ice.initialize(...)` example in `CHANGELOG-3.8.md` is not in that shape.

- Reformat the snippet the way `ruff format` writes it.
- The branch only picked up Ruff 0.16 when the pinned version in `python/uv.lock` was backported; the previous unpinned CI installed 0.15, which left Markdown alone.