### PR TITLE
Fix AMI back-pressure test race

### DIFF
--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1468,6 +1468,9 @@ allTests(TestHelper* helper, bool collocated)
                 auto sleep2Future = p->sleepAsync(1500);
                 auto sleep3Future = p->sleepAsync(1500);
 
+                // Wait until all three server thread pool threads are dispatching sleep before sending the payloads.
+                testController->waitForActiveSleepCalls(3);
+
                 auto onewayProxy = Ice::uncheckedCast<Test::TestIntfPrx>(p->ice_oneway());
 
                 // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.

--- a/cpp/test/Ice/ami/Collocated.cpp
+++ b/cpp/test/Ice/ami/Collocated.cpp
@@ -25,9 +25,10 @@ Collocated::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("ControllerAdapter");
 
-    TestIntfControllerIPtr testController = make_shared<TestIntfControllerI>(adapter);
+    auto test = make_shared<TestIntfI>();
+    TestIntfControllerIPtr testController = make_shared<TestIntfControllerI>(adapter, test);
 
-    adapter->add(make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter->add(test, Ice::stringToIdentity("test"));
     adapter->add(make_shared<TestIntfII>(), Ice::stringToIdentity("test2"));
     // adapter->activate(); // Collocated test doesn't need to activate the OA
 

--- a/cpp/test/Ice/ami/Server.cpp
+++ b/cpp/test/Ice/ami/Server.cpp
@@ -39,9 +39,10 @@ Server::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("ControllerAdapter");
 
-    TestIntfControllerIPtr testController = make_shared<TestIntfControllerI>(adapter);
+    auto test = make_shared<TestIntfI>();
+    TestIntfControllerIPtr testController = make_shared<TestIntfControllerI>(adapter, test);
 
-    adapter->add(make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter->add(test, Ice::stringToIdentity("test"));
     adapter->add(make_shared<TestIntfII>(), Ice::stringToIdentity("test2"));
     adapter->activate();
 

--- a/cpp/test/Ice/ami/Test.ice
+++ b/cpp/test/Ice/ami/Test.ice
@@ -48,6 +48,7 @@ module Test
     {
         void holdAdapter();
         void resumeAdapter();
+        void waitForActiveSleepCalls(int count);
     }
 
     module Outer::Inner

--- a/cpp/test/Ice/ami/TestI.cpp
+++ b/cpp/test/Ice/ami/TestI.cpp
@@ -4,6 +4,8 @@
 #include "Ice/Ice.h"
 #include "TestHelper.h"
 
+#include <thread>
+
 using namespace std;
 using namespace Ice;
 
@@ -121,8 +123,26 @@ TestIntfI::abortConnection(const Ice::Current& current)
 void
 TestIntfI::sleep(int32_t ms, const Ice::Current&)
 {
+    {
+        lock_guard lock(_mutex);
+        ++_activeSleepCalls;
+        _condition.notify_all();
+    }
+
+    this_thread::sleep_for(chrono::milliseconds(ms));
+
+    lock_guard lock(_mutex);
+    --_activeSleepCalls;
+}
+
+void
+TestIntfI::waitForActiveSleepCalls(int32_t count)
+{
     unique_lock lock(_mutex);
-    _condition.wait_for(lock, chrono::milliseconds(ms));
+    while (_activeSleepCalls < count)
+    {
+        test(_condition.wait_for(lock, chrono::seconds(10)) != cv_status::timeout);
+    }
 }
 
 void
@@ -238,7 +258,17 @@ TestIntfControllerI::resumeAdapter(const Ice::Current&)
     _adapter->activate();
 }
 
-TestIntfControllerI::TestIntfControllerI(Ice::ObjectAdapterPtr adapter) : _adapter(std::move(adapter)) {}
+void
+TestIntfControllerI::waitForActiveSleepCalls(int32_t count, const Ice::Current&)
+{
+    _test->waitForActiveSleepCalls(count);
+}
+
+TestIntfControllerI::TestIntfControllerI(Ice::ObjectAdapterPtr adapter, shared_ptr<TestIntfI> test)
+    : _adapter(std::move(adapter)),
+      _test(std::move(test))
+{
+}
 
 int32_t
 TestIntfII::op(int32_t i, int32_t& j, const Ice::Current&)

--- a/cpp/test/Ice/ami/TestI.h
+++ b/cpp/test/Ice/ami/TestI.h
@@ -37,6 +37,7 @@ public:
     void closeConnection(const Ice::Current&) final;
     void abortConnection(const Ice::Current&) final;
     void sleep(std::int32_t, const Ice::Current&) final;
+    void waitForActiveSleepCalls(std::int32_t);
     void startDispatchAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) final;
     void finishDispatch(const Ice::Current&) final;
     void shutdown(const Ice::Current&) final;
@@ -52,6 +53,7 @@ public:
 
 private:
     int _batchCount{0};
+    int _activeSleepCalls{0};
     bool _shutdown{false};
     std::function<void()> _pending;
     std::mutex _mutex;
@@ -63,11 +65,13 @@ class TestIntfControllerI : public Test::TestIntfController
 public:
     void holdAdapter(const Ice::Current&) final;
     void resumeAdapter(const Ice::Current&) final;
+    void waitForActiveSleepCalls(std::int32_t, const Ice::Current&) final;
 
-    TestIntfControllerI(Ice::ObjectAdapterPtr);
+    TestIntfControllerI(Ice::ObjectAdapterPtr, std::shared_ptr<TestIntfI>);
 
 private:
     Ice::ObjectAdapterPtr _adapter;
+    std::shared_ptr<TestIntfI> _test;
     std::mutex _mutex;
 };
 

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -933,7 +933,7 @@ public class AllTests : global::Test.AllTests
         }
         output.WriteLine("ok");
 
-        if (p.supportsBackPressureTests())
+        if (p.ice_getConnection() is not null && p.supportsBackPressureTests())
         {
             output.Write("testing back pressure... ");
             output.Flush();
@@ -945,6 +945,10 @@ public class AllTests : global::Test.AllTests
                 Task sleep1Task = p.sleepAsync(1500);
                 Task sleep2Task = p.sleepAsync(1500);
                 Task sleep3Task = p.sleepAsync(1500);
+
+                // Wait until all three server thread pool threads are dispatching sleep before sending the payloads.
+                await testController.waitForActiveSleepCallsAsync(3);
+
                 bool canceled = false;
                 try
                 {

--- a/csharp/test/Ice/ami/Collocated.cs
+++ b/csharp/test/Ice/ami/Collocated.cs
@@ -12,10 +12,6 @@ public class Collocated : TestHelper
 
         properties.setProperty("Ice.Warn.AMICallback", "0");
 
-        // Limit the send buffer size, this test relies on the socket send() blocking after sending a given
-        // amount of data.
-        properties.setProperty("Ice.TCP.SndSize", "50000");
-
         // We use a client thread pool with more than one thread to test that task inlining works.
         properties.setProperty("Ice.ThreadPool.Client.Size", "5");
         await using Communicator communicator = initialize(properties);
@@ -26,10 +22,11 @@ public class Collocated : TestHelper
         ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
         ObjectAdapter adapter2 = communicator.createObjectAdapter("ControllerAdapter");
 
-        adapter.add(new TestI(), Util.stringToIdentity("test"));
+        var test = new TestI();
+        adapter.add(test, Util.stringToIdentity("test"));
         adapter.add(new TestII(), Util.stringToIdentity("test2"));
         // Collocated test doesn't need to activate the OA
-        adapter2.add(new TestControllerI(adapter), Util.stringToIdentity("testController"));
+        adapter2.add(new TestControllerI(adapter, test), Util.stringToIdentity("testController"));
         // Collocated test doesn't need to activate the OA
 
         await AllTests.allTestsAsync(this, true);

--- a/csharp/test/Ice/ami/Server.cs
+++ b/csharp/test/Ice/ami/Server.cs
@@ -29,10 +29,11 @@ public class Server : TestHelper
         Ice.ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
         Ice.ObjectAdapter adapter2 = communicator.createObjectAdapter("ControllerAdapter");
 
-        adapter.add(new TestI(), Ice.Util.stringToIdentity("test"));
+        var test = new TestI();
+        adapter.add(test, Ice.Util.stringToIdentity("test"));
         adapter.add(new TestII(), Ice.Util.stringToIdentity("test2"));
         adapter.activate();
-        adapter2.add(new TestControllerI(adapter), Ice.Util.stringToIdentity("testController"));
+        adapter2.add(new TestControllerI(adapter, test), Ice.Util.stringToIdentity("testController"));
         adapter2.activate();
         serverReady();
         communicator.waitForShutdown();

--- a/csharp/test/Ice/ami/Test.ice
+++ b/csharp/test/Ice/ami/Test.ice
@@ -50,6 +50,7 @@ module Test
     {
         void holdAdapter();
         void resumeAdapter();
+        void waitForActiveSleepCalls(int count);
     }
 
     module Outer::Inner

--- a/csharp/test/Ice/ami/TestI.cs
+++ b/csharp/test/Ice/ami/TestI.cs
@@ -82,7 +82,38 @@ public class TestI : Test.TestIntfDisp_
     public override void abortConnection(Ice.Current current) => current.con.abort();
 
     public override void
-    sleep(int ms, Ice.Current current) => Thread.Sleep(ms);
+    sleep(int ms, Ice.Current current)
+    {
+        lock (_mutex)
+        {
+            ++_activeSleepCalls;
+            Monitor.PulseAll(_mutex);
+        }
+
+        try
+        {
+            Thread.Sleep(ms);
+        }
+        finally
+        {
+            lock (_mutex)
+            {
+                --_activeSleepCalls;
+            }
+        }
+    }
+
+    internal void
+    waitForActiveSleepCalls(int count)
+    {
+        lock (_mutex)
+        {
+            while (_activeSleepCalls < count)
+            {
+                test(Monitor.Wait(_mutex, 10000));
+            }
+        }
+    }
 
     public override void
     shutdown(Ice.Current current)
@@ -181,6 +212,7 @@ public class TestI : Test.TestIntfDisp_
     }
 
     private int _batchCount;
+    private int _activeSleepCalls;
     private bool _shutdown;
     private TaskCompletionSource<object> _pending;
     private readonly object _mutex = new();
@@ -204,8 +236,16 @@ public class TestControllerI : Test.TestIntfControllerDisp_
     public override void
     resumeAdapter(Ice.Current current) => _adapter.activate();
 
+    public override void
+    waitForActiveSleepCalls(int count, Ice.Current current) => _test.waitForActiveSleepCalls(count);
+
     public
-    TestControllerI(Ice.ObjectAdapter adapter) => _adapter = adapter;
+    TestControllerI(Ice.ObjectAdapter adapter, TestI test)
+    {
+        _adapter = adapter;
+        _test = test;
+    }
 
     private readonly Ice.ObjectAdapter _adapter;
+    private readonly TestI _test;
 }

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -1165,6 +1165,10 @@ public class AllTests {
                 CompletableFuture<Void> sleep1Future = p.sleepAsync(1500);
                 CompletableFuture<Void> sleep2Future = p.sleepAsync(1500);
                 CompletableFuture<Void> sleep3Future = p.sleepAsync(1500);
+
+                // Wait until all three server thread pool threads are dispatching sleep before sending the payloads.
+                testController.waitForActiveSleepCalls(3);
+
                 TestIntfPrx onewayProxy = p.ice_oneway();
 
                 // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.

--- a/java/test/src/main/java/test/Ice/ami/Collocated.java
+++ b/java/test/src/main/java/test/Ice/ami/Collocated.java
@@ -27,11 +27,12 @@ public class Collocated extends TestHelper {
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             ObjectAdapter adapter2 = communicator.createObjectAdapter("ControllerAdapter");
 
-            adapter.add(new TestI(), new Identity("test", ""));
+            var test = new TestI();
+            adapter.add(test, new Identity("test", ""));
             adapter.add(new TestII(), new Identity("test2", ""));
             // adapter.activate(); // Collocated test doesn't need to activate the OA
             adapter2.add(
-                new TestControllerI(adapter),
+                new TestControllerI(adapter, test),
                 new Identity("testController", ""));
             // adapter2.activate(); // Collocated test doesn't need to activate the OA
 

--- a/java/test/src/main/java/test/Ice/ami/Server.java
+++ b/java/test/src/main/java/test/Ice/ami/Server.java
@@ -32,11 +32,12 @@ public class Server extends TestHelper {
             ObjectAdapter adapter2 =
                 communicator.createObjectAdapter("ControllerAdapter");
 
-            adapter.add(new TestI(), new Identity("test", ""));
+            var test = new TestI();
+            adapter.add(test, new Identity("test", ""));
             adapter.add(new TestII(), new Identity("test2", ""));
             adapter.activate();
             adapter2.add(
-                new TestControllerI(adapter),
+                new TestControllerI(adapter, test),
                 new Identity("testController", ""));
             adapter2.activate();
             serverReady();

--- a/java/test/src/main/java/test/Ice/ami/Test.ice
+++ b/java/test/src/main/java/test/Ice/ami/Test.ice
@@ -51,6 +51,7 @@ module Test
     {
         void holdAdapter();
         void resumeAdapter();
+        void waitForActiveSleepCalls(int count);
     }
 
     module Outer::Inner

--- a/java/test/src/main/java/test/Ice/ami/TestControllerI.java
+++ b/java/test/src/main/java/test/Ice/ami/TestControllerI.java
@@ -18,9 +18,16 @@ class TestControllerI implements TestIntfController {
         _adapter.activate();
     }
 
-    public TestControllerI(ObjectAdapter adapter) {
+    @Override
+    public void waitForActiveSleepCalls(int count, Current current) {
+        _test.waitForActiveSleepCalls(count);
+    }
+
+    public TestControllerI(ObjectAdapter adapter, TestI test) {
         _adapter = adapter;
+        _test = test;
     }
 
     private final ObjectAdapter _adapter;
+    private final TestI _test;
 }

--- a/java/test/src/main/java/test/Ice/ami/TestI.java
+++ b/java/test/src/main/java/test/Ice/ami/TestI.java
@@ -148,9 +148,27 @@ public class TestI implements TestIntf {
 
     @Override
     public void sleep(int ms, Current current) {
+        synchronized (this) {
+            ++_activeSleepCalls;
+            notifyAll();
+        }
+
         try {
             Thread.sleep(ms);
-        } catch (InterruptedException ex) {}
+        } catch (InterruptedException ex) {
+        } finally {
+            synchronized (this) {
+                --_activeSleepCalls;
+            }
+        }
+    }
+
+    public synchronized void waitForActiveSleepCalls(int count) {
+        while (_activeSleepCalls < count) {
+            try {
+                wait(10000);
+            } catch (InterruptedException ex) {}
+        }
     }
 
     @Override
@@ -190,6 +208,7 @@ public class TestI implements TestIntf {
     }
 
     private int _batchCount;
+    private int _activeSleepCalls;
     private boolean _shutdown;
     private CompletableFuture<Void> _pending;
 }

--- a/python/test/Ice/ami/Collocated.py
+++ b/python/test/Ice/ami/Collocated.py
@@ -28,9 +28,10 @@ class Collocated(TestHelper):
             adapter = communicator.createObjectAdapter("TestAdapter")
             adapter2 = communicator.createObjectAdapter("ControllerAdapter")
 
-            testController = TestI.TestIntfControllerI(adapter)
+            test = TestI.TestIntfI()
+            testController = TestI.TestIntfControllerI(adapter, test)
 
-            adapter.add(TestI.TestIntfI(), Ice.stringToIdentity("test"))
+            adapter.add(test, Ice.stringToIdentity("test"))
             adapter.add(TestI.TestIntfII(), Ice.stringToIdentity("test2"))
             # adapter.activate() # Collocated test doesn't need to active the OA
 

--- a/python/test/Ice/ami/Server.py
+++ b/python/test/Ice/ami/Server.py
@@ -36,9 +36,10 @@ class Server(TestHelper):
             adapter = communicator.createObjectAdapter("TestAdapter")
             adapter2 = communicator.createObjectAdapter("ControllerAdapter")
 
-            testController = TestI.TestIntfControllerI(adapter)
+            test = TestI.TestIntfI()
+            testController = TestI.TestIntfControllerI(adapter, test)
 
-            adapter.add(TestI.TestIntfI(), Ice.stringToIdentity("test"))
+            adapter.add(test, Ice.stringToIdentity("test"))
             adapter.add(TestI.TestIntfII(), Ice.stringToIdentity("test2"))
             adapter.activate()
 

--- a/python/test/Ice/ami/Test.ice
+++ b/python/test/Ice/ami/Test.ice
@@ -44,6 +44,7 @@ module Test
     {
         void holdAdapter();
         void resumeAdapter();
+        void waitForActiveSleepCalls(int count);
     }
 
     module Outer::Inner

--- a/python/test/Ice/ami/TestI.py
+++ b/python/test/Ice/ami/TestI.py
@@ -14,6 +14,7 @@ class TestIntfI(Test.TestIntf):
     def __init__(self):
         self._cond = threading.Condition()
         self._batchCount = 0
+        self._activeSleepCalls = 0
         self._pending = None
         self._shutdown = False
 
@@ -72,7 +73,19 @@ class TestIntfI(Test.TestIntf):
 
     @override
     def sleep(self, ms: int, current: Ice.Current):
-        time.sleep(ms / 1000.0)
+        with self._cond:
+            self._activeSleepCalls += 1
+            self._cond.notify_all()
+
+        try:
+            time.sleep(ms / 1000.0)
+        finally:
+            with self._cond:
+                self._activeSleepCalls -= 1
+
+    def waitForActiveSleepCalls(self, count: int):
+        with self._cond:
+            assert self._cond.wait_for(lambda: self._activeSleepCalls >= count, timeout=10)
 
     @override
     def startDispatch(self, current: Ice.Current):
@@ -135,11 +148,15 @@ class TestIntfII(Inner_TestIntf):
 
 
 class TestIntfControllerI(Test.TestIntfController):
-    def __init__(self, adapter: Ice.ObjectAdapter):
+    def __init__(self, adapter: Ice.ObjectAdapter, test: TestIntfI):
         self._adapter = adapter
+        self._test = test
 
     def holdAdapter(self, current: Ice.Current):
         self._adapter.hold()
 
     def resumeAdapter(self, current: Ice.Current):
         self._adapter.activate()
+
+    def waitForActiveSleepCalls(self, count: int, current: Ice.Current):
+        self._test.waitForActiveSleepCalls(count)


### PR DESCRIPTION
Fixes #6671

## Summary

- add a controller-adapter barrier that waits until all three sleep dispatches are active
- share the synchronized test servant with the controller in the C++, C#, Java, and Python servers
- make the C++, C#, and Java back-pressure clients start sending only after the server thread pool is exhausted
- run the socket back-pressure phase only when the proxy has a transport connection, keeping the remaining collocated AMI coverage
- remove the unused TCP send-buffer configuration from the C# collocated test

## Cross-language coverage

Ice/ami is a cross-language test and CI runs it with all-cross. The controller operation is therefore implemented by every server mapping that advertises back-pressure support: C++, C#, Java, and Python. The mappings that execute the client-side back-pressure phase are C++, C#, and Java.

The collocated configurations still run the meaningful AMI coverage, but skip this socket-specific phase because a collocated proxy has no transport connection.

## Testing

- built and ran the native C++ AMI client/server and collocated tests
- built the C# AMI projects and ran the native client/server and collocated tests with Release/net8.0
- built the Java test JAR with JDK 17, ran Java checkstyle, and ran the native Java AMI tests
- built the Python mapping and generated tests against Python 3.14
- ran C# to C++ and C++ to C# cross tests
- ran C# to Java and Java to C# cross tests
- ran the C# to Python cross test
- verified the back-pressure phase passed in every non-collocated run