### PR TITLE
Stop compiling the Slice parser into the PHP extension

### DIFF
--- a/packaging/deb/debian/php-zeroc-ice.lintian-overrides
+++ b/packaging/deb/debian/php-zeroc-ice.lintian-overrides
@@ -1,2 +1,2 @@
-# PHP extension module is statically linked with mcpp
+# slice2php is statically linked with mcpp
 php-zeroc-ice: statically-linked-binary

--- a/php/src/Makefile.mk
+++ b/php/src/Makefile.mk
@@ -9,7 +9,6 @@ IcePHP_installdir       := $(install_phplibdir)
 IcePHP_cppflags         := -I$(top_srcdir)/cpp/src $(ice_cpp_cppflags) $(php_cppflags)
 IcePHP_ldflags          := $(php_ldflags)
 IcePHP_dependencies     := IceDiscovery IceLocatorDiscovery Ice
-IcePHP_extra_sources    := $(wildcard $(top_srcdir)/cpp/src/Slice/*.cpp)
 
 projects += $(project)
 srcs:: $(project)


### PR DESCRIPTION
`php/src/Makefile.mk` compiled all of `cpp/src/Slice/*.cpp` into `ice.so`:

```make
IcePHP_extra_sources    := $(wildcard $(top_srcdir)/cpp/src/Slice/*.cpp)
```

but nothing in `php/src` uses the Slice parser (PHP has no `loadSlice`), and unlike IcePy the extension does not link `mcpp`. The Slice preprocessor objects therefore left undefined references in the module:

```
$ nm -D php/lib/ice.so | grep mcpp
                 U mcpp_get_mem_buffer
                 U mcpp_lib_main
                 U mcpp_use_mem_buffers
```

PHP's build rules set `allow-undefined-symbols`, so the link succeeds, and what happens next depends on the distribution's default build flags:

- **Ubuntu, RHEL and Amazon Linux** enable LTO by default (`dpkg-buildflags` / `%build_cflags`). The dead Slice code is discarded at link time, the built module has no mcpp references at all, and everything works. This is why main CI never noticed.
- **Debian** (12, 13, sid) does not enable LTO. `config/Make.rules.Linux` forces `hardening=+bindnow`, so a from-source build produces a module with `BIND_NOW` and dangling symbols, and PHP refuses to load it:

  ```
  Warning: PHP Startup: Unable to load dynamic library 'ice.so'
  (tried: /ice/php/lib/ice.so (/ice/php/lib/ice.so: undefined symbol: mcpp_use_mem_buffers), ...)
  ```

  Every PHP test then fails with `Ice extension is not loaded`.

The shipped `php-zeroc-ice` deb for Debian 12 carries the same three undefined symbols (checked on `3.8.2-1_arm64`), but `debian/rules` exports the `dpkg-buildpackage` LDFLAGS, which have no bindnow, so that module loads lazily and the dangling references are simply never resolved.

This removes the `IcePHP_extra_sources` line. The extension then links with no mcpp references on every platform, and the from-source Debian build loads and passes the PHP test suite.

Found by the CI Linux change for #6712, which will build and test PHP on every supported distribution; that PR is based on this commit.

## Verification

In the `ice-deb-builder-debian12` image: before the change, all 20 PHP tests failed to load the extension; after relinking without the Slice objects, `nm -D` shows no mcpp symbols, the module loads, and the suite passes 20 of 20. Also verified in `ice-deb-builder-ubuntu24.04` (20 of 20) and `ice-rpm-builder-el9` with PHP 8.0.30 (20 of 20).

The `MCPP_LICENSE` entry in the `php-ice` RPM `%files` and the `php-zeroc-ice` lintian override (`statically-linked-binary`) stay: both packages also ship `slice2php`, which is linked with `-static` like every Slice compiler and embeds mcpp. On the shipped Debian 12 deb, `file usr/bin/slice2php` reports "statically linked" with no interpreter and no dynamic section, which is exactly what that lintian tag flags. Only the override's comment wrongly named the extension module; this PR corrects it to name `slice2php`.
