### PR TITLE
Build the Swift tests against the branch's own C++ libraries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -67,23 +67,19 @@ let package = Package(
         ),
         .binaryTarget(
             name: "IceCpp",
-            url: "https://download.zeroc.com/ice/3.8/Ice-3.8.2.xcframework.zip",
-            checksum: "b94cb93b19867314153afc76695f8b97d94935ea79a950300d39d85d952a4adc"
+            path: "cpp/lib/XCFrameworks/Ice.xcframework"
         ),
         .binaryTarget(
             name: "IceDiscoveryCpp",
-            url: "https://download.zeroc.com/ice/3.8/IceDiscovery-3.8.2.xcframework.zip",
-            checksum: "17bdc226ba5a59390da6a571a6fbee3e21dc48c7f0cc294b4b3b8793c4932e42"
+            path: "cpp/lib/XCFrameworks/IceDiscovery.xcframework"
         ),
         .binaryTarget(
             name: "IceLocatorDiscoveryCpp",
-            url: "https://download.zeroc.com/ice/3.8/IceLocatorDiscovery-3.8.2.xcframework.zip",
-            checksum: "95a2186f994cdc32eee2baef991c3b5f5c32d2cf6c6714932d70a3cb0338299a"
+            path: "cpp/lib/XCFrameworks/IceLocatorDiscovery.xcframework"
         ),
         .binaryTarget(
             name: "slice2swift",
-            url: "https://download.zeroc.com/ice/3.8/slice2swift-3.8.2.artifactbundle.zip",
-            checksum: "8f56e65809f8a5b858a470ad2d4dc1b9249a9a29249764f68c0215f4719d4817"
+            path: "cpp/bin/slice2swift.artifactbundle.zip"
         ),
         .plugin(
             name: "CompileSlice",


### PR DESCRIPTION
The 3.8 branch still carries the released 3.8.2 xcframework URLs written into `Package.swift` by the 3.8.2 release commit, so SwiftPM downloads Ice 3.8.2 and the entire Swift test suite runs against the published binaries instead of the C++ built from the branch. `Ice/proxy` is the first Swift test to notice, because the backport of #6304 changed how a negative `LocatorCacheTimeout` property is normalized.

- Point the four binary targets back at `cpp/lib/XCFrameworks/*.xcframework` and `cpp/bin/slice2swift.artifactbundle.zip`, matching `main`.

Release tags still need the download URLs; `packaging/swift/update-ice-swift-nightly.sh` already rewrites either form, and the 3.8.2 release commit shows the same conversion being made at tag time.