### PR TITLE
Update the link checker to lychee 0.24

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check links
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: >-
             --config .lychee.toml

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -52,4 +52,4 @@ exclude_path = [
 accept = [200, 204, 206, 301, 308]
 
 # Include fragments (anchors) in checks
-include_fragments = true
+include_fragments = "anchor-only"

--- a/cpp/BUILDING.md
+++ b/cpp/BUILDING.md
@@ -43,7 +43,7 @@ flowchart LR
 
 ### Installing build dependencies
 
-Ice has dependencies on a number of third-party libraries ([bzip2], [expat], [libedit], LMDB, [mcpp] and [OpenSSL]).
+Ice has dependencies on a number of third-party libraries ([bzip2], [expat], [libedit], [LMDB], [mcpp] and [OpenSSL]).
 
 Bzip, Expat, Libedit and OpenSSL are included with most Linux distributions.
 
@@ -202,7 +202,7 @@ remove the generated files created by the Slice compilers.
 
 ### Installing build dependencies
 
-Ice has dependencies on a number of third-party libraries ([bzip2], [expat], [libedit], LMDB and [mcpp]).
+Ice has dependencies on a number of third-party libraries ([bzip2], [expat], [libedit], [LMDB] and [mcpp]).
 
 bzip, expat and libedit are included with your system.
 
@@ -393,7 +393,7 @@ remove the generated files created by the Slice compilers.
 
 ### Installing build dependencies
 
-Ice has dependencies on a number of third-party libraries ([bzip2], [expat], LMDB, [mcpp] and [OpenSSL]).
+Ice has dependencies on a number of third-party libraries ([bzip2], [expat], [LMDB], [mcpp] and [OpenSSL]).
 
 OpenSSL (openssl.base) is provided by AIX. bzip2 and bzip2-devel are included in the [IBM AIX Toolbox for Linux
 Applications].
@@ -674,6 +674,7 @@ compiler you are using.
 [Ice binary distributions]: https://zeroc.com/ice/downloads/3.7
 [Ice Builder for Xcode]: https://github.com/zeroc-ice/ice-builder-xcode
 [libedit]: https://thrysoee.dk/editline/
+[LMDB]: https://symas.com/lmdb.php
 [mcpp]: https://github.com/zeroc-ice/mcpp
 [OpenSSL]: https://www.openssl.org/
 [supported platforms]: https://archive.zeroc.com/ice/3.7/release-notes/supported-platforms-for-ice-3-7-12

--- a/cpp/BUILDING.md
+++ b/cpp/BUILDING.md
@@ -43,7 +43,7 @@ flowchart LR
 
 ### Installing build dependencies
 
-Ice has dependencies on a number of third-party libraries ([bzip2], [expat], [libedit], [LMDB], [mcpp] and [OpenSSL]).
+Ice has dependencies on a number of third-party libraries ([bzip2], [expat], [libedit], LMDB, [mcpp] and [OpenSSL]).
 
 Bzip, Expat, Libedit and OpenSSL are included with most Linux distributions.
 
@@ -202,7 +202,7 @@ remove the generated files created by the Slice compilers.
 
 ### Installing build dependencies
 
-Ice has dependencies on a number of third-party libraries ([bzip2], [expat], [libedit], [LMDB] and [mcpp]).
+Ice has dependencies on a number of third-party libraries ([bzip2], [expat], [libedit], LMDB and [mcpp]).
 
 bzip, expat and libedit are included with your system.
 
@@ -393,7 +393,7 @@ remove the generated files created by the Slice compilers.
 
 ### Installing build dependencies
 
-Ice has dependencies on a number of third-party libraries ([bzip2], [expat], [LMDB], [mcpp] and [OpenSSL]).
+Ice has dependencies on a number of third-party libraries ([bzip2], [expat], LMDB, [mcpp] and [OpenSSL]).
 
 OpenSSL (openssl.base) is provided by AIX. bzip2 and bzip2-devel are included in the [IBM AIX Toolbox for Linux
 Applications].
@@ -674,7 +674,6 @@ compiler you are using.
 [Ice binary distributions]: https://zeroc.com/ice/downloads/3.7
 [Ice Builder for Xcode]: https://github.com/zeroc-ice/ice-builder-xcode
 [libedit]: https://thrysoee.dk/editline/
-[LMDB]: https://www.symas.com/symas-embedded-database-lmdb
 [mcpp]: https://github.com/zeroc-ice/mcpp
 [OpenSSL]: https://www.openssl.org/
 [supported platforms]: https://archive.zeroc.com/ice/3.7/release-notes/supported-platforms-for-ice-3-7-12


### PR DESCRIPTION
lychee 0.24 takes `include_fragments` as a string enum rather than a bool, so the configuration and the action pin have to move together on this branch.

- Set `include_fragments = "anchor-only"`, matching main and 3.8.
- Pin `lycheeverse/lychee-action` to v2.9.0, which installs lychee 0.24.2.
- Drop the LMDB link from `cpp/BUILDING.md`; the symas.com page returns 404. main and 3.8 mention LMDB without a link.

This unblocks `check-links` on [#6339](https://github.com/zeroc-ice/ice/pull/6339).
