### PR TITLE
Use flush continuation lines in hand-written JSDoc comments

### DIFF
--- a/js/packages/ice/src/Ice/Communicator.d.ts
+++ b/js/packages/ice/src/Ice/Communicator.d.ts
@@ -195,7 +195,7 @@ declare module "@zeroc/ice" {
              * Retrieves the implicit context associated with this communicator.
              *
              * @returns The implicit context associated with this communicator, or `null` if the `Ice.ImplicitContext`
-             *          property is not set or is set to `None`.
+             * property is not set or is set to `None`.
              */
             getImplicitContext(): Ice.ImplicitContext | null;
 
@@ -232,7 +232,7 @@ declare module "@zeroc/ice" {
              * You can also set a router for an individual proxy by calling {@link ObjectPrx#ice_router} on the proxy.
              *
              * @param router - The default router to use for this communicator, or `null` to disable the default
-             *                 router.
+             * router.
              * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link getDefaultRouter}
@@ -259,7 +259,7 @@ declare module "@zeroc/ice" {
              * You can also set a locator for an individual proxy by calling {@link ObjectPrx#ice_locator} on the proxy.
              *
              * @param locator - The default locator to use for this communicator, or `null` to disable the default
-             *                  locator.
+             * locator.
              * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link getDefaultLocator}

--- a/js/packages/ice/src/Ice/Communicator.d.ts
+++ b/js/packages/ice/src/Ice/Communicator.d.ts
@@ -231,8 +231,7 @@ declare module "@zeroc/ice" {
              *
              * You can also set a router for an individual proxy by calling {@link ObjectPrx#ice_router} on the proxy.
              *
-             * @param router - The default router to use for this communicator, or `null` to disable the default
-             * router.
+             * @param router - The default router to use for this communicator, or `null` to disable the default router.
              * @throws {@link CommunicatorDestroyedException} - Thrown when the communicator has been destroyed.
              *
              * @see {@link getDefaultRouter}

--- a/js/packages/ice/src/Ice/Connection.js
+++ b/js/packages/ice/src/Ice/Connection.js
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 /**
- *  Base class providing access to the connection details.
+ * Base class providing access to the connection details.
  */
 export class ConnectionInfo {
     constructor(underlying, adapterName, connectionId) {
@@ -30,7 +30,7 @@ export class ConnectionInfo {
 }
 
 /**
- *  Provides access to the connection details of an IP connection
+ * Provides access to the connection details of an IP connection
  */
 export class IPConnectionInfo extends ConnectionInfo {
     constructor(adapterName, connectionId, localAddress, localPort, remoteAddress, remotePort) {
@@ -59,12 +59,12 @@ export class IPConnectionInfo extends ConnectionInfo {
 }
 
 /**
- *  Provides access to the connection details of a TCP connection
+ * Provides access to the connection details of a TCP connection
  */
 export class TCPConnectionInfo extends IPConnectionInfo {}
 
 /**
- *  Provides access to the connection details of a WebSocket connection
+ * Provides access to the connection details of a WebSocket connection
  */
 export class WSConnectionInfo extends ConnectionInfo {
     constructor(underlying, maxBufferedAmount) {

--- a/js/packages/ice/src/Ice/Endpoint.js
+++ b/js/packages/ice/src/Ice/Endpoint.js
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 /**
- *  Base class providing access to the endpoint details.
+ * Base class providing access to the endpoint details.
  */
 export class EndpointInfo {
     constructor(underlying, timeout, compress) {
@@ -39,8 +39,8 @@ export class EndpointInfo {
 }
 
 /**
- *  Provides access to the address details of a IP endpoint.
- *  @see {@link Endpoint}
+ * Provides access to the address details of a IP endpoint.
+ * @see {@link Endpoint}
  */
 export class IPEndpointInfo extends EndpointInfo {
     constructor(timeout, compress, host, port, sourceAddress) {
@@ -64,8 +64,8 @@ export class IPEndpointInfo extends EndpointInfo {
 }
 
 /**
- *  Provides access to a TCP endpoint's information.
- *  @see {@link Endpoint}
+ * Provides access to a TCP endpoint's information.
+ * @see {@link Endpoint}
  */
 export class TCPEndpointInfo extends IPEndpointInfo {
     constructor(timeout, compress, host, port, sourceAddress, type, secure) {
@@ -84,7 +84,7 @@ export class TCPEndpointInfo extends IPEndpointInfo {
 }
 
 /**
- *  Provides access to a WebSocket endpoint's information.
+ * Provides access to a WebSocket endpoint's information.
  */
 export class WSEndpointInfo extends EndpointInfo {
     constructor(underlying, resource) {
@@ -98,8 +98,8 @@ export class WSEndpointInfo extends EndpointInfo {
 }
 
 /**
- *  Provides access to the details of an opaque endpoint.
- *  @see {@link Endpoint}
+ * Provides access to the details of an opaque endpoint.
+ * @see {@link Endpoint}
  */
 export class OpaqueEndpointInfo extends EndpointInfo {
     constructor(type, rawEncoding, rawBytes) {

--- a/js/packages/ice/src/Ice/EndpointSelectionType.js
+++ b/js/packages/ice/src/Ice/EndpointSelectionType.js
@@ -3,7 +3,7 @@
 import { defineEnum } from "./EnumBase.js";
 
 /**
- *  Determines the order in which the Ice runtime uses the endpoints in a proxy when establishing a connection.
+ * Determines the order in which the Ice runtime uses the endpoints in a proxy when establishing a connection.
  */
 export const EndpointSelectionType = defineEnum([
     ["Random", 0],

--- a/js/packages/ice/src/Ice/FormatType.d.ts
+++ b/js/packages/ice/src/Ice/FormatType.d.ts
@@ -3,7 +3,7 @@
 declare module "@zeroc/ice" {
     namespace Ice {
         /**
-         *  This enumeration describes the possible formats for classes.
+         * This enumeration describes the possible formats for classes.
          */
         class FormatType extends Ice.EnumBase {
             /**

--- a/js/packages/ice/src/Ice/Identity.js
+++ b/js/packages/ice/src/Ice/Identity.js
@@ -3,11 +3,11 @@
 export const Ice = {};
 
 /**
- *  The identity of an Ice object. In a proxy, an empty {@link Identity#name} denotes a nil proxy. An identity with
- *  an empty {@link Identity#name} and a non-empty {@link Identity#category} is illegal. You cannot add a servant
- *  with an empty name to the Active Servant Map.
- *  @see ServantLocator
- *  @see ObjectAdapter#addServantLocator
+ * The identity of an Ice object. In a proxy, an empty {@link Identity#name} denotes a nil proxy. An identity with
+ * an empty {@link Identity#name} and a non-empty {@link Identity#category} is illegal. You cannot add a servant
+ * with an empty name to the Active Servant Map.
+ * @see ServantLocator
+ * @see ObjectAdapter#addServantLocator
  */
 Ice.Identity = class {
     constructor(name = "", category = "") {

--- a/js/packages/ice/src/Ice/InputStream.d.ts
+++ b/js/packages/ice/src/Ice/InputStream.d.ts
@@ -26,7 +26,7 @@ declare module "@zeroc/ice" {
             constructor(communicator: Communicator, encoding: EncodingVersion, buffer: Uint8Array | ArrayBuffer);
 
             /**
-             *  Releases any data retained by encapsulations.
+             * Releases any data retained by encapsulations.
              */
             clear(): void;
 
@@ -298,7 +298,7 @@ declare module "@zeroc/ice" {
             skipSize(): void;
 
             /**
-             *  Returns whether the stream is empty.
+             * Returns whether the stream is empty.
              *
              * @returns True if the internal buffer has no data, false otherwise.
              */

--- a/js/packages/ice/src/Ice/LocalExceptions.d.ts
+++ b/js/packages/ice/src/Ice/LocalExceptions.d.ts
@@ -126,7 +126,7 @@ declare module "@zeroc/ice" {
         }
 
         /**
-         *  The exception that is thrown when an error occurs during marshaling or unmarshaling.
+         * The exception that is thrown when an error occurs during marshaling or unmarshaling.
          */
         class MarshalException extends ProtocolException {}
 

--- a/js/packages/ice/src/Ice/ObjectAdapter.d.ts
+++ b/js/packages/ice/src/Ice/ObjectAdapter.d.ts
@@ -36,7 +36,7 @@ declare module "@zeroc/ice" {
             destroy(): void;
 
             /**
-             *  Adds a middleware to the dispatch pipeline of this object adapter.
+             * Adds a middleware to the dispatch pipeline of this object adapter.
              *
              * @param middlewareFactory The middleware factory that creates the new middleware when this object adapter
              * creates its dispatch pipeline. A middleware factory is a function that takes an Object (the next element
@@ -105,17 +105,17 @@ declare module "@zeroc/ice" {
              * incoming request, it tries to find a servant for the identity and facet carried by the request in the
              * following order:
              *
-             *  - The object adapter tries to find a servant for the identity and facet in the Active Servant Map.
-             *  - If this fails, the object adapter tries to find a default servant for the category component of the
-             *    identity.
-             *  - If this fails, the object adapter tries to find a default servant for the empty category, regardless of
-             *    the category contained in the identity.
-             *  - If this fails, the object adapter tries to find a servant locator for the category component of the
-             *    identity. If there is no such servant locator, the object adapter tries to find a servant locator for the
-             *    empty category.
-             *  - If a servant locator is found, the object adapter tries to find a servant using this servant locator.
-             *  - If all the previous steps fail, the object adapter gives up and the caller receives an
-             *    ObjectNotExistException or a FacetNotExistException.
+             * - The object adapter tries to find a servant for the identity and facet in the Active Servant Map.
+             * - If this fails, the object adapter tries to find a default servant for the category component of the
+             *   identity.
+             * - If this fails, the object adapter tries to find a default servant for the empty category, regardless
+             *   of the category contained in the identity.
+             * - If this fails, the object adapter tries to find a servant locator for the category component of the
+             *   identity. If there is no such servant locator, the object adapter tries to find a servant locator for
+             *   the empty category.
+             * - If a servant locator is found, the object adapter tries to find a servant using this servant locator.
+             * - If all the previous steps fail, the object adapter gives up and the caller receives an
+             *   ObjectNotExistException or a FacetNotExistException.
              *
              * @param servant The default servant to add.
              * @param category The category for which the default servant is registered. The empty category means it will

--- a/js/packages/ice/src/Ice/ObjectAdapter.d.ts
+++ b/js/packages/ice/src/Ice/ObjectAdapter.d.ts
@@ -108,8 +108,8 @@ declare module "@zeroc/ice" {
              * - The object adapter tries to find a servant for the identity and facet in the Active Servant Map.
              * - If this fails, the object adapter tries to find a default servant for the category component of the
              *   identity.
-             * - If this fails, the object adapter tries to find a default servant for the empty category, regardless
-             *   of the category contained in the identity.
+             * - If this fails, the object adapter tries to find a default servant for the empty category, regardless of
+             *   the category contained in the identity.
              * - If this fails, the object adapter tries to find a servant locator for the category component of the
              *   identity. If there is no such servant locator, the object adapter tries to find a servant locator for
              *   the empty category.

--- a/js/packages/ice/src/Ice/ObjectPrx.d.ts
+++ b/js/packages/ice/src/Ice/ObjectPrx.d.ts
@@ -406,8 +406,8 @@ declare module "@zeroc/ice" {
              * @param prx - The source proxy.
              * @param facet - An optional facet name.
              * @param context - The request context.
-             * @returns A promise that resolves to a proxy with the requested type and facet, or `null` if the
-             * target object does not support the requested type.
+             * @returns A promise that resolves to a proxy with the requested type and facet, or `null` if the target
+             * object does not support the requested type.
              */
             static checkedCast(
                 prx: ObjectPrx | null,

--- a/js/packages/ice/src/Ice/ObjectPrx.d.ts
+++ b/js/packages/ice/src/Ice/ObjectPrx.d.ts
@@ -407,7 +407,7 @@ declare module "@zeroc/ice" {
              * @param facet - An optional facet name.
              * @param context - The request context.
              * @returns A promise that resolves to a proxy with the requested type and facet, or `null` if the
-             *          target object does not support the requested type.
+             * target object does not support the requested type.
              */
             static checkedCast(
                 prx: ObjectPrx | null,

--- a/js/packages/ice/src/Ice/OutputStream.d.ts
+++ b/js/packages/ice/src/Ice/OutputStream.d.ts
@@ -22,7 +22,7 @@ declare module "@zeroc/ice" {
             constructor(encoding?: EncodingVersion, format?: FormatType);
 
             /**
-             *  Releases any data retained by encapsulations.
+             * Releases any data retained by encapsulations.
              */
             clear(): void;
 
@@ -186,7 +186,7 @@ declare module "@zeroc/ice" {
              * Writes a byte sequence to the stream.
              *
              * @param v The byte sequence to write to the stream. Passing `null` causes an empty sequence to be written
-             *          to the stream.
+             * to the stream.
              */
             writeByteSeq(v?: Uint8Array): void;
 
@@ -236,7 +236,7 @@ declare module "@zeroc/ice" {
              * Writes a string to the stream.
              *
              * @param v The string to write to the stream. Passing `null` causes an empty string to be written to the
-             *          stream.
+             * stream.
              */
             writeString(v: string | null): void;
 
@@ -279,7 +279,7 @@ declare module "@zeroc/ice" {
             writeException(exception: UserException): void;
 
             /**
-             *  Returns whether the stream is empty.
+             * Returns whether the stream is empty.
              *
              * @returns True if no data has been written yet, false otherwise.
              */

--- a/js/packages/ice/src/Ice/Promise.d.ts
+++ b/js/packages/ice/src/Ice/Promise.d.ts
@@ -10,9 +10,9 @@ declare module "@zeroc/ice" {
             /**
              * Constructs a new promise.
              *
-             *  @param executor - The executor function that is called immediately when the promise is constructed. It
-             *                    is passed two functions, `resolve` and `reject`, that can be called to resolve or
-             *                    reject the promise respectively.
+             * @param executor - The executor function that is called immediately when the promise is constructed. It
+             * is passed two functions, `resolve` and `reject`, that can be called to resolve or reject the promise
+             * respectively.
              */
             constructor(
                 executor?: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason: any) => void) => void,

--- a/js/packages/ice/src/Ice/Promise.d.ts
+++ b/js/packages/ice/src/Ice/Promise.d.ts
@@ -10,8 +10,8 @@ declare module "@zeroc/ice" {
             /**
              * Constructs a new promise.
              *
-             * @param executor - The executor function that is called immediately when the promise is constructed. It
-             * is passed two functions, `resolve` and `reject`, that can be called to resolve or reject the promise
+             * @param executor - The executor function that is called immediately when the promise is constructed. It is
+             * passed two functions, `resolve` and `reject`, that can be called to resolve or reject the promise
              * respectively.
              */
             constructor(

--- a/js/packages/ice/src/Ice/SSL/ConnectionInfo.js
+++ b/js/packages/ice/src/Ice/SSL/ConnectionInfo.js
@@ -3,6 +3,6 @@
 import { ConnectionInfo as IceConnectionInfo } from "../Connection.js";
 
 /**
- *  Provides access to the connection details of an SSL connection
+ * Provides access to the connection details of an SSL connection
  */
 export class ConnectionInfo extends IceConnectionInfo {}

--- a/js/packages/ice/src/Ice/SSL/EndpointInfo.js
+++ b/js/packages/ice/src/Ice/SSL/EndpointInfo.js
@@ -3,6 +3,6 @@
 import { EndpointInfo as IceEndpointInfo } from "../Endpoint.js";
 
 /**
- *  Provides access to an SSL endpoint's information.
+ * Provides access to an SSL endpoint's information.
  */
 export class EndpointInfo extends IceEndpointInfo {}

--- a/js/packages/ice/src/Ice/ServantLocator.d.ts
+++ b/js/packages/ice/src/Ice/ServantLocator.d.ts
@@ -22,8 +22,8 @@ declare module "@zeroc/ice" {
              *
              * @param current - Information about the incoming request being dispatched.
              * @returns An array where:
-             *  - [0]: The located servant, or `null` if no suitable servant was found.
-             *  - [1]: A "cookie" that will be passed to {@link finished}.
+             * - [0]: The located servant, or `null` if no suitable servant was found.
+             * - [1]: A "cookie" that will be passed to {@link finished}.
              * @throws {@link UserException} - The implementation can throw a `UserException`, and the runtime will
              * marshal it as the result of the invocation.
              *

--- a/js/packages/ice/src/Ice/SliceLoader.d.ts
+++ b/js/packages/ice/src/Ice/SliceLoader.d.ts
@@ -11,8 +11,8 @@ declare module "@zeroc/ice" {
              *
              * @param typeId The Slice type ID or compact type ID (a compact type ID is passed as its decimal string
              * representation).
-             * @returns A new instance of the class or exception identified by `typeId`, or `null` if the
-             * implementation cannot find the corresponding class.
+             * @returns A new instance of the class or exception identified by `typeId`, or `null` if the implementation
+             * cannot find the corresponding class.
              * @throws {@link MarshalException} - Thrown when the corresponding class was found but its instantiation
              * failed.
              */

--- a/js/packages/ice/src/Ice/SliceLoader.d.ts
+++ b/js/packages/ice/src/Ice/SliceLoader.d.ts
@@ -10,9 +10,9 @@ declare module "@zeroc/ice" {
              * Creates an instance of a class mapped from a Slice class or exception based on a Slice type ID.
              *
              * @param typeId The Slice type ID or compact type ID (a compact type ID is passed as its decimal string
-             *        representation).
+             * representation).
              * @returns A new instance of the class or exception identified by `typeId`, or `null` if the
-             *          implementation cannot find the corresponding class.
+             * implementation cannot find the corresponding class.
              * @throws {@link MarshalException} - Thrown when the corresponding class was found but its instantiation
              * failed.
              */

--- a/js/packages/ice/src/Ice/ToStringMode.js
+++ b/js/packages/ice/src/Ice/ToStringMode.js
@@ -3,9 +3,9 @@
 import { defineEnum } from "./EnumBase.js";
 
 /**
- *  The output mode for xxxToString methods such as identityToString and proxyToString. The actual encoding format for
- *  the string is the same for all modes: you don't need to specify an encoding format or mode when reading such a
- *  string.
+ * The output mode for xxxToString methods such as identityToString and proxyToString. The actual encoding format for
+ * the string is the same for all modes: you don't need to specify an encoding format or mode when reading such a
+ * string.
  */
 export const ToStringMode = defineEnum([
     ["Unicode", 0],

--- a/js/packages/ice/src/Ice/Version.js
+++ b/js/packages/ice/src/Ice/Version.js
@@ -3,7 +3,7 @@
 export const Ice = {};
 
 /**
- *  A version structure for the protocol version.
+ * A version structure for the protocol version.
  */
 Ice.ProtocolVersion = class {
     constructor(major = 0, minor = 0) {
@@ -30,7 +30,7 @@ Ice.ProtocolVersion = class {
 // defineStruct(ProtocolVersion, true, false);
 
 /**
- *  A version structure for the encoding version.
+ * A version structure for the encoding version.
  */
 Ice.EncodingVersion = class {
     constructor(major = 0, minor = 0) {


### PR DESCRIPTION
The hand-written files under `js/packages/ice/src/Ice` used two styles for doc-comment lines. Most continue flush after the comment star, matching what slice2js generates (`writeDocLines` in `cpp/src/slice2js/Gen.cpp`), while a few aligned continuation lines under the tag's description text:

```ts
 * @param typeId The Slice type ID or compact type ID (a compact type ID is passed as its decimal string
 *        representation).
```

and a few carried a stray extra space after the star (`*  Text`).

This standardizes on the flush style across both the `.d.ts` files and the hand-written `.js` files in the same directory, which had the same stray-space defect:

| | files | lines |
|---|---|---|
| `.d.ts` | 10 | 31 |
| `.js` | 8 | 25 |

Markdown list items indented one space too far (`*  - item`) are pulled flush as well; their continuation lines keep the three-space indent that CommonMark requires and that `ObjectAdapter.d.ts` already used for the list at the top of the file. Rendering is unchanged.

Three lines were re-wrapped where de-indenting a long alignment left them well short of the 120-column guideline (`Promise.d.ts`, and two list items in `ObjectAdapter.d.ts`).

Whitespace only — no content changes. `prettier --check` passes on all 18 files, and a repo-wide grep for non-flush doc lines under `js/` is now empty apart from the intentional markdown list continuations.

Fixes #6673

https://claude.ai/code/session_01WyrJYuDjZ4Eck2yF61iMg6
