### PR TITLE
Treat a filter that throws while a writer selects destinations as not matching

### DIFF
--- a/changelog.d/datastorm/6615.md
+++ b/changelog.d/datastorm/6615.md
@@ -1,4 +1,0 @@
-- Fixed a bug where a key filter or sample filter that threw while a writer was selecting the destinations of a
-  sample terminated the writer's process. Such a predicate is now treated as not matching, like one that returns
-  false: the sample is skipped for that subscriber only, the writer's other subscribers still receive it, the
-  writer still records it in its history, and the failure is logged.

--- a/changelog.d/datastorm/6615.md
+++ b/changelog.d/datastorm/6615.md
@@ -1,0 +1,4 @@
+- Fixed a bug where a key filter or sample filter that threw while a writer was selecting the destinations of a
+  sample terminated the writer's process. Such a predicate is now treated as not matching, like one that returns
+  false: the sample is skipped for that subscriber only, the writer's other subscribers still receive it, the
+  writer still records it in its history, and the failure is logged.

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -732,13 +732,9 @@ DataElementI::disconnect()
 bool
 DataElementI::matchOne(const Listener& listener, const shared_ptr<Sample>& sample, bool matchKey) const
 {
-    // Runs a peer reader's key filter or sample filter predicate, which is application code. Treating a throwing
-    // predicate as not matching skips that subscriber and lets the scan continue with the listener's remaining
-    // subscribers, the way a predicate that returns false does. Letting it escape would abort the publication
-    // instead: the writer forwards a sample through a collocated twoway invocation, so the exception resurfaces
-    // from send() as an UnknownException, the listeners after the throwing one are never forwarded to, and the
-    // writer records neither the sample nor its per-key base. It would also reach the application out of remove,
-    // which is noexcept.
+    // Runs a peer reader's key filter or sample filter predicate, which is application code. We treat a throwing
+    // predicate as not matching: the subscriber is skipped and the scan continues with the listener's remaining
+    // subscribers, the way a predicate that returns false does.
     auto match = [this, &sample](const shared_ptr<Filter>& filter, const shared_ptr<Filterable>& value)
     {
         try
@@ -747,21 +743,12 @@ DataElementI::matchOne(const Listener& listener, const shared_ptr<Sample>& sampl
         }
         catch (const std::exception& ex)
         {
-            // The element's toString runs the application's key formatter — more application code — so it can throw
-            // too; the placeholder keeps such a throw from escaping the guard.
-            string elementString;
-            try
-            {
-                elementString = toString();
-            }
-            catch (const std::exception&)
-            {
-                elementString = "<unavailable>";
-            }
-
+            // Streaming the element would run the application's key formatter inside this very catch, so print the
+            // element id instead. The sample can still reach this listener through another of its subscribers, so
+            // report the skipped subscriber rather than the sample not being sent.
             Warning out(_traceLevels->logger);
-            out << elementString << ": did not send sample " << sample->id << " to a subscriber: the '"
-                << filter->getName() << "' filter failed:\n"
+            out << 'e' << _id << ": skipped a reader for sample " << sample->id << ": the '" << filter->getName()
+                << "' filter failed:\n"
                 << ex.what();
             return false;
         }

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -729,13 +729,63 @@ DataElementI::disconnect()
     }
 }
 
+bool
+DataElementI::matchOne(const Listener& listener, const shared_ptr<Sample>& sample, bool matchKey) const
+{
+    // Runs a peer reader's key filter or sample filter predicate, which is application code. Treating a throwing
+    // predicate as not matching skips that subscriber and lets the scan continue with the listener's remaining
+    // subscribers, the way a predicate that returns false does. Letting it escape would abort the publication
+    // instead: the writer forwards a sample through a collocated twoway invocation, so the exception resurfaces
+    // from send() as an UnknownException, the listeners after the throwing one are never forwarded to, and the
+    // writer records neither the sample nor its per-key base. It would also reach the application out of remove,
+    // which is noexcept.
+    auto match = [this, &sample](const shared_ptr<Filter>& filter, const shared_ptr<Filterable>& value)
+    {
+        try
+        {
+            return filter->match(value);
+        }
+        catch (const std::exception& ex)
+        {
+            // The element's toString runs the application's key formatter — more application code — so it can throw
+            // too; the placeholder keeps such a throw from escaping the guard.
+            string elementString;
+            try
+            {
+                elementString = toString();
+            }
+            catch (const std::exception&)
+            {
+                elementString = "<unavailable>";
+            }
+
+            Warning out(_traceLevels->logger);
+            out << elementString << ": did not send sample " << sample->id << " to a subscriber: the '"
+                << filter->getName() << "' filter failed:\n"
+                << ex.what();
+            return false;
+        }
+    };
+
+    for (const auto& [_, subscriber] : listener.subscribers)
+    {
+        if ((!matchKey || subscriber->keys.empty() || subscriber->keys.find(sample->key) != subscriber->keys.end()) &&
+            (!subscriber->filter || match(subscriber->filter, sample->key)) &&
+            (!subscriber->sampleFilter || match(subscriber->sampleFilter, sample)))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void
 DataElementI::forward(const ByteSeq& inParams, const Current& current) const
 {
     for (const auto& [_, listener] : _listeners)
     {
         // If we are forwarding a sample, check whether at least one of the listeners is interested in it.
-        if (!_sample || listener.matchOne(_sample, false))
+        if (!_sample || matchOne(listener, _sample, false))
         {
             // Forward the call using the listener's session proxy. We don't need to wait for the result.
             listener.proxy
@@ -1753,7 +1803,22 @@ KeyDataWriterI::send(const shared_ptr<Key>& key, const shared_ptr<Sample>& sampl
     assert(key || _keys.size() == 1);
     _sample = sample;
     _sample->key = key ? key : _keys[0];
-    _subscribers->s(_parent->getId(), _keys.empty() ? -_id : _id, toSample(sample, getCommunicator(), _keys.empty()));
+    try
+    {
+        _subscribers->s(
+            _parent->getId(),
+            _keys.empty() ? -_id : _id,
+            toSample(sample, getCommunicator(), _keys.empty()));
+    }
+    catch (...)
+    {
+        // The forwarding runs collocated, so a failure in forward() resurfaces here. Clear the sample being
+        // forwarded on the way out: this element forwards again while it is torn down, and a stale _sample would be
+        // matched against the listeners then. With a filter predicate as the original cause, that second match
+        // throws again while the first exception unwinds, which terminates the process.
+        _sample = nullptr;
+        throw;
+    }
     _sample = nullptr;
 }
 
@@ -1765,7 +1830,7 @@ KeyDataWriterI::forward(const ByteSeq& inParams, const Current& current) const
         // Forward the sample if the listener has at least one subscriber interested in the update. The key is
         // always matched: a multi-key writer's sessions don't necessarily subscribe to every key of the writer,
         // and an unmatched key's sample would be wasted bandwidth at best (the receiver never subscribed its id).
-        if (!_sample || listener.matchOne(_sample, true))
+        if (!_sample || matchOne(listener, _sample, true))
         {
             // Forward the call using the listener's session proxy. We don't need to wait for the result.
             listener.proxy

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -82,27 +82,6 @@ namespace DataStormI
             {
             }
 
-            /// Determines if any subscriber matches the given sample.
-            ///
-            /// @param sample The sample to evaluate against the subscribers.
-            /// @param matchKey If true, the sample's key is matched against subscriber keys.
-            ///                 If false, the key match is skipped.
-            /// @return `true` if at least one subscriber matches the sample, otherwise false.
-            [[nodiscard]] bool matchOne(const std::shared_ptr<Sample>& sample, bool matchKey) const
-            {
-                for (const auto& [_, subscriber] : subscribers)
-                {
-                    if ((!matchKey || subscriber->keys.empty() ||
-                         subscriber->keys.find(sample->key) != subscriber->keys.end()) &&
-                        (!subscriber->filter || subscriber->filter->match(sample->key)) &&
-                        (!subscriber->sampleFilter || subscriber->sampleFilter->match(sample)))
-                    {
-                        return true;
-                    }
-                }
-                return false;
-            }
-
             [[nodiscard]] std::shared_ptr<Subscriber> addOrGet(
                 std::int64_t topicId,
                 std::int64_t elementId,
@@ -317,6 +296,15 @@ namespace DataStormI
         // A map containing the element listeners, indexed by the session servant and the target facet. The
         // implementation of forward utilizes the listener map to forward calls to the peer sessions.
         std::map<ListenerKey, Listener> _listeners;
+
+        /// Determines whether any of a listener's subscribers matches the given sample.
+        /// @param listener The listener whose subscribers are evaluated.
+        /// @param sample The sample to evaluate against the subscribers.
+        /// @param matchKey If true, the sample's key is matched against the subscriber keys. If false, the key match
+        /// is skipped.
+        /// @return `true` if at least one subscriber matches the sample, `false` otherwise.
+        [[nodiscard]] bool
+        matchOne(const Listener& listener, const std::shared_ptr<Sample>& sample, bool matchKey) const;
 
     private:
         virtual void forward(const Ice::ByteSeq&, const Ice::Current&) const;

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -539,6 +539,43 @@ void ::Reader::run(int argc, char* argv[])
         doneWriter.update(0);
     }
 
+    // An unfiltered reader and a sample-filtered one on the same writer and key. The writer runs the sample filter
+    // while it selects the live destinations, and the predicate throws for one update and for the remove. Those
+    // samples are skipped for the filtered reader only; the unfiltered reader receives all of them.
+    {
+        Topic<string, string> topic(node, "liveSampleFilterThrow");
+        Topic<string, int> done(node, "liveSampleFilterThrowDone");
+
+        auto reader = makeSingleKeyReader(topic, "elem", "", config);
+        auto filtered = makeSingleKeyReader(topic, "elem", Filter<string>("throwOnValue", "boom"), "", config);
+
+        auto sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Add);
+        test(sample.getValue() == "value1");
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Update);
+        test(sample.getValue() == "boom");
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Update);
+        test(sample.getValue() == "value2");
+        sample = reader.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Remove);
+
+        // The filtered reader skips the two samples whose predicate threw, and nothing else: had "boom" been
+        // delivered, it would be this sample instead of "value2".
+        sample = filtered.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Add);
+        test(sample.getValue() == "value1");
+        sample = filtered.getNextUnread();
+        test(sample.getEvent() == SampleEvent::Update);
+        test(sample.getValue() == "value2");
+        test(!filtered.hasUnread());
+
+        auto doneWriter = makeSingleKeyWriter(done, "done");
+        doneWriter.waitForReaders();
+        doneWriter.update(0);
+    }
+
     // Coexisting any-key and filtered readers on the same topic: each keeps its own subscription. Both receive a
     // sample matching the filter, and destroying the filtered reader leaves the any-key reader subscribed.
     {

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -536,6 +536,44 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
+    // The sample filter also runs on this writer while it selects the destinations of a live publication, once per
+    // sample per destination facet. A predicate that throws there must not abort the publication: the unfiltered
+    // reader still receives the sample, the writer still records it, and the remove — whose caller is noexcept —
+    // must not terminate the process.
+    cout << "testing sample filter that throws during a live publish... " << flush;
+    {
+        Topic<string, string> topic(node, "liveSampleFilterThrow");
+        Topic<string, int> done(node, "liveSampleFilterThrowDone");
+
+        topic.setSampleFilter<string>(
+            "throwOnValue",
+            [](const string& boom)
+            {
+                return [boom](const Sample<string, string>& sample)
+                {
+                    // A remove carries no value, so check the event first.
+                    if (sample.getEvent() == SampleEvent::Remove || sample.getValue() == boom)
+                    {
+                        throw runtime_error("the sample filter failed");
+                    }
+                    return true;
+                };
+            });
+
+        auto writer = makeSingleKeyWriter(topic, "elem", "", config);
+
+        // The unfiltered reader and the sample-filtered one, each addressed under its own destination facet.
+        writer.waitForReaders(2);
+
+        writer.add("value1");
+        writer.update("boom"); // The predicate throws for the filtered reader's facet.
+        writer.update("value2");
+        writer.remove(); // The predicate throws again, from a noexcept caller.
+
+        [[maybe_unused]] auto _ = makeSingleKeyReader(done, "done").getNextUnread();
+    }
+    cout << "ok" << endl;
+
     // An any-key reader and a filtered reader coexisting on the same topic must each keep their own subscription:
     // both receive matching samples, and destroying one must not detach the other.
     cout << "testing coexisting any-key and filtered readers... " << flush;

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -538,8 +538,7 @@ void ::Writer::run(int argc, char* argv[])
 
     // The sample filter also runs on this writer while it selects the destinations of a live publication, once per
     // sample per destination facet. A predicate that throws there must not abort the publication: the unfiltered
-    // reader still receives the sample, the writer still records it, and the remove — whose caller is noexcept —
-    // must not terminate the process.
+    // reader still receives the sample, and the writer still records it.
     cout << "testing sample filter that throws during a live publish... " << flush;
     {
         Topic<string, string> topic(node, "liveSampleFilterThrow");


### PR DESCRIPTION
Fixes #6615.

A writer runs each peer reader's key filter and sample filter to decide which destinations a sample goes to.
`Listener::matchOne` ran those predicates — application code — without an exception boundary, the last such call site
in DataStorm: the attachment scans were guarded by #6578 and #6608, and the reader's own key filter by #6344.

### What happens without the fix

The forwarding is a collocated twoway invocation, so `ForwarderManager` funnels the throw into the invocation's
exception callback and it resurfaces from `send()` as an `Ice::UnknownException`. The listeners after the throwing one
are never forwarded to, and `DataWriterI::publish` records neither the sample nor its per-key base, even though earlier
destinations already received it.

`send()` also left `_sample` set on that path, and that turns out to be the dominant failure: the element forwards
again while it is torn down, the stale sample is matched a second time, the predicate throws again while the first
exception is unwinding, and the process terminates. Measured in the container with the new test, all three builds:

| Build | Result |
| --- | --- |
| unfixed | `terminate called after throwing an instance of 'Ice::UnknownException'`, exit **-6** |
| `_sample` cleanup only | clean `UnknownException` out of `update()`, exit **1** |
| this PR | passes |

That refines the issue's analysis, which attributed the termination to `remove()` being `noexcept`. That is real, but
it is not what fires first: the abort happens on `add`/`update` too, before `remove()` is ever reached. Instrumenting
the writer showed it dying at `update()`, which is not `noexcept`.

### The fix

`matchOne` moves out of `Listener` and into `DataElementI`, where the trace levels and the element string are
available, and guards each predicate the way `KeyDataWriterI::getSamples` already does: log the element, sample id and
filter name, and treat the predicate as not matching. The sample is then skipped for that subscriber alone, the
listener's other subscribers still receive it, and the publication finishes and updates the writer's history. Both
`subscriber->filter` and `subscriber->sampleFilter` go through the same guard. The key-filter half is hard to reach
with a deterministic predicate, though — for a keyed writer the filter already ran on that key at attach without
throwing, and the `_filteredElements` branch stores DataStorm's own `alwaysMatchFilter` — so only a predicate that
throws after having accepted the same key at attach gets in. It is guarded because the guard is shared, not because
that path is known to be reachable.
`send()` clears `_sample` on the throwing path, so a failure in any other forwarding operation cannot leave a stale
sample behind either.

### Test

A paired `DataStorm/events` case: an unfiltered reader and a sample-filtered one on the same writer and key, with a
predicate that throws for one update and for the remove. The unfiltered reader receives all four samples including the
throwing ones, the filtered reader receives exactly the two the predicate accepted, and `remove()` does not terminate
the writer.

No changelog fragment, matching the sibling fixes #6344, #6578 and #6608.

Built and tested on Linux in a container from `.devcontainer/debian12`; 13/13 DataStorm suites pass.

https://claude.ai/code/session_01SNHcCThYs46uCZnopdPaau

