### PR TITLE
Sync the winget-pkgs fork and submit the 4-part package version to WinGet

### DIFF
--- a/.github/workflows/publish-windows-installer.yml
+++ b/.github/workflows/publish-windows-installer.yml
@@ -77,22 +77,36 @@ jobs:
         run: |
           gh run download "${{ inputs.run_id }}" --repo ${{ github.repository }} --pattern "windows-installer" --dir staging
 
+      - name: Sync the winget-pkgs fork with upstream
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_GITHUB_PAT }}
+        run: |
+          # wingetcreate submits from the token owner's winget-pkgs fork and fails when GitHub cannot bring that
+          # fork's master up to date with upstream. The fork exists only for these submissions, so reset it to
+          # upstream before submitting.
+          fork_owner=$(gh api user --jq .login)
+          gh repo sync "${fork_owner}/winget-pkgs" --source microsoft/winget-pkgs --branch master --force
+        shell: bash
+
       - name: Submit to WinGet
         env:
           CHANNEL: ${{ inputs.channel }}
-          WINGET_PAT: ${{ secrets.WINGET_GITHUB_PAT }}
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_PAT }}
         run: |
           $exeFile = Get-ChildItem staging/windows-installer/*.exe | Select-Object -First 1
           $downloadUrl = "https://download.zeroc.com/ice/${env:CHANNEL}/$($exeFile.Name)"
 
+          # The installer bundle registers as <BASE_VERSION>.0 in Apps & Features (see Bundle.wxs), and the
+          # WinGet package version must match what is installed.
+          $packageVersion = "$($env:BASE_VERSION).0"
+
           Write-Host "Download URL: $downloadUrl"
-          Write-Host "Version: $env:BASE_VERSION"
+          Write-Host "Version: $packageVersion"
 
           Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
           .\wingetcreate.exe update ZeroC.IceServices `
             --urls $downloadUrl `
-            --version $env:BASE_VERSION `
-            --submit `
-            --token $env:WINGET_PAT
+            --version $packageVersion `
+            --submit
         shell: pwsh


### PR DESCRIPTION
The WinGet submission of the Windows installer has failed on every stable release so far, and the versions that did reach WinGet were submitted by hand. Two causes, both fixed here.

wingetcreate submits from the token owner's `winget-pkgs` fork and first asks GitHub to bring the fork's `master` up to date with upstream. That call is unreliable once the fork has diverged (for 3.8.3 it was 2 commits ahead and about 40k behind), and wingetcreate then stops with "The forked repository could not be synced with the upstream commits". A new step hard-resets the fork's `master` to `microsoft/winget-pkgs` before submitting. The fork exists only for these submissions and carries nothing of its own.

The installer bundle registers as `<version>.0` in Apps & Features (`Bundle.wxs` sets `Version="$(Version).0"`), and the earlier hand submissions used 3.8.1.0 and 3.8.2.0 to match. The workflow passed the 3-part `BASE_VERSION`, which produced 3.8.3 for the last release. It now submits `<BASE_VERSION>.0`.

The token is passed through `WINGET_CREATE_GITHUB_TOKEN`, the mechanism winget-create documents for CI, instead of `--token`, which wingetcreate warns may end up in logs.

The submit step only runs for stable releases, so this is verified with actionlint and against the failing job log of the 3.8.3 publish run; the first real exercise will be the next stable release.
