### PR TITLE
Report an any-key reader's resume points to an any-key writer

### DIFF
--- a/changelog.d/datastorm/6621.md
+++ b/changelog.d/datastorm/6621.md
@@ -1,3 +1,2 @@
 - Fixed a bug where an any-key or filtered reader connected to an any-key writer received the writer's retained
-  samples again every time its session reconnected. The reader now reports how far it had read, and the writer
-  replays only the samples the reader had not received.
+  samples again after each reconnection.

--- a/changelog.d/datastorm/6621.md
+++ b/changelog.d/datastorm/6621.md
@@ -1,0 +1,3 @@
+- Fixed a bug where an any-key or filtered reader connected to an any-key writer received the writer's retained
+  samples again every time its session reconnected. The reader now reports how far it had read, and the writer
+  replays only the samples the reader had not received.

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -148,7 +148,11 @@ DataElementI::attach(
     {
         auto q = data.lastIds.find(_id);
         int64_t lastId = q != data.lastIds.end() ? q->second : 0;
-        LongLongDict lastIds = key ? session->getLastIds(topicId, id, shared_from_this()) : LongLongDict{};
+        // Report this element's resume points so the peer replays only what the element has not seen. `getLastIds`
+        // picks the key or filter branch from `id`, and reports the filter subscriptions without using the key, so
+        // this also covers a filtered element paired with a peer filtered element, where the topic has no key to
+        // pass (`id` is then always negative).
+        LongLongDict lastIds = session->getLastIds(topicId, id, shared_from_this());
         DataSamples initializationBatch = getSamples(key, sampleFilter, data.config, lastId, now);
 
         acks.push_back(ElementDataAck{

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -148,10 +148,7 @@ DataElementI::attach(
     {
         auto q = data.lastIds.find(_id);
         int64_t lastId = q != data.lastIds.end() ? q->second : 0;
-        // Report this element's resume points so the peer replays only what the element has not seen. `getLastIds`
-        // picks the key or filter branch from `id`, and reports the filter subscriptions without using the key, so
-        // this also covers a filtered element paired with a peer filtered element, where the topic has no key to
-        // pass (`id` is then always negative).
+        // Report this element's resume points so the peer replays only what the element has not seen.
         LongLongDict lastIds = session->getLastIds(topicId, id, shared_from_this());
         DataSamples initializationBatch = getSamples(key, sampleFilter, data.config, lastId, now);
 

--- a/cpp/test/DataStorm/reliability/Reader.cpp
+++ b/cpp/test/DataStorm/reliability/Reader.cpp
@@ -170,6 +170,51 @@ void ::Reader::run(int argc, char* argv[])
     }
 
     {
+        Topic<string, int> topic(node, "anyKeyReaderReconnect");
+        Topic<string, int> barrier(node, "anyKeyReaderReconnectBarrier");
+        // An any-key reader against the any-key writer. Both elements are filtered elements, so the topic has no key
+        // to pair them with, and the reader has to report its resume points from its filter subscriptions instead.
+        auto reader = makeAnyKeyReader<string, int>(topic, "", config);
+        auto writerB = makeSingleKeyWriter(barrier, "reader_barrier");
+
+        string session;
+        for (int i = 0; i < 100; ++i)
+        {
+            auto sample = reader.getNextUnread();
+            if (sample.getValue() != i)
+            {
+                cerr << "unexpected sample: " << sample.getValue() << " expected:" << i << endl;
+                test(false);
+            }
+            session = sample.getSession();
+        }
+
+        // Force a session reconnect while the writer retains its history.
+        auto connection = node.getSessionConnection(session);
+        test(connection);
+        connection->close().get();
+
+        // Tell the writer the connection closed (processed after reconnect); it then sends the second batch.
+        writerB.waitForReaders();
+        writerB.update(0);
+
+        // After the reconnect the reader must continue from 100: the writer resumes from the reader's last received
+        // sample rather than re-sending its whole retained queue (which would re-deliver 0..99).
+        for (int i = 0; i < 100; ++i)
+        {
+            auto sample = reader.getNextUnread();
+            if (sample.getValue() != i + 100)
+            {
+                cerr << "duplicate or rewound sample: " << sample.getValue() << " expected:" << (i + 100) << endl;
+                test(false);
+            }
+        }
+
+        writerB.waitForReaders();
+        writerB.update(0);
+    }
+
+    {
         Topic<string, string> topic(node, "partialUpdateReconnect");
         Topic<string, int> barrier(node, "partialUpdateReconnectBarrier");
         topic.setUpdater<string>("append", [](string& value, const string& suffix) { value += suffix; });

--- a/cpp/test/DataStorm/reliability/Reader.cpp
+++ b/cpp/test/DataStorm/reliability/Reader.cpp
@@ -127,8 +127,7 @@ void ::Reader::run(int argc, char* argv[])
     {
         Topic<string, int> topic(node, "anyKeyReconnect");
         Topic<string, int> barrier(node, "anyKeyReconnectBarrier");
-        // A plain single-key reader against the any-key (filtered) writer: reconnect resumption is driven by the
-        // writer being filtered, so a reader of any kind connected to it must resume rather than re-read history.
+        // A plain single-key reader against the any-key (filtered) writer; the any-key reader case is below.
         auto reader = makeSingleKeyReader(topic, "k", "", config);
         auto writerB = makeSingleKeyWriter(barrier, "reader_barrier");
 
@@ -174,7 +173,11 @@ void ::Reader::run(int argc, char* argv[])
         Topic<string, int> barrier(node, "anyKeyReaderReconnectBarrier");
         // An any-key reader against the any-key writer. Both elements are filtered elements, so the topic has no key
         // to pair them with, and the reader has to report its resume points from its filter subscriptions instead.
-        auto reader = makeAnyKeyReader<string, int>(topic, "", config);
+        // A sample-filtered any-key reader sits alongside it, so the writer addresses the two under different
+        // facets and each has to resume from its own point.
+        auto reader = makeAnyKeyReader(topic, "", config);
+        auto filtered =
+            makeAnyKeyReader(topic, Filter<SampleEventSeq>("_event", SampleEventSeq{SampleEvent::Update}), "", config);
         auto writerB = makeSingleKeyWriter(barrier, "reader_barrier");
 
         string session;
@@ -187,6 +190,14 @@ void ::Reader::run(int argc, char* argv[])
                 test(false);
             }
             session = sample.getSession();
+
+            auto filteredSample = filtered.getNextUnread();
+            if (filteredSample.getValue() != i)
+            {
+                cerr << "unexpected sample on the filtered reader: " << filteredSample.getValue() << " expected:" << i
+                     << endl;
+                test(false);
+            }
         }
 
         // Force a session reconnect while the writer retains its history.
@@ -206,6 +217,14 @@ void ::Reader::run(int argc, char* argv[])
             if (sample.getValue() != i + 100)
             {
                 cerr << "duplicate or rewound sample: " << sample.getValue() << " expected:" << (i + 100) << endl;
+                test(false);
+            }
+
+            auto filteredSample = filtered.getNextUnread();
+            if (filteredSample.getValue() != i + 100)
+            {
+                cerr << "duplicate or rewound sample on the filtered reader: " << filteredSample.getValue()
+                     << " expected:" << (i + 100) << endl;
                 test(false);
             }
         }

--- a/cpp/test/DataStorm/reliability/Writer.cpp
+++ b/cpp/test/DataStorm/reliability/Writer.cpp
@@ -130,6 +130,31 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    cout << "testing reconnect with an any-key reader without duplicate samples... " << flush;
+    {
+        Topic<string, int> topic(node, "anyKeyReaderReconnect");
+        Topic<string, int> barrier(node, "anyKeyReaderReconnectBarrier");
+        auto writer = makeAnyKeyWriter(topic, "", config);
+        writer.waitForReaders();
+        for (int i = 0; i < 100; ++i)
+        {
+            writer.update("k", i);
+        }
+
+        // Wait for the reader to signal it read the batch and closed the connection.
+        auto readerB = makeSingleKeyReader(barrier, "reader_barrier");
+        auto sample = readerB.getNextUnread();
+
+        // The session has been reestablished; send a second batch. The reader must continue from 100, not
+        // re-receive the retained 0..99.
+        for (int i = 0; i < 100; ++i)
+        {
+            writer.update("k", i + 100);
+        }
+        sample = readerB.getNextUnread();
+    }
+    cout << "ok" << endl;
+
     cout << "testing partial update after reconnect... " << flush;
     {
         Topic<string, string> topic(node, "partialUpdateReconnect");


### PR DESCRIPTION
Fixes #6621.

> [!NOTE]
> Stacked on #6675 — review that one first; this PR's diff is the single commit on top of it. GitHub retargets this
> PR to `main` when #6675 merges.

An element reports how far it has read through `session->getLastIds(...)` in `DataElementI::attach`, but the call was
gated on the topic having paired it with the peer element under a key:

```cpp
LongLongDict lastIds = key ? session->getLastIds(topicId, id, shared_from_this()) : LongLongDict{};
```

An any-key or filtered reader attached to an any-key writer has no such key. Both are filtered elements, so
`TopicI::attachElements` pairs them filter to filter and passes `key == nullptr`. The reconnect ack then carried an
empty resume map, the writer resolved a resume point of 0 and replayed its whole retained history, and the reader —
which does not deduplicate samples once its attachment state is reset — delivered them to the application again.

`getLastIds` already selects its key or filter branch from the element id, and the filter branch reports the element's
subscriptions without consulting the key, so the gate was vestigial after #5604. `key == nullptr` also implies
`id < 0`: the `_keyElements` branch of `attachElements` always resolves a key, and the `_filteredElements` branch
leaves it null only when `spec.id < 0`. So the newly reached call always takes the filter branch.

### Ordering with #6675

#6675 should land first, and not only because of the stack. Today's empty resume map means "replay everything", which
masks #6624 for this pairing; once this fix lands these readers honour their resume points, so an inflated `lastId`
would turn duplicate delivery into silently missing samples. This pairing is also the most exposed to #6624, because
an any-key writer marshals the key inline (`keyId == 0`) and the `keyId <= 0` gate in `SubscriberSessionI::s()` then
admits every subscriber of the writer element.

### Test

`reliability` already had *"testing reconnect with an any-key writer without duplicate samples"*, but it pairs the
any-key writer with a **single-key** reader, which has a key and so already reported its resume points — its comment
claimed the resumption was "driven by the writer being filtered, so a reader of any kind connected to it must resume",
which is the over-broad claim this issue flagged. The new case mirrors it with an any-key reader. Without the fix it
fails with `duplicate or rewound sample: 0 expected:100`; with it, 13/13 DataStorm suites pass.

https://claude.ai/code/session_01SNHcCThYs46uCZnopdPaau
