### PR TITLE
Fix Makefile Generation: Escape Special Characters and Handle Multiple Source Files

### DIFF
--- a/changelog.d/general/depend-makefile-output.md
+++ b/changelog.d/general/depend-makefile-output.md
@@ -1,0 +1,4 @@
+- The Makefile dependency output of the Slice compilers (`--depend`) now escapes file names holding
+  Make-significant characters: spaces, `#`, and `$`.
+- `--depend --depend-file FILE` now writes a rule for every Slice file passed to the compiler; previously the
+  dependency file only kept the last Slice file's rule.

--- a/cpp/cmake/slice2cpp_depend.cmake
+++ b/cpp/cmake/slice2cpp_depend.cmake
@@ -11,11 +11,12 @@
 #   DEPFILE            - output path for the generated .d file
 
 # Escapes a path the way compiler depfiles do, so it can be compared or joined with the paths
-# slice2cpp writes (zeroc-ice/ice#6329).
+# slice2cpp writes: '$'->'$$', '#'->'\#', whitespace get a preceding backslash,
+# and a run of backslashes immediately before whitespace is doubled.
 function(escape_depfile_path out_var path)
     string(REPLACE "$" "$$" path "${path}")
     string(REPLACE "#" "\\#" path "${path}")
-    string(REPLACE " " "\\ " path "${path}")
+    string(REGEX REPLACE "(\\\\*)([ \t])" "\\1\\1\\\\\\2" path "${path}")
     set(${out_var} "${path}" PARENT_SCOPE)
 endfunction()
 

--- a/cpp/cmake/slice2cpp_depend.cmake
+++ b/cpp/cmake/slice2cpp_depend.cmake
@@ -10,6 +10,15 @@
 #   EXPECTED_HEADER    - header name declared to CMake, checked against what slice2cpp will write
 #   DEPFILE            - output path for the generated .d file
 
+# Escapes a path the way compiler depfiles do, so it can be compared or joined with the paths
+# slice2cpp writes (zeroc-ice/ice#6329).
+function(escape_depfile_path out_var path)
+    string(REPLACE "$" "$$" path "${path}")
+    string(REPLACE "#" "\\#" path "${path}")
+    string(REPLACE " " "\\ " path "${path}")
+    set(${out_var} "${path}" PARENT_SCOPE)
+endfunction()
+
 set(include_options "")
 foreach(dir IN LISTS SLICE_INCLUDE_DIRS)
     list(APPEND include_options "-I${dir}")
@@ -39,9 +48,11 @@ if(NOT depend_output MATCHES "^([^:]+): \\\\")
 endif()
 set(actual_header "${CMAKE_MATCH_1}")
 
-# --depend names the header slice2cpp will actually write, cpp:header-ext metadata included. Report
-# a mismatch here rather than rerun forever a command whose declared output never appears.
-if(NOT actual_header STREQUAL EXPECTED_HEADER)
+# --depend names the header slice2cpp will actually write, cpp:header-ext metadata included, in
+# depfile-escaped form. Report a mismatch here rather than rerun forever a command whose declared
+# output never appears.
+escape_depfile_path(expected_header_escaped "${EXPECTED_HEADER}")
+if(NOT actual_header STREQUAL expected_header_escaped)
     message(FATAL_ERROR
         "slice2cpp generates '${actual_header}' for ${SLICE_FILE}, but slice2cpp_generate declared "
         "'${EXPECTED_HEADER}'. Set the extension with OPTIONS --header-ext; cpp:header-ext metadata "
@@ -49,11 +60,8 @@ if(NOT actual_header STREQUAL EXPECTED_HEADER)
 endif()
 
 # The prefix is a path slice2cpp never sees, so escape it here the way compiler depfiles escape
-# paths. The paths slice2cpp itself writes are its own to escape (zeroc-ice/ice#6329).
-set(header_dir_escaped "${HEADER_DIR}")
-string(REPLACE "$" "$$" header_dir_escaped "${header_dir_escaped}")
-string(REPLACE "#" "\\#" header_dir_escaped "${header_dir_escaped}")
-string(REPLACE " " "\\ " header_dir_escaped "${header_dir_escaped}")
+# paths. The paths slice2cpp itself writes arrive already escaped.
+escape_depfile_path(header_dir_escaped "${HEADER_DIR}")
 
 string(LENGTH "${actual_header}" target_length)
 string(SUBSTRING "${depend_output}" ${target_length} -1 depend_tail)

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -129,6 +129,40 @@ namespace
         os << '"';
         return os.str();
     }
+
+    // Escapes a file name for use in a Makefile rule, following the escaping rules GCC uses in the dependency
+    // files it emits: '$' becomes '$$'; '#', space, and tab get a preceding backslash; and backslashes
+    // immediately preceding a space or tab are doubled.
+    string escapeMakefilePath(string_view name)
+    {
+        ostringstream os;
+        size_t backslashes = 0;
+        for (char c : name)
+        {
+            switch (c)
+            {
+                case ' ':
+                case '\t':
+                    for (size_t i = 0; i < backslashes; ++i)
+                    {
+                        os << '\\';
+                    }
+                    os << '\\';
+                    break;
+                case '#':
+                    os << '\\';
+                    break;
+                case '$':
+                    os << '$';
+                    break;
+                default:
+                    break;
+            }
+            backslashes = (c == '\\') ? backslashes + 1 : 0;
+            os << c;
+        }
+        return os.str();
+    }
 }
 
 string
@@ -726,30 +760,23 @@ Slice::DependencyGenerator::addDependenciesFor(const UnitPtr& unit)
 }
 
 void
-Slice::DependencyGenerator::writeMakefileDependencies(
-    const string& dependFile,
-    const string& source,
-    const string& target)
+Slice::DependencyGenerator::addMakefileRule(const string& source, const string& target)
+{
+    _makefileRules.emplace_back(source, target);
+}
+
+void
+Slice::DependencyGenerator::writeMakefileDependencies(const string& dependFile)
 {
     ostringstream os;
-    StringList dependencies = _dependencyMap[source];
-    // Write the target
-    if (dependencies.empty())
+    for (const auto& [source, target] : _makefileRules)
     {
-        os << target << ":" << std::endl;
-    }
-    else
-    {
-        os << target << ": \\" << std::endl;
-        for (const auto& dependency : dependencies)
+        os << escapeMakefilePath(target) << ":";
+        for (const auto& dependency : _dependencyMap[source])
         {
-            os << " " << dependency;
-            if (dependency != dependencies.back())
-            {
-                os << " \\";
-            }
-            os << std::endl;
+            os << " \\" << endl << " " << escapeMakefilePath(dependency);
         }
+        os << endl;
     }
     writeDependencies(os.str(), dependFile);
 }

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -96,14 +96,20 @@ namespace Slice
     public:
         void addDependenciesFor(const UnitPtr& unit);
 
+        /// Records a Makefile rule for a file that is generated from the specified source. The rule's prerequisites
+        /// are the dependencies recorded for the source by addDependenciesFor.
+        ///
+        /// @param source The source file that the target is generated from.
+        /// @param target The generated file, used as the Makefile target.
+        void addMakefileRule(const std::string& source, const std::string& target);
+
         /// Writes the dependencies in Makefile format to the specified file. If 'dependFile' is empty, it writes the
         /// dependencies to standard output instead.
         ///
+        /// This method writes one rule for each target recorded with addMakefileRule.
+        ///
         /// @param dependFile The file to write the dependencies to or empty to write to standard output.
-        /// @param source The source file for which dependencies are being written.
-        /// @param target The target file that is generated from the source. This is used as the Makefile target.
-        void
-        writeMakefileDependencies(const std::string& dependFile, const std::string& source, const std::string& target);
+        void writeMakefileDependencies(const std::string& dependFile);
 
         /// Writes the dependencies in XML format to the specified file. If 'dependFile' is empty, it writes the
         /// dependencies to standard output instead.
@@ -123,6 +129,9 @@ namespace Slice
 
     private:
         std::map<std::string, StringList> _dependencyMap;
+
+        // The rules recorded by addMakefileRule: (source, target) pairs, in recording order.
+        std::vector<std::pair<std::string, std::string>> _makefileRules;
     };
 
     /// Helper method to create the directory structure for a package path.

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -235,9 +235,9 @@ compile(const vector<string>& argv)
                     assert(dc);
                     string target = removeExtension(baseName(fileName)) + "." +
                                     dc->getMetadataArgs("cpp:header-ext").value_or(headerExtension);
-                    dependencyGenerator.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                    dependencyGenerator.addMakefileRule(unit->topLevelFile(), target);
                 }
-                // else XML dependencies are written below after all units have been processed.
+                // The dependencies are written below, after all units have been processed.
             }
             else
             {
@@ -291,7 +291,11 @@ compile(const vector<string>& argv)
         return status;
     }
 
-    if (dependXML)
+    if (depend)
+    {
+        dependencyGenerator.writeMakefileDependencies(dependFile);
+    }
+    else if (dependXML)
     {
         dependencyGenerator.writeXMLDependencies(dependFile);
     }

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -217,9 +217,9 @@ compile(const vector<string>& argv)
                 {
                     string target = removeExtension(baseName(fileName)) +
                                     (genMode == Slice::GenMode::IceRpc ? ".IceRpc.cs" : ".cs");
-                    dependencyGenerator.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                    dependencyGenerator.addMakefileRule(unit->topLevelFile(), target);
                 }
-                // else XML dependencies are written below after all units have been processed.
+                // The dependencies are written below, after all units have been processed.
             }
             else
             {
@@ -268,7 +268,11 @@ compile(const vector<string>& argv)
         return status;
     }
 
-    if (dependXML)
+    if (depend)
+    {
+        dependencyGenerator.writeMakefileDependencies(dependFile);
+    }
+    else if (dependXML)
     {
         dependencyGenerator.writeXMLDependencies(dependFile);
     }

--- a/cpp/src/slice2js/Main.cpp
+++ b/cpp/src/slice2js/Main.cpp
@@ -228,9 +228,9 @@ compile(const vector<string>& argv)
                 if (depend)
                 {
                     string target = removeExtension(baseName(fileName)) + ".js";
-                    dependencyGenerator.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                    dependencyGenerator.addMakefileRule(unit->topLevelFile(), target);
                 }
-                // Else JSON and XML dependencies are written below after all units have been processed.
+                // The dependencies are written below, after all units have been processed.
             }
             else
             {
@@ -285,7 +285,11 @@ compile(const vector<string>& argv)
         return status;
     }
 
-    if (dependJSON)
+    if (depend)
+    {
+        dependencyGenerator.writeMakefileDependencies(dependFile);
+    }
+    else if (dependJSON)
     {
         dependencyGenerator.writeJSONDependencies(dependFile);
     }

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -1267,9 +1267,9 @@ compile(const vector<string>& argv)
                 if (depend)
                 {
                     string target = removeExtension(baseName(fileName)) + ".php";
-                    dependencyGenerator.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                    dependencyGenerator.addMakefileRule(unit->topLevelFile(), target);
                 }
-                // Else XML dependencies are handled below after all units have been processed.
+                // The dependencies are written below, after all units have been processed.
             }
             else
             {
@@ -1330,7 +1330,11 @@ compile(const vector<string>& argv)
         return status;
     }
 
-    if (dependXML)
+    if (depend)
+    {
+        dependencyGenerator.writeMakefileDependencies(dependFile);
+    }
+    else if (dependXML)
     {
         dependencyGenerator.writeXMLDependencies(dependFile);
     }

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -3336,9 +3336,10 @@ Slice::Python::compile(const vector<string>& args)
         {
             for (const auto& file : files)
             {
-                dependencyGenerator->writeMakefileDependencies(dependFile, source, file);
+                dependencyGenerator->addMakefileRule(source, file);
             }
         }
+        dependencyGenerator->writeMakefileDependencies(dependFile);
     }
     else if (dependXML)
     {

--- a/cpp/src/slice2rb/Ruby.cpp
+++ b/cpp/src/slice2rb/Ruby.cpp
@@ -171,9 +171,9 @@ Slice::Ruby::compile(const vector<string>& argv)
                 if (depend)
                 {
                     string target = removeExtension(baseName(fileName)) + ".rb";
-                    dependencyGenerator.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                    dependencyGenerator.addMakefileRule(unit->topLevelFile(), target);
                 }
-                // Else XML dependencies are written below after all units have been processed.
+                // The dependencies are written below, after all units have been processed.
             }
             else
             {
@@ -241,7 +241,11 @@ Slice::Ruby::compile(const vector<string>& argv)
         return status;
     }
 
-    if (dependXML)
+    if (depend)
+    {
+        dependencyGenerator.writeMakefileDependencies(dependFile);
+    }
+    else if (dependXML)
     {
         dependencyGenerator.writeXMLDependencies(dependFile);
     }

--- a/cpp/src/slice2swift/Main.cpp
+++ b/cpp/src/slice2swift/Main.cpp
@@ -195,9 +195,9 @@ compile(const vector<string>& argv)
                 if (depend)
                 {
                     string target = removeExtension(baseName(fileName)) + ".swift";
-                    dependencyGenerator.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                    dependencyGenerator.addMakefileRule(unit->topLevelFile(), target);
                 }
-                // Else XML dependencies are written below after all units have been processed.
+                // The dependencies are written below, after all units have been processed.
             }
             else
             {
@@ -243,7 +243,11 @@ compile(const vector<string>& argv)
         return status;
     }
 
-    if (dependXML)
+    if (depend)
+    {
+        dependencyGenerator.writeMakefileDependencies(dependFile);
+    }
+    else if (dependXML)
     {
         dependencyGenerator.writeXMLDependencies(dependFile);
     }

--- a/cpp/test/Slice/dependencies/my project/g.ice
+++ b/cpp/test/Slice/dependencies/my project/g.ice
@@ -1,0 +1,9 @@
+#include "../slices/a.ice"
+
+module Test
+{
+    interface G
+    {
+        void op(A a);
+    }
+}

--- a/cpp/test/Slice/dependencies/test.py
+++ b/cpp/test/Slice/dependencies/test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import xml.etree.ElementTree as ElementTree
 
 from Util import ClientTestCase, Driver, SliceTranslator, TestSuite
@@ -11,6 +12,10 @@ from Util import ClientTestCase, Driver, SliceTranslator, TestSuite
 # e.ice and f.ice sit in a directory whose name holds an XML-significant character, so both the source and the
 # dependency entries of e.ice are only parsable when the compiler escapes the file names it writes.
 ampersandDirectory = "a&b"
+
+# g.ice sits in a directory whose name holds a space, which separates prerequisites in Makefile rules, so its rule
+# only parses back into complete paths when the compiler escapes the file names it writes.
+spaceDirectory = "my project"
 
 # The expected dependencies of the compiled sources, keyed by the directory and file name of the source.
 expectedDependencies = {
@@ -20,6 +25,7 @@ expectedDependencies = {
         os.path.join("slices", "a.ice"),
         os.path.join(ampersandDirectory, "f.ice"),
     ],
+    os.path.join(spaceDirectory, "g.ice"): [os.path.join("slices", "a.ice")],
 }
 
 
@@ -31,6 +37,7 @@ class SliceDependenciesTestCase(ClientTestCase):
             os.path.join("slices", "c.ice"),
             os.path.join("slices", "d.ice"),
             os.path.join(ampersandDirectory, "e.ice"),
+            os.path.join(spaceDirectory, "g.ice"),
         ]
 
         current.write("testing dependencies in JSON format... ")
@@ -49,6 +56,25 @@ class SliceDependenciesTestCase(ClientTestCase):
         os.remove("depend.xml")
         current.writeln("ok")
 
+        current.write("testing dependencies in Makefile format... ")
+        slice2js.run(current, args=["--depend", "--depend-file", "depend.mk"] + sources)
+        with open("depend.mk", encoding="utf-8") as file:
+            rules = self.parseMakefileRules(file.read())
+
+        # Each source produces one rule: the target is derived from the source's file name, and the source itself is
+        # the rule's first prerequisite.
+        dependencies = {}
+        for target, prerequisites in rules.items():
+            if not prerequisites:
+                raise RuntimeError("failed! the rule for {0} has no prerequisites".format(target))
+            source = prerequisites[0]
+            if target != os.path.basename(source).replace(".ice", ".js"):
+                raise RuntimeError("failed! expected a rule for {0} but got {1}".format(source, target))
+            dependencies[source] = prerequisites[1:]
+        self.checkDependencies(dependencies)
+        os.remove("depend.mk")
+        current.writeln("ok")
+
     def checkDependencies(self, dependencies: dict[str, list[str]]) -> None:
         # The sources and their dependencies are reported as absolute paths; compare the directory and file name,
         # so that a directory holding an XML-significant character must come back spelled exactly as it is on disk.
@@ -62,6 +88,21 @@ class SliceDependenciesTestCase(ClientTestCase):
 
     def tail(self, path: str) -> str:
         return os.path.join(os.path.basename(os.path.dirname(path)), os.path.basename(path))
+
+    def parseMakefileRules(self, text: str) -> dict[str, list[str]]:
+        # Join the continuation lines, then split each rule on its first ':' into a target and its prerequisites.
+        # Prerequisites are separated by unescaped whitespace; unescape the file names once they are split apart.
+        rules = {}
+        for line in text.replace("\\\n", "").splitlines():
+            if line.strip():
+                target, _, prerequisites = line.partition(":")
+                rules[self.unescape(target)] = [
+                    self.unescape(prerequisite) for prerequisite in re.split(r"(?<!\\)\s+", prerequisites.strip())
+                ]
+        return rules
+
+    def unescape(self, path: str) -> str:
+        return path.replace("\\ ", " ").replace("\\#", "#").replace("$$", "$")
 
 
 TestSuite(__name__, [SliceDependenciesTestCase()], chdir=True)


### PR DESCRIPTION
This PR fixes both #6329 and #6330, which dealt with bugs in our Makefile generation.

The first bug was that we were not escaping Makefile-special characters in file-paths, which would cause us to generate invalid Makefiles if they appeared in the path of a Slice file.

The 2nd bug was that we would only ever write a single source's rule. So, in the case where a user provided more than 1 Slice source file to a compiler, only the last file would have it's Makefile generated correctly.

----

A changelog fragment was included for both fixes. Since even something as simple as a space character would break Makefiles and need escaping. And compiling multiple Slice files at once is a common and clearly supported behavior. And both of these bugs caused user-facing issues.