### PR TITLE
Reject non-.md entries in changelog.d section directories

### DIFF
--- a/scripts/collate_changelog.py
+++ b/scripts/collate_changelog.py
@@ -65,7 +65,9 @@ def read_fragments(changelog_d: Path) -> dict[str, list[str]]:
             die(f"unexpected file {path}: fragments belong in a section directory")
         if path.name not in known:
             die(f"unknown section directory {path}: add it to the taxonomy in {Path(__file__).name} first")
-        for fragment in sorted(path.glob("*.md")):
+        for fragment in sorted(path.iterdir()):
+            if not fragment.is_file() or fragment.suffix != ".md":
+                die(f"unexpected entry {fragment}: a section directory holds only .md fragments")
             text = fragment.read_text(encoding="utf-8").strip()
             if not text.startswith("- "):
                 die(f"{fragment} does not start with a '- ' bullet")


### PR DESCRIPTION
A fragment saved as anything but `<section>/<name>.md` — a fumbled extension, an editor backup, a nested directory —
is passed over without a word, so the change it documents misses its release while the script reports success and
deletes everything around it. An unexpected file directly under `changelog.d/` is already a hard error; one level
down, the loop just globs and moves on:

https://github.com/zeroc-ice/ice/blob/afb766d1cd6b1a4968b4cd1dd70f8124badd7cad/scripts/collate_changelog.py#L64-L68

- `read_fragments` now fails on any entry in a section directory that is not an `.md` file, matching the strictness it
  already applies to `changelog.d` itself.
- The collated output is unchanged for a well-formed `changelog.d`; no misnamed fragment has been committed to date.
