### PR TITLE
Fix Java IceSSL store type defaults

### DIFF
--- a/changelog.d/java/6485.md
+++ b/changelog.d/java/6485.md
@@ -1,0 +1,4 @@
+- Java `IceSSL.TruststoreType` no longer reports `JKS` as its property default when IceSSL actually uses the JVM's
+  default key store type.
+- Java IceSSL no longer silently loads password-protected PKCS12 key and trust stores without their certificates when
+  the store type is lowercase or selected through the JVM default.

--- a/changelog.d/java/6485.md
+++ b/changelog.d/java/6485.md
@@ -1,4 +1,4 @@
-- Fixed a silent misconfiguration with PKCS12 key and trust stores: when `IceSSL.KeystorePassword` or
-  `IceSSL.TruststorePassword` was omitted, the store loaded without its certificates and TLS handshakes failed with an
-  unrelated error. Communicator initialization now fails with an `InitializationException` that names the property to
-  check.
+- Fixed a silent misconfiguration with PKCS12 key and trust stores: when the store was loaded without the password
+  that protects its certificates (typically because `IceSSL.KeystorePassword` or `IceSSL.TruststorePassword` was
+  omitted), the certificates were skipped and TLS handshakes failed with an unrelated error. Communicator
+  initialization now fails with an `InitializationException` that names the setting to check.

--- a/changelog.d/java/6485.md
+++ b/changelog.d/java/6485.md
@@ -1,4 +1,6 @@
-- Java `IceSSL.TruststoreType` no longer reports `JKS` as its property default when IceSSL actually uses the JVM's
-  default key store type.
-- Java IceSSL no longer silently accepts password-protected PKCS12 key and trust stores whose certificates could not
-  be decrypted because the corresponding store password was omitted.
+- Fixed a bug where `IceSSL.TruststoreType` reported `JKS` as its default value. The property has no default; when it
+  is not set, IceSSL uses the JVM's default key store type.
+- Fixed a silent misconfiguration with PKCS12 key and trust stores: when `IceSSL.KeystorePassword` or
+  `IceSSL.TruststorePassword` was omitted, the store loaded without its certificates and TLS handshakes failed with an
+  unrelated error. Communicator initialization now fails with an `InitializationException` that names the property to
+  check.

--- a/changelog.d/java/6485.md
+++ b/changelog.d/java/6485.md
@@ -1,4 +1,4 @@
 - Java `IceSSL.TruststoreType` no longer reports `JKS` as its property default when IceSSL actually uses the JVM's
   default key store type.
-- Java IceSSL no longer silently loads password-protected PKCS12 key and trust stores without their certificates when
-  the store type is lowercase or selected through the JVM default.
+- Java IceSSL no longer silently accepts password-protected PKCS12 key and trust stores whose certificates could not
+  be decrypted because the corresponding store password was omitted.

--- a/changelog.d/java/6485.md
+++ b/changelog.d/java/6485.md
@@ -1,5 +1,3 @@
-- Fixed a bug where `IceSSL.TruststoreType` reported `JKS` as its default value. The property has no default; when it
-  is not set, IceSSL uses the JVM's default key store type.
 - Fixed a silent misconfiguration with PKCS12 key and trust stores: when `IceSSL.KeystorePassword` or
   `IceSSL.TruststorePassword` was omitted, the store loaded without its certificates and TLS handshakes failed with an
   unrelated error. Communicator initialization now fails with an `InitializationException` that names the property to

--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -326,7 +326,7 @@
         <property name="TrustOnly.Server.[any]" languages="cpp,csharp,java" />
         <property name="Truststore" languages="java" />
         <property name="TruststorePassword" languages="java" />
-        <property name="TruststoreType" languages="java" default="JKS" />
+        <property name="TruststoreType" languages="java" />
         <property name="UsePlatformCAs" languages="cpp,csharp,java" default="0" />
         <property name="VerifyPeer" languages="cpp,csharp,java" default="2" />
     </section>

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
@@ -280,7 +280,7 @@ final class PropertyNames {
             new Property("TrustOnly\\.Server\\.[^\\s]+", true, "", false, null),
             new Property("Truststore", false, "", false, null),
             new Property("TruststorePassword", false, "", false, null),
-            new Property("TruststoreType", false, "JKS", false, null),
+            new Property("TruststoreType", false, "", false, null),
             new Property("UsePlatformCAs", false, "0", false, null),
             new Property("VerifyPeer", false, "2", false, null)
         });

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -80,8 +80,7 @@ public class SSLEngine {
                 // The password for the keystore.
                 String keystorePassword = properties.getIceProperty("IceSSL.KeystorePassword");
 
-                // The default keystore type is usually "JKS", but the legal values are determined by the JVM
-                // implementation. Other possibilities include "PKCS12" and "BKS".
+                // The default and supported keystore types are determined by the installed security providers.
                 final String defaultType = KeyStore.getDefaultType();
                 final String keystoreType = properties.getPropertyWithDefault("IceSSL.KeystoreType", defaultType);
 
@@ -95,8 +94,6 @@ public class SSLEngine {
                 // The password for the truststore.
                 String truststorePassword = properties.getIceProperty("IceSSL.TruststorePassword");
 
-                // The default truststore type is usually "JKS", but the legal values are determined by the JVM
-                // implementation. Other possibilities include "PKCS12" and "BKS".
                 final String truststoreType = properties.getPropertyWithDefault("IceSSL.TruststoreType", defaultType);
 
                 // Collect the key managers.
@@ -114,8 +111,10 @@ public class SSLEngine {
                         char[] passwordChars = null;
                         if (!keystorePassword.isEmpty()) {
                             passwordChars = keystorePassword.toCharArray();
-                        } else if ("BKS".equals(keystoreType) || "PKCS12".equals(keystoreType)) {
-                            // Bouncy Castle or PKCS12 does not permit null passwords.
+                        } else if ("BKS".equalsIgnoreCase(keystoreType)
+                            || "PKCS12".equalsIgnoreCase(keystoreType)) {
+                            // Use an empty password for store types where a null password has special semantics.
+                            // In particular, PKCS12 providers can skip encrypted certificates with a null password.
                             passwordChars = new char[0];
                         }
 
@@ -198,8 +197,10 @@ public class SSLEngine {
                             char[] passwordChars = null;
                             if (!truststorePassword.isEmpty()) {
                                 passwordChars = truststorePassword.toCharArray();
-                            } else if ("BKS".equals(truststoreType) || "PKCS12".equals(truststoreType)) {
-                                // Bouncy Castle or PKCS12 does not permit null passwords.
+                            } else if ("BKS".equalsIgnoreCase(truststoreType)
+                                || "PKCS12".equalsIgnoreCase(truststoreType)) {
+                                // Use an empty password for store types where a null password has special semantics.
+                                // In particular, PKCS12 providers can skip encrypted certificates with a null password.
                                 passwordChars = new char[0];
                             }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -18,6 +18,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -111,10 +112,8 @@ public class SSLEngine {
                         char[] passwordChars = null;
                         if (!keystorePassword.isEmpty()) {
                             passwordChars = keystorePassword.toCharArray();
-                        } else if ("BKS".equalsIgnoreCase(keystoreType)
-                            || "PKCS12".equalsIgnoreCase(keystoreType)) {
-                            // Use an empty password for store types where a null password has special semantics.
-                            // In particular, PKCS12 providers can skip encrypted certificates with a null password.
+                        } else if ("BKS".equals(keystoreType) || "PKCS12".equals(keystoreType)) {
+                            // BKS requires a non-null password. PKCS12 distinguishes an empty password from null.
                             passwordChars = new char[0];
                         }
 
@@ -137,15 +136,6 @@ public class SSLEngine {
                         }
                     }
 
-                    String algorithm = KeyManagerFactory.getDefaultAlgorithm();
-                    KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
-                    // This password cannot be null.
-                    char[] passwordChars = password.isEmpty() ? new char[0] : password.toCharArray();
-                    kmf.init(keys, passwordChars);
-                    Arrays.fill(passwordChars, '\0');
-                    password = null;
-                    keyManagers = kmf.getKeyManagers();
-
                     // If no alias is specified, we look for the first key entry in the key store.
                     //
                     // This is required to force the key manager to always choose a certificate even if there's no
@@ -166,6 +156,26 @@ public class SSLEngine {
                                 "SSL transport: keystore does not contain an entry with alias `" + alias + "'");
                         }
                     }
+
+                    if (!alias.isEmpty()) {
+                        // A PKCS12 store loaded with a null password can contain a key entry without its encrypted
+                        // certificate chain.
+                        Certificate[] chain = keys.getCertificateChain(alias);
+                        if (chain == null || chain.length == 0) {
+                            throw new InitializationException(
+                                "SSL transport: keystore entry with alias `" + alias
+                                    + "` does not contain a certificate chain; check IceSSL.KeystorePassword");
+                        }
+                    }
+
+                    String algorithm = KeyManagerFactory.getDefaultAlgorithm();
+                    KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
+                    // This password cannot be null.
+                    char[] passwordChars = password.isEmpty() ? new char[0] : password.toCharArray();
+                    kmf.init(keys, passwordChars);
+                    Arrays.fill(passwordChars, '\0');
+                    password = null;
+                    keyManagers = kmf.getKeyManagers();
 
                     if (!alias.isEmpty()) {
                         // wrap the key managers in order to return the desired alias.
@@ -197,10 +207,9 @@ public class SSLEngine {
                             char[] passwordChars = null;
                             if (!truststorePassword.isEmpty()) {
                                 passwordChars = truststorePassword.toCharArray();
-                            } else if ("BKS".equalsIgnoreCase(truststoreType)
-                                || "PKCS12".equalsIgnoreCase(truststoreType)) {
-                                // Use an empty password for store types where a null password has special semantics.
-                                // In particular, PKCS12 providers can skip encrypted certificates with a null password.
+                            } else if ("BKS".equals(truststoreType) || "PKCS12".equals(truststoreType)) {
+                                // BKS requires a non-null password. PKCS12 distinguishes an empty password from
+                                // null.
                                 passwordChars = new char[0];
                             }
 
@@ -238,7 +247,23 @@ public class SSLEngine {
                         // eventually result in an exception such as: `InvalidAlgorithmParameterException` the
                         // trustAnchors parameter must be non-empty.
                         if (truststore.size() == 0) {
-                            throw new InitializationException("SSL transport: truststore is empty");
+                            throw new InitializationException(
+                                "SSL transport: truststore is empty; check IceSSL.TruststorePassword");
+                        }
+
+                        boolean containsCertificate = false;
+                        for (Enumeration<String> e = truststore.aliases(); e.hasMoreElements(); ) {
+                            if (truststore.getCertificate(e.nextElement()) != null) {
+                                containsCertificate = true;
+                                break;
+                            }
+                        }
+                        if (!containsCertificate) {
+                            // A PKCS12 store loaded with a null password can contain key entries without their
+                            // encrypted certificates.
+                            throw new InitializationException(
+                                "SSL transport: truststore does not contain any certificates; check "
+                                    + "IceSSL.TruststorePassword");
                         }
                         tmf.init(truststore);
                         trustManagers = tmf.getTrustManagers();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -136,6 +136,15 @@ public class SSLEngine {
                         }
                     }
 
+                    String algorithm = KeyManagerFactory.getDefaultAlgorithm();
+                    KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
+                    // This password cannot be null.
+                    char[] passwordChars = password.isEmpty() ? new char[0] : password.toCharArray();
+                    kmf.init(keys, passwordChars);
+                    Arrays.fill(passwordChars, '\0');
+                    password = null;
+                    keyManagers = kmf.getKeyManagers();
+
                     // If no alias is specified, we look for the first key entry in the key store.
                     //
                     // This is required to force the key manager to always choose a certificate even if there's no
@@ -155,7 +164,7 @@ public class SSLEngine {
                         // If the user selected a specific alias, ensure it corresponds to a private key entry.
                         if (!keys.entryInstanceOf(alias, KeyStore.PrivateKeyEntry.class)) {
                             throw new InitializationException(
-                                "SSL transport: keystore does not contain a private key entry with alias `" + alias
+                                "SSL transport: keystore does not contain a private key entry with alias '" + alias
                                     + "'");
                         }
                     }
@@ -166,22 +175,11 @@ public class SSLEngine {
                         Certificate[] chain = keys.getCertificateChain(alias);
                         if (chain == null || chain.length == 0) {
                             throw new InitializationException(
-                                "SSL transport: keystore entry with alias `" + alias
-                                    + "` does not contain a certificate chain; check IceSSL.KeystorePassword or,"
+                                "SSL transport: keystore entry with alias '" + alias
+                                    + "' does not contain a certificate chain; check IceSSL.KeystorePassword or,"
                                     + " for a password-less PKCS12 store, set IceSSL.KeystoreType=PKCS12");
                         }
-                    }
 
-                    String algorithm = KeyManagerFactory.getDefaultAlgorithm();
-                    KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
-                    // This password cannot be null.
-                    char[] passwordChars = password.isEmpty() ? new char[0] : password.toCharArray();
-                    kmf.init(keys, passwordChars);
-                    Arrays.fill(passwordChars, '\0');
-                    password = null;
-                    keyManagers = kmf.getKeyManagers();
-
-                    if (!alias.isEmpty()) {
                         // wrap the key managers in order to return the desired alias.
                         for (int i = 0; i < keyManagers.length; i++) {
                             keyManagers[i] =
@@ -249,13 +247,8 @@ public class SSLEngine {
                         TrustManagerFactory tmf = TrustManagerFactory.getInstance(algorithm);
                         // Attempting to establish an outgoing connection with an empty truststore can cause hangs that
                         // eventually result in an exception such as: `InvalidAlgorithmParameterException` the
-                        // trustAnchors parameter must be non-empty.
-                        if (truststore.size() == 0) {
-                            throw new InitializationException(
-                                "SSL transport: truststore is empty; check IceSSL.TruststorePassword or, for a"
-                                    + " password-less PKCS12 store, set IceSSL.TruststoreType=PKCS12");
-                        }
-
+                        // trustAnchors parameter must be non-empty. A PKCS12 store loaded with a null password can also
+                        // contain key entries without their encrypted certificates.
                         boolean containsCertificate = false;
                         for (Enumeration<String> e = truststore.aliases(); e.hasMoreElements(); ) {
                             if (truststore.getCertificate(e.nextElement()) != null) {
@@ -264,8 +257,6 @@ public class SSLEngine {
                             }
                         }
                         if (!containsCertificate) {
-                            // A PKCS12 store loaded with a null password can contain key entries without their
-                            // encrypted certificates.
                             throw new InitializationException(
                                 "SSL transport: truststore does not contain any certificates; check"
                                     + " IceSSL.TruststorePassword or, for a password-less PKCS12 store, set"

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -144,7 +144,9 @@ public class SSLEngine {
                     if (alias.isEmpty()) {
                         for (Enumeration<String> e = keys.aliases(); e.hasMoreElements(); ) {
                             String a = e.nextElement();
-                            if (keys.isKeyEntry(a)) {
+                            // Skip secret-key entries, which isKeyEntry also matches. A PKCS12 private key loaded with
+                            // a null password is still a private key entry, without its chain; it is reported below.
+                            if (keys.entryInstanceOf(a, KeyStore.PrivateKeyEntry.class)) {
                                 alias = a;
                                 break;
                             }
@@ -164,7 +166,8 @@ public class SSLEngine {
                         if (chain == null || chain.length == 0) {
                             throw new InitializationException(
                                 "SSL transport: keystore entry with alias `" + alias
-                                    + "` does not contain a certificate chain; check IceSSL.KeystorePassword");
+                                    + "` does not contain a certificate chain; check IceSSL.KeystorePassword or,"
+                                    + " for a password-less PKCS12 store, set IceSSL.KeystoreType=PKCS12");
                         }
                     }
 
@@ -248,7 +251,8 @@ public class SSLEngine {
                         // trustAnchors parameter must be non-empty.
                         if (truststore.size() == 0) {
                             throw new InitializationException(
-                                "SSL transport: truststore is empty; check IceSSL.TruststorePassword");
+                                "SSL transport: truststore is empty; check IceSSL.TruststorePassword or, for a"
+                                    + " password-less PKCS12 store, set IceSSL.TruststoreType=PKCS12");
                         }
 
                         boolean containsCertificate = false;
@@ -262,8 +266,9 @@ public class SSLEngine {
                             // A PKCS12 store loaded with a null password can contain key entries without their
                             // encrypted certificates.
                             throw new InitializationException(
-                                "SSL transport: truststore does not contain any certificates; check "
-                                    + "IceSSL.TruststorePassword");
+                                "SSL transport: truststore does not contain any certificates; check"
+                                    + " IceSSL.TruststorePassword or, for a password-less PKCS12 store, set"
+                                    + " IceSSL.TruststoreType=PKCS12");
                         }
                         tmf.init(truststore);
                         trustManagers = tmf.getTrustManagers();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -152,10 +152,11 @@ public class SSLEngine {
                             }
                         }
                     } else {
-                        // If the user selected a specific alias, ensure it correspond with a key entry.
-                        if (!keys.isKeyEntry(alias)) {
+                        // If the user selected a specific alias, ensure it corresponds to a private key entry.
+                        if (!keys.entryInstanceOf(alias, KeyStore.PrivateKeyEntry.class)) {
                             throw new InitializationException(
-                                "SSL transport: keystore does not contain an entry with alias `" + alias + "'");
+                                "SSL transport: keystore does not contain a private key entry with alias `" + alias
+                                    + "'");
                         }
                     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -145,27 +145,35 @@ public class SSLEngine {
                     password = null;
                     keyManagers = kmf.getKeyManagers();
 
-                    // If no alias is specified, we look for the first key entry in the key store.
+                    // If no alias is specified, we look for the first key entry with a certificate chain in the key
+                    // store, and fall back to the first key entry so that a missing chain is reported below.
                     //
                     // This is required to force the key manager to always choose a certificate even if there's no
                     // certificate signed by any of the CA names sent by the server. Ice servers might indeed not
                     // always send the CA names of their trusted roots.
                     if (alias.isEmpty()) {
+                        String firstKeyEntry = "";
                         for (Enumeration<String> e = keys.aliases(); e.hasMoreElements(); ) {
                             String a = e.nextElement();
-                            // Skip secret-key entries, which isKeyEntry also matches. A PKCS12 private key loaded with
-                            // a null password is still a private key entry, without its chain; it is reported below.
-                            if (keys.entryInstanceOf(a, KeyStore.PrivateKeyEntry.class)) {
-                                alias = a;
-                                break;
+                            if (keys.isKeyEntry(a)) {
+                                Certificate[] chain = keys.getCertificateChain(a);
+                                if (chain != null && chain.length > 0) {
+                                    alias = a;
+                                    break;
+                                }
+                                if (firstKeyEntry.isEmpty()) {
+                                    firstKeyEntry = a;
+                                }
                             }
                         }
+                        if (alias.isEmpty()) {
+                            alias = firstKeyEntry;
+                        }
                     } else {
-                        // If the user selected a specific alias, ensure it corresponds to a private key entry.
-                        if (!keys.entryInstanceOf(alias, KeyStore.PrivateKeyEntry.class)) {
+                        // If the user selected a specific alias, ensure it correspond with a key entry.
+                        if (!keys.isKeyEntry(alias)) {
                             throw new InitializationException(
-                                "SSL transport: keystore does not contain a private key entry with alias '" + alias
-                                    + "'");
+                                "SSL transport: keystore does not contain an entry with alias '" + alias + "'");
                         }
                     }
 

--- a/java/test/src/main/java/test/Ice/properties/Client.java
+++ b/java/test/src/main/java/test/Ice/properties/Client.java
@@ -121,6 +121,8 @@ public class Client extends TestHelper {
 
             String stringValue = properties.getIceProperty("Ice.Default.Host");
             test(stringValue.isEmpty());
+            test(properties.getIceProperty("IceSSL.KeystoreType").isEmpty());
+            test(properties.getIceProperty("IceSSL.TruststoreType").isEmpty());
 
             int intValue = properties.getIcePropertyAsInt("Ice.Default.Host");
             test(intValue == 0);

--- a/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
@@ -30,6 +30,14 @@ public class AllTests {
         }
     }
 
+    private static void testStorePasswordFailure(InitializationData initData, String store) {
+        try (Communicator communicator = new Communicator(initData)) {
+            test(false);
+        } catch (InitializationException ex) {
+            test(ex.getMessage().contains("unable to load " + store));
+        }
+    }
+
     private static X509Certificate loadCertificate(String path, String alias) {
         try {
             KeyStore keystore = KeyStore.getInstance("JKS");
@@ -610,6 +618,29 @@ public class AllTests {
             } catch (LocalException ex) {
                 ex.printStackTrace();
                 test(false);
+            }
+
+            if ("PKCS12".equals(keystoreType)) {
+                // Key store type names are case-insensitive. Verify lowercase PKCS12 names don't cause IceSSL to use
+                // a null password and silently load stores without their encrypted certificates.
+                initData = createClientProps(defaultProperties);
+                initData.properties.setProperty("IceSSL.Keystore", "ca1/client.p12");
+                initData.properties.setProperty("IceSSL.KeystoreType", "pkcs12");
+                initData.properties.setProperty("IceSSL.Password", "password");
+                testStorePasswordFailure(initData, "keystore");
+
+                initData = createClientProps(defaultProperties);
+                initData.properties.setProperty("IceSSL.Truststore", "ca1/ca1.p12");
+                initData.properties.setProperty("IceSSL.TruststoreType", "pkcs12");
+                testStorePasswordFailure(initData, "truststore");
+
+                if ("PKCS12".equalsIgnoreCase(KeyStore.getDefaultType())) {
+                    // KeyStore.getDefaultType() normally returns the lower-case value "pkcs12" on standard JDKs.
+                    initData = createClientProps(defaultProperties);
+                    initData.properties.setProperty("IceSSL.Keystore", "ca1/client.p12");
+                    initData.properties.setProperty("IceSSL.Password", "password");
+                    testStorePasswordFailure(initData, "keystore");
+                }
             }
         }
         out.println("ok");

--- a/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
@@ -16,12 +16,17 @@ import test.IceSSL.configuration.Test.ServerFactoryPrx;
 import test.IceSSL.configuration.Test.ServerPrx;
 import test.TestHelper;
 
+import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.PrintWriter;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.crypto.KeyGenerator;
 
 public class AllTests {
     private static void test(boolean b) {
@@ -40,6 +45,48 @@ public class AllTests {
 
     private static void testStoreLoads(InitializationData initData) {
         try (Communicator communicator = new Communicator(initData)) {}
+    }
+
+    // Creates a PKCS12 key store holding an AES secret key ahead of the ca1 client key pair, and returns its path.
+    private static String createMixedKeystore(String defaultDir) {
+        try {
+            char[] password = "password".toCharArray();
+            KeyStore.PasswordProtection protection = new KeyStore.PasswordProtection(password);
+
+            KeyStore client = KeyStore.getInstance("PKCS12");
+            try (FileInputStream in = new FileInputStream(defaultDir + "/ca1/client.p12")) {
+                client.load(in, password);
+            }
+
+            KeyStore mixed = KeyStore.getInstance("PKCS12");
+            mixed.load(null, null);
+            mixed.setEntry(
+                "aes", new KeyStore.SecretKeyEntry(KeyGenerator.getInstance("AES").generateKey()), protection);
+            for (Enumeration<String> e = client.aliases(); e.hasMoreElements(); ) {
+                String alias = e.nextElement();
+                if (client.entryInstanceOf(alias, KeyStore.PrivateKeyEntry.class)) {
+                    mixed.setEntry(alias, client.getEntry(alias, protection), protection);
+                }
+            }
+
+            File file = File.createTempFile("mixed", ".p12");
+            file.deleteOnExit();
+            try (FileOutputStream out = new FileOutputStream(file)) {
+                mixed.store(out, password);
+            }
+
+            // The test relies on the secret key being enumerated first.
+            KeyStore reloaded = KeyStore.getInstance("PKCS12");
+            try (FileInputStream in = new FileInputStream(file)) {
+                reloaded.load(in, password);
+            }
+            test("aes".equals(reloaded.aliases().nextElement()));
+            return file.getAbsolutePath();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            test(false);
+            return null;
+        }
     }
 
     private static X509Certificate loadCertificate(String path, String alias) {
@@ -625,8 +672,9 @@ public class AllTests {
             }
 
             if ("PKCS12".equals(keystoreType)) {
-                // Key store type names are case-insensitive. Verify that IceSSL detects when a null password causes a
-                // PKCS12 store to load without its encrypted certificates.
+                // KeyStore.getInstance accepts the type name in any case, but only the exact spelling "PKCS12" selects
+                // an empty store password: with "pkcs12" the store loads with a null password, so IceSSL must detect
+                // that the encrypted certificates were skipped.
                 initData = createClientProps(defaultProperties);
                 initData.properties.setProperty("IceSSL.Keystore", "ca1/client.p12");
                 initData.properties.setProperty("IceSSL.KeystoreType", "pkcs12");
@@ -638,8 +686,8 @@ public class AllTests {
                 initData.properties.setProperty("IceSSL.TruststoreType", "pkcs12");
                 testStorePasswordFailure(initData, "IceSSL.TruststorePassword");
 
-                if ("PKCS12".equalsIgnoreCase(KeyStore.getDefaultType())) {
-                    // KeyStore.getDefaultType() normally returns the lower-case value "pkcs12" on standard JDKs.
+                if ("pkcs12".equals(KeyStore.getDefaultType())) {
+                    // Standard JDKs report the default type as "pkcs12", which takes the null-password path above.
                     initData = createClientProps(defaultProperties);
                     initData.properties.setProperty("IceSSL.Keystore", "ca1/client.p12");
                     initData.properties.setProperty("IceSSL.Password", "password");
@@ -667,6 +715,15 @@ public class AllTests {
                 initData = createClientProps(defaultProperties);
                 initData.properties.setProperty("IceSSL.Truststore", "ca1/client_password_less.p12");
                 initData.properties.setProperty("IceSSL.TruststoreType", "PKCS12");
+                testStoreLoads(initData);
+
+                // A key store can hold a secret key ahead of the key pair. The secret key is not usable for TLS, so
+                // IceSSL must select the key pair instead of rejecting the store.
+                initData = createClientProps(defaultProperties);
+                initData.properties.setProperty("IceSSL.Keystore", createMixedKeystore(defaultDir));
+                initData.properties.setProperty("IceSSL.KeystoreType", "PKCS12");
+                initData.properties.setProperty("IceSSL.KeystorePassword", "password");
+                initData.properties.setProperty("IceSSL.Password", "password");
                 testStoreLoads(initData);
             }
         }

--- a/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
@@ -30,12 +30,16 @@ public class AllTests {
         }
     }
 
-    private static void testStorePasswordFailure(InitializationData initData, String store) {
+    private static void testStorePasswordFailure(InitializationData initData, String passwordProperty) {
         try (Communicator communicator = new Communicator(initData)) {
             test(false);
         } catch (InitializationException ex) {
-            test(ex.getMessage().contains("unable to load " + store));
+            test(ex.getMessage().contains(passwordProperty));
         }
+    }
+
+    private static void testStoreLoads(InitializationData initData) {
+        try (Communicator communicator = new Communicator(initData)) {}
     }
 
     private static X509Certificate loadCertificate(String path, String alias) {
@@ -621,26 +625,49 @@ public class AllTests {
             }
 
             if ("PKCS12".equals(keystoreType)) {
-                // Key store type names are case-insensitive. Verify lowercase PKCS12 names don't cause IceSSL to use
-                // a null password and silently load stores without their encrypted certificates.
+                // Key store type names are case-insensitive. Verify that IceSSL detects when a null password causes a
+                // PKCS12 store to load without its encrypted certificates.
                 initData = createClientProps(defaultProperties);
                 initData.properties.setProperty("IceSSL.Keystore", "ca1/client.p12");
                 initData.properties.setProperty("IceSSL.KeystoreType", "pkcs12");
                 initData.properties.setProperty("IceSSL.Password", "password");
-                testStorePasswordFailure(initData, "keystore");
+                testStorePasswordFailure(initData, "IceSSL.KeystorePassword");
 
                 initData = createClientProps(defaultProperties);
                 initData.properties.setProperty("IceSSL.Truststore", "ca1/ca1.p12");
                 initData.properties.setProperty("IceSSL.TruststoreType", "pkcs12");
-                testStorePasswordFailure(initData, "truststore");
+                testStorePasswordFailure(initData, "IceSSL.TruststorePassword");
 
                 if ("PKCS12".equalsIgnoreCase(KeyStore.getDefaultType())) {
                     // KeyStore.getDefaultType() normally returns the lower-case value "pkcs12" on standard JDKs.
                     initData = createClientProps(defaultProperties);
                     initData.properties.setProperty("IceSSL.Keystore", "ca1/client.p12");
                     initData.properties.setProperty("IceSSL.Password", "password");
-                    testStorePasswordFailure(initData, "keystore");
+                    testStorePasswordFailure(initData, "IceSSL.KeystorePassword");
+
+                    // The default PKCS12 implementation can also load JKS stores. A null password must be preserved
+                    // in this case so JKS can skip its integrity check.
+                    initData = createClientProps(defaultProperties);
+                    initData.properties.setProperty("IceSSL.Keystore", "ca1/client.jks");
+                    initData.properties.setProperty("IceSSL.Password", "password");
+                    testStoreLoads(initData);
+
+                    initData = createClientProps(defaultProperties);
+                    initData.properties.setProperty("IceSSL.Truststore", "ca1/ca1.jks");
+                    testStoreLoads(initData);
                 }
+
+                // A passwordless PKCS12 store still contains a usable certificate chain when loaded with an empty
+                // password.
+                initData = createClientProps(defaultProperties);
+                initData.properties.setProperty("IceSSL.Keystore", "ca1/client_password_less.p12");
+                initData.properties.setProperty("IceSSL.KeystoreType", "PKCS12");
+                testStoreLoads(initData);
+
+                initData = createClientProps(defaultProperties);
+                initData.properties.setProperty("IceSSL.Truststore", "ca1/client_password_less.p12");
+                initData.properties.setProperty("IceSSL.TruststoreType", "PKCS12");
+                testStoreLoads(initData);
             }
         }
         out.println("ok");

--- a/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
@@ -672,26 +672,17 @@ public class AllTests {
             }
 
             if ("PKCS12".equals(keystoreType)) {
-                // KeyStore.getInstance accepts the type name in any case, but only the exact spelling "PKCS12" selects
-                // an empty store password: with "pkcs12" the store loads with a null password, so IceSSL must detect
-                // that the encrypted certificates were skipped.
-                initData = createClientProps(defaultProperties);
-                initData.properties.setProperty("IceSSL.Keystore", "ca1/client.p12");
-                initData.properties.setProperty("IceSSL.KeystoreType", "pkcs12");
-                initData.properties.setProperty("IceSSL.Password", "password");
-                testStorePasswordFailure(initData, "IceSSL.KeystorePassword");
-
-                initData = createClientProps(defaultProperties);
-                initData.properties.setProperty("IceSSL.Truststore", "ca1/ca1.p12");
-                initData.properties.setProperty("IceSSL.TruststoreType", "pkcs12");
-                testStorePasswordFailure(initData, "IceSSL.TruststorePassword");
-
                 if ("pkcs12".equals(KeyStore.getDefaultType())) {
-                    // Standard JDKs report the default type as "pkcs12", which takes the null-password path above.
+                    // With the store type omitted, standard JDKs load the store with a null password. A PKCS12 store
+                    // then loads without its encrypted certificates, and IceSSL must detect it.
                     initData = createClientProps(defaultProperties);
                     initData.properties.setProperty("IceSSL.Keystore", "ca1/client.p12");
                     initData.properties.setProperty("IceSSL.Password", "password");
                     testStorePasswordFailure(initData, "IceSSL.KeystorePassword");
+
+                    initData = createClientProps(defaultProperties);
+                    initData.properties.setProperty("IceSSL.Truststore", "ca1/ca1.p12");
+                    testStorePasswordFailure(initData, "IceSSL.TruststorePassword");
 
                     // The default PKCS12 implementation can also load JKS stores. A null password must be preserved
                     // in this case so JKS can skip its integrity check.

--- a/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
@@ -718,13 +718,20 @@ public class AllTests {
                 testStoreLoads(initData);
 
                 // A key store can hold a secret key ahead of the key pair. The secret key is not usable for TLS, so
-                // IceSSL must select the key pair instead of rejecting the store.
-                initData = createClientProps(defaultProperties);
+                // IceSSL must select the key pair and authenticate the client with it.
+                initData = createClientProps(defaultProperties, "", "ca1/ca1", keystoreType);
                 initData.properties.setProperty("IceSSL.Keystore", createMixedKeystore(defaultDir));
                 initData.properties.setProperty("IceSSL.KeystoreType", "PKCS12");
                 initData.properties.setProperty("IceSSL.KeystorePassword", "password");
-                initData.properties.setProperty("IceSSL.Password", "password");
-                testStoreLoads(initData);
+                try (Communicator comm = new Communicator(initData)) {
+                    ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
+                    test(fact != null);
+                    d = createServerProps(defaultProperties, "ca1/server", "ca1/ca1", keystoreType);
+                    d.put("IceSSL.VerifyPeer", "2");
+                    ServerPrx server = fact.createServer(d);
+                    server.ice_ping();
+                    fact.destroyServer(server);
+                }
             }
         }
         out.println("ok");


### PR DESCRIPTION
This PR aligns Java IceSSL store-type metadata and password handling with the runtime behavior described in #6485.

- Remove the stale static `JKS` default from `IceSSL.TruststoreType`; `SSLEngine` continues to use `KeyStore.getDefaultType()`.
- Keep the null-password load for stores whose type is omitted, so JKS files loaded through the JDK's PKCS12 compatibility mode still skip the integrity check.
- Validate the selected key entry and the truststore after loading: a key entry without a certificate chain, or a truststore without any certificate, now fails communicator initialization with an `InitializationException` that points at `IceSSL.KeystorePassword` / `IceSSL.TruststorePassword`, or at `IceSSL.KeystoreType=PKCS12` / `IceSSL.TruststoreType=PKCS12` for a password-less PKCS12 store. Previously such stores loaded silently and every TLS handshake that needed them failed with an unrelated error.
- Select the first private key entry as the default alias instead of the first key entry, so a store holding a secret key ahead of the key pair keeps working.
- Add regressions for omitted-type JKS, protected/default/lowercase PKCS12, passwordless PKCS12, and a PKCS12 store with a secret key ahead of the key pair.

Tests:
- `./gradlew build`
- `./gradlew rewriteDryRun --no-parallel --no-configuration-cache`
- `python3 allTests.py Ice/properties IceSSL/configuration` with JDK 17

Relates to #6485.
Follow-up for 3.9.0 (store password selection by type spelling): #6700
