### PR TITLE
Remove changelog.d fragments backported to Ice 3.8

### DIFF
--- a/changelog.d/cpp/6620.md
+++ b/changelog.d/cpp/6620.md
@@ -1,6 +1,0 @@
-- Fixed syslog logging (`Ice.UseSyslog=1`) with multiple communicators in the same process. Previously, each
-  communicator opened and closed the process-global syslog connection independently, corrupting the shared logging
-  state. All communicators now share a single syslog connection: the first communicator's program name provides the
-  syslog ident, and a communicator with a different program name logs it at the beginning of each message. In
-  particular, an IceBox server configured with `Ice.UseSyslog=1` and `IceBox.InheritProperties=1` now logs all its
-  services to syslog.

--- a/changelog.d/general/depend-makefile-output.md
+++ b/changelog.d/general/depend-makefile-output.md
@@ -1,4 +1,0 @@
-- The Makefile dependency output of the Slice compilers (`--depend`) now escapes file names holding
-  Make-significant characters: spaces, `#`, and `$`.
-- `--depend --depend-file FILE` now writes a rule for every Slice file passed to the compiler; previously the
-  dependency file only kept the last Slice file's rule.

--- a/changelog.d/ruby/ruby-comparison-semantics.md
+++ b/changelog.d/ruby/ruby-comparison-semantics.md
@@ -1,4 +1,0 @@
-- The comparison methods (`<=>`, `==`, `eql?`) of Ice types in Ruby (Slice-generated enums, `Ice::Identity`,
-  `Ice::ObjectPrx`, and `Ice::Endpoint`) now follow standard Ruby semantics for an operand of a different type: `==`
-  and `eql?` return `false` and `<=>` returns `nil`, instead of raising an exception. On enums, which are
-  `Comparable`, ordered comparisons such as `<` still raise `ArgumentError`.

--- a/changelog.d/service-icegrid/reaper-destroyed-sessions.md
+++ b/changelog.d/service-icegrid/reaper-destroyed-sessions.md
@@ -1,4 +1,0 @@
-- Fixed a slow memory accumulation in the IceGrid registry: a session destroyed by the client was retained by the
-  registry until the connection used to create this session closed. This affects only registries with no node (a
-  common setup when using dynamic registration) and no replica, with sessions created and destroyed through Glacier2,
-  as Glacier2 maintains a long-lived connection to the registry.

--- a/changelog.d/swift/6629.md
+++ b/changelog.d/swift/6629.md
@@ -1,3 +1,0 @@
-- The CompileSlice plugin now tracks Slice include dependencies: editing a Slice file included by other Slice files
-  regenerates the Swift code for those files as well. The plugin also regenerates the Swift code when `slice2swift`
-  itself changes.


### PR DESCRIPTION
These five fixes were cherry-picked to the 3.8 branch and ship in Ice 3.8.3, so they are documented in
`CHANGELOG-3.8.md` rather than the 3.9 changelog. Collated by #6665. Follows the convention of 474ba6fb76, #6157,
and #6612.

After this change `main`'s `changelog.d/` contains only `README.md`.
