### PR TITLE
Send DataStorm test multicast announcements over the loopback interface

### DIFF
--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -11,12 +11,14 @@ from Util import (
     Client,
     ClientServerTestCase,
     Driver,
+    Linux,
     Mapping,
     Process,
     ProcessFromBinDir,
     Props,
     Server,
     TestSuite,
+    platform,
 )
 
 # Regex pattern to match placeholders like {port1}, {port2}, ..., {portXX}
@@ -76,9 +78,16 @@ class Writer(Client, DataStormProcess):
             # Send the announcements over the loopback interface. The tests run on 127.0.0.1, and without an explicit
             # interface the announcements go out the host's default multicast interface, which isn't necessarily able
             # to route the group. When that send fails the peers never discover each other and the test hangs.
-            props["DataStorm.Node.Multicast.Proxy"] = (
-                f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
-            )
+            #
+            # Not on Linux though: the loopback interface has no IFF_MULTICAST flag there, so the receiving side
+            # (which joins the group on every multicast-capable interface) never joins it on the loopback interface and
+            # announcements sent over 127.0.0.1 are dropped.
+            if isinstance(platform, Linux):
+                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
+            else:
+                props["DataStorm.Node.Multicast.Proxy"] = (
+                    f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
+                )
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(
@@ -107,9 +116,16 @@ class Reader(Server, DataStormProcess):
             # Send the announcements over the loopback interface. The tests run on 127.0.0.1, and without an explicit
             # interface the announcements go out the host's default multicast interface, which isn't necessarily able
             # to route the group. When that send fails the peers never discover each other and the test hangs.
-            props["DataStorm.Node.Multicast.Proxy"] = (
-                f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
-            )
+            #
+            # Not on Linux though: the loopback interface has no IFF_MULTICAST flag there, so the receiving side
+            # (which joins the group on every multicast-capable interface) never joins it on the loopback interface and
+            # announcements sent over 127.0.0.1 are dropped.
+            if isinstance(platform, Linux):
+                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
+            else:
+                props["DataStorm.Node.Multicast.Proxy"] = (
+                    f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
+                )
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(

--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -75,15 +75,15 @@ class Writer(Client, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
-            # Pin the announcements to the loopback interface: the default multicast interface can't always route the
-            # group, and a failed send hangs the test as the peers never discover each other. We can't do this on
-            # Linux, where the loopback interface isn't multicast-capable: the receiver never joins the group on it.
-            if isinstance(platform, Linux):
-                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
-            else:
+            # Send the announcements over the loopback interface: the default multicast interface can't always route
+            # the group, and a failed send hangs the test as the peers never discover each other. Not on Linux, where
+            # the loopback interface isn't multicast-capable: the receiver never joins the group on it.
+            if not isinstance(platform, Linux):
                 props["DataStorm.Node.Multicast.Proxy"] = (
                     f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
                 )
+            else:
+                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(
@@ -109,15 +109,15 @@ class Reader(Server, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
-            # Pin the announcements to the loopback interface: the default multicast interface can't always route the
-            # group, and a failed send hangs the test as the peers never discover each other. We can't do this on
-            # Linux, where the loopback interface isn't multicast-capable: the receiver never joins the group on it.
-            if isinstance(platform, Linux):
-                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
-            else:
+            # Send the announcements over the loopback interface: the default multicast interface can't always route
+            # the group, and a failed send hangs the test as the peers never discover each other. Not on Linux, where
+            # the loopback interface isn't multicast-capable: the receiver never joins the group on it.
+            if not isinstance(platform, Linux):
                 props["DataStorm.Node.Multicast.Proxy"] = (
                     f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
                 )
+            else:
+                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(

--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -109,13 +109,9 @@ class Reader(Server, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
-            # Send the announcements over the loopback interface. The tests run on 127.0.0.1, and without an explicit
-            # interface the announcements go out the host's default multicast interface, which isn't necessarily able
-            # to route the group. When that send fails the peers never discover each other and the test hangs.
-            #
-            # Not on Linux though: the loopback interface has no IFF_MULTICAST flag there, so the receiving side
-            # (which joins the group on every multicast-capable interface) never joins it on the loopback interface and
-            # announcements sent over 127.0.0.1 are dropped.
+            # Pin the announcements to the loopback interface: the default multicast interface can't always route the
+            # group, and a failed send hangs the test as the peers never discover each other. We can't do this on
+            # Linux, where the loopback interface isn't multicast-capable: the receiver never joins the group on it.
             if isinstance(platform, Linux):
                 props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
             else:

--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -75,13 +75,9 @@ class Writer(Client, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
-            # Send the announcements over the loopback interface. The tests run on 127.0.0.1, and without an explicit
-            # interface the announcements go out the host's default multicast interface, which isn't necessarily able
-            # to route the group. When that send fails the peers never discover each other and the test hangs.
-            #
-            # Not on Linux though: the loopback interface has no IFF_MULTICAST flag there, so the receiving side
-            # (which joins the group on every multicast-capable interface) never joins it on the loopback interface and
-            # announcements sent over 127.0.0.1 are dropped.
+            # Pin the announcements to the loopback interface: the default multicast interface can't always route the
+            # group, and a failed send hangs the test as the peers never discover each other. We can't do this on
+            # Linux, where the loopback interface isn't multicast-capable: the receiver never joins the group on it.
             if isinstance(platform, Linux):
                 props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
             else:

--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -10,7 +10,6 @@ from typing import Any
 from Util import (
     Client,
     ClientServerTestCase,
-    Darwin,
     Driver,
     Mapping,
     Process,
@@ -18,7 +17,6 @@ from Util import (
     Props,
     Server,
     TestSuite,
-    platform,
 )
 
 # Regex pattern to match placeholders like {port1}, {port2}, ..., {portXX}
@@ -75,13 +73,12 @@ class Writer(Client, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
-            # Need to use --interface 127.0.0.1 for the macOS GitHub runners.
-            if isinstance(platform, Darwin):
-                props["DataStorm.Node.Multicast.Proxy"] = (
-                    f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
-                )
-            else:
-                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
+            # Send the announcements over the loopback interface. The tests run on 127.0.0.1, and without an explicit
+            # interface the announcements go out the host's default multicast interface, which isn't necessarily able
+            # to route the group. When that send fails the peers never discover each other and the test hangs.
+            props["DataStorm.Node.Multicast.Proxy"] = (
+                f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
+            )
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(
@@ -107,13 +104,12 @@ class Reader(Server, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
-            # Need to use --interface 127.0.0.1 for the macOS GitHub runners.
-            if isinstance(platform, Darwin):
-                props["DataStorm.Node.Multicast.Proxy"] = (
-                    f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
-                )
-            else:
-                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port}"
+            # Send the announcements over the loopback interface. The tests run on 127.0.0.1, and without an explicit
+            # interface the announcements go out the host's default multicast interface, which isn't necessarily able
+            # to route the group. When that send fails the peers never discover each other and the test hangs.
+            props["DataStorm.Node.Multicast.Proxy"] = (
+                f"DataStorm/Lookup2 -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
+            )
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(


### PR DESCRIPTION
The DataStorm tests that enable multicast build `DataStorm.Node.Multicast.Proxy` without an `--interface`, so Ice never sets `IP_MULTICAST_IF` ([`UdpTransceiver.cpp`](https://github.com/zeroc-ice/ice/blob/main/cpp/src/Ice/UdpTransceiver.cpp#L699-L703) only sets it when an interface is given) and the announcements go out whatever the host picks as its default multicast interface.

When that interface cannot route the group, the send fails with `WSAEHOSTUNREACH` and nothing reports it: the announcements are sent as `announceTopicReaderAsync(topic, node, nullptr)`, and `LambdaInvoke::handleException` drops the exception when the callback is null. The failure happens in `doConnect` before any `ConnectionI` exists, so `Ice.Warn.Connections` does not cover it either. The peers simply never discover each other and both processes hang forever in `waitForReaders`.

I hit this on Windows: `cpp/DataStorm/callbacks|config|events|partial|partialReconnect|types` hung on the multicast case, and both processes were parked in `DataElementI::waitForListeners`. Their trace logs contained only the collocated self-sessions — no `topic reader ... announced` line from the peer and no `matched elements` — while a probe confirmed that sending to the group over the default interface was failing with `WSAEHOSTUNREACH` even though sending over any explicit interface worked.

Pin the outgoing interface to `127.0.0.1`, which the tests already use for `Ice.Default.Host`. This was previously done for macOS only. `DataStorm.Node.Multicast.Endpoints` is unchanged, so the nodes still join the group on every interface.

Linux is excluded: its loopback interface has no `IFF_MULTICAST` flag, and `getLocalAddresses` only joins the group on interfaces that have it, so the receiving node never joins on loopback and announcements sent over `127.0.0.1` are dropped. That is what hung the same six tests on every Linux CI job of the first revision. On Linux the proxy stays interface-less, as on `main`.

## Verification

A listener joined to `239.255.0.1` on `127.0.0.1` only — so it can see a datagram only if it was really sent over loopback — while running `cpp/DataStorm/callbacks|config|events|partial|partialReconnect|types`:

| | packets on loopback |
| --- | --- |
| before | 0 (all announcements went out Wi-Fi) |
| after | 6, all from `127.0.0.1` |

`DataStorm/(callbacks|config|events|partial|partialReconnect|types)` pass on Debug/Win32, and in the ubuntu24.04 builder image (where the first revision hung in the multicast case).

