### PR TITLE
Advance a DataStorm reader's resume point only for its own facet

### DIFF
--- a/changelog.d/datastorm/6624.md
+++ b/changelog.d/datastorm/6624.md
@@ -1,0 +1,4 @@
+- Fixed a bug where a reader could stop receiving a sample after its session reconnected. When a node had a reader
+  with a sample filter and a reader without one on the same writer and key, a sample delivered to one of them
+  advanced the other's reconnect resume point, and the writer then skipped that sample when it replayed the samples
+  the reader had not received.

--- a/changelog.d/datastorm/6624.md
+++ b/changelog.d/datastorm/6624.md
@@ -1,4 +1,3 @@
-- Fixed a bug where a reader could stop receiving a sample after its session reconnected. When a node had a reader
-  with a sample filter and a reader without one on the same writer and key, a sample delivered to one of them
-  advanced the other's reconnect resume point, and the writer then skipped that sample when it replayed the samples
-  the reader had not received.
+- Fixed a bug where a reader could permanently miss a sample after a reconnection. When a node had a reader with a
+  sample filter and a reader without one on the same writer and key, a sample delivered to one reader was marked as
+  received by the other, and the writer therefore never resent it.

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -600,7 +600,6 @@ DataElementI::queue(
     const shared_ptr<Sample>&,
     int,
     const shared_ptr<SessionI>&,
-    const string&,
     const chrono::time_point<chrono::system_clock>&,
     bool)
 {
@@ -1048,23 +1047,11 @@ DataReaderI::queue(
     const shared_ptr<Sample>& sample,
     int priority,
     const shared_ptr<SessionI>&,
-    const string& facet,
     const chrono::time_point<chrono::system_clock>& now,
     bool checkKey)
 {
-    // The writer forwards a sample once per destination facet, and this reader is attached to exactly one of them:
-    // the facet it configured for its sample filter, or the unfaceted destination when it has no sample filter.
-    // Accept only the copy addressed to this reader's destination.
-    if (_config->facet ? *_config->facet != facet : !facet.empty())
-    {
-        if (_traceLevels->data > 2)
-        {
-            Trace out(_traceLevels->logger, _traceLevels->dataCat);
-            out << this << ": skipped sample " << sample->id << " (facet doesn't match)";
-        }
-        return;
-    }
-    else if (checkKey)
+    // The session only queues the copy addressed to this reader's destination facet, so no facet check is needed here.
+    if (checkKey)
     {
         bool matched;
         try

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -1050,7 +1050,6 @@ DataReaderI::queue(
     const chrono::time_point<chrono::system_clock>& now,
     bool checkKey)
 {
-    // The session only queues the copy addressed to this reader's destination facet, so no facet check is needed here.
     if (checkKey)
     {
         bool matched;

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -276,7 +276,6 @@ namespace DataStormI
             const std::shared_ptr<Sample>&,
             int,
             const std::shared_ptr<SessionI>&,
-            const std::string&,
             const std::chrono::time_point<std::chrono::system_clock>&,
             bool);
 
@@ -287,6 +286,17 @@ namespace DataStormI
         [[nodiscard]] std::int64_t getId() const { return _id; }
 
         [[nodiscard]] std::shared_ptr<DataStormContract::ElementConfig> getConfig() const;
+
+        /// Determines whether a sample forwarded to the given session facet is addressed to this element.
+        /// The writer forwards a sample once per destination facet, and this element is attached to exactly one of
+        /// them: the facet it configured for its sample filter, or the unfaceted destination when it has no sample
+        /// filter.
+        /// @param facet The facet the sample was forwarded to.
+        /// @return `true` if the sample is addressed to this element, `false` otherwise.
+        [[nodiscard]] bool matchFacet(const std::string& facet) const
+        {
+            return _config->facet ? *_config->facet == facet : facet.empty();
+        }
 
         void waitForListeners(int count) const;
         [[nodiscard]] bool hasListeners() const;
@@ -358,7 +368,6 @@ namespace DataStormI
             const std::shared_ptr<Sample>&,
             int,
             const std::shared_ptr<SessionI>&,
-            const std::string&,
             const std::chrono::time_point<std::chrono::system_clock>&,
             bool) override;
 

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -33,7 +33,7 @@ namespace
                 {
                     // Forward the call to the target session, don't need to wait for the result. The facet is part
                     // of the addressing and is carried over: a writer addresses a sample-filtered reader under a
-                    // facet of its own, and the receiving session delivers the call to the element attached to it.
+                    // facet of its own.
                     Identity id{.name = current.id.name.substr(0, pos), .category = current.id.category.substr(0, 1)};
                     session->getConnection()
                         ->createProxy(std::move(id))

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -33,7 +33,7 @@ namespace
                 {
                     // Forward the call to the target session, don't need to wait for the result. The facet is part
                     // of the addressing and is carried over: a writer addresses a sample-filtered reader under a
-                    // facet of its own, and the reader discards a sample that does not arrive under it.
+                    // facet of its own, and the receiving session delivers the call to the element attached to it.
                     Identity id{.name = current.id.name.substr(0, pos), .category = current.id.category.substr(0, 1)};
                     session->getConnection()
                         ->createProxy(std::move(id))

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1734,19 +1734,22 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
                     {
                         out << " facet=" << current.facet;
                     }
+                    // Only the elements attached to this copy's destination facet, which are the ones that
+                    // process it below.
                     out << " to [";
                     bool first = true;
                     for (const auto& [element, elementSubscriber] : elementSubscribers->getSubscribers())
                     {
+                        if (!element->matchFacet(current.facet))
+                        {
+                            continue;
+                        }
+
                         if (!first)
                         {
                             out << ", ";
                         }
                         out << element;
-                        if (!elementSubscriber.facet.empty())
-                        {
-                            out << ":" << elementSubscriber.facet;
-                        }
                         first = false;
                     }
                     out << "]";
@@ -1818,17 +1821,9 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
                 for (auto& [element, elementSubscriber] : elementSubscribers->getSubscribers())
                 {
                     // The writer forwards a sample once per destination facet, and each element subscribed to the
-                    // writer element is attached to exactly one of them. Skip the elements this copy isn't addressed
-                    // to: `lastId` is the resume point the peer replays from after a reconnect, so advancing it for a
-                    // copy the element discards can move it past a sample the element never received.
+                    // writer element is attached to exactly one. Skip the elements this copy isn't addressed to.
                     if (!element->matchFacet(current.facet))
                     {
-                        if (_traceLevels->session > 2)
-                        {
-                            Trace out(_traceLevels->logger, _traceLevels->sessionCat);
-                            out << _id << ": skipping '" << element << "' for sample '" << dataSample.id
-                                << "': the sample is not addressed to its facet";
-                        }
                         continue;
                     }
 

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1817,6 +1817,21 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
 
                 for (auto& [element, elementSubscriber] : elementSubscribers->getSubscribers())
                 {
+                    // The writer forwards a sample once per destination facet, and each element subscribed to the
+                    // writer element is attached to exactly one of them. Skip the elements this copy isn't addressed
+                    // to: `lastId` is the resume point the peer replays from after a reconnect, so advancing it for a
+                    // copy the element discards can move it past a sample the element never received.
+                    if (!element->matchFacet(current.facet))
+                    {
+                        if (_traceLevels->session > 2)
+                        {
+                            Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+                            out << _id << ": skipping '" << element << "' for sample '" << dataSample.id
+                                << "': the sample is not addressed to its facet";
+                        }
+                        continue;
+                    }
+
                     if (elementSubscriber.initialized &&
                         (dataSample.keyId <= 0 || elementSubscriber.keys.find(key) != elementSubscriber.keys.end()))
                     {
@@ -1828,7 +1843,6 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
                             elementSample,
                             elementSubscribers->priority,
                             shared_from_this(),
-                            current.facet,
                             now,
                             dataSample.keyId == 0);
                     }

--- a/cpp/test/DataStorm/reliability/Reader.cpp
+++ b/cpp/test/DataStorm/reliability/Reader.cpp
@@ -210,8 +210,7 @@ void ::Reader::run(int argc, char* argv[])
 
         // An unfiltered reader and a sample-filtered one on the same writer and key. The writer addresses the
         // sample-filtered reader under a facet of its own, so a sample only one of them matches is forwarded once,
-        // to that reader's destination. A copy addressed to the other reader must not become this reader's resume
-        // point: the reader never receives it, and the reattach would then resume past it.
+        // to that reader's destination.
         auto reader = makeSingleKeyReader(topic, "key", "", config);
         auto filtered = makeSingleKeyReader(topic, "key", Filter<int>("armed", 0), "", config);
 
@@ -242,6 +241,11 @@ void ::Reader::run(int argc, char* argv[])
 
         sample = filtered.getNextUnread();
         test(sample.getValue() == 2);
+
+        // The unfiltered reader received the first sample before the reconnect, so the reattach must not replay it:
+        // the next sample it reads is the one published after the reconnect. This catches the mirror regression,
+        // where the empty-facet destination stops advancing its resume point.
+        test(reader.getNextUnread().getValue() == 2);
 
         auto finished = makeSingleKeyWriter(barrier, "done");
         finished.waitForReaders();

--- a/cpp/test/DataStorm/reliability/Reader.cpp
+++ b/cpp/test/DataStorm/reliability/Reader.cpp
@@ -203,6 +203,50 @@ void ::Reader::run(int argc, char* argv[])
         done.waitForReaders();
         done.update(0);
     }
+
+    {
+        Topic<string, int> topic(node, "facetResumePoint");
+        Topic<string, int> barrier(node, "facetResumePointBarrier");
+
+        // An unfiltered reader and a sample-filtered one on the same writer and key. The writer addresses the
+        // sample-filtered reader under a facet of its own, so a sample only one of them matches is forwarded once,
+        // to that reader's destination. A copy addressed to the other reader must not become this reader's resume
+        // point: the reader never receives it, and the reattach would then resume past it.
+        auto reader = makeSingleKeyReader(topic, "key", "", config);
+        auto filtered = makeSingleKeyReader(topic, "key", Filter<int>("armed", 0), "", config);
+
+        // Published while the writer's filter rejects it, so only the unfiltered reader receives it.
+        auto sample = reader.getNextUnread();
+        test(sample.getValue() == 1);
+
+        // Have the writer accept from now on, and wait for it to confirm before dropping the session, so the replay
+        // is evaluated with the filter accepting.
+        auto ready = makeSingleKeyWriter(barrier, "ready");
+        ready.waitForReaders();
+        ready.update(0);
+        [[maybe_unused]] auto armed = makeSingleKeyReader(barrier, "armed").getNextUnread();
+
+        auto connection = node.getSessionConnection(sample.getSession());
+        test(connection);
+        connection->close().get();
+
+        // The reattach replays what each reader has not seen. The filtered reader never received the first sample,
+        // so it must arrive now, ahead of the one the writer publishes after the reconnect.
+        sample = filtered.getNextUnread();
+        if (sample.getValue() != 1)
+        {
+            cerr << "filtered reader resumed past a sample it never received: " << sample.getValue() << " expected:1"
+                 << endl;
+            test(false);
+        }
+
+        sample = filtered.getNextUnread();
+        test(sample.getValue() == 2);
+
+        auto finished = makeSingleKeyWriter(barrier, "done");
+        finished.waitForReaders();
+        finished.update(0);
+    }
 }
 
 DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/reliability/Writer.cpp
+++ b/cpp/test/DataStorm/reliability/Writer.cpp
@@ -3,6 +3,7 @@
 #include "DataStorm/DataStorm.h"
 #include "TestHelper.h"
 
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 
@@ -183,6 +184,71 @@ void ::Writer::run(int argc, char* argv[])
         writer.update("done");
 
         // Keep the writer alive until the reader verifies both post-reconnect samples.
+        [[maybe_unused]] auto done = makeSingleKeyReader(barrier, "done").getNextUnread();
+        writer.waitForNoReaders();
+    }
+    cout << "ok" << endl;
+
+    cout << "testing resume after a sample addressed to another reader's facet... " << flush;
+    {
+        Topic<string, int> topic(node, "facetResumePoint");
+        Topic<string, int> barrier(node, "facetResumePointBarrier");
+
+        // Sample filters are evaluated here, on the writer. This one answers from a flag the test flips, so the same
+        // sample is rejected when it is published and accepted when the reader reattaches and the writer replays what
+        // the reader has not seen.
+        auto accept = make_shared<atomic<bool>>(false);
+        topic.setSampleFilter<int>(
+            "armed",
+            [accept](int) { return [accept](const Sample<string, int>&) { return accept->load(); }; });
+
+        WriterConfig retained = config;
+        retained.sampleCount = -1; // Retain the rejected sample so the reattach can replay it.
+        auto writer = makeSingleKeyWriter(topic, "key", "", retained);
+
+        auto gate = make_shared<ReconnectGate>();
+        writer.onConnectedReaders(
+            [](const vector<string>&) {},
+            [gate](CallbackReason reason, const string&)
+            {
+                lock_guard lock{gate->mutex};
+                if (reason == CallbackReason::Disconnect)
+                {
+                    gate->disconnected = true;
+                }
+                else if (gate->disconnected)
+                {
+                    gate->reconnected = true;
+                    gate->condition.notify_all();
+                }
+            });
+
+        // The unfiltered reader and the sample-filtered one, each addressed under its own destination facet.
+        writer.waitForReaders(2);
+
+        // The filter rejects this sample, so it is forwarded only to the unfiltered reader's destination.
+        writer.update(1);
+
+        // The unfiltered reader has it. Accept from now on, and tell the reader it may drop the session.
+        [[maybe_unused]] auto ready = makeSingleKeyReader(barrier, "ready").getNextUnread();
+        accept->store(true);
+        auto armed = makeSingleKeyWriter(barrier, "armed");
+        armed.waitForReaders();
+        armed.update(0);
+
+        {
+            // Bounded so a failure asserts rather than blocks; see the wait in the partial update test above.
+            unique_lock lock{gate->mutex};
+            test(gate->condition.wait_for(lock, chrono::seconds(90), [&gate] { return gate->reconnected; }));
+        }
+
+        // The latch records that a reader reconnected, not that one is attached now, so keep the level check too.
+        writer.waitForReaders(2);
+
+        // A second sample, which the filter now accepts as well. The filtered reader must see the replayed first
+        // sample before it.
+        writer.update(2);
+
         [[maybe_unused]] auto done = makeSingleKeyReader(barrier, "done").getNextUnread();
         writer.waitForNoReaders();
     }


### PR DESCRIPTION
Fixes #6624.

A writer forwards a sample once per destination facet: the unfaceted destination for the readers without a sample
filter, and a facet of its own for each sample-filtered reader. `SubscriberSessionI::s` advanced the `lastId` of every
initialized, key-matching element before handing the copy to the element, and the element then discarded the copies
addressed to another facet.

`lastId` is the resume point the peer replays from after a reconnect (`getLastIds` → `ElementDataAck.lastIds` →
`getSamples`, which skips `id <= lastId`), so a copy an element discards could move its resume point past a sample the
element never received. A node with a filterless reader and a sample-filtered reader on the same writer and key gets
two copies of a sample both match; if the connection drops between the two dispatches, the faceted reader resumes past
the copy it never got and the sample is lost for good. A stateful sample filter that rejects a sample live and accepts
it on replay reaches the same suppression with no message loss, because `getSamples` drops the sample on the id check
before the filter sees it.

The fix applies the destination-facet check before advancing `lastId`, so a copy only ever advances the resume point of
the element it is addressed to. The predicate is the one the reader already applied when queuing the sample (added in
#6473), moved up to the session as `DataElementI::matchFacet`; `SessionI.cpp` is the only caller of
`DataElementI::queue`, so `queue` no longer needs the facet.

### Notes

- Not a regression from #6466/#6473. The facet family shipped with #2902; the same advance-before-check loop is in
  `v3.8.0` and `v3.8.2`.
- The fix as described in the issue — comparing `ElementSubscriber::facet` to `current.facet` — would break every
  sample-filtered reader. On a subscriber session that field holds the *peer writer's* facet (always empty), because
  `attach` reads `data.config->facet`, the sender's config. It has to keep that meaning: `detachKey`/`detachFilter`
  use it to find the `{session, facet}` listener entry that attach created.
- Relays are unaffected: `SessionForwarder::ice_invoke` preserves the facet on the forwarded invocation (#6475) and
  does not go through `queue`.
- Regression test in `cpp/test/DataStorm/reliability`. Sample filters are evaluated on the writer, so a filter that
  rejects a sample on its live evaluation and accepts it on replay reaches this without needing to interleave the two
  per-facet dispatches: the sample is forwarded only to the unfiltered reader, that copy stamps the filtered reader's
  resume point, and after an ordinary reconnect the filtered reader must receive the replayed sample ahead of the one
  published after the reconnect. Without the fix it fails with `filtered reader resumed past a sample it never
  received: 2 expected:1`. The unfiltered reader's own resume point is asserted too, covering the mirror regression.
- Verified with the 13 C++ DataStorm suites, plus a two-node repro confirming that each per-facet copy now advances
  only its addressee's resume point.

https://claude.ai/code/session_01SNHcCThYs46uCZnopdPaau

