### PR TITLE
Use a 4MB payload in the AMI back pressure tests

### DIFF
--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1471,11 +1471,13 @@ allTests(TestHelper* helper, bool collocated)
                 auto onewayProxy = Ice::uncheckedCast<Test::TestIntfPrx>(p->ice_oneway());
 
                 // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.
-                // On Windows, the kernel can absorb several whole sends into its own buffering (auto-tuning appears
-                // to ignore the configured send buffer size) before a send blocks: 4 x 768KB, about 3MB, were
-                // absorbed on windows-2025. We send a 4MB payload, larger than any buffering observed so far, and
-                // the servers raise Ice.MessageSizeMax to accept it. We still loop a few times as a safety net in
-                // case a send is absorbed anyway.
+                // Winsock completes the first two sends on a socket whatever their size: a send made while the
+                // socket is within its SO_SNDBUF quota completes, and so does one more send while only one earlier
+                // send is still buffered. From the third send on, the data is still copied but the completion is
+                // deferred until the earlier sends drain (KB214397, "Winsock uses the following rules to indicate
+                // a send completion"). So at least 3 sends are needed for one to block, and each one must be too
+                // large for the peer's kernel to absorb the earlier ones: on windows-2025, four 768KB sends all
+                // completed. We loop 4 times with a 4MB payload; the servers raise Ice.MessageSizeMax to accept it.
                 Ice::ByteSeq seq;
                 seq.resize(4 * 1024 * 1024);
 

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1471,13 +1471,9 @@ allTests(TestHelper* helper, bool collocated)
                 auto onewayProxy = Ice::uncheckedCast<Test::TestIntfPrx>(p->ice_oneway());
 
                 // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.
-                // Winsock completes the first two sends on a socket whatever their size: a send made while the
-                // socket is within its SO_SNDBUF quota completes, and so does one more send while only one earlier
-                // send is still buffered. From the third send on, the data is still copied but the completion is
-                // deferred until the earlier sends drain (KB214397, "Winsock uses the following rules to indicate
-                // a send completion"). So at least 3 sends are needed for one to block, and each one must be too
-                // large for the peer's kernel to absorb the earlier ones: on windows-2025, four 768KB sends all
-                // completed. We loop 4 times with a 4MB payload; the servers raise Ice.MessageSizeMax to accept it.
+                // On Windows, Winsock completes the first two sends on a socket regardless of their size and only
+                // defers completion from the third send on (KB214397), so we loop 4 times with a payload too large
+                // for the peer's kernel to absorb.
                 Ice::ByteSeq seq;
                 seq.resize(4 * 1024 * 1024);
 

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1471,10 +1471,13 @@ allTests(TestHelper* helper, bool collocated)
                 auto onewayProxy = Ice::uncheckedCast<Test::TestIntfPrx>(p->ice_oneway());
 
                 // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.
-                // We loop up to 4 times because on Windows with TCP, the Socket.Send call appears to always succeed
-                // twice before blocking.
+                // On Windows, the kernel can absorb several whole sends into its own buffering (auto-tuning appears
+                // to ignore the configured send buffer size) before a send blocks: 4 x 768KB, about 3MB, were
+                // absorbed on windows-2025. We send a 4MB payload, larger than any buffering observed so far, and
+                // the servers raise Ice.MessageSizeMax to accept it. We still loop a few times as a safety net in
+                // case a send is absorbed anyway.
                 Ice::ByteSeq seq;
-                seq.resize(768 * 1024);
+                seq.resize(4 * 1024 * 1024);
 
                 bool timedOut = false;
                 for (int i = 0; i < 4; ++i)

--- a/cpp/test/Ice/ami/Server.cpp
+++ b/cpp/test/Ice/ami/Server.cpp
@@ -30,6 +30,11 @@ Server::run(int argc, char** argv)
     //
     properties->setProperty("Ice.TCP.RcvSize", "50000");
 
+    //
+    // The back pressure test sends a 4MB payload, above the default message size limit.
+    //
+    properties->setProperty("Ice.MessageSizeMax", "8192");
+
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -953,12 +953,15 @@ public class AllTests : global::Test.AllTests
                     // Sending should be canceled because the TCP send/receive buffer size on the server is set
                     // to 50KB. Note: we don't use the cancel parameter of the operation here because the
                     // cancellation doesn't cancel the operation whose payload is being sent.
-                    // We loop up to 4 times because on Windows with TCP, the Socket.Send call appears to always succeed
-                    // twice before blocking.
+                    // On Windows, the kernel can absorb several whole sends into its own buffering (auto-tuning
+                    // appears to ignore the configured send buffer size) before a send blocks: 4 x 768KB, about
+                    // 3MB, were absorbed on windows-2025. We send a 4MB payload, larger than any buffering observed
+                    // so far, and the servers raise Ice.MessageSizeMax to accept it. We still loop a few times as a
+                    // safety net in case a send is absorbed anyway.
                     for (int i = 0; i < 4; ++i)
                     {
                         using var cts = new CancellationTokenSource(200);
-                        await onewayProxy.opWithPayloadAsync(new byte[768 * 1024]).WaitAsync(cts.Token);
+                        await onewayProxy.opWithPayloadAsync(new byte[4 * 1024 * 1024]).WaitAsync(cts.Token);
                     }
                 }
                 catch (OperationCanceledException)

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -953,11 +953,14 @@ public class AllTests : global::Test.AllTests
                     // Sending should be canceled because the TCP send/receive buffer size on the server is set
                     // to 50KB. Note: we don't use the cancel parameter of the operation here because the
                     // cancellation doesn't cancel the operation whose payload is being sent.
-                    // On Windows, the kernel can absorb several whole sends into its own buffering (auto-tuning
-                    // appears to ignore the configured send buffer size) before a send blocks: 4 x 768KB, about
-                    // 3MB, were absorbed on windows-2025. We send a 4MB payload, larger than any buffering observed
-                    // so far, and the servers raise Ice.MessageSizeMax to accept it. We still loop a few times as a
-                    // safety net in case a send is absorbed anyway.
+                    // Winsock completes the first two sends on a socket whatever their size: a send made while
+                    // the socket is within its SO_SNDBUF quota completes, and so does one more send while only
+                    // one earlier send is still buffered. From the third send on, the data is still copied but
+                    // the completion is deferred until the earlier sends drain (KB214397, "Winsock uses the
+                    // following rules to indicate a send completion"). So at least 3 sends are needed for one to
+                    // block, and each one must be too large for the peer's kernel to absorb the earlier ones:
+                    // on windows-2025, four 768KB sends all completed. We loop 4 times with a 4MB payload; the
+                    // servers raise Ice.MessageSizeMax to accept it.
                     for (int i = 0; i < 4; ++i)
                     {
                         using var cts = new CancellationTokenSource(200);

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -953,14 +953,9 @@ public class AllTests : global::Test.AllTests
                     // Sending should be canceled because the TCP send/receive buffer size on the server is set
                     // to 50KB. Note: we don't use the cancel parameter of the operation here because the
                     // cancellation doesn't cancel the operation whose payload is being sent.
-                    // Winsock completes the first two sends on a socket whatever their size: a send made while
-                    // the socket is within its SO_SNDBUF quota completes, and so does one more send while only
-                    // one earlier send is still buffered. From the third send on, the data is still copied but
-                    // the completion is deferred until the earlier sends drain (KB214397, "Winsock uses the
-                    // following rules to indicate a send completion"). So at least 3 sends are needed for one to
-                    // block, and each one must be too large for the peer's kernel to absorb the earlier ones:
-                    // on windows-2025, four 768KB sends all completed. We loop 4 times with a 4MB payload; the
-                    // servers raise Ice.MessageSizeMax to accept it.
+                    // On Windows, Winsock completes the first two sends on a socket regardless of their size and
+                    // only defers completion from the third send on (KB214397), so we loop 4 times with a payload
+                    // too large for the peer's kernel to absorb.
                     for (int i = 0; i < 4; ++i)
                     {
                         using var cts = new CancellationTokenSource(200);

--- a/csharp/test/Ice/ami/Server.cs
+++ b/csharp/test/Ice/ami/Server.cs
@@ -21,6 +21,11 @@ public class Server : TestHelper
         //
         properties.setProperty("Ice.TCP.RcvSize", "50000");
 
+        //
+        // The back pressure test sends a 4MB payload, above the default message size limit.
+        //
+        properties.setProperty("Ice.MessageSizeMax", "8192");
+
         using Communicator communicator = initialize(properties);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -1168,11 +1168,9 @@ public class AllTests {
                 TestIntfPrx onewayProxy = p.ice_oneway();
 
                 // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.
-                // Winsock completes the first two sends on a socket whatever their size (KB214397), but the JDK
-                // splits each write into WSASend calls of at most 128KB, so a large message stays pending once
-                // its third chunk would block. Still, each message must be too large for the peer's kernel to
-                // absorb: on windows-2025, four 768KB sends all completed in C#. We send a 4MB payload; the
-                // servers raise Ice.MessageSizeMax to accept it.
+                // On Windows, Winsock completes the first two sends on a socket regardless of their size
+                // (KB214397), but the JDK splits each write into WSASend calls of at most 128KB, so a single
+                // send of a payload too large for the peer's kernel to absorb is enough.
                 CompletableFuture<Void> future = onewayProxy.opWithPayloadAsync(new byte[4 * 1024 * 1024]);
                 boolean timeout = false;
                 try {

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -1168,7 +1168,11 @@ public class AllTests {
                 TestIntfPrx onewayProxy = p.ice_oneway();
 
                 // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.
-                CompletableFuture<Void> future = onewayProxy.opWithPayloadAsync(new byte[768 * 1024]);
+                // On Windows, the kernel can absorb several whole sends into its own buffering (auto-tuning
+                // appears to ignore the configured send buffer size) before a send blocks: 4 x 768KB, about 3MB,
+                // were absorbed on windows-2025. We send a 4MB payload, larger than any buffering observed so
+                // far, and the servers raise Ice.MessageSizeMax to accept it.
+                CompletableFuture<Void> future = onewayProxy.opWithPayloadAsync(new byte[4 * 1024 * 1024]);
                 boolean timeout = false;
                 try {
                     future.get(200, TimeUnit.MILLISECONDS);

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -1168,10 +1168,11 @@ public class AllTests {
                 TestIntfPrx onewayProxy = p.ice_oneway();
 
                 // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.
-                // On Windows, the kernel can absorb several whole sends into its own buffering (auto-tuning
-                // appears to ignore the configured send buffer size) before a send blocks: 4 x 768KB, about 3MB,
-                // were absorbed on windows-2025. We send a 4MB payload, larger than any buffering observed so
-                // far, and the servers raise Ice.MessageSizeMax to accept it.
+                // Winsock completes the first two sends on a socket whatever their size (KB214397), but the JDK
+                // splits each write into WSASend calls of at most 128KB, so a large message stays pending once
+                // its third chunk would block. Still, each message must be too large for the peer's kernel to
+                // absorb: on windows-2025, four 768KB sends all completed in C#. We send a 4MB payload; the
+                // servers raise Ice.MessageSizeMax to accept it.
                 CompletableFuture<Void> future = onewayProxy.opWithPayloadAsync(new byte[4 * 1024 * 1024]);
                 boolean timeout = false;
                 try {

--- a/java/test/src/main/java/test/Ice/ami/Server.java
+++ b/java/test/src/main/java/test/Ice/ami/Server.java
@@ -20,6 +20,8 @@ public class Server extends TestHelper {
         // Limit the recv buffer size, this test relies on the socket
         // send() blocking after sending a given amount of data.
         initData.properties.setProperty("Ice.TCP.RcvSize", "50000");
+        // The back pressure test sends a 4MB payload, above the default message size limit.
+        initData.properties.setProperty("Ice.MessageSizeMax", "8192");
 
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));

--- a/python/test/Ice/ami/Server.py
+++ b/python/test/Ice/ami/Server.py
@@ -28,6 +28,11 @@ class Server(TestHelper):
         #
         properties.setProperty("Ice.TCP.RcvSize", "50000")
 
+        #
+        # The back pressure test sends a 4MB payload, above the default message size limit.
+        #
+        properties.setProperty("Ice.MessageSizeMax", "8192")
+
         with self.initialize(properties=properties) as communicator:
             communicator.getProperties().setProperty("TestAdapter.Endpoints", self.getTestEndpoint())
             communicator.getProperties().setProperty("ControllerAdapter.Endpoints", self.getTestEndpoint(num=1))


### PR DESCRIPTION
On windows-2025, Windows absorbed all four 768KB oneway sends of the C# `Ice/ami` back pressure test into kernel buffering, so no send ever blocked and the 200ms cancellation never fired. The failure is intermittent and the C++ and Java tests send the same payload, so the same behavior can affect them.

- The C++, C# and Java back pressure tests now send a 4MB payload, larger than any buffering observed so far.
- A 4MB message exceeds the default `Ice.MessageSizeMax` (1MB), so the `Ice/ami` servers of every mapping these clients can be cross-tested with (C++, C#, Java, Python) raise it to 8MB. Without it the server closes the connection and the test fails with `ConnectionLostException`. The Swift server opts out of the back pressure test and is left unchanged.
- The C++ and C# tests keep their loop of 4 sends because Winsock always completes the first two sends on a socket regardless of their size and only defers completion from the third send on ([KB214397](https://learn.microsoft.com/en-US/troubleshoot/windows/win32/data-segment-tcp-winsock)). The Java test needs no loop because the JDK splits each write into WSASend calls of at most 128KB. The comments now document this.

Verified locally on macOS: the C++ and C# suites, plus both cross directions between them, pass.

Closes #6671
