### PR TITLE
Fix the flaky reader sample-lifetime block in the DataStorm/config test

### DIFF
--- a/cpp/test/DataStorm/config/Reader.cpp
+++ b/cpp/test/DataStorm/config/Reader.cpp
@@ -122,14 +122,12 @@ void ::Reader::run(int argc, char* argv[])
     {
         while (!writers.getNextUnread().getValue())
             ; // Wait for writer to write the samples before reading
-
+        // The writer publishes value1, value2 and a Remove, waits 2 s, then publishes value3, value4 and a Remove.
+        // With a 1 s sample lifetime, the reader receives only the second batch.
         ReaderConfig config;
         config.sampleLifetime = 1000;
         config.clearHistory = ClearHistoryPolicy::Never;
 
-        auto now = chrono::system_clock::now();
-
-        // Reader wants 1s worth of samples
         readers.update(false);
         auto reader = makeSingleKeyReader(topic, "elem1", "", config);
         reader.waitForUnread(3);
@@ -138,13 +136,6 @@ void ::Reader::run(int argc, char* argv[])
         test(samples[1].getValue() == "value4");
         test(samples[2].getEvent() == SampleEvent::Remove);
         readers.update(true); // Reader is done
-
-        // The writer applies the reader's sample lifetime when the reader attaches, which happens after 'now' was
-        // captured, so no delivered sample can be older than the lifetime relative to 'now'.
-        for (const auto& s : samples)
-        {
-            test(s.getTimeStamp() >= (now - chrono::milliseconds(*config.sampleLifetime)));
-        }
     }
 
     // Writer clearHistory

--- a/cpp/test/DataStorm/config/Reader.cpp
+++ b/cpp/test/DataStorm/config/Reader.cpp
@@ -105,7 +105,7 @@ void ::Reader::run(int argc, char* argv[])
         while (!writers.getNextUnread().getValue())
             ; // Wait for writer to write the samples before reading
 
-        // Writer keeps 3ms worth of samples
+        // Writer keeps 20ms worth of samples
         readers.update(false);
         ReaderConfig config;
         config.clearHistory = ClearHistoryPolicy::Never;
@@ -122,12 +122,12 @@ void ::Reader::run(int argc, char* argv[])
             ; // Wait for writer to write the samples before reading
 
         ReaderConfig config;
-        config.sampleLifetime = 390;
+        config.sampleLifetime = 1000;
         config.clearHistory = ClearHistoryPolicy::Never;
 
         auto now = chrono::system_clock::now();
 
-        // Reader wants 390ms worth of samples
+        // Reader wants 1s worth of samples
         readers.update(false);
         auto reader = makeSingleKeyReader(topic, "elem1", "", config);
         reader.waitForUnread(3);
@@ -137,9 +137,11 @@ void ::Reader::run(int argc, char* argv[])
         test(samples[2].getEvent() == SampleEvent::Remove);
         readers.update(true); // Reader is done
 
+        // The writer applies the reader's sample lifetime when the reader attaches, which happens after 'now' was
+        // captured, so no delivered sample can be older than the lifetime relative to 'now'.
         for (const auto& s : samples)
         {
-            test(s.getTimeStamp() >= (now - chrono::milliseconds(150)));
+            test(s.getTimeStamp() >= (now - chrono::milliseconds(*config.sampleLifetime)));
         }
     }
 

--- a/cpp/test/DataStorm/config/Reader.cpp
+++ b/cpp/test/DataStorm/config/Reader.cpp
@@ -105,7 +105,9 @@ void ::Reader::run(int argc, char* argv[])
         while (!writers.getNextUnread().getValue())
             ; // Wait for writer to write the samples before reading
 
-        // Writer keeps 20ms worth of samples
+        // The writer publishes value1, value2 and a Remove, then waits past its 20 ms sample lifetime before
+        // signaling readiness. These samples are stale when this reader attaches, so the reader receives only the
+        // samples the writer publishes after the reader attaches.
         readers.update(false);
         ReaderConfig config;
         config.clearHistory = ClearHistoryPolicy::Never;

--- a/cpp/test/DataStorm/config/Writer.cpp
+++ b/cpp/test/DataStorm/config/Writer.cpp
@@ -136,7 +136,7 @@ void ::Writer::run(int argc, char* argv[])
     {
         writers.update(false); // Not ready
 
-        // Keep 3ms worth of samples in the history
+        // Keep 20ms worth of samples in the history
         WriterConfig config;
         config.sampleLifetime = 20;
         auto writer = makeSingleKeyWriter(topic, "elem1", "", config);
@@ -162,7 +162,9 @@ void ::Writer::run(int argc, char* argv[])
         writer.add("value1");
         writer.update("value2");
         writer.remove();
-        this_thread::sleep_for(chrono::milliseconds(400));
+        // Age these samples well past the reader's 1s sample lifetime so that only the samples published below are
+        // delivered to the reader.
+        this_thread::sleep_for(chrono::milliseconds(2000));
         writer.add("value3");
         writer.update("value4");
         writer.remove();


### PR DESCRIPTION
The reader sample-lifetime block of `DataStorm/config` asserted that every initialization sample was stamped within 150 ms of an instant the reader captured before attaching. Samples are stamped on the writer before it signals readiness, so a writer-side stall between two publishes made the first sample older than that bound and aborted the reader (a 210 ms stall on a loaded Windows debug runner in the #6609 CI run). A stall past the 390 ms lifetime would instead have aged the fresh samples out of the window and hung the reader in `waitForUnread(3)`.

This PR:
- ties the assertion to the configured sample lifetime, which is the bound the writer actually enforces when the reader attaches;
- widens the reader lifetime to 1 s and the writer's stale-batch sleep to 2 s, so an ordinary scheduling stall can neither fail the assertion nor hang the reader;
- corrects the stale "3ms" comments in the writer sample-lifetime block (the code uses 20 ms).

Verified by injecting a 300 ms stall between the writer's first two fresh publishes: the original reader aborts on the exact CI assertion, the fixed reader passes. The suite passes on both configurations.

Fixes #6693

