### PR TITLE
Fix a race in the DataStorm events initialization key filter test

### DIFF
--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -399,6 +399,10 @@ void ::Reader::run(int argc, char* argv[])
         auto reader = makeFilteredKeyReader(topic, Filter<string>("throwOnKey", "k1"), "", config);
         test(reader.getNextUnread().getKey() == "k2");
         test(reader.getNextUnread().getKey() == "sentinel");
+
+        auto done = makeSingleKeyWriter(readyTopic, "done");
+        done.waitForReaders(1);
+        done.add("done");
     }
 
     {

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -426,8 +426,10 @@ void ::Writer::run(int argc, char* argv[])
         auto ready = makeSingleKeyWriter(readyTopic, "ready", "", config);
         ready.add("go");
 
-        writer.waitForReaders(1);
-        writer.waitForNoReaders();
+        // The reader acknowledges on the ready topic once it has read all its samples; keep the writers alive until
+        // then.
+        auto done = makeSingleKeyReader(readyTopic, "done");
+        test(done.getNextUnread().getValue() == "done");
     }
     cout << "ok" << endl;
 


### PR DESCRIPTION
The `DataStorm/events` test hangs on 3.8 in the `debug on ubuntu-24.04` job, timing out on "testing filtered reader whose key filter throws during initialization". The writer waits for the reader to detach while the reader is still reading, so neither side makes progress.

- Cherry-pick #6633, which has the reader acknowledge on the ready topic and the writer wait for that acknowledgement.