### PR TITLE
Build and test Python and PHP in the CI Linux distribution jobs

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -60,12 +60,15 @@ jobs:
             arch: arm64
             image_type: deb
 
+          # Debian 12 ships Python 3.11; Ice for Python requires 3.12, so only PHP is built there.
           - distribution: debian12
             arch: amd64
             image_type: deb
+            languages: php
           - distribution: debian12
             arch: arm64
             image_type: deb
+            languages: php
 
           - distribution: debian13
             arch: amd64
@@ -100,30 +103,57 @@ jobs:
           username: zeroc-ice
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and test C++
+      - name: Build and test
         run: |
           docker run --rm \
             -v "$GITHUB_WORKSPACE:/ice" \
-            -w /ice/cpp \
+            -w /ice \
             ghcr.io/zeroc-ice/ice-${{ matrix.image_type }}-builder-${{ matrix.distribution }}:${CHANNEL} \
             bash -c "
               set -ex
-              make -j\$(nproc) srcs
-              make -j\$(nproc) tests
+              python=${{ matrix.python || 'python3' }}
+
+              # The native language mappings built and tested in addition to C++. Each one is compiled
+              # against the interpreter the distribution ships, which is what the distribution packages
+              # target. Ruby is not included: Ice for Ruby requires Ruby 3.4, which none of these
+              # distributions ship.
+              languages='${{ matrix.languages || 'python php' }}'
+
+              make -j\$(nproc) -C cpp srcs
+              make -j\$(nproc) -C cpp tests
+              for lang in \$languages; do
+                make -j\$(nproc) -C \$lang PYTHON=\$python
+              done
 
               # The --rfilter option excludes tests matching the regex. These tests are excluded because
               # they require dependencies or permissions not available in the Docker builder images:
               # - IceUtil/priority, Ice/threadPoolPriority: require CAP_SYS_NICE for thread priorities
               # - Glacier2/*: require the passlib Python module
               # - IceSSL/configuration: requires the openssl CLI tool
-              ${{ matrix.python || 'python3' }} allTests.py --workers=4 --debug --continue \
-                --rfilter='IceUtil/priority|Ice/threadPoolPriority|Glacier2/|IceSSL/configuration'
+              # - python/Ice/info: requires the cryptography Python module
+              rfilter='IceUtil/priority|Ice/threadPoolPriority|Glacier2/|IceSSL/configuration'
+              python_rfilter=\$rfilter'|Ice/info'
+
+              # Every test suite runs even if an earlier one fails, so that a C++ failure does not hide the
+              # results of the other mappings; the step fails at the end if any suite failed.
+              status=0
+              for lang in cpp \$languages; do
+                case \$lang in
+                  python) filter=\$python_rfilter ;;
+                  *) filter=\$rfilter ;;
+                esac
+                (cd \$lang && \$python allTests.py --workers=4 --debug --continue --rfilter=\$filter) || status=1
+              done
+              exit \$status
             "
 
       - name: Upload test logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ matrix.distribution }}-${{ matrix.arch }}
-          path: cpp/**/*.log
+          path: |
+            cpp/**/*.log
+            python/**/*.log
+            php/**/*.log
           if-no-files-found: ignore
         if: always()

--- a/php/src/Makefile.mk
+++ b/php/src/Makefile.mk
@@ -9,7 +9,6 @@ IcePHP_installdir       := $(install_phplibdir)
 IcePHP_cppflags         := -I$(top_srcdir)/cpp/src $(ice_cpp_cppflags) $(php_cppflags)
 IcePHP_ldflags          := $(php_ldflags)
 IcePHP_dependencies     := IceDiscovery IceLocatorDiscovery Ice
-IcePHP_extra_sources    := $(wildcard $(top_srcdir)/cpp/src/Slice/*.cpp)
 
 projects += $(project)
 srcs:: $(project)


### PR DESCRIPTION
Fixes #6712

The `CI Linux` jobs ran on every supported distribution but only built and tested C++. This extends the "Build and test" step so that, after C++, each job also builds and tests the Python and PHP mappings inside the same container, against the interpreter the distribution ships, which is what the distribution packages target.

- A per-distribution `languages` matrix value selects the mappings (default `python php`). Debian 12 ships Python 3.11, below the 3.12 that Ice for Python requires, so it builds only PHP, matching the `nopython` profile of its deb package.
- Ruby is not included. There is no Ruby distribution package to validate (the gem is the only Ruby deliverable), and Ice for Ruby requires Ruby 3.4 while the newest Ruby on any supported distribution is 3.3.8 (Debian 13, Ubuntu 26.04, sid).
- Every test suite runs even if an earlier one fails, so a C++ failure no longer hides the PHP and Python results. The step fails at the end if any suite failed.
- The Python `Ice/info` test is excluded: it imports the `cryptography` module, which main CI installs with pip but the builder images do not provide (Ubuntu 24.04 happens to have it; Debian 13 and the rpm images do not, and Amazon Linux has no package for Python 3.12). Adding it to the images is a possible follow-up.
- The test-log artifact now also collects `python/**/*.log` and `php/**/*.log`.

No builder image changes are needed: the deb image already installs `php-dev`, `python3-dev` and `python3-passlib`, and the rpm images get `php-devel` and `python3.12-devel` through the spec's `BuildRequires`.

## What it found

The first run of the new step on Debian 12 failed every PHP test with `Ice extension is not loaded`: the module had undefined references to `mcpp_lib_main`, `mcpp_use_mem_buffers` and `mcpp_get_mem_buffer`, because `php/src/Makefile.mk` compiled the Slice parser sources into the extension without ever using or linking them. Ubuntu, RHEL and Amazon Linux enable LTO by default and discard that dead code, which is why main CI never saw it; Debian does not, and the `-z now` forced by the Linux build rules turns the dangling references into a load failure. The first commit here is the same change as #6714; this PR is based on it so that the new step passes on Debian, and rebases to the workflow change alone once #6714 merges.

## Verification

Run locally in the builder images with the exact step script (C++ suite skipped, it is unchanged):

| Image | Interpreters | Result |
|---|---|---|
| debian12 | PHP 8.2 (Python 3.11 harness) | PHP: 20 of 20 passed after the Makefile fix; all 20 failed to load before it |
| el9 | PHP 8.0.30, Python 3.12 | PHP: 20 of 20. Python: 34 of 34 with Ice/info excluded; Ice/info passes once `python3.12-cryptography` is installed |
| ubuntu24.04 | PHP 8.3, Python 3.12 | PHP: 20 of 20. Python: 34 of 34 |

The workflow file parses, `actionlint` reports only the two pre-existing shellcheck notes, and the inner script rendered with the matrix expressions substituted passes `bash -n`.
