### PR TITLE
Remove stray blank line in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -72,7 +72,6 @@ let package = Package(
         .binaryTarget(
             name: "IceDiscoveryCpp",
             path: "cpp/lib/XCFrameworks/IceDiscovery.xcframework"
-
         ),
         .binaryTarget(
             name: "IceLocatorDiscoveryCpp",


### PR DESCRIPTION
`Package.swift` has a stray blank line inside the `IceDiscoveryCpp` binary target, between the `path:` argument and the closing paren. `swift-format` doesn't flag it — `respectsExistingLineBreaks` plus `maximumBlankLines: 1` make it legal.

- Drop the blank line so the target matches the other `binaryTarget` entries.