### PR TITLE
Run Lintian with the Debian profile on the Ubuntu DEB builders

### DIFF
--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -100,12 +100,15 @@ jobs:
             /workspace/ice/packaging/deb/build-package.sh
         shell: bash
 
+      # The packaging targets Debian unstable. Use the Debian profile on every builder: the Ubuntu builders default to
+      # the Ubuntu vendor profile, which only recognizes Ubuntu release names and rejects "unstable" with
+      # bad-distribution-in-changes-file.
       - name: Run Lintian
         run: |
           docker run --rm \
             -v "$GITHUB_WORKSPACE:/workspace" \
             ghcr.io/zeroc-ice/ice-deb-builder-${{ matrix.distribution }}:${CHANNEL} \
-            bash -c 'lintian /workspace/*_source.changes'
+            bash -c 'lintian --profile debian /workspace/*_source.changes'
         shell: bash
 
       - name: Upload Artifacts


### PR DESCRIPTION
Forward-port of the workflow fix from #6733 (first commit). The Lintian step in `build-deb-packages.yml` is identical on main, so a release build with a `debian/changelog` entry targeting `unstable` fails the same way on the Ubuntu builders.