### PR TITLE
Remove changelog.d fragments backported to Ice 3.8

### DIFF
--- a/changelog.d/datastorm/6621.md
+++ b/changelog.d/datastorm/6621.md
@@ -1,2 +1,0 @@
-- Fixed a bug where an any-key or filtered reader connected to an any-key writer received the writer's retained
-  samples again after each reconnection.

--- a/changelog.d/datastorm/6624.md
+++ b/changelog.d/datastorm/6624.md
@@ -1,3 +1,0 @@
-- Fixed a bug where a reader could permanently miss a sample after a reconnection. When a node had a reader with a
-  sample filter and a reader without one on the same writer and key, a sample delivered to one reader was marked as
-  received by the other, and the writer therefore never resent it.

--- a/changelog.d/java/6485.md
+++ b/changelog.d/java/6485.md
@@ -1,4 +1,0 @@
-- Fixed a silent misconfiguration with PKCS12 key and trust stores: when the store was loaded without the password
-  that protects its certificates (typically because `IceSSL.KeystorePassword` or `IceSSL.TruststorePassword` was
-  omitted), the certificates were skipped and TLS handshakes failed with an unrelated error. Communicator
-  initialization now fails with an `InitializationException` that names the setting to check.

--- a/changelog.d/packaging/6711.md
+++ b/changelog.d/packaging/6711.md
@@ -1,3 +1,0 @@
-- The `php-ice` RPM now requires the PHP API and Zend ABI versions it was built against. Installing it on a host
-  running a different PHP version (for example, after switching to the `php:8.2` module stream on RHEL 9) now fails
-  with a clear dependency error from `dnf`, instead of succeeding and leaving PHP unable to load the extension.


### PR DESCRIPTION
These four fixes were cherry-picked to the 3.8 branch and ship in Ice 3.8.3, so they are documented in
`CHANGELOG-3.8.md` rather than the 3.9 changelog:

- `changelog.d/datastorm/6624.md` (#6675, on 3.8 as 550b3f5575)
- `changelog.d/datastorm/6621.md` (#6679, on 3.8 as f77c3b9e58)
- `changelog.d/java/6485.md` (#6698, on 3.8 as 8364e8a9e7)
- `changelog.d/packaging/6711.md` (#6713, on 3.8 as cd38977432)

Follows the convention of 474ba6fb76, #6157, #6612, and #6667. After this change `main`'s `changelog.d/`
contains only `README.md`.
