### PR TITLE
Document the Commons Compress dependency of Ice for Java protocol compression

### DIFF
--- a/csharp/src/Ice/README.md
+++ b/csharp/src/Ice/README.md
@@ -85,13 +85,16 @@ internal class Chatbot : GreeterDisp_
 ## Protocol Compression
 
 Ice for C# implements protocol compression with the native bzip2 library: `bzip2.dll` on Windows, `libbz2.so.1` on
-Linux, and `libbz2.dylib` on macOS. Ice loads this library dynamically at run time, so it must be next to your
+Linux, and `libbz2.dylib` on macOS. Ice loads this library dynamically at run time, so the library must be next to your
 application or in a directory on the system library path (`PATH` on Windows). The ZeroC.Ice package does not bundle
-it. When Ice cannot load it, Ice sends all messages uncompressed and throws an exception when it receives a compressed
-message.
+this library.
 
-Linux distributions and macOS provide this library. On Windows, `bzip2.dll` is available from the
+Linux distributions and macOS provide bzip2. On Windows, `bzip2.dll` is available from the
 [ZeroC.Bzip2 NuGet package][bzip2-package], the [Ice for C++ NuGet package][cpp-package], and the Windows installer.
+
+When Ice cannot load this library, Ice sends all messages uncompressed. If Ice receives a compressed message, it aborts
+the connection: the sender gets a `ConnectionLostException`, and the receiver logs a warning when `Ice.Warn.Connections`
+is enabled.
 
 [api]: https://code.zeroc.com/ice/main/api/csharp/api/Ice.html
 [bzip2-package]: https://www.nuget.org/packages/ZeroC.Bzip2

--- a/java/README.md
+++ b/java/README.md
@@ -82,8 +82,25 @@ class Chatbot implements Greeter {
 }
 ```
 
+## Protocol Compression
+
+Ice for Java implements protocol compression with the bzip2 classes of [Apache Commons Compress][commons-compress].
+Ice loads these classes reflectively at run time, and the Ice JAR does not declare a dependency on this library. To
+enable compression, add `org.apache.commons:commons-compress` to your application's runtime class path, for example
+with Gradle:
+
+```groovy
+dependencies {
+    runtimeOnly "org.apache.commons:commons-compress:1.28.0"
+}
+```
+
+When Ice cannot find these classes, it sends all messages uncompressed and throws an exception when it receives a
+compressed message.
+
 [Examples]: https://github.com/zeroc-ice/ice-demos/tree/main/java
 [Documentation]: https://docs.zeroc.com/ice/latest/java
 [API Reference]: https://code.zeroc.com/ice/main/api/java/index.html
 [Building from source]: ./BUILDING.md
 [Ice framework]: https://github.com/zeroc-ice/ice
+[commons-compress]: https://commons.apache.org/proper/commons-compress/

--- a/java/README.md
+++ b/java/README.md
@@ -95,8 +95,9 @@ dependencies {
 }
 ```
 
-When Ice cannot find these classes, it sends all messages uncompressed and throws an exception when it receives a
-compressed message.
+When Ice cannot find these classes, it sends all messages uncompressed. If Ice receives a compressed message, it aborts
+the connection: the sender gets a `ConnectionLostException`, and the receiver logs a warning when `Ice.Warn.Connections`
+is enabled.
 
 [Examples]: https://github.com/zeroc-ice/ice-demos/tree/main/java
 [Documentation]: https://docs.zeroc.com/ice/latest/java

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -1704,7 +1704,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 } else {
                     throw new FeatureNotSupportedException(
                         "Cannot uncompress compressed message: "
-                            + "org.apache.tools.bzip2.CBZip2OutputStream was not found");
+                            + "org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream was not found");
                 }
             }
             info.stream.pos(Protocol.headerSize);

--- a/java/test/android/controller/build.gradle
+++ b/java/test/android/controller/build.gradle
@@ -168,7 +168,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
 
     implementation files("${rootProject.projectDir}/../../../lib/test.jar")
-    runtimeOnly "org.apache.commons:commons-compress:1.20"
+    runtimeOnly "org.apache.commons:commons-compress:1.28.0"
 
     rewrite(
         "org.openrewrite.recipe:rewrite-static-analysis:2.19.0",

--- a/java/test/build.gradle
+++ b/java/test/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
 if(!gradle.startParameter.isOffline()) {
     dependencies {
-        runtimeOnly "org.apache.commons:commons-compress:1.20"
+        runtimeOnly "org.apache.commons:commons-compress:1.28.0"
     }
 }
 


### PR DESCRIPTION
Ice for Java implements protocol compression with the bzip2 classes of Apache Commons Compress, loaded reflectively
at run time. The Ice JAR declares no dependency on this library, and nothing documented that an application must add
it to its class path to get compression. This PR:

- adds a "Protocol Compression" section to the Java README, modeled on the ZeroC.Ice C# README, with the Gradle
  `runtimeOnly` line to add
- fixes the `FeatureNotSupportedException` message thrown when a compressed message arrives without the library: it
  still named the Ant class `org.apache.tools.bzip2.CBZip2OutputStream`, which Ice stopped using long ago
- bumps the test dependency from commons-compress 1.20 (2020) to 1.28.0, the current release

Verified with Ice/operations and Ice/info in Release, including `--compress`, against commons-compress 1.28.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
