### PR TITLE
Replace 'Thrown if' with 'Thrown when' in doc comments

### DIFF
--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -23,7 +23,7 @@ module IceStormElection
     /// A sequence of topic content.
     sequence<TopicContent> TopicContentSeq;
 
-    /// Thrown if an observer detects an inconsistency.
+    /// Thrown when an observer detects an inconsistency.
     exception ObserverInconsistencyException
     {
         /// The reason for the inconsistency.

--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -23,7 +23,7 @@ module IceStormElection
     /// A sequence of topic content.
     sequence<TopicContent> TopicContentSeq;
 
-    /// Thrown when an observer detects an inconsistency.
+    /// The exception that is thrown when an observer detects an inconsistency.
     exception ObserverInconsistencyException
     {
         /// The reason for the inconsistency.

--- a/cpp/src/IceStorm/IceStormInternal.ice
+++ b/cpp/src/IceStorm/IceStormInternal.ice
@@ -40,7 +40,7 @@ module IceStorm
         void forward(EventDataSeq events);
     }
 
-    /// Thrown when the {@link TopicInternal::reap} call would block.
+    /// The exception that is thrown when the {@link TopicInternal::reap} call would block.
     exception ReapWouldBlock
     {
     }

--- a/cpp/src/IceStorm/IceStormInternal.ice
+++ b/cpp/src/IceStorm/IceStormInternal.ice
@@ -40,7 +40,7 @@ module IceStorm
         void forward(EventDataSeq events);
     }
 
-    /// Thrown if the {@link TopicInternal::reap} call would block.
+    /// Thrown when the {@link TopicInternal::reap} call would block.
     exception ReapWouldBlock
     {
     }

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -499,7 +499,7 @@ Slice::IceRpc::TypesVisitor::visitEnum(const EnumPtr& p)
     writeDocLine(
         _out,
         R"(exception cref="System.IO.InvalidDataException")",
-        "Thrown if the integer value does not correspond to any enumerator of " + escapedName + ".",
+        "Thrown when the integer value does not correspond to any enumerator of " + escapedName + ".",
         "exception");
     _out << nl << accessModifier(p) << " static " << escapedName << " As" << name << "(this int value) =>";
     _out.inc();

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2649,7 +2649,7 @@ Slice::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << " * @param communicator - The communicator for the new proxy.";
     _out << nl << " * @param proxyString - The string representation of the proxy.";
     _out << nl << " * @returns The new " << prxName << " proxy.";
-    _out << nl << " * @throws ParseException - Thrown if the proxyString is not a valid proxy string.";
+    _out << nl << " * @throws ParseException - Thrown when the proxyString is not a valid proxy string.";
     _out << nl << " */";
     _out << nl << "constructor(communicator: " << _iceImportPrefix << "Ice.Communicator, proxyString: string);";
 

--- a/csharp/src/Ice/LocalExceptions.cs
+++ b/csharp/src/Ice/LocalExceptions.cs
@@ -32,7 +32,7 @@ public class DispatchException : LocalException
     /// <param name="replyStatus">The reply status. It must be greater than <see cref="ReplyStatus.UserException" />.
     /// </param>
     /// <param name="message">The exception message.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="replyStatus" /> is equal to <see
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="replyStatus" /> is equal to <see
     /// cref="ReplyStatus.Ok" /> or <see cref="ReplyStatus.UserException" />.</exception>
     public DispatchException(ReplyStatus replyStatus, string? message = null)
         : base(message ?? $"The dispatch failed with reply status {replyStatus}.") =>

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -406,7 +406,7 @@ public sealed class ObjectAdapter
     /// <returns>This object adapter.</returns>
     /// <remarks>All middleware must be installed before the first dispatch. The middleware are executed in the order
     /// they are installed.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown if the object adapter's dispatch pipeline has already been
+    /// <exception cref="InvalidOperationException">Thrown when the object adapter's dispatch pipeline has already been
     /// created. This creation typically occurs the first time the object adapter dispatches an incoming request.
     /// </exception>
     public ObjectAdapter use(Func<Object, Object> middleware)

--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -94,7 +94,7 @@ public sealed class Properties
     /// </summary>
     /// <param name="key">The property key.</param>
     /// <returns>The property value or the default value.</returns>
-    /// <exception cref="PropertyException">Thrown if the property is not a known Ice property.</exception>
+    /// <exception cref="PropertyException">Thrown when the property is not a known Ice property.</exception>
     public string getIceProperty(string key) => getPropertyWithDefault(key, getDefaultProperty(key));
 
     /// <summary>
@@ -124,7 +124,7 @@ public sealed class Properties
     /// </summary>
     /// <param name="key">The property key.</param>
     /// <returns>The property value interpreted as an integer.</returns>
-    /// <exception cref="PropertyException">Thrown if the property value is not a valid integer.</exception>
+    /// <exception cref="PropertyException">Thrown when the property value is not a valid integer.</exception>
     public int getPropertyAsInt(string key) => getPropertyAsIntWithDefault(key, 0);
 
     /// <summary>
@@ -133,7 +133,7 @@ public sealed class Properties
     /// </summary>
     /// <param name="key">The property key.</param>
     /// <returns>The property value interpreted as an integer, or the default value.</returns>
-    /// <exception cref="PropertyException">Thrown if the property is not a known Ice property or the value is not a
+    /// <exception cref="PropertyException">Thrown when the property is not a known Ice property or the value is not a
     /// valid integer.</exception>
     public int getIcePropertyAsInt(string key)
     {
@@ -154,7 +154,7 @@ public sealed class Properties
     /// <param name="key">The property key.</param>
     /// <param name="value">The default value to use if the property does not exist.</param>
     /// <returns>The property value interpreted as an integer, or the default value.</returns>
-    /// <exception cref="PropertyException">Thrown if the property value is not a valid integer.</exception>
+    /// <exception cref="PropertyException">Thrown when the property value is not a valid integer.</exception>
     public int getPropertyAsIntWithDefault(string key, int value)
     {
         lock (_mutex)
@@ -197,7 +197,7 @@ public sealed class Properties
     /// </summary>
     /// <param name="key">The property key.</param>
     /// <returns>The property value interpreted as list of strings, or the default value.</returns>
-    /// <exception cref="PropertyException">Thrown if the property is not a known Ice property.</exception>
+    /// <exception cref="PropertyException">Thrown when the property is not a known Ice property.</exception>
     public string[] getIcePropertyAsList(string key)
     {
         string[] defaultList = UtilInternal.StringUtil.splitString(getDefaultProperty(key), ", \t\r\n");
@@ -463,7 +463,7 @@ public sealed class Properties
     /// <param name="prefix">The property prefix to validate.</param>
     /// <param name="properties">The properties to consider. </param>
     /// <param name="propertyArray">The property array to search against.</param>
-    /// <exception cref="PropertyException"> Thrown if unknown properties are found.</exception>
+    /// <exception cref="PropertyException">Thrown when unknown properties are found.</exception>
     internal static void validatePropertiesWithPrefix(
         string prefix,
         Properties properties,
@@ -579,7 +579,7 @@ public sealed class Properties
     /// </summary>
     /// <param name="key">The Ice property key.</param>
     /// <returns>The default property value, or an empty string if the default is unspecified.</returns>
-    /// <exception cref="PropertyException">Thrown if the property is not a known Ice property.</exception>
+    /// <exception cref="PropertyException">Thrown when the property is not a known Ice property.</exception>
     private static string getDefaultProperty(string key)
     {
         // Find the property, don't log any warnings.

--- a/js/packages/ice/src/Ice/Communicator.d.ts
+++ b/js/packages/ice/src/Ice/Communicator.d.ts
@@ -21,7 +21,7 @@ declare module "@zeroc/ice" {
              * default options.
              *
              * @param initData The optional initialization data for the new communicator.
-             * @throws {@link InitializationException} If an error occurs during initialization.
+             * @throws {@link InitializationException} - Thrown when an error occurs during initialization.
              */
             constructor(initData?: InitializationData);
 
@@ -30,7 +30,7 @@ declare module "@zeroc/ice" {
              *
              * @param args A command-line argument vector. Any Ice-related options in this vector are used to initialize
              * the communicator. This method modifies the argument vector by removing any Ice-related options.
-             * @throws {@link InitializationException} If an error occurs during initialization.
+             * @throws {@link InitializationException} - Thrown when an error occurs during initialization.
              */
             constructor(args: string[]);
 

--- a/js/packages/ice/src/Ice/Connection.d.ts
+++ b/js/packages/ice/src/Ice/Connection.d.ts
@@ -116,8 +116,8 @@ declare module "@zeroc/ice" {
 
             /**
              * Throw an exception indicating the reason for connection closure. For example,
-             * {@link CloseConnectionException} is raised if the connection was closed gracefully by the peer, whereas
-             * {@link ConnectionAbortedException}/{@link ConnectionClosedException} is raised if the connection was
+             * {@link CloseConnectionException} is thrown when the connection was closed gracefully by the peer, whereas
+             * {@link ConnectionAbortedException}/{@link ConnectionClosedException} is thrown when the connection was
              * manually closed by the application. This operation does nothing if the connection is not yet closing
              * or closed.
              */

--- a/js/packages/ice/src/Ice/Initialize.d.ts
+++ b/js/packages/ice/src/Ice/Initialize.d.ts
@@ -11,7 +11,7 @@ declare module "@zeroc/ice" {
          *
          * @param initData The optional initialization data for the new communicator.
          * @returns The initialized communicator.
-         * @throws {@link InitializationException} If an error occurs during initialization.
+         * @throws {@link InitializationException} - Thrown when an error occurs during initialization.
          */
         function initialize(initData?: InitializationData): Communicator;
 
@@ -24,7 +24,7 @@ declare module "@zeroc/ice" {
          * @param args A command-line argument vector. Any Ice-related options in this vector are used to initialize
          * the communicator. This method modifies the argument vector by removing any Ice-related options.
          * @returns The initialized communicator.
-         * @throws {@link InitializationException} If an error occurs during initialization.
+         * @throws {@link InitializationException} - Thrown when an error occurs during initialization.
          */
         function initialize(args: string[]): Communicator;
 

--- a/js/packages/ice/src/Ice/ObjectAdapter.d.ts
+++ b/js/packages/ice/src/Ice/ObjectAdapter.d.ts
@@ -42,7 +42,7 @@ declare module "@zeroc/ice" {
              * creates its dispatch pipeline. A middleware factory is a function that takes an Object (the next element
              * in the dispatch pipeline) and returns a new Object (the middleware you want to install in the pipeline).
              * @returns This object adapter.
-             * @throws `Error` Thrown if the object adapter's dispatch pipeline has already been
+             * @throws `Error` Thrown when the object adapter's dispatch pipeline has already been
              * created. This creation typically occurs the first time the object adapter dispatches an incoming request.
              */
             use(middlewareFactory: (next: Ice.Object) => Ice.Object): ObjectAdapter;

--- a/js/packages/ice/src/Ice/ObjectAdapter.d.ts
+++ b/js/packages/ice/src/Ice/ObjectAdapter.d.ts
@@ -42,7 +42,7 @@ declare module "@zeroc/ice" {
              * creates its dispatch pipeline. A middleware factory is a function that takes an Object (the next element
              * in the dispatch pipeline) and returns a new Object (the middleware you want to install in the pipeline).
              * @returns This object adapter.
-             * @throws `Error` Thrown when the object adapter's dispatch pipeline has already been
+             * @throws `Error` - Thrown when the object adapter's dispatch pipeline has already been
              * created. This creation typically occurs the first time the object adapter dispatches an incoming request.
              */
             use(middlewareFactory: (next: Ice.Object) => Ice.Object): ObjectAdapter;
@@ -54,7 +54,7 @@ declare module "@zeroc/ice" {
              * @param servant The servant to add.
              * @param id The identity of the Ice object that is implemented by the servant.
              * @returns A proxy with the given id, created by this object adapter.
-             * @throws {@link AlreadyRegisteredException} Thrown when a servant with the same identity is already
+             * @throws {@link AlreadyRegisteredException} - Thrown when a servant with the same identity is already
              * registered.
              *
              * @see {@link Identity}
@@ -75,7 +75,7 @@ declare module "@zeroc/ice" {
              * @param id The identity of the Ice object that is implemented by the servant.
              * @param facet The facet of the Ice object that is implemented by the servant.
              * @returns A proxy with the given id and facet, created by this object adapter.
-             * @throws {@link AlreadyRegisteredException} Thrown when a servant with the same identity and facet is
+             * @throws {@link AlreadyRegisteredException} - Thrown when a servant with the same identity and facet is
              * already registered.
              */
             addFacet(servant: Ice.Object, id: Identity, facet: string): Ice.ObjectPrx;
@@ -120,7 +120,7 @@ declare module "@zeroc/ice" {
              * @param servant The default servant to add.
              * @param category The category for which the default servant is registered. The empty category means it will
              * handle all categories.
-             * @throws {@link AlreadyRegisteredException} Thrown when a default servant with the same category is
+             * @throws {@link AlreadyRegisteredException} - Thrown when a default servant with the same category is
              * already registered.
              */
             addDefaultServant(servant: Ice.Object, category: string): void;
@@ -129,7 +129,7 @@ declare module "@zeroc/ice" {
              * Removes a servant from the object adapter's Active Servant Map.
              * @param id The identity of the Ice object that is implemented by the servant.
              * @returns The removed servant.
-             * @throws {@link NotRegisteredException} Thrown when no servant with the given identity is registered.
+             * @throws {@link NotRegisteredException} - Thrown when no servant with the given identity is registered.
              */
             remove(id: Identity): Ice.Object;
 
@@ -138,7 +138,7 @@ declare module "@zeroc/ice" {
              * @param id The identity of the Ice object that is implemented by the servant.
              * @param facet The facet. An empty facet means the default facet.
              * @returns The removed servant.
-             * @throws {@link NotRegisteredException} Thrown when no servant with the given identity and facet is
+             * @throws {@link NotRegisteredException} - Thrown when no servant with the given identity and facet is
              * registered.
              */
             removeFacet(id: Identity, facet: string): Ice.Object;
@@ -148,7 +148,7 @@ declare module "@zeroc/ice" {
              * the Ice object, including its default facet.
              * @param id The identity of the Ice object to be removed.
              * @returns A collection containing all the facet names and servants of the removed Ice object.
-             * @throws {@link NotRegisteredException} Thrown when no servant with the given identity is registered.
+             * @throws {@link NotRegisteredException} - Thrown when no servant with the given identity is registered.
              */
             removeAllFacets(id: Identity): Map<string, Ice.Object>;
 
@@ -156,7 +156,7 @@ declare module "@zeroc/ice" {
              * Removes the default servant for a specific category.
              * @param category The category of the default servant to remove.
              * @returns The default servant.
-             * @throws {@link NotRegisteredException} Thrown when no default servant is registered for the given
+             * @throws {@link NotRegisteredException} - Thrown when no default servant is registered for the given
              * category.
              */
             removeDefaultServant(category: string): Ice.Object;
@@ -208,7 +208,7 @@ declare module "@zeroc/ice" {
              *
              * @param locator The servant locator to add.
              * @param category The category. The empty category means the locator handles all categories.
-             * @throws {@link AlreadyRegisteredException} Thrown when a servant locator with the same category is
+             * @throws {@link AlreadyRegisteredException} - Thrown when a servant locator with the same category is
              * already registered.
              */
             addServantLocator(locator: Ice.ServantLocator, category: string): void;
@@ -218,7 +218,7 @@ declare module "@zeroc/ice" {
              *
              * @param category The category.
              * @returns The servant locator.
-             * @throws {@link NotRegisteredException} Thrown when no servant locator with the given category is
+             * @throws {@link NotRegisteredException} - Thrown when no servant locator with the given category is
              * registered.
              */
             removeServantLocator(category: string): Ice.ServantLocator;
@@ -279,7 +279,7 @@ declare module "@zeroc/ice" {
             /**
              * Sets the endpoints that proxies created by this object adapter will contain.
              * @param newEndpoints The new set of endpoints that the object adapter will embed in proxies.
-             * @throws `Error` Thrown when the `newEndpoints` is empty or this adapter is associated with a router.
+             * @throws `Error` - Thrown when the `newEndpoints` is empty or this adapter is associated with a router.
              */
             setPublishedEndpoints(newEndpoints: Ice.Endpoint[]): void;
         }

--- a/js/packages/ice/src/Ice/ObjectPrx.d.ts
+++ b/js/packages/ice/src/Ice/ObjectPrx.d.ts
@@ -12,7 +12,7 @@ declare module "@zeroc/ice" {
              * @param communicator - The communicator for the new proxy.
              * @param proxyString - The string representation of the proxy.
              * @returns The newly constructed proxy.
-             * @throws {@link ParseException} - Thrown if the proxyString is not a valid proxy string.
+             * @throws {@link ParseException} - Thrown when the proxyString is not a valid proxy string.
              */
             constructor(communicator: Communicator, proxyString: string);
 

--- a/js/packages/ice/src/Ice/Properties.d.ts
+++ b/js/packages/ice/src/Ice/Properties.d.ts
@@ -103,7 +103,7 @@ declare module "@zeroc/ice" {
              *
              * @param key - The property key.
              * @returns The property value interpreted as a list of strings.
-             * @throws {@link PropertyException} - Thrown if the property is not a known Ice property.
+             * @throws {@link PropertyException} - Thrown when the property is not a known Ice property.
              *
              * @see {@link setProperty}
              */

--- a/js/packages/ice/src/Ice/ServantLocator.d.ts
+++ b/js/packages/ice/src/Ice/ServantLocator.d.ts
@@ -24,7 +24,7 @@ declare module "@zeroc/ice" {
              * @returns An array where:
              *  - [0]: The located servant, or `null` if no suitable servant was found.
              *  - [1]: A "cookie" that will be passed to {@link finished}.
-             * @throws {@link UserException} - The implementation can raise a `UserException`, and the runtime will
+             * @throws {@link UserException} - The implementation can throw a `UserException`, and the runtime will
              * marshal it as the result of the invocation.
              *
              * @see {@link ObjectAdapter}
@@ -43,8 +43,8 @@ declare module "@zeroc/ice" {
              * @param current - Information about the incoming request being dispatched.
              * @param servant - The servant that was returned by `locate`.
              * @param cookie - The cookie that was returned by `locate`.
-             * @throws {@link UserException} - The implementation can raise a `UserException`, and the runtime will marshal it as the
-             * result of the invocation.
+             * @throws {@link UserException} - The implementation can throw a `UserException`, and the runtime will
+             * marshal it as the result of the invocation.
              *
              * @see {@link ObjectAdapter}
              * @see {@link locate}

--- a/js/packages/ice/src/Ice/SliceLoader.d.ts
+++ b/js/packages/ice/src/Ice/SliceLoader.d.ts
@@ -13,7 +13,8 @@ declare module "@zeroc/ice" {
              *        representation).
              * @returns A new instance of the class or exception identified by `typeId`, or `null` if the
              *          implementation cannot find the corresponding class.
-             * @throws {@link MarshalException} If the corresponding class was found but its instantiation failed.
+             * @throws {@link MarshalException} - Thrown when the corresponding class was found but its instantiation
+             * failed.
              */
             newInstance(typeId: string): Ice.Value | Ice.UserException | null;
         }

--- a/js/packages/ice/src/Ice/StringToIdentity.d.ts
+++ b/js/packages/ice/src/Ice/StringToIdentity.d.ts
@@ -7,7 +7,7 @@ declare module "@zeroc/ice" {
          *
          * @param s - The string to convert.
          * @returns The converted object identity.
-         * @throws {@link ParseException} - Thrown if the string cannot be parsed.
+         * @throws {@link ParseException} - Thrown when the string cannot be parsed.
          */
         function stringToIdentity(s: string): Identity;
     }

--- a/slice/Ice/RemoteLogger.ice
+++ b/slice/Ice/RemoteLogger.ice
@@ -93,7 +93,7 @@ module Ice
         /// (send all trace categories).
         /// @param messageMax The maximum number of log messages (of all types) to be provided to
         /// {@link RemoteLogger::init}. A negative value requests all messages available.
-        /// @throws RemoteLoggerAlreadyAttachedException Thrown if this remote logger is already attached to this admin
+        /// @throws RemoteLoggerAlreadyAttachedException Thrown when this remote logger is already attached to this admin
         /// object.
         void attachRemoteLogger(
             RemoteLogger* prx,


### PR DESCRIPTION
This PR replaces "Thrown if" with "Thrown when" in doc comments, as the counterpart of icerpc/icerpc-csharp#4895. It also removes a stray space before "Thrown" in one C# doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)