### PR TITLE
Update the third-party libraries bundled with the Windows build

### DIFF
--- a/changelog.d/cpp/update-windows-third-party-libraries.md
+++ b/changelog.d/cpp/update-windows-third-party-libraries.md
@@ -1,0 +1,3 @@
+- Updated the third-party libraries bundled with the Windows build: bzip2 from 1.0.6 to 1.0.8, Expat from 2.4.1 to
+  2.8.4, and LMDB from 0.9.29 to 0.9.36. The bzip2 update fixes an out-of-bounds write when decompressing a
+  malformed compressed message, which a peer could trigger over the wire.

--- a/changelog.d/cpp/update-windows-third-party-libraries.md
+++ b/changelog.d/cpp/update-windows-third-party-libraries.md
@@ -1,3 +1,0 @@
-- Updated the third-party libraries bundled with the Windows build: bzip2 from 1.0.6 to 1.0.8, Expat from 2.4.1 to
-  2.8.4, and LMDB from 0.9.29 to 0.9.36. The bzip2 update fixes an out-of-bounds write when decompressing a
-  malformed compressed message, which a peer could trigger over the wire.

--- a/changelog.d/python/update-windows-third-party-libraries.md
+++ b/changelog.d/python/update-windows-third-party-libraries.md
@@ -1,0 +1,2 @@
+- Updated the bzip2 sources bundled with the Windows wheels from 1.0.6 to 1.0.8. The bzip2 update fixes an
+  out-of-bounds write when decompressing a malformed compressed message, which a peer could trigger over the wire.

--- a/changelog.d/python/update-windows-third-party-libraries.md
+++ b/changelog.d/python/update-windows-third-party-libraries.md
@@ -1,2 +1,0 @@
-- Updated the bzip2 sources bundled with the Windows wheels from 1.0.6 to 1.0.8. The bzip2 update fixes an
-  out-of-bounds write when decompressing a malformed compressed message, which a peer could trigger over the wire.

--- a/cpp/msbuild/THIRD_PARTY_LICENSE.txt
+++ b/cpp/msbuild/THIRD_PARTY_LICENSE.txt
@@ -39,7 +39,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Julian Seward, jseward@bzip.org
-bzip2/libbzip2 version 1.0.6 of 6 September 2010
+bzip2/libbzip2 version 1.0.8 of 13 July 2019
 
 --------------------------------------------------------------------------
 
@@ -47,7 +47,7 @@ License agreement for Expat:
 -----------------------------
 
 Copyright (c) 1998-2000 Thai Open Source Software Center Ltd and Clark Cooper
-Copyright (c) 2001-2017 Expat maintainers
+Copyright (c) 2001-2025 Expat maintainers
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/cpp/msbuild/THIRD_PARTY_LICENSE.txt
+++ b/cpp/msbuild/THIRD_PARTY_LICENSE.txt
@@ -4,7 +4,7 @@ License agreement for bzip2/libbzip2:
 --------------------------------------------------------------------------
 
 This program, "bzip2", the associated library "libbzip2", and all
-documentation, are copyright (C) 1996-2010 Julian R Seward.  All
+documentation, are copyright (C) 1996-2019 Julian R Seward.  All
 rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -38,7 +38,7 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Julian Seward, jseward@bzip.org
+Julian Seward, jseward@acm.org
 bzip2/libbzip2 version 1.0.8 of 13 July 2019
 
 --------------------------------------------------------------------------

--- a/cpp/src/Ice/msbuild/ice/ice.vcxproj
+++ b/cpp/src/Ice/msbuild/ice/ice.vcxproj
@@ -1036,12 +1036,12 @@ mc -h "$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice" -r $
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\..\..\msbuild\packages\ZeroC.Bzip2.1.0.6\build\native\ZeroC.Bzip2.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.Bzip2.1.0.6\build\native\ZeroC.Bzip2.targets')" />
+    <Import Project="..\..\..\..\msbuild\packages\ZeroC.Bzip2.1.0.8\build\native\ZeroC.Bzip2.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.Bzip2.1.0.8\build\native\ZeroC.Bzip2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.Bzip2.1.0.6\build\native\ZeroC.Bzip2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.Bzip2.1.0.6\build\native\ZeroC.Bzip2.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.Bzip2.1.0.8\build\native\ZeroC.Bzip2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.Bzip2.1.0.8\build\native\ZeroC.Bzip2.targets'))" />
   </Target>
 </Project>

--- a/cpp/src/Ice/msbuild/ice/packages.config
+++ b/cpp/src/Ice/msbuild/ice/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ZeroC.Bzip2" version="1.0.6" targetFramework="native" />
+  <package id="ZeroC.Bzip2" version="1.0.8" targetFramework="native" />
 </packages>

--- a/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj
@@ -169,12 +169,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets')" />
+    <Import Project="..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets'))" />
   </Target>
 </Project>

--- a/cpp/src/IceGrid/msbuild/icegridadmin/packages.config
+++ b/cpp/src/IceGrid/msbuild/icegridadmin/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ZeroC.Expat" version="2.4.1" targetFramework="native" />
+  <package id="ZeroC.Expat" version="2.8.4" targetFramework="native" />
 </packages>

--- a/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj
@@ -268,14 +268,14 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" />
-    <Import Project="..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets')" />
+    <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets')" />
+    <Import Project="..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets'))" />
   </Target>
 </Project>

--- a/cpp/src/IceGrid/msbuild/icegridnode/packages.config
+++ b/cpp/src/IceGrid/msbuild/icegridnode/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ZeroC.LMDB" version="0.9.29" targetFramework="native" />
-  <package id="ZeroC.Expat" version="2.4.1" targetFramework="native" />
+  <package id="ZeroC.LMDB" version="0.9.36" targetFramework="native" />
+  <package id="ZeroC.Expat" version="2.8.4" targetFramework="native" />
 </packages>

--- a/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj
@@ -262,14 +262,14 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" />
-    <Import Project="..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets')" />
+    <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets')" />
+    <Import Project="..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.Expat.2.4.1\build\native\ZeroC.Expat.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.Expat.2.8.4\build\native\ZeroC.Expat.targets'))" />
   </Target>
 </Project>

--- a/cpp/src/IceGrid/msbuild/icegridregistry/packages.config
+++ b/cpp/src/IceGrid/msbuild/icegridregistry/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ZeroC.LMDB" version="0.9.29" targetFramework="native" />
-  <package id="ZeroC.Expat" version="2.4.1" targetFramework="native" />
+  <package id="ZeroC.LMDB" version="0.9.36" targetFramework="native" />
+  <package id="ZeroC.Expat" version="2.8.4" targetFramework="native" />
 </packages>

--- a/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
@@ -267,12 +267,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" />
+    <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets'))" />
   </Target>
 </Project>

--- a/cpp/src/IceStorm/msbuild/icestormdb/packages.config
+++ b/cpp/src/IceStorm/msbuild/icestormdb/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ZeroC.LMDB" version="0.9.29" targetFramework="native" />
+  <package id="ZeroC.LMDB" version="0.9.36" targetFramework="native" />
 </packages>

--- a/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
@@ -395,12 +395,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" />
+    <Import Project="..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets'))" />
   </Target>
 </Project>

--- a/cpp/src/IceStorm/msbuild/icestormservice/packages.config
+++ b/cpp/src/IceStorm/msbuild/icestormservice/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ZeroC.LMDB" version="0.9.29" targetFramework="native" />
+  <package id="ZeroC.LMDB" version="0.9.36" targetFramework="native" />
 </packages>

--- a/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
+++ b/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
@@ -171,12 +171,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" />
+    <Import Project="..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets" Condition="Exists('..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\ZeroC.LMDB.0.9.29\build\native\ZeroC.LMDB.targets'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\ZeroC.LMDB.0.9.36\build\native\ZeroC.LMDB.targets'))" />
   </Target>
 </Project>

--- a/cpp/src/icegriddb/msbuild/packages.config
+++ b/cpp/src/icegriddb/msbuild/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ZeroC.LMDB" version="0.9.29" targetFramework="native" />
+  <package id="ZeroC.LMDB" version="0.9.36" targetFramework="native" />
 </packages>

--- a/csharp/test/Ice/operations/BatchOneways.cs
+++ b/csharp/test/Ice/operations/BatchOneways.cs
@@ -142,6 +142,10 @@ internal class BatchOneways
 
         p.ice_ping();
 
+        // The Ice runtime loads bzip2 at run time and silently sends uncompressed messages when it cannot. The test
+        // environment must provide bzip2, otherwise the compression checks below exercise nothing.
+        test(Ice.Internal.BZip2.isLoaded(p.ice_getCommunicator().getLogger()));
+
         bool supportsCompress = true;
         try
         {

--- a/csharp/test/Ice/operations/MyDerivedInterfaceAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedInterfaceAMDI.cs
@@ -47,7 +47,8 @@ public sealed class MyDerivedInterfaceI : Test.AsyncMyDerivedInterfaceDisp_
         return Task.CompletedTask;
     }
 
-    public override Task<bool> supportsCompressAsync(Current current) => Task.FromResult<bool>(true);
+    public override Task<bool> supportsCompressAsync(Current current) =>
+        Task.FromResult(Ice.Internal.BZip2.isLoaded(current.adapter.getCommunicator().getLogger()));
 
     public override Task opVoidAsync(Current current)
     {

--- a/packaging/windows-installer/docs/THIRD_PARTY_LICENSE.txt
+++ b/packaging/windows-installer/docs/THIRD_PARTY_LICENSE.txt
@@ -39,7 +39,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Julian Seward, jseward@bzip.org
-bzip2/libbzip2 version 1.0.6 of 6 September 2010
+bzip2/libbzip2 version 1.0.8 of 13 July 2019
 
 --------------------------------------------------------------------------
 
@@ -47,7 +47,7 @@ License agreement for Expat:
 -----------------------------
 
 Copyright (c) 1998-2000 Thai Open Source Software Center Ltd and Clark Cooper
-Copyright (c) 2001-2017 Expat maintainers
+Copyright (c) 2001-2025 Expat maintainers
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/packaging/windows-installer/docs/THIRD_PARTY_LICENSE.txt
+++ b/packaging/windows-installer/docs/THIRD_PARTY_LICENSE.txt
@@ -4,7 +4,7 @@ License agreement for bzip2/libbzip2:
 --------------------------------------------------------------------------
 
 This program, "bzip2", the associated library "libbzip2", and all
-documentation, are copyright (C) 1996-2010 Julian R Seward.  All
+documentation, are copyright (C) 1996-2019 Julian R Seward.  All
 rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -38,7 +38,7 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Julian Seward, jseward@bzip.org
+Julian Seward, jseward@acm.org
 bzip2/libbzip2 version 1.0.8 of 13 July 2019
 
 --------------------------------------------------------------------------

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,7 +16,7 @@ mcpp_url = f"https://github.com/zeroc-ice/mcpp/archive/refs/tags/v{mcpp_version}
 mcpp_local_filename = f"dist/mcpp-{mcpp_version}.tar.gz"
 
 bzip2_version = "1.0.8"
-bzip2_url = f"https://sourceware.org/pub/bzip2/bzip2-{bzip2_version}.tar.gz"
+bzip2_url = f"https://download.zeroc.com/bzip2/bzip2-{bzip2_version}.tar.gz"
 bzip2_local_filename = f"dist/bzip2-{bzip2_version}.tar.gz"
 
 script_directory = os.path.dirname(os.path.abspath(__file__))

--- a/python/setup.py
+++ b/python/setup.py
@@ -15,8 +15,8 @@ mcpp_version = "2.7.2.20"
 mcpp_url = f"https://github.com/zeroc-ice/mcpp/archive/refs/tags/v{mcpp_version}.tar.gz"
 mcpp_local_filename = f"dist/mcpp-{mcpp_version}.tar.gz"
 
-bzip2_version = "1.0.6.6"
-bzip2_url = f"https://github.com/zeroc-ice/bzip2/archive/refs/tags/v{bzip2_version}.tar.gz"
+bzip2_version = "1.0.8"
+bzip2_url = f"https://sourceware.org/pub/bzip2/bzip2-{bzip2_version}.tar.gz"
 bzip2_local_filename = f"dist/bzip2-{bzip2_version}.tar.gz"
 
 script_directory = os.path.dirname(os.path.abspath(__file__))

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -4406,12 +4406,21 @@ class CSharpMapping(Mapping):
     def getEnv(self, process: Process, current: Driver.Current) -> Envs:
         env = {}
         if isinstance(platform, Windows):
+            # The C# tests load bzip2.dll from the ZeroC.Bzip2 NuGet package restored for the C++ build. Read the
+            # package version from the Ice C++ project's packages.config so that upgrading the package there is enough.
+            packagesConfig = os.path.join(
+                self.component.getSourceDir(), "cpp", "src", "Ice", "msbuild", "ice", "packages.config"
+            )
+            with open(packagesConfig, "r") as config:
+                m = re.search(r'id="ZeroC\.Bzip2" version="([^"]+)"', config.read())
+            if not m:
+                raise RuntimeError("couldn't find the ZeroC.Bzip2 package version in `{0}'".format(packagesConfig))
             env["PATH"] = os.path.join(
                 self.component.getSourceDir(),
                 "cpp",
                 "msbuild",
                 "packages",
-                "bzip2.{0}.1.0.6.10".format(platform.getPlatformToolset()),
+                "ZeroC.Bzip2.{0}".format(m.group(1)),
                 "build",
                 "native",
                 "bin",

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -4414,7 +4414,7 @@ class CSharpMapping(Mapping):
             with open(packagesConfig, "r") as config:
                 m = re.search(r'id="ZeroC\.Bzip2" version="([^"]+)"', config.read())
             if not m:
-                raise RuntimeError("couldn't find the ZeroC.Bzip2 package version in `{0}'".format(packagesConfig))
+                raise RuntimeError("couldn't find the ZeroC.Bzip2 package version in '{0}'".format(packagesConfig))
             env["PATH"] = os.path.join(
                 self.component.getSourceDir(),
                 "cpp",


### PR DESCRIPTION
Updates the third-party libraries bundled with the Windows build:

| Package | From | To |
| --- | --- | --- |
| `ZeroC.Bzip2` | 1.0.6 | 1.0.8 |
| `ZeroC.Expat` | 2.4.1 | 2.8.4 |
| `ZeroC.LMDB` | 0.9.29 | 0.9.36 |

The bzip2 update also applies to the Windows Python wheels: `python/setup.py` now builds bzip2 1.0.8 from ZeroC's copy of the upstream tarball instead of 1.0.6 from the `zeroc-ice/bzip2` fork.

## Also in this PR

* `scripts/Util.py` put the pre-#3615 package directory (`bzip2.v143.1.0.6.10`) on the C# test PATH, so the C# tests on Windows never loaded bzip2 and the compression checks in `Ice/operations` were exercising nothing. The script now reads the ZeroC.Bzip2 version from the C++ `packages.config`, and the C# tests assert that bzip2 loads before exercising compression. The C# packages not bundling bzip2 is by design since #3615; #6730 documented this and cleaned up the leftovers.
