### PR TITLE
Identify DataStorm session creation exchanges so both nodes commit the same one

### DIFF
--- a/changelog.d/datastorm/6644.md
+++ b/changelog.d/datastorm/6644.md
@@ -1,0 +1,3 @@
+- Fixed a bug in DataStorm where a reader could permanently stop receiving samples after a connection closure, with
+  a call such as `getNextUnread` then blocking forever. This bug affected readers and writers that reach each other
+  through more than one relay node.

--- a/cpp/msbuild/ice.test.slnx
+++ b/cpp/msbuild/ice.test.slnx
@@ -50,6 +50,10 @@
     <Project Path="../test/DataStorm/reliability/msbuild/reader/reader.vcxproj" />
     <Project Path="../test/DataStorm/reliability/msbuild/writer/writer.vcxproj" />
   </Folder>
+  <Folder Name="/DataStorm/sessionHandshake/">
+    <Project Path="../test/DataStorm/sessionHandshake/msbuild/client/client.vcxproj" />
+    <Project Path="../test/DataStorm/sessionHandshake/msbuild/writer/writer.vcxproj" />
+  </Folder>
   <Folder Name="/DataStorm/topicDestroy/">
     <Project Path="../test/DataStorm/topicDestroy/msbuild/reader/reader.vcxproj" />
     <Project Path="../test/DataStorm/topicDestroy/msbuild/writer/writer.vcxproj" />

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -33,7 +33,7 @@ module DataStormContract
 
     dictionary<long, long> LongLongDict;
 
-    /// Represents a data sample, the fundamental unit of data exchanged between DataStorm readers and writers.
+    /// Represents a data sample, the fundamental unit of data handshaked between DataStorm readers and writers.
     struct DataSample
     {
         /// The unique identifier for the sample.
@@ -384,7 +384,10 @@ module DataStormContract
         ///
         /// For sessions established through a relay node, this operation is invoked by the relay node if the connection
         /// between the relay node and the target node is lost.
-        void disconnected();
+        ///
+        /// @param handshakeId The identifier of the session creation handshake this notification applies to. The
+        /// receiver ignores a notification for a handshake other than the one that established its session.
+        void disconnected(long handshakeId);
     }
 
     /// The PublisherSession servant is hosted by the publisher node and is accessed by the subscriber node.
@@ -414,6 +417,9 @@ module DataStormContract
 
         /// A confirmation was received for a session that doesn't exist.
         SessionNotFound,
+
+        /// The session creation handshake was superseded by a more recent handshake, which determines the outcome.
+        Superseded,
 
         /// The session creation failed due to an internal error.
         Internal,
@@ -457,16 +463,22 @@ module DataStormContract
         /// @param subscriber The subscriber node initiating the session. This proxy is never null.
         /// @param session The subscriber session being created. This proxy is never null.
         /// @param fromRelay Indicates whether the session is being created from a relay node.
+        /// @param handshakeId The identifier of this session creation handshake, allocated by the subscriber. The
+        /// publisher echoes it in the matching {@link Node::confirmCreateSession}. Identifiers increase over time, and
+        /// a node acts only on the most recent handshake it has seen.
         /// @throws SessionCreationException Thrown when the session cannot be created.
-        void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay)
+        void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay, long handshakeId)
             throws SessionCreationException;
 
         /// Confirm the creation of a publisher session with a node.
         ///
         /// @param publisher The publisher node confirming the session. The proxy is never null.
         /// @param session The publisher session being confirmed. The proxy is never null.
+        /// @param handshakeId The identifier of the session creation handshake this confirmation belongs to, as
+        /// provided by the subscriber in {@link Node::createSession}.
         /// @throws SessionCreationException Thrown when the session cannot be created.
-        void confirmCreateSession(Node* publisher, PublisherSession* session) throws SessionCreationException;
+        void confirmCreateSession(Node* publisher, PublisherSession* session, long handshakeId)
+            throws SessionCreationException;
     }
 
     /// The lookup interface is used by DataStorm nodes to announce their topic readers and writers to other connected

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -103,7 +103,7 @@ NodeI::destroy(bool ownsCommunicator)
                 try
                 {
                     // Notify subscriber session of the disconnection, don't need to wait for the result.
-                    session->disconnectedAsync(nullptr);
+                    session->disconnectedAsync(subscriber->handshakeId(), nullptr);
                 }
                 catch (const LocalException&)
                 {
@@ -118,7 +118,7 @@ NodeI::destroy(bool ownsCommunicator)
                 try
                 {
                     // Notify publisher session of the disconnection, don't need to wait for the result.
-                    session->disconnectedAsync(nullptr);
+                    session->disconnectedAsync(publisher->handshakeId(), nullptr);
                 }
                 catch (const LocalException&)
                 {
@@ -182,6 +182,7 @@ NodeI::createSessionAsync(
     optional<NodePrx> subscriber,
     optional<SubscriberSessionPrx> subscriberSession,
     bool fromRelay,
+    int64_t handshakeId,
     function<void()> response,
     function<void(exception_ptr)> exception,
     const Current& current)
@@ -228,9 +229,17 @@ NodeI::createSessionAsync(
         s->ice_getConnectionAsync(
             [=, self = shared_from_this()](const auto& connection) mutable
             {
-                if (session->checkSession())
+                const auto disposition = session->beginHandshake(handshakeId);
+
+                // Re-read the attempt token now that this handshake is starting. It was first read when the
+                // request was dispatched, but acquiring the connection above is asynchronous and the session can
+                // have connected in the meantime, which advances the token. A failure of this handshake reported
+                // against the earlier value would be dismissed as belonging to an attempt that has since been
+                // superseded, leaving the session with neither a retry nor a removal.
+                connectAttempt = session->connectAttempt();
+                if (disposition == SessionI::HandshakeDisposition::Duplicate)
                 {
-                    // The session is already connected.
+                    // The subscriber is repeating the handshake this session is already connected under.
                     if (traceLevels->session > 2)
                     {
                         Trace out(traceLevels->logger, traceLevels->sessionCat);
@@ -240,6 +249,21 @@ NodeI::createSessionAsync(
                     }
                     exception(
                         std::make_exception_ptr(SessionCreationException{SessionCreationError::AlreadyConnected}));
+                    return;
+                }
+                else if (disposition == SessionI::HandshakeDisposition::Stale)
+                {
+                    // A more recent handshake from this subscriber is already under way and decides the outcome.
+                    exception(std::make_exception_ptr(SessionCreationException{SessionCreationError::Superseded}));
+                    return;
+                }
+                else if (disposition == SessionI::HandshakeDisposition::Destroyed)
+                {
+                    // This session was removed while the request was dispatched: acquiring the connection above
+                    // is asynchronous, and the callback keeps the servant alive past its removal from the node.
+                    // Report a plain failure so the subscriber retries and creates a session against a fresh
+                    // servant, rather than waiting on a handshake this node can no longer carry.
+                    exception(std::make_exception_ptr(SessionCreationException{SessionCreationError::Internal}));
                     return;
                 }
                 response();
@@ -267,17 +291,38 @@ NodeI::createSessionAsync(
                     s->confirmCreateSessionAsync(
                         self->_proxy,
                         uncheckedCast<PublisherSessionPrx>(session->getProxy()),
-                        [session, subscriberSession, connection, instance]
+                        handshakeId,
+                        [session, subscriberSession, connection, instance, handshakeId]
                         {
                             // Session::connected informs the subscriber session of all the topic writers in the
-                            // current node.
-                            session->connected(
-                                *subscriberSession,
-                                connection,
-                                instance->getTopicFactory()->getTopicWriters());
+                            // current node. It refuses a confirmation this session cannot commit: one from a
+                            // handshake superseded while it was in flight, or one that completed after the session
+                            // was destroyed or connected by another handshake.
+                            if (!session->connected(
+                                    *subscriberSession,
+                                    connection,
+                                    instance->getTopicFactory()->getTopicWriters(),
+                                    handshakeId))
+                            {
+                                // The subscriber connects its session before answering the confirmation, so a
+                                // refusal here leaves it connected to a session this node is not using, and it
+                                // would wait forever for samples that never come. Tell it to drop that handshake.
+                                // The notification names the handshake, so a subscriber that has already moved on
+                                // ignores it and only one that is still on this handshake acts on it.
+                                try
+                                {
+                                    subscriberSession->disconnectedAsync(handshakeId, nullptr);
+                                }
+                                catch (const LocalException&)
+                                {
+                                    // The subscriber is unreachable, so it will find out on its own.
+                                }
+                            }
                         },
-                        [self, subscriber, session, connectAttempt](auto ex)
-                        { self->retryPublisherSessionCreation(*subscriber, session, ex, connectAttempt); });
+                        [self, subscriber, session, connectAttempt, handshakeId](auto ex)
+                        {
+                            self->retryPublisherSessionCreation(*subscriber, session, ex, connectAttempt, handshakeId);
+                        });
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
@@ -289,12 +334,17 @@ NodeI::createSessionAsync(
                 }
                 catch (const LocalException&)
                 {
-                    self->retryPublisherSessionCreation(*subscriber, session, current_exception(), connectAttempt);
+                    self->retryPublisherSessionCreation(
+                        *subscriber,
+                        session,
+                        current_exception(),
+                        connectAttempt,
+                        handshakeId);
                 }
             },
-            [self = shared_from_this(), session, subscriber, exception, connectAttempt](exception_ptr ex)
+            [self = shared_from_this(), session, subscriber, exception, connectAttempt, handshakeId](exception_ptr ex)
             {
-                self->retryPublisherSessionCreation(*subscriber, session, ex, connectAttempt);
+                self->retryPublisherSessionCreation(*subscriber, session, ex, connectAttempt, handshakeId);
                 exception(make_exception_ptr(SessionCreationException{SessionCreationError::Internal}));
             });
     }
@@ -312,7 +362,7 @@ NodeI::createSessionAsync(
     {
         assert(session);
         exception(make_exception_ptr(SessionCreationException{SessionCreationError::Internal}));
-        retryPublisherSessionCreation(*subscriber, session, current_exception(), connectAttempt);
+        retryPublisherSessionCreation(*subscriber, session, current_exception(), connectAttempt, handshakeId);
     }
 }
 
@@ -320,6 +370,7 @@ void
 NodeI::confirmCreateSessionAsync(
     optional<NodePrx> publisher,
     optional<PublisherSessionPrx> publisherSession,
+    int64_t handshakeId,
     function<void()> response,
     function<void(exception_ptr)> exception,
     const Current& current)
@@ -375,12 +426,49 @@ NodeI::confirmCreateSessionAsync(
     // Session::connected informs the publisher session of all the topic readers in the current node. The publisher
     // session is not connected yet - it connects when the confirmation response arrives - so it drops this initial
     // announcement; the attachment is instead driven by the publisher's own topic announcement, sent once connected.
-    session->connected(*publisherSession, current.con, instance->getTopicFactory()->getTopicReaders());
+    if (!session
+             ->connected(*publisherSession, current.con, instance->getTopicFactory()->getTopicReaders(), handshakeId))
+    {
+        // This node started a more recent handshake while this confirmation was in flight. Reporting it as
+        // superseded rather than as a plain failure keeps the publisher from spending a retry on a handshake
+        // neither node is waiting for: the newer handshake decides the outcome for both.
+        if (traceLevels->session > 2)
+        {
+            Trace out(traceLevels->logger, traceLevels->sessionCat);
+            out << "node '" << current.id << "' is ignoring '" << current.operation << "' request from '" << publisher
+                << "' because session creation handshake " << handshakeId << " was superseded";
+        }
+        exception(make_exception_ptr(SessionCreationException{SessionCreationError::Superseded}));
+        return;
+    }
 
     // Send the response only after this session is connected: the response is the publisher's send barrier. The
     // publisher marks its session connected and starts announcing topics and forwarding samples only after this node
     // acknowledges the confirmation.
     response();
+}
+
+int64_t
+NodeI::nextHandshakeId()
+{
+    // Called with the node mutex locked.
+    //
+    // Peers order handshakes by this identifier, so it has to increase. The order is purely local: only a
+    // subscriber allocates identifiers, a session belongs to exactly one peer node, and a relay forwards the
+    // identifier unchanged - so every comparison is between two identifiers from this one sequence. Nothing here
+    // depends on clocks being synchronized between nodes. An opaque identifier such as a UUID cannot be used: it
+    // would give uniqueness but not the order the peer needs to reject a handshake older than one it has seen.
+    //
+    // The clock supplies the one thing a plain counter cannot - identifiers that outrank the previous incarnation
+    // of this node after a restart, which matters because a peer keeps a session for up to a minute after this
+    // node disappears and would otherwise reject every identifier the restarted node allocates. Taking the clock
+    // on each allocation rather than incrementing a seed keeps the sequence from drifting ahead of the clock and
+    // staying there; the floor keeps it increasing within a millisecond. The residual failure mode is this node's
+    // own clock stepping backwards across its own restart by more than the peer's session hold time.
+    const auto now =
+        chrono::duration_cast<chrono::milliseconds>(chrono::system_clock::now().time_since_epoch()).count();
+    _nextHandshakeId = std::max(now, _nextHandshakeId + 1);
+    return _nextHandshakeId;
 }
 
 void
@@ -445,6 +533,7 @@ NodeI::createPublisherSession(
     auto traceLevels = instance->getTraceLevels();
 
     int64_t connectAttempt = session ? session->connectAttempt() : 0;
+    optional<int64_t> handshakeId;
 
     try
     {
@@ -470,13 +559,24 @@ NodeI::createPublisherSession(
         }
 
         assert(session);
+
+        // The subscriber allocates the handshake identifier; the publisher echoes it in its confirmation so both
+        // nodes commit the same handshake even when several are in flight over different routes.
+        //
+        // A retry task can fire just as the session connects, so a connected session repeats the handshake it is
+        // connected under: starting a new one would tell the publisher that this node no longer has the session -
+        // which is how it reads a request naming a different handshake - and it would drop a session both nodes are
+        // happily using.
+        handshakeId = session->beginOutgoingHandshake(nextHandshakeId());
+
         p->createSessionAsync(
             _proxy,
             uncheckedCast<SubscriberSessionPrx>(session->getProxy()),
             false,
+            *handshakeId,
             nullptr,
-            [self = shared_from_this(), publisher, session, connectAttempt](exception_ptr ex)
-            { self->retrySubscriberSessionCreation(publisher, session, ex, connectAttempt); });
+            [self = shared_from_this(), publisher, session, connectAttempt, handshakeId](exception_ptr ex)
+            { self->retrySubscriberSessionCreation(publisher, session, ex, connectAttempt, handshakeId); });
     }
     catch (const CommunicatorDestroyedException&)
     {
@@ -490,7 +590,7 @@ NodeI::createPublisherSession(
     }
     catch (const LocalException&)
     {
-        retrySubscriberSessionCreation(publisher, session, current_exception(), connectAttempt);
+        retrySubscriberSessionCreation(publisher, session, current_exception(), connectAttempt, handshakeId);
         throw SessionCreationException{SessionCreationError::Internal};
     }
 }
@@ -500,9 +600,10 @@ NodeI::retrySubscriberSessionCreation(
     const NodePrx& node,
     const shared_ptr<SubscriberSessionI>& session,
     exception_ptr ex,
-    std::int64_t connectAttempt)
+    std::int64_t connectAttempt,
+    optional<int64_t> handshakeId)
 {
-    if (!session->sessionCreationFailed(node, ex, connectAttempt))
+    if (!session->sessionCreationFailed(node, ex, connectAttempt, handshakeId))
     {
         removeSubscriberSession(node, session, ex);
     }
@@ -530,9 +631,10 @@ NodeI::retryPublisherSessionCreation(
     const NodePrx& node,
     const shared_ptr<PublisherSessionI>& session,
     exception_ptr ex,
-    std::int64_t connectAttempt)
+    std::int64_t connectAttempt,
+    optional<int64_t> handshakeId)
 {
-    if (!session->sessionCreationFailed(node, ex, connectAttempt))
+    if (!session->sessionCreationFailed(node, ex, connectAttempt, handshakeId))
     {
         removePublisherSession(node, session, ex);
     }

--- a/cpp/src/DataStorm/NodeI.h
+++ b/cpp/src/DataStorm/NodeI.h
@@ -36,6 +36,7 @@ namespace DataStormI
             std::optional<DataStormContract::NodePrx>,
             std::optional<DataStormContract::SubscriberSessionPrx>,
             bool,
+            std::int64_t,
             std::function<void()>,
             std::function<void(std::exception_ptr)>,
             const Ice::Current&) final;
@@ -43,6 +44,7 @@ namespace DataStormI
         void confirmCreateSessionAsync(
             std::optional<DataStormContract::NodePrx>,
             std::optional<DataStormContract::PublisherSessionPrx>,
+            std::int64_t,
             std::function<void()>,
             std::function<void(std::exception_ptr)>,
             const Ice::Current&) final;
@@ -57,21 +59,24 @@ namespace DataStormI
             const Ice::ConnectionPtr&,
             std::shared_ptr<SubscriberSessionI>);
 
-        /// Handles the failure of a session creation attempt. The last parameter is the value
-        /// SessionI::connectAttempt returned when the attempt was started; a reply from a superseded attempt is
-        /// discarded rather than charged against the current attempt's retry budget.
+        /// Handles the failure of a session creation attempt.
+        /// @param connectAttempt The value SessionI::connectAttempt returned when the attempt was started; a reply
+        /// from a superseded attempt is discarded rather than charged against the current attempt's retry budget.
+        /// @param handshakeId The handshake the attempt belongs to, when it had one.
         void retrySubscriberSessionCreation(
             const DataStormContract::NodePrx&,
             const std::shared_ptr<SubscriberSessionI>&,
             std::exception_ptr,
-            std::int64_t);
+            std::int64_t connectAttempt,
+            std::optional<std::int64_t> handshakeId = std::nullopt);
 
         /// @copydoc retrySubscriberSessionCreation
         void retryPublisherSessionCreation(
             const DataStormContract::NodePrx&,
             const std::shared_ptr<PublisherSessionI>&,
             std::exception_ptr,
-            std::int64_t);
+            std::int64_t,
+            std::optional<std::int64_t> = std::nullopt);
 
         void removeSubscriberSession(
             const DataStormContract::NodePrx&,
@@ -105,6 +110,9 @@ namespace DataStormI
         }
 
     private:
+        /// Allocates the identifier of a new session creation handshake. Called with the node mutex locked.
+        [[nodiscard]] std::int64_t nextHandshakeId();
+
         [[nodiscard]] std::shared_ptr<SubscriberSessionI>
         createSubscriberSessionServant(const DataStormContract::NodePrx&);
 
@@ -118,6 +126,10 @@ namespace DataStormI
         mutable std::mutex _mutex;
         std::int64_t _nextPublisherSessionId{0};
         std::int64_t _nextSubscriberSessionId{0};
+
+        // The last handshake identifier this node allocated as a subscriber. Identifiers must keep increasing for a
+        // given peer, so the sequence is node-wide: a session servant recreated for the same peer continues it.
+        std::int64_t _nextHandshakeId{0};
 
         // The proxy for this node.
         DataStormContract::NodePrx _proxy;

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -68,6 +68,7 @@ namespace
             optional<NodePrx> subscriber,
             optional<SubscriberSessionPrx> subscriberSession,
             bool /* fromRelay */,
+            int64_t handshakeId,
             function<void()> response,
             function<void(exception_ptr)> exception,
             const Current& current) final
@@ -90,10 +91,17 @@ namespace
                     nodeSession->addSession(
                         subscriber->ice_getIdentity(),
                         subscriberSession->ice_getIdentity(),
-                        subscriberIsHostedOnRelay ? subscriberSession->ice_fixed(current.con) : *subscriberSession);
+                        subscriberIsHostedOnRelay ? subscriberSession->ice_fixed(current.con) : *subscriberSession,
+                        handshakeId);
 
                     // Forward the call to the target Node.
-                    _node->createSessionAsync(subscriber, subscriberSessionForwarder, true, response, exception);
+                    _node->createSessionAsync(
+                        subscriber,
+                        subscriberSessionForwarder,
+                        true,
+                        handshakeId,
+                        response,
+                        exception);
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
@@ -110,6 +118,7 @@ namespace
         void confirmCreateSessionAsync(
             optional<NodePrx> publisher,
             optional<PublisherSessionPrx> publisherSession,
+            int64_t handshakeId,
             function<void()> response,
             function<void(exception_ptr)> exception,
             const Current& current) final
@@ -131,9 +140,15 @@ namespace
                     nodeSession->addSession(
                         publisher->ice_getIdentity(),
                         publisherSession->ice_getIdentity(),
-                        publisherIsHostedOnRelay ? publisherSession->ice_fixed(current.con) : *publisherSession);
+                        publisherIsHostedOnRelay ? publisherSession->ice_fixed(current.con) : *publisherSession,
+                        handshakeId);
                     // Forward the request to the target subscriber.
-                    _node->confirmCreateSessionAsync(publisher, publisherSessionForwarder, response, exception);
+                    _node->confirmCreateSessionAsync(
+                        publisher,
+                        publisherSessionForwarder,
+                        handshakeId,
+                        response,
+                        exception);
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
@@ -246,10 +261,12 @@ NodeSessionI::destroy()
             _instance->getObjectAdapter()->remove(_publicNode->ice_getIdentity());
         }
 
-        for (const auto& [_, session] : _sessions)
+        for (const auto& [_, forwarded] : _sessions)
         {
-            // Notify each session of the disconnection; we don't wait for the result.
-            session->disconnectedAsync(nullptr);
+            // Notify each session of the disconnection; we don't wait for the result. The notification names the
+            // handshake this relay forwarded, so a peer that has since established the session over another route
+            // ignores it.
+            forwarded.session->disconnectedAsync(forwarded.handshakeId, nullptr);
         }
     }
     catch (const ObjectAdapterDestroyedException&)
@@ -267,8 +284,18 @@ NodeSessionI::destroy()
 }
 
 void
-NodeSessionI::addSession(Identity nodeId, Identity sessionId, SessionPrx session)
+NodeSessionI::addSession(Identity nodeId, Identity sessionId, SessionPrx session, int64_t handshakeId)
 {
     lock_guard<mutex> lock(_mutex);
-    _sessions.insert_or_assign(std::pair{std::move(nodeId), std::move(sessionId)}, std::move(session));
+    auto key = std::pair{std::move(nodeId), std::move(sessionId)};
+    auto p = _sessions.find(key);
+    if (p != _sessions.end() && handshakeId < p->second.handshakeId)
+    {
+        // Requests for different handshakes arrive in any order. Recording an older one would make the disconnect
+        // notification sent when this node session is destroyed name a handshake the peer has moved past, and the
+        // peer would ignore it - never learning that the route through this relay is gone.
+        return;
+    }
+
+    _sessions.insert_or_assign(std::move(key), ForwardedSession{std::move(session), handshakeId});
 }

--- a/cpp/src/DataStorm/NodeSessionI.h
+++ b/cpp/src/DataStorm/NodeSessionI.h
@@ -16,7 +16,11 @@ namespace DataStormI
 
         void init();
         void destroy();
-        void addSession(Ice::Identity nodeId, Ice::Identity sessionId, DataStormContract::SessionPrx session);
+        void addSession(
+            Ice::Identity nodeId,
+            Ice::Identity sessionId,
+            DataStormContract::SessionPrx session,
+            std::int64_t handshakeId);
 
         [[nodiscard]] DataStormContract::NodePrx getPublicNode() const
         {
@@ -73,7 +77,17 @@ namespace DataStormI
         //
         // We use a map keyed on this pair (rather than a vector or list) so that re-adding a session with an
         // existing key replaces its proxy in place via insert_or_assign, instead of leaving a stale entry behind.
-        std::map<std::pair<Ice::Identity, Ice::Identity>, DataStormContract::SessionPrx> _sessions;
+        //
+        // The handshake identifier is kept alongside the proxy so that the disconnect notification this session
+        // sends when it is destroyed names the handshake it forwarded, and a peer that has since moved to another
+        // route ignores it instead of tearing down a session this relay no longer carries.
+        struct ForwardedSession
+        {
+            DataStormContract::SessionPrx session;
+            std::int64_t handshakeId;
+        };
+
+        std::map<std::pair<Ice::Identity, Ice::Identity>, ForwardedSession> _sessions;
     };
 }
 #endif

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -652,23 +652,115 @@ SessionI::initSamples(int64_t topicId, int64_t peerTopicId, DataSamplesSeq initi
 }
 
 void
-SessionI::disconnected(const Current& current)
+SessionI::disconnected(int64_t handshakeId, const Current& current)
 {
-    if (!handleDisconnected(current.con, nullptr))
+    if (!handleDisconnected(current.con, nullptr, handshakeId))
     {
         remove();
     }
 }
 
-void
-SessionI::connected(SessionPrx session, const ConnectionPtr& newConnection, const TopicInfoSeq& topics)
+SessionI::HandshakeDisposition
+SessionI::beginHandshake(int64_t handshakeId)
+{
+    lock_guard<mutex> lock(_mutex);
+    if (_destroyed)
+    {
+        // The session was removed from the node while this request was dispatched: it cannot carry a handshake.
+        // Reporting a failure has the peer start a fresh handshake, which creates a new session servant.
+        return HandshakeDisposition::Destroyed;
+    }
+    else if (handshakeId < _pendingHandshakeId)
+    {
+        // Handshake identifiers increase, and requests for different handshakes arrive in any order because each can
+        // take a different route. Adopting an older one here would leave this node waiting on a handshake the peer
+        // has already moved past, and reject the newer handshake's confirmation when it completes.
+        if (_traceLevels->session > 1)
+        {
+            Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+            out << _id << ": ignoring session creation handshake " << handshakeId << ", the pending handshake is "
+                << _pendingHandshakeId;
+        }
+        return HandshakeDisposition::Stale;
+    }
+
+    if (checkSessionImpl())
+    {
+        if (handshakeId == _handshakeId)
+        {
+            return HandshakeDisposition::Duplicate;
+        }
+
+        // The peer is creating a session under a handshake other than the one this session is connected under, so
+        // it no longer has that session. Drop it here rather than rejecting the request: the handshake starting now
+        // takes over the reconnection, and refusing it would leave this node connected to a session that is gone
+        // while the peer retries forever.
+        if (_traceLevels->session > 1)
+        {
+            Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+            out << _id << ": superseding session creation handshake " << _handshakeId << " with " << handshakeId;
+        }
+        static_cast<void>(disconnectedImpl(nullptr, nullptr));
+    }
+
+    _pendingHandshakeId = handshakeId;
+    return HandshakeDisposition::Proceed;
+}
+
+int64_t
+SessionI::beginOutgoingHandshake(int64_t candidate)
+{
+    lock_guard<mutex> lock(_mutex);
+    if (checkSessionImpl())
+    {
+        // Already connected: repeat the handshake this session is connected under instead of starting a new one. A
+        // retry task can fire just as the session connects, and naming a new handshake would tell the publisher that
+        // this node lost the session - which is how it reads a request for a different handshake - making it drop a
+        // session both nodes are using. Repeating the current one leaves the request to be recognized as the
+        // duplicate it is. The check and the choice are one step because the session can connect at any moment.
+        return _handshakeId;
+    }
+
+    _pendingHandshakeId = candidate;
+    return _pendingHandshakeId;
+}
+
+int64_t
+SessionI::handshakeId() const
+{
+    lock_guard<mutex> lock(_mutex);
+    return _handshakeId;
+}
+
+bool
+SessionI::connected(
+    SessionPrx session,
+    const ConnectionPtr& newConnection,
+    const TopicInfoSeq& topics,
+    int64_t handshakeId)
 {
     lock_guard<mutex> lock(_mutex);
     if (_destroyed || _session)
     {
         // Nothing to do, we are either destroyed or already connected.
-        return;
+        return false;
     }
+    else if (handshakeId != _pendingHandshakeId)
+    {
+        // A confirmation from a handshake that was superseded while it was in flight. Committing it would connect
+        // this session to a peer session the peer has already moved off, and every later attempt from that peer
+        // would then be rejected as already connected. The handshake that superseded this one decides the outcome,
+        // so there is nothing to retry here either.
+        if (_traceLevels->session > 1)
+        {
+            Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+            out << _id << ": ignoring the confirmation of session creation handshake " << handshakeId
+                << ", the pending handshake is " << _pendingHandshakeId;
+        }
+        return false;
+    }
+
+    _handshakeId = handshakeId;
 
     _session = std::move(session);
     _connection = newConnection;
@@ -722,13 +814,14 @@ SessionI::connected(SessionPrx session, const ConnectionPtr& newConnection, cons
             // Ignore
         }
     }
+    return true;
 }
 
 bool
-SessionI::handleDisconnected(const ConnectionPtr& connection, exception_ptr ex)
+SessionI::handleDisconnected(const ConnectionPtr& connection, exception_ptr ex, optional<int64_t> handshakeId)
 {
     lock_guard<mutex> lock(_mutex);
-    if (!disconnectedImpl(connection, ex))
+    if (!disconnectedImpl(connection, ex, handshakeId))
     {
         // Nothing to do: the session is destroyed, already reconnected, or the disconnect was already handled.
         return true;
@@ -737,12 +830,19 @@ SessionI::handleDisconnected(const ConnectionPtr& connection, exception_ptr ex)
 }
 
 bool
-SessionI::disconnectedImpl(const ConnectionPtr& connection, exception_ptr ex)
+SessionI::disconnectedImpl(const ConnectionPtr& connection, exception_ptr ex, optional<int64_t> handshakeId)
 {
     // Called with the session mutex locked.
     if (_destroyed)
     {
         // Ignore already destroyed.
+        return false;
+    }
+    else if (handshakeId && *handshakeId < _pendingHandshakeId)
+    {
+        // A notification for a handshake this session has already moved past. It reports the loss of a route the
+        // session no longer uses, so it must be ignored whether or not the session is currently connected - while
+        // disconnected it would otherwise be taken for a fresh failure and consume a retry.
         return false;
     }
     else if (!_session)
@@ -757,6 +857,12 @@ SessionI::disconnectedImpl(const ConnectionPtr& connection, exception_ptr ex)
     else if (connection && _connection != connection)
     {
         // Ignore the session has already reconnected using a new connection.
+        return false;
+    }
+    else if (handshakeId && *handshakeId != _handshakeId)
+    {
+        // A notification for a handshake this session has already replaced. It reports the loss of a route the
+        // session no longer uses, so acting on it would tear down a healthy session.
         return false;
     }
 
@@ -813,7 +919,11 @@ SessionI::disconnectedImpl(const ConnectionPtr& connection, exception_ptr ex)
 }
 
 bool
-SessionI::sessionCreationFailed(NodePrx node, exception_ptr exception, int64_t connectAttempt)
+SessionI::sessionCreationFailed(
+    NodePrx node,
+    exception_ptr exception,
+    int64_t connectAttempt,
+    optional<int64_t> handshakeId)
 {
     lock_guard<mutex> lock(_mutex);
 
@@ -849,6 +959,34 @@ SessionI::sessionCreationFailed(NodePrx node, exception_ptr exception, int64_t c
                 // A concurrent session creation from the peer succeeded, no need to retry.
                 return true;
             }
+            else if (ex.error == SessionCreationError::Superseded && !allocatesHandshakes())
+            {
+                // The peer allocates the handshake identifiers for this session, so its word that a newer handshake
+                // replaced this one is authoritative: it allocated that handshake before reporting this one
+                // superseded, and it drives it from there. Charging a retry now would spend this session's budget
+                // on a handshake nobody is waiting for, and the retry would prompt yet another handshake whose
+                // predecessor is refused the same way, exhausting the budget on a session that is recovering
+                // normally.
+                //
+                // The peer's word covers the handshake it allocated, not its delivery: it can die immediately after
+                // reporting this one superseded, and nothing here would notice. Park the session so it is removed
+                // if the peer never does re-establish it, rather than lingering unusable until the node shuts
+                // down. A peer that does re-establish it cancels the timer by connecting.
+                parkForPeer();
+                return true;
+            }
+            else if (handshakeId && *handshakeId < _pendingHandshakeId)
+            {
+                // A failure of a handshake this node has already moved past, whatever the reason. The handshake
+                // that replaced it decides the outcome, so this one must not consume its retry budget.
+                //
+                // For a Superseded failure this is also the only evidence a node that allocates its own
+                // identifiers accepts: a peer ordering against an identifier from a previous incarnation of this
+                // node - one allocated before a restart across which the clock moved backwards - reports every
+                // fresh handshake as superseded, and believing that would leave the session with no handshake in
+                // flight, no retry, and nothing to recover it.
+                return true;
+            }
         }
         catch (const std::exception&)
         {
@@ -864,6 +1002,29 @@ SessionI::connectAttempt() const
 {
     lock_guard<mutex> lock(_mutex);
     return _connectAttempt;
+}
+
+void
+SessionI::parkForPeer()
+{
+    // Called with the session mutex locked.
+    if (_destroyed || _retryTask)
+    {
+        // Something is already watching this session.
+        return;
+    }
+
+    // The same wait retryImpl uses when it has no endpoints to retry to and can only wait for the peer.
+    auto delay = _instance->getRetryDelay(_instance->getRetryCount()) * 2;
+
+    if (_traceLevels->session > 0)
+    {
+        Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+        out << _id << ": waiting " << delay.count() << " (ms) for the peer to re-establish the session";
+    }
+
+    _retryTask = make_shared<IceInternal::InlineTimerTask>([self = shared_from_this()] { self->remove(); });
+    _instance->scheduleTimerTask(_retryTask, delay);
 }
 
 bool

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -307,25 +307,76 @@ namespace DataStormI
 
         void initSamples(std::int64_t, std::int64_t, DataStormContract::DataSamplesSeq, const Ice::Current&) final;
 
-        void disconnected(const Ice::Current&) final;
+        void disconnected(std::int64_t handshakeId, const Ice::Current&) final;
 
-        void
-        connected(DataStormContract::SessionPrx, const Ice::ConnectionPtr&, const DataStormContract::TopicInfoSeq&);
+        /// The outcome of an incoming session creation request.
+        enum class HandshakeDisposition
+        {
+            /// Carry on with the handshake; it is now this session's pending one.
+            Proceed,
+
+            /// The peer is repeating the handshake this session is already connected under.
+            Duplicate,
+
+            /// The request belongs to a handshake older than the one this session is already working on.
+            Stale,
+
+            /// The session was destroyed while the request was being dispatched.
+            Destroyed
+        };
+
+        /// Registers an incoming session creation request as this session's pending handshake.
+        ///
+        /// A request naming a handshake other than the one this session is connected under is proof that the peer no
+        /// longer has that session, so the session is disconnected here and the new handshake takes over the
+        /// reconnection.
+        [[nodiscard]] HandshakeDisposition beginHandshake(std::int64_t handshakeId);
+
+        /// Records a handshake this node is starting as the pending one. Only the subscriber allocates handshake
+        /// identifiers; the publisher adopts the one it receives.
+        /// @param candidate The identifier allocated for a new handshake.
+        /// @return The identifier to send: @p candidate, or the handshake this session is already connected under.
+        /// The peer reads a request naming a different handshake as proof that this node lost the session, so a
+        /// connected session repeats its current handshake rather than announcing a new one.
+        [[nodiscard]] std::int64_t beginOutgoingHandshake(std::int64_t candidate);
+
+        /// The handshake this session is connected under. Only meaningful while the session is connected.
+        [[nodiscard]] std::int64_t handshakeId() const;
+
+        /// Connects the session, unless the handshake is no longer the pending one.
+        /// @return `false` when the handshake was superseded, or the session is destroyed or already connected.
+        [[nodiscard]] bool connected(
+            DataStormContract::SessionPrx session,
+            const Ice::ConnectionPtr& connection,
+            const DataStormContract::TopicInfoSeq& topics,
+            std::int64_t handshakeId);
 
         /// Handles a disconnect notification (the peer's disconnected() request or the connection closure) and,
         /// when the session was connected, schedules the reconnection retry. Handling both under a single lock
         /// acquisition keeps a concurrent duplicate notification for the same disconnect from consuming an
         /// additional retry attempt.
+        /// @param handshakeId When set, the handshake the notification refers to; a notification for a handshake this
+        /// session has already replaced is ignored.
         /// @return `false` when the retry limit was reached or no retry is possible: the caller must remove the
         /// session.
-        [[nodiscard]] bool handleDisconnected(const Ice::ConnectionPtr&, std::exception_ptr);
+        [[nodiscard]] bool handleDisconnected(
+            const Ice::ConnectionPtr&,
+            std::exception_ptr,
+            std::optional<std::int64_t> handshakeId = std::nullopt);
 
         void destroyImpl(const std::exception_ptr&);
 
         // The implementations of checkSession, disconnected and retry; called with the session mutex locked.
         [[nodiscard]] bool checkSessionImpl();
-        bool disconnectedImpl(const Ice::ConnectionPtr&, std::exception_ptr);
+        bool disconnectedImpl(
+            const Ice::ConnectionPtr&,
+            std::exception_ptr,
+            std::optional<std::int64_t> handshakeId = std::nullopt);
         [[nodiscard]] bool retryImpl(DataStormContract::NodePrx, std::exception_ptr);
+
+        /// Parks the session until the peer re-establishes it, scheduling its removal if the peer never does. Called
+        /// with the session mutex locked; does nothing when a retry or removal is already scheduled.
+        void parkForPeer();
 
         // Cancels and clears any pending retry task, breaking the _retryTask -> task -> lambda -> self reference
         // cycle so the session can be reclaimed. Used by NodeI::destroy, which drops sessions without calling
@@ -350,12 +401,15 @@ namespace DataStormI
         /// @param connectAttempt The value #connectAttempt returned when the attempt was started. A reply from an
         /// attempt that has since been superseded is ignored, so it cannot consume the current attempt's retry
         /// budget; without this a burst of late replies destroys a session that is reconnecting normally.
+        /// @param handshakeId The handshake the failed attempt belongs to, when it had one. A failure of a handshake
+        /// older than the pending one is ignored.
         /// @return `false` when the retry limit was reached or no retry is possible: the caller must remove the
         /// session.
         [[nodiscard]] bool sessionCreationFailed(
             DataStormContract::NodePrx node,
             std::exception_ptr exception,
-            std::int64_t connectAttempt);
+            std::int64_t connectAttempt,
+            std::optional<std::int64_t> handshakeId = std::nullopt);
 
         [[nodiscard]] DataStormContract::SessionPrx getProxy() const { return _proxy; }
 
@@ -489,6 +543,9 @@ namespace DataStormI
         /// @return A vector containing the topics that match the specified name.
         virtual std::vector<std::shared_ptr<TopicI>> getTopics(const std::string& name) const = 0;
 
+        /// Whether this node allocates the handshake identifiers for this session. Only the subscriber does.
+        [[nodiscard]] virtual bool allocatesHandshakes() const = 0;
+
         virtual void remove() = 0;
 
         const std::shared_ptr<Instance> _instance;
@@ -523,6 +580,16 @@ namespace DataStormI
         // the session with no attempt, no retry task, and no removal.
         std::int64_t _connectAttempt{0};
 
+        // The invariant both nodes maintain: commit only the newest handshake seen, and never go back to an older
+        // one. "Seen" rather than "in flight" is what makes it work - a handshake that has been superseded must go on
+        // suppressing the ones before it, so _pendingHandshakeId is a high-water mark and is deliberately never
+        // reset, not on disconnect and not on destruction.
+        //
+        // _handshakeId is the handshake this session is connected under; it equals _pendingHandshakeId while the
+        // session is connected.
+        std::int64_t _handshakeId{0};
+        std::int64_t _pendingHandshakeId{0};
+
         // A retry task, scheduled if an attempt to reconnect the session is underway; nullptr if no retry is scheduled.
         IceInternal::TimerTaskPtr _retryTask;
 
@@ -541,6 +608,8 @@ namespace DataStormI
     class SubscriberSessionI : public SessionI, public DataStormContract::SubscriberSession
     {
     public:
+        [[nodiscard]] bool allocatesHandshakes() const final { return true; }
+
         SubscriberSessionI(
             std::shared_ptr<Instance>,
             std::shared_ptr<NodeI>,
@@ -558,6 +627,8 @@ namespace DataStormI
     class PublisherSessionI : public SessionI, public DataStormContract::PublisherSession
     {
     public:
+        [[nodiscard]] bool allocatesHandshakes() const final { return false; }
+
         PublisherSessionI(
             std::shared_ptr<Instance>,
             std::shared_ptr<NodeI>,

--- a/cpp/test/DataStorm/sessionHandshake/Client.cpp
+++ b/cpp/test/DataStorm/sessionHandshake/Client.cpp
@@ -1,0 +1,435 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "Test.h"
+#include "TestHelper.h"
+
+#include <algorithm>
+#include <condition_variable>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+using namespace std;
+using namespace DataStormContract;
+
+namespace
+{
+    // Stands in for the peer's session servant. What the node under test sends over an established session is
+    // irrelevant here, so accepting every operation avoids implementing the whole Session interface. The
+    // operations are counted because they tell the test what the node decided: a node announces its topics to a
+    // session it has just connected, and disconnects one it has refused to connect.
+    class SessionStub final : public Ice::Blobject
+    {
+    public:
+        bool ice_invoke(Ice::ByteSeq inParams, Ice::ByteSeq&, const Ice::Current& current) final
+        {
+            {
+                lock_guard<mutex> lock(_mutex);
+                ++_counts[current.operation];
+                if (current.operation == "disconnected")
+                {
+                    // Decode the handshake the notification names: the point of the notification is that it is
+                    // scoped, so a test that only counted the operation would pass on a notification naming the
+                    // wrong handshake - which is the harmful case, since it tears down a session that is fine.
+                    Ice::InputStream in{current.adapter->getCommunicator(), inParams};
+                    in.startEncapsulation();
+                    int64_t handshakeId{0};
+                    in.read(handshakeId);
+                    in.endEncapsulation();
+                    _disconnected.push_back(handshakeId);
+                }
+            }
+            _condition.notify_all();
+            return true;
+        }
+
+        [[nodiscard]] int count(const string& operation)
+        {
+            lock_guard<mutex> lock(_mutex);
+            return _counts[operation];
+        }
+
+        /// Waits for @p operation to be dispatched more than @p count times, and reports whether it was.
+        [[nodiscard]] bool waitFor(const string& operation, int count, chrono::milliseconds timeout)
+        {
+            unique_lock<mutex> lock(_mutex);
+            return _condition.wait_for(lock, timeout, [this, &operation, count] { return _counts[operation] > count; });
+        }
+
+        /// Reports whether a disconnect notification naming @p handshakeId has arrived.
+        [[nodiscard]] bool sawDisconnect(int64_t handshakeId)
+        {
+            lock_guard<mutex> lock(_mutex);
+            return find(_disconnected.begin(), _disconnected.end(), handshakeId) != _disconnected.end();
+        }
+
+        /// Waits for a disconnect notification naming @p handshakeId, and reports whether one arrived.
+        [[nodiscard]] bool waitForDisconnect(int64_t handshakeId, chrono::milliseconds timeout)
+        {
+            unique_lock<mutex> lock(_mutex);
+            return _condition.wait_for(
+                lock,
+                timeout,
+                [this, handshakeId]
+                { return find(_disconnected.begin(), _disconnected.end(), handshakeId) != _disconnected.end(); });
+        }
+
+    private:
+        mutex _mutex;
+        condition_variable _condition;
+        map<string, int> _counts;
+        vector<int64_t> _disconnected;
+    };
+
+    // A peer node that plays the subscriber against the node under test, and holds each confirmCreateSession
+    // response until the test releases it. Holding the response is what lets the test place a session creation
+    // handshake's completion after the events that supersede it.
+    class PeerNode final : public AsyncNode
+    {
+    public:
+        struct Confirmation
+        {
+            optional<PublisherSessionPrx> session;
+            Ice::ConnectionPtr connection;
+            int64_t handshakeId;
+            function<void()> response;
+            function<void(exception_ptr)> exception;
+        };
+
+        void initiateCreateSessionAsync(
+            optional<NodePrx> publisher,
+            function<void()> response,
+            function<void(exception_ptr)>,
+            const Ice::Current&) final
+        {
+            {
+                lock_guard<mutex> lock(_mutex);
+                _publisherNode = std::move(publisher);
+                ++_initiateCount;
+            }
+            _condition.notify_all();
+            response();
+        }
+
+        // The node under test is the publisher; it never asks this peer to create a session.
+        void createSessionAsync(
+            optional<NodePrx>,
+            optional<SubscriberSessionPrx>,
+            bool,
+            int64_t,
+            function<void()> response,
+            function<void(exception_ptr)>,
+            const Ice::Current&) final
+        {
+            response();
+        }
+
+        void confirmCreateSessionAsync(
+            optional<NodePrx>,
+            optional<PublisherSessionPrx> session,
+            int64_t handshakeId,
+            function<void()> response,
+            function<void(exception_ptr)> exception,
+            const Ice::Current& current) final
+        {
+            {
+                lock_guard<mutex> lock(_mutex);
+                // The node addresses this session over the connection the createSession request arrived on, so the
+                // test has to answer it over that same connection: a disconnect notification that reaches the node
+                // over any other connection is ignored as belonging to a superseded incarnation.
+                _confirmations.push_back(Confirmation{
+                    std::move(session),
+                    current.con,
+                    handshakeId,
+                    std::move(response),
+                    std::move(exception)});
+            }
+            _condition.notify_all();
+        }
+
+        [[nodiscard]] NodePrx waitForPublisherNode()
+        {
+            unique_lock<mutex> lock(_mutex);
+            _condition.wait(lock, [this] { return _publisherNode.has_value(); });
+            return *_publisherNode;
+        }
+
+        /// The number of times the node asked this peer to initiate session creation. The node does that when it
+        /// schedules a reconnection, so it reports whether a failure consumed the session's retry budget.
+        [[nodiscard]] int initiateCount()
+        {
+            lock_guard<mutex> lock(_mutex);
+            return _initiateCount;
+        }
+
+        /// Waits for the node to ask this peer to initiate session creation more than @p count times.
+        [[nodiscard]] bool waitForInitiate(int count, chrono::milliseconds timeout)
+        {
+            unique_lock<mutex> lock(_mutex);
+            return _condition.wait_for(lock, timeout, [this, count] { return _initiateCount > count; });
+        }
+
+        [[nodiscard]] Confirmation waitForConfirmation()
+        {
+            unique_lock<mutex> lock(_mutex);
+            _condition.wait(lock, [this] { return !_confirmations.empty(); });
+            Confirmation confirmation = std::move(_confirmations.front());
+            _confirmations.pop_front();
+            return confirmation;
+        }
+
+    private:
+        mutex _mutex;
+        condition_variable _condition;
+        optional<NodePrx> _publisherNode;
+        int _initiateCount{0};
+        deque<Confirmation> _confirmations;
+    };
+}
+
+class Client : public Test::TestHelper
+{
+public:
+    Client() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Client::run(int argc, char* argv[])
+{
+    Ice::CommunicatorHolder holder{initialize(argc, argv)};
+    auto communicator = holder.communicator();
+    auto adapter = communicator->createObjectAdapterWithEndpoints("peer", getTestEndpoint(12));
+    auto peer = make_shared<PeerNode>();
+    auto peerNode = adapter->add<NodePrx>(peer, Ice::Identity{.name = "peer-app", .category = ""});
+    auto session = make_shared<SessionStub>();
+    adapter->addDefaultServant(session, "s");
+    adapter->activate();
+    auto peerSession = adapter->createProxy<SubscriberSessionPrx>(Ice::Identity{.name = "1", .category = "s"});
+
+    cout << "testing that a superseded session confirmation does not connect the session... " << flush;
+    {
+        // Announcing a reader for the topic the node writes makes the node drive session creation with this peer.
+        LookupPrx lookup{communicator, "DataStorm/Lookup2:" + getTestEndpoint(11)};
+
+        // The node under test may still be starting up.
+        while (true)
+        {
+            try
+            {
+                lookup->announceTopicReader("string", peerNode);
+                break;
+            }
+            catch (const Ice::LocalException&)
+            {
+                this_thread::sleep_for(chrono::milliseconds(50));
+            }
+        }
+        auto publisher = peer->waitForPublisherNode();
+
+        // The node fixes the session proxies to the connection createSession arrives on, so this peer has to
+        // dispatch the node's callbacks on that connection.
+        publisher->ice_getConnection()->setAdapter(adapter);
+
+        // First handshake: hold its confirmation, so that it completes only after later events superseded it.
+        publisher->createSession(peerNode, peerSession, false, 1);
+        auto first = peer->waitForConfirmation();
+        test(first.handshakeId == 1);
+
+        // Second handshake, answered right away: the node connects the session under this one.
+        publisher->createSession(peerNode, peerSession, false, 2);
+        auto second = peer->waitForConfirmation();
+        test(second.handshakeId == 2);
+        second.response();
+
+        // Drop the session the node just connected, naming the handshake it is connected under.
+        second.session->ice_fixed(second.connection)->ice_twoway()->disconnected(2);
+
+        // Release the superseded confirmation. The node must not commit it: it announces its topics to a session
+        // it has just connected, so an announcement here would mean it acted on a handshake this peer had already
+        // replaced.
+        const int announced = session->count("announceTopics");
+        first.response();
+        test(!session->waitFor("announceTopics", announced, chrono::seconds(1)));
+
+        // Having refused the confirmation, the node must tell this peer to drop that handshake: the peer connects
+        // its session before answering a confirmation, so it is left connected to a session the node is not using
+        // and would wait forever for samples that never arrive.
+        // Scoped to the refused handshake, and to that one only: a notification naming the handshake this peer is
+        // working on would tear down a session that is fine, which is the failure the scoping exists to prevent.
+        test(session->waitForDisconnect(1, chrono::seconds(10)));
+        test(!session->sawDisconnect(2));
+
+        // The node is expected to accept a fresh handshake. While the bug is present it answers AlreadyConnected
+        // forever, because the superseded confirmation connected it to a session this peer no longer has.
+        bool accepted = false;
+        for (int i = 0; i < 30 && !accepted; ++i)
+        {
+            try
+            {
+                publisher->createSession(peerNode, peerSession, false, 3);
+                accepted = true;
+            }
+            catch (const SessionCreationException& ex)
+            {
+                test(ex.error == SessionCreationError::AlreadyConnected);
+                this_thread::sleep_for(chrono::milliseconds(100));
+            }
+        }
+        test(accepted);
+
+        auto third = peer->waitForConfirmation();
+        test(third.handshakeId == 3);
+
+        // The node commits the handshake when it processes this reply, and announces its topics to this peer's
+        // session once it has. The checks below are about the committed handshake, so wait for that announcement
+        // rather than assuming the reply was processed by the time the next request arrives.
+        const int connecting = session->count("announceTopics");
+        third.response();
+        test(session->waitFor("announceTopics", connecting, chrono::seconds(10)));
+
+        // A repeat of the handshake the node is connected under is a duplicate and is rejected as such.
+        try
+        {
+            publisher->createSession(peerNode, peerSession, false, 3);
+            test(false);
+        }
+        catch (const SessionCreationException& ex)
+        {
+            test(ex.error == SessionCreationError::AlreadyConnected);
+        }
+
+        // A different handshake is proof that this peer no longer has the session the node is connected under, so
+        // the node gives up that session and takes the new handshake instead of stonewalling the peer.
+        publisher->createSession(peerNode, peerSession, false, 4);
+        auto fourth = peer->waitForConfirmation();
+        test(fourth.handshakeId == 4);
+
+        // Wait for the commit, as after handshake 3: the reply is processed asynchronously, and the next scenario
+        // starts from the node being connected under this handshake.
+        const int connected4 = session->count("announceTopics");
+        fourth.response();
+        test(session->waitFor("announceTopics", connected4, chrono::seconds(10)));
+    }
+    cout << "ok" << endl;
+
+    cout << "testing that a superseded confirmation does not consume the retry budget... " << flush;
+    {
+        // The node is connected under handshake 4. Start handshake 5 and refuse its confirmation the way a peer
+        // does when it has already moved to a newer handshake of its own.
+        auto publisher = peer->waitForPublisherNode();
+        const int initiated = peer->initiateCount();
+
+        publisher->createSession(peerNode, peerSession, false, 5);
+        auto fifth = peer->waitForConfirmation();
+        test(fifth.handshakeId == 5);
+        fifth.exception(make_exception_ptr(SessionCreationException{SessionCreationError::Superseded}));
+
+        // This peer allocates the handshake identifiers, so the node has to take its word for it and leave the
+        // session to the handshake the peer says it started. Spending a retry here would prompt a reconnection -
+        // which reaches this peer as a request to initiate session creation - and each such round would refuse
+        // its predecessor the same way, exhausting the budget of a session that is recovering normally.
+        test(!peer->waitForInitiate(initiated, chrono::seconds(2)));
+
+        // Leaving the session to the peer does not mean forgetting it: the peer's word covers the handshake it
+        // allocated, not its delivery, so the node parks the session and removes it if the peer never does
+        // re-establish it. Once that happens a fresh handshake is served by a new session servant.
+        const auto parked = fifth.session->ice_getIdentity();
+        bool replaced = false;
+        for (int i = 0; i < 100 && !replaced; ++i)
+        {
+            publisher->createSession(peerNode, peerSession, false, 6 + i);
+            auto next = peer->waitForConfirmation();
+            replaced = next.session->ice_getIdentity() != parked;
+            next.exception(make_exception_ptr(SessionCreationException{SessionCreationError::Superseded}));
+            if (!replaced)
+            {
+                this_thread::sleep_for(chrono::milliseconds(100));
+            }
+        }
+        test(replaced);
+    }
+    cout << "ok" << endl;
+
+    cout << "testing that re-establishing a parked session cancels its removal... " << flush;
+    {
+        auto publisher = peer->waitForPublisherNode();
+
+        // Park the session again, then re-establish it before the removal timer expires.
+        publisher->createSession(peerNode, peerSession, false, 200);
+        auto parked = peer->waitForConfirmation();
+        test(parked.handshakeId == 200);
+        const auto servant = parked.session->ice_getIdentity();
+        parked.exception(make_exception_ptr(SessionCreationException{SessionCreationError::Superseded}));
+
+        publisher->createSession(peerNode, peerSession, false, 201);
+        auto revived = peer->waitForConfirmation();
+        test(revived.handshakeId == 201);
+        test(revived.session->ice_getIdentity() == servant);
+        const int connected201 = session->count("announceTopics");
+        revived.response();
+        test(session->waitFor("announceTopics", connected201, chrono::seconds(10)));
+
+        // Well past the park timeout the session must still be the one that was parked: connecting cancels the
+        // removal, rather than the timer firing later and dropping a session the peer is using.
+        this_thread::sleep_for(chrono::seconds(3));
+        publisher->createSession(peerNode, peerSession, false, 202);
+        auto after = peer->waitForConfirmation();
+        test(after.session->ice_getIdentity() == servant);
+        after.response();
+    }
+    cout << "ok" << endl;
+
+    cout << "testing that stale requests and notifications are ignored... " << flush;
+    {
+        auto publisher = peer->waitForPublisherNode();
+
+        // Start handshake 400 and hold its confirmation, leaving the session disconnected with 400 pending.
+        publisher->createSession(peerNode, peerSession, false, 400);
+        auto pending = peer->waitForConfirmation();
+        test(pending.handshakeId == 400);
+
+        // A request for a handshake older than the pending one is refused rather than adopted. Requests take
+        // different routes and arrive in any order, so adopting an older one would leave the node waiting on a
+        // handshake this peer has already moved past, and refuse the newer one's confirmation when it completes.
+        try
+        {
+            publisher->createSession(peerNode, peerSession, false, 399);
+            test(false);
+        }
+        catch (const SessionCreationException& ex)
+        {
+            test(ex.error == SessionCreationError::Superseded);
+        }
+
+        // A disconnect naming that older handshake, while the session is disconnected with a newer one pending,
+        // reports the loss of a route the session no longer uses. Treating it as a fresh failure would spend a
+        // retry, which reaches this peer as a request to initiate session creation.
+        auto session400 = pending.session->ice_fixed(pending.connection)->ice_twoway();
+        const int initiated = peer->initiateCount();
+        session400->disconnected(399);
+        test(!peer->waitForInitiate(initiated, chrono::seconds(2)));
+
+        const int connected400 = session->count("announceTopics");
+        pending.response();
+        test(session->waitFor("announceTopics", connected400, chrono::seconds(10)));
+
+        // The same stale notification, now that the session is connected under the newer handshake, leaves it
+        // alone: the node still treats handshake 400 as the one it is connected under.
+        session400->disconnected(399);
+        try
+        {
+            publisher->createSession(peerNode, peerSession, false, 400);
+            test(false);
+        }
+        catch (const SessionCreationException& ex)
+        {
+            test(ex.error == SessionCreationError::AlreadyConnected);
+        }
+    }
+    cout << "ok" << endl;
+}
+
+DEFINE_TEST(::Client)

--- a/cpp/test/DataStorm/sessionHandshake/Makefile.mk
+++ b/cpp/test/DataStorm/sessionHandshake/Makefile.mk
@@ -1,0 +1,14 @@
+# Copyright (c) ZeroC, Inc.
+
+$(project)_programs            = client writer
+$(project)_dependencies        = TestCommon Ice
+
+# The client speaks the session protocol directly, from its own restatement of it in Test.ice. It must not link the
+# DataStorm library: the library carries its own copy of the generated contract, and the two copies would compete
+# to supply the exception factories.
+$(project)_client_sources      = Client.cpp Test.ice
+
+$(project)_writer_sources      = Writer.cpp
+$(project)_writer_dependencies = DataStorm Ice TestCommon
+
+tests += $(project)

--- a/cpp/test/DataStorm/sessionHandshake/Test.ice
+++ b/cpp/test/DataStorm/sessionHandshake/Test.ice
@@ -1,0 +1,52 @@
+// Copyright (c) ZeroC, Inc.
+
+#pragma once
+
+// The part of the DataStorm session protocol this test drives, restated here so the test peer can speak it
+// without linking the DataStorm library - the library carries its own copy of the generated contract, and two
+// copies in one process compete to supply the exception factories.
+//
+// Only what the test invokes or implements is declared. The names, the operation signatures and the order of the
+// SessionCreationError enumerators have to match cpp/src/DataStorm/Contract.ice; a mismatch shows up as a
+// marshaling failure, which is the intended signal.
+module DataStormContract
+{
+    enum SessionCreationError
+    {
+        AlreadyConnected,
+        NodeShutdown,
+        SessionNotFound,
+        Superseded,
+        Internal,
+    }
+
+    exception SessionCreationException
+    {
+        SessionCreationError error;
+    }
+
+    interface Session
+    {
+        void disconnected(long handshakeId);
+    }
+
+    interface SubscriberSession extends Session {}
+
+    interface PublisherSession extends Session {}
+
+    interface Node
+    {
+        void initiateCreateSession(Node* publisher) throws SessionCreationException;
+
+        void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay, long handshakeId)
+            throws SessionCreationException;
+
+        void confirmCreateSession(Node* publisher, PublisherSession* session, long handshakeId)
+            throws SessionCreationException;
+    }
+
+    interface Lookup
+    {
+        idempotent void announceTopicReader(string topic, Node* subscriber);
+    }
+}

--- a/cpp/test/DataStorm/sessionHandshake/Writer.cpp
+++ b/cpp/test/DataStorm/sessionHandshake/Writer.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DataStorm/DataStorm.h"
+#include "TestHelper.h"
+
+using namespace std;
+
+// The node under test. It only has to offer a topic writer for the peer to announce a reader for; the peer drives
+// every session creation exchange from there.
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**) override;
+};
+
+void ::Writer::run(int argc, char* argv[])
+{
+    DataStorm::Node node(argc, argv);
+    DataStorm::Topic<string, string> topic(node, "string");
+    auto writer = DataStorm::makeSingleKeyWriter(topic, "element");
+    writer.update("value");
+
+    // The peer decides when the test is over; this node runs until the test framework stops it.
+    node.getCommunicator()->waitForShutdown();
+}
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/sessionHandshake/msbuild/client/client.vcxproj
+++ b/cpp/test/DataStorm/sessionHandshake/msbuild/client/client.vcxproj
@@ -1,0 +1,146 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Client.cpp" />
+    <ClCompile Include="Win32\Debug\Test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
+    </ClCompile>
+    <ClCompile Include="Win32\Release\Test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
+    </ClCompile>
+    <ClCompile Include="x64\Debug\Test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
+    </ClCompile>
+    <ClCompile Include="x64\Release\Test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <SliceCompile Include="..\..\Test.ice" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Win32\Debug\Test.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\Test.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\Test.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
+    </ClInclude>
+    <ClInclude Include="x64\Release\Test.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Test.ice</SliceCompileSource>
+    </ClInclude>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7D563A06-6CAB-432B-80A0-21B7348613F5}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/cpp/test/DataStorm/sessionHandshake/msbuild/client/client.vcxproj.filters
+++ b/cpp/test/DataStorm/sessionHandshake/msbuild/client/client.vcxproj.filters
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Slice Files">
+      <UniqueIdentifier>{fcef0a0c-3c3e-43f2-8584-8850460418b6}</UniqueIdentifier>
+      <Extensions>ice</Extensions>
+    </Filter>
+    <Filter Include="Source Files\Win32">
+      <UniqueIdentifier>{6d35b729-7499-4927-8b1d-344747798f3a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Win32\Debug">
+      <UniqueIdentifier>{a97fe3cb-c593-4e50-bbbe-415511aed4dd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Win32">
+      <UniqueIdentifier>{0c3eb08a-c284-489a-8e6f-c7501179ee69}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Win32\Debug">
+      <UniqueIdentifier>{a0fecb4c-510f-4425-9f5d-e80b53d6c905}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\x64">
+      <UniqueIdentifier>{f0a4408b-c54f-4b07-8092-d2394aea6c07}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\x64\Debug">
+      <UniqueIdentifier>{f9da6281-b997-452f-80b1-47d9b981c1b8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\x64">
+      <UniqueIdentifier>{fe4db0c6-e9d2-4eb0-93b2-daa9fcd4e42a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\x64\Debug">
+      <UniqueIdentifier>{0281fd82-ed95-42a3-a941-d84d5daf06c0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Win32\Release">
+      <UniqueIdentifier>{da1bc916-c3e8-423f-b68d-9446a40a33b4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Win32\Release">
+      <UniqueIdentifier>{a5c7ef45-3e6a-4729-b215-cfb91a156ec2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\x64\Release">
+      <UniqueIdentifier>{4cba710e-1737-4813-a306-3e3d46610032}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\x64\Release">
+      <UniqueIdentifier>{2f850c71-5340-46fe-ae9a-a0ab87d74d65}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Client.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32\Debug\Test.cpp">
+      <Filter>Source Files\Win32\Debug</Filter>
+    </ClCompile>
+    <ClCompile Include="x64\Debug\Test.cpp">
+      <Filter>Source Files\x64\Debug</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32\Release\Test.cpp">
+      <Filter>Source Files\Win32\Release</Filter>
+    </ClCompile>
+    <ClCompile Include="x64\Release\Test.cpp">
+      <Filter>Source Files\x64\Release</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <SliceCompile Include="..\..\Test.ice" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Win32\Debug\Test.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\Test.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\Test.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\Test.h">
+      <Filter>Header Files\x64\Release</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/sessionHandshake/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/sessionHandshake/msbuild/writer/writer.vcxproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{FBA8DEB6-C7C7-4E65-8043-9A153B5477DA}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\ice.test.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\msbuild\testcommon.vcxproj" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/cpp/test/DataStorm/sessionHandshake/msbuild/writer/writer.vcxproj.filters
+++ b/cpp/test/DataStorm/sessionHandshake/msbuild/writer/writer.vcxproj.filters
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{2efb87e2-44aa-4907-b445-4ded9dc175c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{fa2de026-c14d-4caf-904b-245988a34bec}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Writer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/cpp/test/DataStorm/sessionHandshake/test.py
+++ b/cpp/test/DataStorm/sessionHandshake/test.py
@@ -1,0 +1,46 @@
+# Copyright (c) ZeroC, Inc.
+
+#
+# A peer that speaks the DataStorm session protocol directly drives session creation with a real DataStorm node,
+# controlling when each confirmCreateSession is answered. Two handshakes are outstanding at once - which a
+# two-relay topology produces on its own, since every reconnection attempt can take a different route - so the
+# handshake the node acts on is not the one that is still current.
+#
+
+from typing import Any
+
+from DataStormUtil import DataStormProcess
+from Util import Client, ClientServerTestCase, Server, TestSuite
+
+traceProps = {
+    "DataStorm.Trace.Topic": 1,
+    "DataStorm.Trace.Session": 3,
+    "DataStorm.Trace.Data": 2,
+}
+
+
+class Peer(Client, DataStormProcess):
+    processType = "client"
+
+
+class NodeUnderTest(Server, DataStormProcess):
+    processType = "writer"
+
+    def __init__(self, *args: Any, **kargs: Any):
+        Server.__init__(self, *args, waitForShutdown=False, readyCount=0, **kargs)
+
+
+nodeProps = {
+    "DataStorm.Node.Multicast.Enabled": 0,
+    "DataStorm.Node.Server.Endpoints": "tcp -p {port1}",
+    "DataStorm.Node.ConnectTo": "",
+    "DataStorm.Node.Name": "node-under-test",
+    # A session parked for its peer is removed after getRetryDelay(RetryCount) * 2, which is 128 times this
+    # value. Keeping it small lets the test observe that removal instead of waiting a minute for it.
+    "DataStorm.Node.RetryDelay": 10,
+}
+
+TestSuite(
+    __file__,
+    [ClientServerTestCase(client=Peer(), server=NodeUnderTest(props=nodeProps), traceProps=traceProps)],
+)


### PR DESCRIPTION
Fixes #6644.

## The bug

With two relay nodes between two applications, several session creation exchanges are in flight at once — each
reconnection attempt can take a different route, and nothing serialized them. Neither node could tell one exchange
from another, so `SessionI::connected` committed whichever confirmation happened to arrive while the session was
disconnected, and silently dropped any that arrived while it was already connected.

Both CI occurrences are that, from opposite ends:

- **macOS** ([run 32167353565](https://github.com/zeroc-ice/ice/actions/runs/32167353565)) — the reply to a
  `confirmCreateSession` issued 28 ms and three attempts earlier arrived after the session had connected,
  disconnected and scheduled two retries, and was committed anyway. The relay's `disconnected` for that route had
  arrived 1 ms before and was dropped, because `disconnectedImpl` records nothing when the session is disconnected
  with a retry pending.
- **Windows** ([run 32051635716](https://github.com/zeroc-ice/ice/actions/runs/32051635716)) — two confirmations
  both got `Ok` (an intervening subscriber-side disconnect makes that possible), the publisher committed the one
  that arrived first and silently dropped the other, which was the one the subscriber had committed. The two sides
  ended up on different relay routes; one route died and only that side noticed.

Either way the nodes disagree permanently: the connected side answers every attempt with `AlreadyConnected`,
`checkSessionImpl` only probes the local relay connection which stays open, DataStorm never closes a connection
itself, and `destroyImpl` notifies nobody. The reader parks in `getNextUnread` / `getSessionConnection` until the
harness kills it.

## The fix

Each exchange carries an identifier. The subscriber allocates it, the publisher echoes it in
`confirmCreateSession`, and `Session::disconnected` names the exchange it refers to. Then:

- a session commits an exchange only while it is still the pending one;
- it ignores a disconnect notification for an exchange it has already replaced, so a route torn down after the
  session moved on cannot tear down its replacement;
- a creation request naming a *different* exchange is proof the peer no longer has this session, so the session is
  dropped and the new exchange takes over — instead of refusing the peer forever with `AlreadyConnected`;
- a new `SessionCreationError::Superseded` says "a newer exchange decides this", so the loser neither retries nor
  gives up.

## Wire compatibility

`createSession`, `confirmCreateSession` and `disconnected` change signature, and `SessionCreationError` gains an
enumerator. `Contract.ice` is internal — only `SampleEvent.ice` ships in `slice/`, and no other language mapping
implements the contract — so there is no public API impact, but DataStorm nodes running this build do not
interoperate with older ones. That is already true of 3.8.3: #6138 changed the lookup identity to
`DataStorm/Lookup2`, and `CHANGELOG-3.8.md` already tells users to upgrade all DataStorm nodes together.

## Testing

New `cpp/test/DataStorm/sessionHandshake` suite. The peer speaks the session protocol directly (its own minimal
restatement in `Test.ice`; it must not link libDataStorm, or the two copies of the generated contract compete to
supply the exception factories) and holds each `confirmCreateSession` response until the test releases it, so the
race is deterministic — no sleeps, no relays, no luck. It reproduced the macOS variant red before the fix
(`is ignoring 'createSession' ... already connected` ×100) and both halves of the fix are pinned by mutation.

- 14/14 DataStorm suites pass.
- `DataStorm/reliability` **30/30 clean** (16 topologies each, 480 topology runs), including both topologies named
  in the issue.
- Full C++ suite 110/111; `IceGrid/activation` fails only under `--workers=4` and passes standalone.
- macOS only so far — hence opening this for CI. The Windows variant is covered by the same commit rule but has no
  local repro.

https://claude.ai/code/session_011ZpgLtM2dBZz3xW5uAKxox
