### PR TITLE
Run publish-all when the nightly-only publish jobs are skipped

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -150,6 +150,10 @@ jobs:
   # Gate job that waits for all publish jobs to complete.
   # Other jobs can depend on this instead of listing all publish jobs individually.
   publish-all:
+    # publish-brew-packages and publish-swift-packages only run for nightly builds, and GitHub skips a job whose
+    # needs include a skipped job. Run whenever no publish job failed or was cancelled, so that the jobs below also
+    # run for stable releases.
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     runs-on: ubuntu-24.04
     needs:
       - publish-brew-packages
@@ -168,7 +172,7 @@ jobs:
       - publish-cpp-swift-deps
       - publish-symbols-sources
     steps:
-      - run: echo "All publish jobs completed successfully"
+      - run: echo "All publish jobs completed"
 
   invalidate-cloudfront-cache:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
`publish-all` lists `publish-brew-packages` and `publish-swift-packages` in its `needs`, and both only run for nightly builds. GitHub skips a job whose `needs` include a skipped job, so on every stable release `publish-all` is skipped, and `invalidate-cloudfront-cache` and `upload-release-assets` behind it are skipped as well. The 3.8.1, 3.8.2 and 3.8.3 publish runs all show this, and the CloudFront invalidation and the release asset upload had to be done by hand each time. Nightly runs, where nothing is skipped, are the only ones where these jobs ever ran.

`publish-all` now runs whenever no publish job failed or was cancelled, so skipped jobs no longer block it. The two downstream jobs keep their conditions, which only look at `publish-all`.

Verified with actionlint. The next nightly run exercises the new condition on the all-succeeded path; the skipped-needs path is only exercised by a stable release.
