### PR TITLE
Skip C# AMI socket back-pressure test when collocated

### DIFF
--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -933,7 +933,7 @@ public class AllTests : global::Test.AllTests
         }
         output.WriteLine("ok");
 
-        if (p.supportsBackPressureTests())
+        if (p.ice_getConnection() is not null && p.supportsBackPressureTests())
         {
             output.Write("testing back pressure... ");
             output.Flush();

--- a/csharp/test/Ice/ami/Collocated.cs
+++ b/csharp/test/Ice/ami/Collocated.cs
@@ -12,10 +12,6 @@ public class Collocated : TestHelper
 
         properties.setProperty("Ice.Warn.AMICallback", "0");
 
-        // Limit the send buffer size, this test relies on the socket send() blocking after sending a given
-        // amount of data.
-        properties.setProperty("Ice.TCP.SndSize", "50000");
-
         // We use a client thread pool with more than one thread to test that task inlining works.
         properties.setProperty("Ice.ThreadPool.Client.Size", "5");
         await using Communicator communicator = initialize(properties);


### PR DESCRIPTION
Split from #6692 following review feedback.

## Summary

- run the C# AMI socket back-pressure phase only when the proxy has a transport connection
- remove the unused Ice.TCP.SndSize setting from the collocated test setup
- retain the rest of the collocated AMI coverage

This aligns the C# test with the C++ and Java mappings, which already guard this phase on the presence of a connection.

## Testing

- built the C# AMI client, server, and collocated projects in Release/net8.0
- ran python allTests.py --filter=Ice/ami --csharp-config=Release --target-framework=net8.0
- verified client/server still exercises the back-pressure phase
- verified collocated skips only the socket-specific phase