### PR TITLE
Run the coverage workflow only on zeroc-ice/ice

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   generate-cpp-coverage-report:
+    if: github.repository == 'zeroc-ice/ice'
     runs-on: macos-26
     steps:
       - name: Checkout repository
@@ -58,9 +59,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_CODE_BUCKET: ${{ secrets.AWS_S3_CODE_BUCKET }}
           AWS_DEFAULT_REGION: us-east-1
-        if: github.ref == 'refs/heads/main' && github.repository == 'zeroc-ice/ice'
+        if: github.ref == 'refs/heads/main'
 
   generate-csharp-coverage-report:
+    if: github.repository == 'zeroc-ice/ice'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
@@ -108,9 +110,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_CODE_BUCKET: ${{ secrets.AWS_S3_CODE_BUCKET }}
           AWS_DEFAULT_REGION: us-east-1
-        if: github.ref == 'refs/heads/main' && github.repository == 'zeroc-ice/ice'
+        if: github.ref == 'refs/heads/main'
 
   generate-java-coverage-report:
+    if: github.repository == 'zeroc-ice/ice'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
@@ -142,9 +145,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_CODE_BUCKET: ${{ secrets.AWS_S3_CODE_BUCKET }}
           AWS_DEFAULT_REGION: us-east-1
-        if: github.ref == 'refs/heads/main' && github.repository == 'zeroc-ice/ice'
+        if: github.ref == 'refs/heads/main'
 
   generate-js-coverage-report:
+    if: github.repository == 'zeroc-ice/ice'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
@@ -181,4 +185,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_CODE_BUCKET: ${{ secrets.AWS_S3_CODE_BUCKET }}
           AWS_DEFAULT_REGION: us-east-1
-        if: github.ref == 'refs/heads/main' && github.repository == 'zeroc-ice/ice'
+        if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
The weekly coverage schedule fires on every fork with Actions enabled, spending four runners on a full build and test cycle for an S3 upload no fork can make.

- Guards all four coverage jobs on `github.repository == 'zeroc-ice/ice'`, matching the `dispatch-*` workflows.
- Leaves the `refs/heads/main` check on the S3 sync steps, which still matters for a `workflow_dispatch` run from a branch.
