### PR TITLE
Run Lintian with the Debian profile on the Ubuntu DEB builders

### DIFF
--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -100,12 +100,15 @@ jobs:
             /workspace/ice/packaging/deb/build-package.sh
         shell: bash
 
+      # The packaging targets Debian unstable. Use the Debian profile on every builder: the Ubuntu builders default to
+      # the Ubuntu vendor profile, which only recognizes Ubuntu release names and rejects "unstable" with
+      # bad-distribution-in-changes-file.
       - name: Run Lintian
         run: |
           docker run --rm \
             -v "$GITHUB_WORKSPACE:/workspace" \
             ghcr.io/zeroc-ice/ice-deb-builder-${{ matrix.distribution }}:${CHANNEL} \
-            bash -c 'lintian /workspace/*_source.changes'
+            bash -c 'lintian --profile debian /workspace/*_source.changes'
         shell: bash
 
       - name: Upload Artifacts

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -2,7 +2,7 @@ zeroc-ice (3.8.3-1) unstable; urgency=medium
 
   * New upstream version 3.8.3
 
- -- José Gutiérrez de la Concha <jose@zeroc.com>  Wed, 01 Jul 2026 12:00:00 +0200
+ -- José Gutiérrez de la Concha <jose@zeroc.com>  Wed, 09 Sep 2026 12:00:00 +0200
 
 zeroc-ice (3.8.2-1) unstable; urgency=medium
 

--- a/packaging/rpm/ice.spec
+++ b/packaging/rpm/ice.spec
@@ -664,7 +664,7 @@ exit 0
 %{_mandir}/man1/slice2py.1*
 
 %changelog
-* Wed Jul 1 2026 José Gutiérrez de la Concha <jose@zeroc.com> 3.8.3
+* Wed Sep 9 2026 José Gutiérrez de la Concha <jose@zeroc.com> 3.8.3
 - The 3.8.3 release
 
 * Tue Jun 2 2026 José Gutiérrez de la Concha <jose@zeroc.com> 3.8.2


### PR DESCRIPTION
The 3.8.3 release build (https://github.com/zeroc-ice/ice/actions/runs/34388086560) failed the Lintian step of the ubuntu24.04-arm64 DEB job:

```
E: zeroc-ice changes: bad-distribution-in-changes-file unstable
```

The packaging targets Debian `unstable`. On the Ubuntu builders Lintian selects the Ubuntu vendor profile, whose `known-dists` list only contains Ubuntu release names, so `unstable` is rejected. Nightly builds never hit this because `build-package.sh` rewrites the changelog entry with `UNRELEASED`, which Lintian accepts. The Lintian step was added to the 3.8 workflow after the 3.8.2 release, so 3.8.3 is the first release build to run it.

This PR passes `--profile debian` to Lintian on every builder. It is a no-op on the Debian builders (their default profile), and the Ubuntu builders now lint the package as the Debian source package it is.

Verified by building the 3.8 source package with `dpkg-buildpackage -S` inside the Ubuntu 24.04 builder image (Lintian 2.117.0ubuntu1.4) and the Ubuntu 26.04 builder image (Lintian 2.129.0ubuntu2.1): the default profile reproduces the error with exit code 2 on both, and `--profile debian` exits 0 on both.

The second commit sets the 3.8.3 entries in `debian/changelog` and `ice.spec` to today's date. They were dated from an earlier release attempt that was not published.
