### PR TITLE
Mark DataStorm getSession and getSessionConnection @private and drop the throwing-updater doc

### DIFF
--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -72,6 +72,9 @@ namespace DataStorm
         [[nodiscard]] const std::string& getOrigin() const noexcept;
 
         /// @private
+        /// Gets the session identifier of the session that received this sample.
+        /// This session identifier can be used to retrieve the Ice connection with the node.
+        /// @return The session identifier.
         [[nodiscard]] const std::string& getSession() const noexcept;
 
         /// @private

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -379,8 +379,8 @@ namespace DataStorm
         void setReaderDefaultConfig(const ReaderConfig& config) noexcept;
 
         /// Sets an updater function for the given update tag. The function is called when a partial update is
-        /// received or sent to compute the new value. The function is provided the latest value and the partial
-        /// update. It should return the new value.
+        /// received or sent to compute the new value. The function is provided a copy of the latest value and the
+        /// partial update, and it updates this value in place.
         /// @param tag The update tag.
         /// @param updater The updater function.
         template<typename UpdateValue>

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -71,9 +71,7 @@ namespace DataStorm
         /// @return The origin of the sample.
         [[nodiscard]] const std::string& getOrigin() const noexcept;
 
-        /// Gets the session identifier of the session that received this sample.
-        /// This session identifier can be used to retrieve the Ice connection with the node.
-        /// @return The session identifier.
+        /// @private
         [[nodiscard]] const std::string& getSession() const noexcept;
 
         /// @private
@@ -380,8 +378,6 @@ namespace DataStorm
         /// Sets an updater function for the given update tag. The function is called when a partial update is
         /// received or sent to compute the new value. The function is provided the latest value and the partial
         /// update. It should return the new value.
-        /// An updater that throws when applying a received partial update causes the sample to be dropped: a
-        /// warning is logged and the following samples are delivered normally.
         /// @param tag The update tag.
         /// @param updater The updater function.
         template<typename UpdateValue>

--- a/cpp/include/DataStorm/Node.h
+++ b/cpp/include/DataStorm/Node.h
@@ -104,6 +104,11 @@ namespace DataStorm
         [[nodiscard]] Ice::CommunicatorPtr getCommunicator() const noexcept;
 
         /// @private
+        /// Returns the Ice connection associated with a session given a session identifier. Session identifiers are
+        /// returned by DataStorm::Sample::getSession.
+        /// @param ident The session identifier.
+        /// @return The connection associated with the given session
+        /// @see DataStorm::Sample::getSession
         [[nodiscard]] Ice::ConnectionPtr getSessionConnection(std::string_view ident) const noexcept;
 
     private:

--- a/cpp/include/DataStorm/Node.h
+++ b/cpp/include/DataStorm/Node.h
@@ -103,11 +103,7 @@ namespace DataStorm
         /// Returns the Ice communicator associated with the node.
         [[nodiscard]] Ice::CommunicatorPtr getCommunicator() const noexcept;
 
-        /// Returns the Ice connection associated with a session given a session identifier. Session identifiers are
-        /// returned by DataStorm::Sample::getSession.
-        /// @param ident The session identifier.
-        /// @return The connection associated with the given session
-        /// @see DataStorm::Sample::getSession
+        /// @private
         [[nodiscard]] Ice::ConnectionPtr getSessionConnection(std::string_view ident) const noexcept;
 
     private:


### PR DESCRIPTION
Doc-comment only changes to the DataStorm C++ headers.

- `Sample::getSession` and `Node::getSessionConnection` are an escape hatch from the DataStorm abstraction down to the underlying Ice connection, used only by DataStorm's own tests to force-close connections and exercise reconnect paths. Both are now marked `@private` so they no longer appear in the generated API reference. The functions remain public and callable; the user-facing way to identify a sample's sender is `Sample::getOrigin`.
- The `Topic::setUpdater` doc-comment no longer describes what happens when the updater throws. An updater is not expected to throw; dropping the sample and logging a warning is graceful degradation, not part of the API contract.

Closes #6706
Closes #6707