### PR TITLE
MATLAB: reject encoding 1.0 object reference with index INT32_MIN

### DIFF
--- a/matlab/lib/+IceInternal/EncapsDecoder10.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder10.m
@@ -30,7 +30,7 @@ classdef (Hidden) EncapsDecoder10 < IceInternal.EncapsDecoder
             % Object references are encoded as a negative integer in 1.0.
             %
             index = obj.is.readInt();
-            if index > 0
+            if index > 0 || index == intmin('int32')
                 throw(Ice.MarshalException('invalid object id'));
             end
             index = -index;


### PR DESCRIPTION
In the 1.0 encoding, an object reference is marshaled as a negative index. #6160 made C++ and Swift throw `MarshalException` with `invalid object id` when this index is `INT32_MIN`, whose negation does not fit in an `int32`.

This PR applies the same guard to the MATLAB decoder. Previously, `readValue` in `EncapsDecoder10` negated the index with MATLAB's saturating `int32` arithmetic, turning `INT32_MIN` into `intmax('int32')`; decoding then failed later with a misleading error about an unresolved instance. The check uses `intmin('int32')`, which is an `int32`-typed value like the index returned by `readInt`.

This is a diagnostic improvement for malformed input only — MATLAB already rejected the message — so there is no changelog entry.

Fixes #6668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
