### PR TITLE
Require the PHP API and Zend ABI in the php-ice RPM

### DIFF
--- a/changelog.d/packaging/6711.md
+++ b/changelog.d/packaging/6711.md
@@ -1,0 +1,3 @@
+- The `php-ice` RPM now requires the PHP API and Zend ABI versions it was built against. Installing it on a host
+  running a different PHP version (for example, after switching to the `php:8.2` module stream on RHEL 9) now fails
+  with a clear dependency error from `dnf`, instead of succeeding and leaving PHP unable to load the extension.

--- a/packaging/rpm/ice.spec
+++ b/packaging/rpm/ice.spec
@@ -299,6 +299,8 @@ Summary: PHP extension for Ice.
 Requires: lib%{?nameprefix}ice%{mmversion}-c++ = %{version}-%{release}
 Requires: %{?nameprefix}ice-slice = %{version}-%{release}
 Requires: %{phpcommon}
+Requires: php(zend-abi) = %{php_zend_api}
+Requires: php(api) = %{php_core_api}
 
 %description -n %{phpname}-%{?nameprefix}ice
 This package contains a PHP extension for communicating with Ice.


### PR DESCRIPTION
Fixes #6711

The `php-ice` subpackage only required `php-common`, so an RPM built against the distribution's default PHP could be installed on a host running a different PHP module stream. The install succeeded and PHP then refused to load the extension with a module API mismatch. This adds the standard `php(zend-abi)` and `php(api)` requirements, so `dnf` refuses the install instead. This is the RPM counterpart of what `dh_php` already generates for the deb packages via `${php:Depends}`.

## Verification

Expanded the modified spec with `rpmspec -P` in each RPM builder image, built a noarch RPM carrying exactly the expanded PHP requirements, and installed it:

| Image | PHP | Expanded requirement | Install on stock PHP |
|---|---|---|---|
| el9 | 8.0.30 | `php(api) = 20200930-64` | succeeds |
| el10 | 8.4.24 | `php(api) = 20240924-64` | succeeds |
| amzn2023 | 8.4.24 | `php(api) = 20240924-64` (package `php8.4-ice`) | succeeds |

On el9, after `dnf module switch-to php:8.2`, the install is now refused:

```
Problem: package php-ice-deptest-1-1.noarch requires php(api) = 20200930-64, but none of the providers can be installed
```

The `%{php_zend_api}` / `%{php_core_api}` macros come from `macros.php`, installed by `php-devel` (already a `BuildRequires`), and are present on all three images.
